### PR TITLE
[PATCH v1] linux-gen: buffer: clean checkpatch warnings

### DIFF
--- a/platform/linux-generic/odp_buffer.c
+++ b/platform/linux-generic/odp_buffer.c
@@ -65,16 +65,16 @@ int odp_buffer_snprint(char *str, uint32_t n, odp_buffer_t buf)
 	hdr = buf_hdl_to_hdr(buf);
 	pool = hdr->pool_ptr;
 
-	len += snprintf(&str[len], n-len,
+	len += snprintf(&str[len], n - len,
 			"Buffer\n");
-	len += snprintf(&str[len], n-len,
+	len += snprintf(&str[len], n - len,
 			"  pool         %" PRIu64 "\n",
 			odp_pool_to_u64(pool->pool_hdl));
-	len += snprintf(&str[len], n-len,
+	len += snprintf(&str[len], n - len,
 			"  addr         %p\n",          hdr->seg[0].data);
-	len += snprintf(&str[len], n-len,
+	len += snprintf(&str[len], n - len,
 			"  size         %" PRIu32 "\n", odp_buffer_size(buf));
-	len += snprintf(&str[len], n-len,
+	len += snprintf(&str[len], n - len,
 			"  type         %i\n",          hdr->type);
 
 	return len;
@@ -86,7 +86,7 @@ void odp_buffer_print(odp_buffer_t buf)
 	char str[max_len];
 	int len;
 
-	len = odp_buffer_snprint(str, max_len-1, buf);
+	len = odp_buffer_snprint(str, max_len - 1, buf);
 	str[len] = 0;
 
 	ODP_PRINT("\n%s\n", str);


### PR DESCRIPTION
Checkpatch reported warnings when running it against the file.
Corrected all reported warnings.

Signed-off-by: Petri Savolainen <petri.savolainen@linaro.org>