### PR TITLE
[PATCH v2] validation: scheduler: test fixes

### DIFF
--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -1671,10 +1671,7 @@ static void scheduler_test_pause_resume(void)
 		CU_ASSERT_FATAL(buf != ODP_BUFFER_INVALID);
 		ev = odp_buffer_to_event(buf);
 		ret = odp_queue_enq(queue, ev);
-		CU_ASSERT(ret == 0);
-
-		if (ret)
-			odp_buffer_free(buf);
+		CU_ASSERT_FATAL(ret == 0);
 	}
 
 	for (i = 0; i < NUM_BUFS_BEFORE_PAUSE; i++) {
@@ -1699,7 +1696,7 @@ static void scheduler_test_pause_resume(void)
 		local_bufs++;
 	}
 
-	CU_ASSERT(local_bufs < NUM_BUFS_PAUSE - NUM_BUFS_BEFORE_PAUSE);
+	CU_ASSERT(local_bufs <= NUM_BUFS_PAUSE - NUM_BUFS_BEFORE_PAUSE);
 
 	odp_schedule_resume();
 

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -54,7 +54,7 @@
 #define CHAOS_PTR_TO_NDX(p) ((uint64_t)(uint32_t)(uintptr_t)p)
 #define CHAOS_NDX_TO_PTR(n) ((void *)(uintptr_t)n)
 
-#define ODP_WAIT_TOLERANCE	(150 * ODP_TIME_MSEC_IN_NS)
+#define WAIT_TOLERANCE (150 * ODP_TIME_MSEC_IN_NS)
 #define WAIT_1MS_RETRIES 1000
 
 /* Test global variables */
@@ -192,7 +192,7 @@ static void scheduler_test_wait_time(void)
 
 	diff = odp_time_diff(end_time, start_time);
 	lower_limit = ODP_TIME_NULL;
-	upper_limit = odp_time_local_from_ns(ODP_WAIT_TOLERANCE);
+	upper_limit = odp_time_local_from_ns(WAIT_TOLERANCE);
 
 	CU_ASSERT(odp_time_cmp(diff, lower_limit) >= 0);
 	CU_ASSERT(odp_time_cmp(diff, upper_limit) <= 0);
@@ -205,9 +205,9 @@ static void scheduler_test_wait_time(void)
 
 	diff = odp_time_diff(end_time, start_time);
 	lower_limit = odp_time_local_from_ns(5 * ODP_TIME_SEC_IN_NS -
-							ODP_WAIT_TOLERANCE);
+					     WAIT_TOLERANCE);
 	upper_limit = odp_time_local_from_ns(5 * ODP_TIME_SEC_IN_NS +
-							ODP_WAIT_TOLERANCE);
+					     WAIT_TOLERANCE);
 
 	if (odp_time_cmp(diff, lower_limit) <= 0) {
 		fprintf(stderr, "Exceed lower limit: "


### PR DESCRIPTION
V2:
- `schedule_retries != WAIT_1MS_RETRIES` -> `schedule_retries < WAIT_1MS_RETRIES` (Stan)