### PR TITLE
[PATCH v4] API: queue parameter to disable reordering

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.5])
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [21])
-m4_define([odpapi_minor_version], [0])
+m4_define([odpapi_minor_version], [1])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])

--- a/include/odp/api/spec/queue_types.h
+++ b/include/odp/api/spec/queue_types.h
@@ -123,6 +123,37 @@ typedef enum odp_nonblocking_t {
 } odp_nonblocking_t;
 
 /**
+ * Original event order maintenance options
+ *
+ * Options to keep or ignore the original event order of a source queue. This
+ * option is relevant for (plain or parallel scheduled) queues that are
+ * destinations for events enqueued while holding an ordered queue
+ * synchronization context. By default, an ordered context maintains original
+ * event order regardless of the destination queue type. Event re-ordering may
+ * cause extra synchronization effort for implementation and a long delay before
+ * application can receive a re-ordered event from the destination queue. This
+ * is wasteful and in some cases the extra delay is not acceptable for those
+ * destination queues that do not need to maintain the original event order.
+ * Application can use ODP_QUEUE_ORDER_IGNORE option to prevent implementation
+ * from performing unnecessary event re-ordering and negative side-effects of
+ * that.
+ */
+typedef enum odp_queue_order_t {
+	/** Keep original event order. Events enqueued into this queue while
+	 *  holding an ordered queue synchronization context maintain the
+	 *  original event order of the source queue.
+	 */
+	ODP_QUEUE_ORDER_KEEP = 0,
+
+	/** Ignore original event order. Events enqueued into this queue do not
+	 *  need to maintain the original event order of the source queue.
+	 *  Implementation must avoid significant event re-ordering delays.
+	 */
+	ODP_QUEUE_ORDER_IGNORE
+
+} odp_queue_order_t;
+
+/**
  * Queue capabilities
  */
 typedef struct odp_queue_capability_t {
@@ -261,6 +292,12 @@ typedef struct odp_queue_param_t {
 	  * These parameters are considered only when queue type is
 	  * ODP_QUEUE_TYPE_SCHED. */
 	odp_schedule_param_t sched;
+
+	/** Original event order maintenance
+	  *
+	  * Keep or ignore the original event order of a source queue.
+	  * The default value is ODP_QUEUE_ORDER_KEEP. */
+	odp_queue_order_t order;
 
 	/** Non-blocking level
 	  *

--- a/include/odp/api/spec/schedule_types.h
+++ b/include/odp/api/spec/schedule_types.h
@@ -77,7 +77,10 @@ extern "C" {
  * The atomic queue synchronization context is dedicated to the thread until it
  * requests another event from the scheduler, which implicitly releases the
  * context. User may allow the scheduler to release the context earlier than
- * that by calling odp_schedule_release_atomic().
+ * that by calling odp_schedule_release_atomic(). However, this call is just
+ * a hint to the implementation and the context may be held until the next
+ * schedule call.
+ *
  * When scheduler is enabled as flow-aware, the event flow id value affects
  * scheduling of the event and synchronization is maintained per flow within
  * each queue.
@@ -97,7 +100,9 @@ extern "C" {
  * queue synchronization context. A thread holds the context until it
  * requests another event from the scheduler, which implicitly releases the
  * context. User may allow the scheduler to release the context earlier than
- * that by calling odp_schedule_release_ordered().
+ * that by calling odp_schedule_release_ordered(). However, this call is just
+ * a hint to the implementation and the context may be held until the next
+ * schedule call.
  *
  * Events from the same (source) queue appear in their original order
  * when dequeued from a destination queue. The destination queue can have any
@@ -107,6 +112,11 @@ extern "C" {
  * (e.g. freed or stored) within the context are considered missing from
  * reordering and are skipped at this time (but can be ordered again within
  * another context).
+ *
+ * Unnecessary event re-ordering may be avoided for those destination queues
+ * that do not need to maintain the original event order by setting 'order'
+ * queue parameter to ODP_QUEUE_ORDER_IGNORE.
+ *
  * When scheduler is enabled as flow-aware, the event flow id value affects
  * scheduling of the event and synchronization is maintained per flow within
  * each queue.

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -615,6 +615,7 @@ static void queue_param_init(odp_queue_param_t *params)
 	params->enq_mode = ODP_QUEUE_OP_MT;
 	params->deq_mode = ODP_QUEUE_OP_MT;
 	params->nonblocking = ODP_BLOCKING;
+	params->order = ODP_QUEUE_ORDER_KEEP;
 	params->sched.prio  = odp_schedule_default_prio();
 	params->sched.sync  = ODP_SCHED_SYNC_PARALLEL;
 	params->sched.group = ODP_SCHED_GROUP_ALL;

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -632,7 +632,8 @@ static int _queue_enq_multi(odp_queue_t handle, odp_buffer_hdr_t *buf_hdr[],
 
 	queue = qentry_from_int(handle);
 	ts = sched_ts;
-	if (ts && odp_unlikely(ts->out_of_order)) {
+	if (ts && odp_unlikely(ts->out_of_order) &&
+	    (queue->s.param.order == ODP_QUEUE_ORDER_KEEP)) {
 		actual = rctx_save(queue, buf_hdr, num);
 		return actual;
 	}
@@ -888,6 +889,7 @@ static void queue_param_init(odp_queue_param_t *params)
 	params->sched.prio = odp_schedule_default_prio();
 	params->sched.sync = ODP_SCHED_SYNC_PARALLEL;
 	params->sched.group = ODP_SCHED_GROUP_ALL;
+	params->order = ODP_QUEUE_ORDER_KEEP;
 }
 
 static int queue_info(odp_queue_t handle, odp_queue_info_t *info)

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -846,9 +846,13 @@ static int schedule_ord_enq_multi(odp_queue_t dst_queue, void *buf_hdr[],
 	if (sched_local.ordered.in_order)
 		return 0;
 
+	dst_qentry = qentry_from_handle(dst_queue);
+
+	if (dst_qentry->s.param.order == ODP_QUEUE_ORDER_IGNORE)
+		return 0;
+
 	src_queue  = sched_local.ordered.src_queue;
 	stash_num  = sched_local.ordered.stash_num;
-	dst_qentry = qentry_from_handle(dst_queue);
 
 	if (ordered_own_turn(src_queue)) {
 		/* Own turn, so can do enqueue directly. */

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -2064,8 +2064,9 @@ static int ord_enq_multi(odp_queue_t handle, void *buf_hdr[], int num,
 	int actual;
 
 	ts = sched_ts;
-	if (ts && odp_unlikely(ts->out_of_order)) {
-		queue = qentry_from_int(handle);
+	queue = qentry_from_int(handle);
+	if (ts && odp_unlikely(ts->out_of_order) &&
+	    (queue->s.param.order == ODP_QUEUE_ORDER_KEEP)) {
 		actual = rctx_save(queue, (odp_buffer_hdr_t **)buf_hdr, num);
 		*ret = actual;
 		return 1;

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -149,17 +149,17 @@ static void release_context(odp_schedule_sync_t sync)
 
 static void scheduler_test_capa(void)
 {
-	odp_schedule_capability_t capa;
+	odp_schedule_capability_t sched_capa;
 	odp_queue_capability_t queue_capa;
 
-	memset(&capa, 0, sizeof(odp_schedule_capability_t));
-	CU_ASSERT_FATAL(odp_schedule_capability(&capa) == 0);
+	memset(&sched_capa, 0, sizeof(odp_schedule_capability_t));
+	CU_ASSERT_FATAL(odp_schedule_capability(&sched_capa) == 0);
 	CU_ASSERT_FATAL(odp_queue_capability(&queue_capa) == 0);
 
-	CU_ASSERT(capa.max_groups != 0);
-	CU_ASSERT(capa.max_prios != 0);
-	CU_ASSERT(capa.max_queues != 0);
-	CU_ASSERT(queue_capa.max_queues >= capa.max_queues);
+	CU_ASSERT(sched_capa.max_groups != 0);
+	CU_ASSERT(sched_capa.max_prios != 0);
+	CU_ASSERT(sched_capa.max_queues != 0);
+	CU_ASSERT(queue_capa.max_queues >= sched_capa.max_queues);
 }
 
 static void scheduler_test_wait_time(void)
@@ -422,7 +422,6 @@ static void scheduler_test_wait(void)
 
 static void scheduler_test_queue_size(void)
 {
-	odp_queue_capability_t queue_capa;
 	odp_schedule_config_t default_config;
 	odp_pool_t pool;
 	odp_pool_param_t pool_param;
@@ -436,8 +435,10 @@ static void scheduler_test_queue_size(void)
 				      ODP_SCHED_SYNC_ATOMIC,
 				      ODP_SCHED_SYNC_ORDERED};
 
-	CU_ASSERT_FATAL(odp_queue_capability(&queue_capa) == 0);
 	queue_size = DEFAULT_NUM_EV;
+
+	/* Scheduler has been already configured. Use default config as max
+	 * queue size. */
 	odp_schedule_config_init(&default_config);
 	if (default_config.queue_size &&
 	    queue_size > default_config.queue_size)
@@ -1779,7 +1780,7 @@ static void scheduler_test_ordered_lock(void)
 static int create_queues(test_globals_t *globals)
 {
 	int i, j, prios, rc;
-	odp_queue_capability_t capa;
+	odp_queue_capability_t queue_capa;
 	odp_schedule_capability_t sched_capa;
 	odp_schedule_config_t default_config;
 	odp_pool_t queue_ctx_pool;
@@ -1793,7 +1794,7 @@ static int create_queues(test_globals_t *globals)
 	int queues_per_prio;
 	int sched_types;
 
-	if (odp_queue_capability(&capa) < 0) {
+	if (odp_queue_capability(&queue_capa) < 0) {
 		printf("Queue capability query failed\n");
 		return -1;
 	}
@@ -1826,8 +1827,9 @@ static int create_queues(test_globals_t *globals)
 	num_sched = (prios * queues_per_prio * sched_types) + CHAOS_NUM_QUEUES;
 	num_plain = (prios * queues_per_prio);
 	while ((num_sched > default_config.num_queues ||
-		num_plain > capa.plain.max_num ||
-		num_sched + num_plain > capa.max_queues) && queues_per_prio) {
+		num_plain > queue_capa.plain.max_num ||
+		num_sched + num_plain > queue_capa.max_queues) &&
+		queues_per_prio) {
 		queues_per_prio--;
 		num_sched = (prios * queues_per_prio * sched_types) +
 				CHAOS_NUM_QUEUES;


### PR DESCRIPTION
Application may do enqueues to multiple destination queues from within an ordered scheduling context. It's wasteful and sometimes not acceptable (due to potentially large reordering delay) to reorder all destination queues. E.g. application may use plain queues as temporary object storage, etc which do not benefit from enqueue operation reordering. Ordering context is released during the next schedule call (odp_schedule_release_ordered() is just a hint), so it would be complex for application to avoid unnecessary re-ordering.