### PR TITLE
[PATCH v3] api: shm: add ODP_SHM_HP flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.5])
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [21])
-m4_define([odpapi_minor_version], [1])
+m4_define([odpapi_minor_version], [2])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])

--- a/include/odp/api/spec/shared_memory.h
+++ b/include/odp/api/spec/shared_memory.h
@@ -1,4 +1,5 @@
-/* Copyright (c) 2013-2018, Linaro Limited
+/* Copyright (c) 2019, Nokia
+ * Copyright (c) 2013-2018, Linaro Limited
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -39,11 +40,17 @@ extern "C" {
  * Maximum shared memory block name length in chars including null char
  */
 
-/*
- * Shared memory flags:
+ /* Shared memory flags */
+
+/**
+ * Application SW only, no HW access
  */
-#define ODP_SHM_SW_ONLY		0x1 /**< Application SW only, no HW access   */
-#define ODP_SHM_PROC		0x2 /**< Share with external processes       */
+#define ODP_SHM_SW_ONLY		0x1
+
+/**
+ * Share with external processes
+ */
+#define ODP_SHM_PROC		0x2
 
 /**
  * Single virtual address
@@ -61,6 +68,15 @@ extern "C" {
  * through odp_shm_import().
  */
 #define ODP_SHM_EXPORT		0x08
+
+/**
+ * Use huge pages
+ *
+ * When set, this flag guarantees that the memory reserved by odp_shm_reserve()
+ * is allocated from huge pages. The reserve call will return failure if enough
+ * huge page memory is not available.
+ */
+#define ODP_SHM_HP		0x10
 
 /**
  * Shared memory block info

--- a/platform/linux-generic/include/odp_shm_internal.h
+++ b/platform/linux-generic/include/odp_shm_internal.h
@@ -1,4 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
+/* Copyright (c) 2019, Nokia
+ * Copyright (c) 2016-2018, Linaro Limited
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -20,7 +21,6 @@ extern "C" {
 #define _ODP_ISHM_SINGLE_VA		1
 #define _ODP_ISHM_LOCK			2
 #define _ODP_ISHM_EXPORT		4 /* create export descr file in /tmp */
-#define _ODP_ISHM_USE_HP		8 /* allocate memory from huge pages */
 
 /**
  * Shared memory block info
@@ -33,9 +33,6 @@ typedef struct _odp_ishm_info_t {
 	uint32_t    flags;     /**< _ODP_ISHM_* flags */
 	uint32_t    user_flags;/**< user specific flags */
 } _odp_ishm_info_t;
-
-odp_shm_t _odp_shm_reserve(const char *name, uint64_t size, uint32_t align,
-			   uint32_t flags, uint32_t extra_flags);
 
 int   _odp_ishm_reserve(const char *name, uint64_t size, int fd, uint32_t align,
 			uint64_t offset, uint32_t flags, uint32_t user_flags);

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -1,4 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
+/* Copyright (c) 2019, Nokia
+ * Copyright (c) 2016-2018, Linaro Limited
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -1114,7 +1115,7 @@ int _odp_ishm_reserve(const char *name, uint64_t size, int fd,
 	}
 
 	/* Otherwise, Try first huge pages when possible and needed: */
-	if ((fd < 0) && page_hp_size && ((flags &  _ODP_ISHM_USE_HP) ||
+	if ((fd < 0) && page_hp_size && ((user_flags &  ODP_SHM_HP) ||
 					 size > ishm_tbl->huge_page_limit)) {
 		/* at least, alignment in VA should match page size, but user
 		 * can request more: If the user requirement exceeds the page
@@ -1168,6 +1169,11 @@ int _odp_ishm_reserve(const char *name, uint64_t size, int fd,
 
 	/* Try normal pages if huge pages failed */
 	if (fd < 0) {
+		if (user_flags & ODP_SHM_HP) {
+			odp_spinlock_unlock(&ishm_tbl->lock);
+			ODP_ERR("Unable to allocate memory from huge pages\n");
+			return -1;
+		}
 		/* at least, alignment in VA should match page size, but user
 		 * can request more: If the user requirement exceeds the page
 		 * size then we have to make sure the block will be mapped at

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -1,4 +1,5 @@
-/* Copyright (c) 2013-2018, Linaro Limited
+/* Copyright (c) 2019, Nokia
+ * Copyright (c) 2013-2018, Linaro Limited
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -384,7 +385,6 @@ static odp_pool_t pool_create(const char *name, odp_pool_param_t *params,
 	uint32_t max_len;
 	uint32_t ring_size;
 	uint32_t num_extra = 0;
-	uint32_t extra_shm_flags = 0;
 	int name_len;
 	const char *postfix = "_uarea";
 	char uarea_name[ODP_POOL_NAME_LEN + sizeof(postfix)];
@@ -514,7 +514,7 @@ static odp_pool_t pool_create(const char *name, odp_pool_param_t *params,
 			return ODP_POOL_INVALID;
 		}
 		if (dpdk_obj_size != block_size)
-			extra_shm_flags |= _ODP_ISHM_USE_HP;
+			shmflags |= ODP_SHM_HP;
 		block_size = dpdk_obj_size;
 	}
 
@@ -548,8 +548,8 @@ static odp_pool_t pool_create(const char *name, odp_pool_param_t *params,
 	pool->ext_desc       = NULL;
 	pool->ext_destroy    = NULL;
 
-	shm = _odp_shm_reserve(pool->name, pool->shm_size,
-			       ODP_PAGE_SIZE, shmflags, extra_shm_flags);
+	shm = odp_shm_reserve(pool->name, pool->shm_size, ODP_PAGE_SIZE,
+			      shmflags);
 
 	pool->shm = shm;
 

--- a/platform/linux-generic/odp_shared_memory.c
+++ b/platform/linux-generic/odp_shared_memory.c
@@ -1,4 +1,5 @@
-/* Copyright (c) 2013-2018, Linaro Limited
+/* Copyright (c) 2019, Nokia
+ * Copyright (c) 2013-2018, Linaro Limited
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -44,22 +45,6 @@ static uint32_t get_ishm_flags(uint32_t flags)
 	return f;
 }
 
-odp_shm_t _odp_shm_reserve(const char *name, uint64_t size, uint32_t align,
-			   uint32_t flags, uint32_t extra_flags)
-{
-	int block_index;
-	uint32_t flgs = 0; /* internal ishm flags */
-
-	flgs = get_ishm_flags(flags);
-	flgs |= extra_flags;
-
-	block_index = _odp_ishm_reserve(name, size, -1, align, 0, flgs, flags);
-	if (block_index >= 0)
-		return to_handle(block_index);
-	else
-		return ODP_SHM_INVALID;
-}
-
 int odp_shm_capability(odp_shm_capability_t *capa)
 {
 	memset(capa, 0, sizeof(odp_shm_capability_t));
@@ -74,7 +59,16 @@ int odp_shm_capability(odp_shm_capability_t *capa)
 odp_shm_t odp_shm_reserve(const char *name, uint64_t size, uint64_t align,
 			  uint32_t flags)
 {
-	return  _odp_shm_reserve(name, size, align, flags, 0);
+	int block_index;
+	uint32_t flgs = 0; /* internal ishm flags */
+
+	flgs = get_ishm_flags(flags);
+
+	block_index = _odp_ishm_reserve(name, size, -1, align, 0, flgs, flags);
+	if (block_index >= 0)
+		return to_handle(block_index);
+	else
+		return ODP_SHM_INVALID;
 }
 
 odp_shm_t odp_shm_import(const char *remote_name,


### PR DESCRIPTION
When set, this flag guarantees that the memory reserved by odp_shm_reserve() is allocated from huge pages. The call will fail if enough huge page memory is not available.

V2:
- ODP_SHM_HP comment wording and comment clean-up (Petri)
- Removed internal _odp_shm_reserve() function
