### PR TITLE
[PATCH v2] Fix array out of bounds

### DIFF
--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -262,7 +262,7 @@ static odp_timer_pool_t timer_pool_new(const char *name,
 		return ODP_TIMER_POOL_INVALID;
 	}
 
-	for (i = 0; i < MAX_TIMER_POOLS; i++) {
+	for (i = 0; i < MAX_TIMER_POOLS - 1; i++) {
 		if (timer_global.timer_pool_used[i] == 0) {
 			timer_global.timer_pool_used[i] = 1;
 			break;


### PR DESCRIPTION
Array 'timer_global.timer_pool[32]' accessed at index 32, which is out of
bounds in line 323.

If the i variable in the for statement goes all the way to the end of the condition, the i variable will be 32 and out of the bounds problem will occur on the 323 line.