### PR TITLE
[PATCH v2] linux-gen: pool: implement pool using pointer ring

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -126,10 +126,13 @@ noinst_HEADERS = \
 		  include/odp_queue_basic_internal.h \
 		  include/odp_queue_lf.h \
 		  include/odp_queue_scalable_internal.h \
+		  include/odp_ring_common.h \
 		  include/odp_ring_internal.h \
 		  include/odp_ring_mpmc_internal.h \
+		  include/odp_ring_ptr_internal.h \
 		  include/odp_ring_spsc_internal.h \
 		  include/odp_ring_st_internal.h \
+		  include/odp_ring_u32_internal.h \
 		  include/odp_schedule_if.h \
 		  include/odp_schedule_scalable_config.h \
 		  include/odp_schedule_scalable.h \

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -23,7 +23,7 @@ extern "C" {
 
 #include <odp_buffer_internal.h>
 #include <odp_config_internal.h>
-#include <odp_ring_u32_internal.h>
+#include <odp_ring_ptr_internal.h>
 #include <odp/api/plat/strong_types.h>
 
 typedef struct ODP_ALIGNED_CACHE pool_cache_t {
@@ -38,10 +38,10 @@ typedef struct ODP_ALIGNED_CACHE pool_cache_t {
 /* Buffer header ring */
 typedef struct ODP_ALIGNED_CACHE {
 	/* Ring header */
-	ring_u32_t hdr;
+	ring_ptr_t hdr;
 
 	/* Ring data: buffer handles */
-	uint32_t buf[CONFIG_POOL_MAX_NUM + 1];
+	odp_buffer_hdr_t *buf_hdr[CONFIG_POOL_MAX_NUM + 1];
 
 } pool_ring_t;
 

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -23,7 +23,7 @@ extern "C" {
 
 #include <odp_buffer_internal.h>
 #include <odp_config_internal.h>
-#include <odp_ring_internal.h>
+#include <odp_ring_u32_internal.h>
 #include <odp/api/plat/strong_types.h>
 
 typedef struct ODP_ALIGNED_CACHE pool_cache_t {
@@ -38,7 +38,7 @@ typedef struct ODP_ALIGNED_CACHE pool_cache_t {
 /* Buffer header ring */
 typedef struct ODP_ALIGNED_CACHE {
 	/* Ring header */
-	ring_t   hdr;
+	ring_u32_t hdr;
 
 	/* Ring data: buffer handles */
 	uint32_t buf[CONFIG_POOL_MAX_NUM + 1];

--- a/platform/linux-generic/include/odp_ring_common.h
+++ b/platform/linux-generic/include/odp_ring_common.h
@@ -1,0 +1,21 @@
+/* Copyright (c) 2019, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_RING_COMMON_H_
+#define ODP_RING_COMMON_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define _ODP_RING_TYPE_U32 1
+#define _ODP_RING_TYPE_PTR 2
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp_ring_internal.h
+++ b/platform/linux-generic/include/odp_ring_internal.h
@@ -1,8 +1,12 @@
 /* Copyright (c) 2016-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
  */
+
+/* This header should NOT be included directly. There are no include guards for
+ * the function definitions! */
 
 #ifndef ODP_RING_INTERNAL_H_
 #define ODP_RING_INTERNAL_H_
@@ -17,8 +21,9 @@ extern "C" {
 #include <odp_align_internal.h>
 #include <odp/api/plat/atomic_inlines.h>
 #include <odp/api/plat/cpu_inlines.h>
+#include <odp_ring_common.h>
 
-/* Ring of uint32_t data
+/* Generic ring implementation
  *
  * Ring stores head and tail counters. Ring indexes are formed from these
  * counters with a mask (mask = ring_size - 1), which requires that ring size
@@ -26,7 +31,8 @@ extern "C" {
  * number of data items that will be stored on it as write operations are
  * assumed to succeed eventually (after readers complete their current
  * operations). */
-typedef struct ODP_ALIGNED_CACHE {
+
+struct ring_common {
 	/* Writer head and tail */
 	odp_atomic_u32_t w_head;
 	odp_atomic_u32_t w_tail;
@@ -35,9 +41,17 @@ typedef struct ODP_ALIGNED_CACHE {
 	/* Reader head and tail */
 	odp_atomic_u32_t r_head;
 	odp_atomic_u32_t r_tail;
+};
 
+typedef struct ODP_ALIGNED_CACHE {
+	struct ring_common r;
 	uint32_t data[0];
-} ring_t;
+} ring_u32_t;
+
+typedef struct ODP_ALIGNED_CACHE {
+	struct ring_common r;
+	void *data[0];
+} ring_ptr_t;
 
 /* 32-bit CAS with memory order selection */
 static inline int cas_mo_u32(odp_atomic_u32_t *atom, uint32_t *old_val,
@@ -49,35 +63,69 @@ static inline int cas_mo_u32(odp_atomic_u32_t *atom, uint32_t *old_val,
 					   mo_failure);
 }
 
+#endif /* End of include guards */
+
+#undef _ring_gen_t
+#undef _ring_data_t
+#undef _RING_INIT
+#undef _RING_DEQ
+#undef _RING_DEQ_MULTI
+#undef _RING_ENQ
+#undef _RING_ENQ_MULTI
+
+/* Remap generic types and function names to ring data type specific ones. One
+ * should never use the generic names (e.g. _RING_INIT) directly. */
+
+#if _ODP_RING_TYPE == _ODP_RING_TYPE_U32
+	#define _ring_gen_t ring_u32_t
+	#define _ring_data_t uint32_t
+
+	#define _RING_INIT ring_u32_init
+	#define _RING_DEQ ring_u32_deq
+	#define _RING_DEQ_MULTI ring_u32_deq_multi
+	#define _RING_ENQ ring_u32_enq
+	#define _RING_ENQ_MULTI ring_u32_enq_multi
+#elif _ODP_RING_TYPE == _ODP_RING_TYPE_PTR
+	#define _ring_gen_t ring_ptr_t
+	#define _ring_data_t void *
+
+	#define _RING_INIT ring_ptr_init
+	#define _RING_DEQ ring_ptr_deq
+	#define _RING_DEQ_MULTI ring_ptr_deq_multi
+	#define _RING_ENQ ring_ptr_enq
+	#define _RING_ENQ_MULTI ring_ptr_enq_multi
+#endif
+
 /* Initialize ring */
-static inline void ring_init(ring_t *ring)
+static inline void _RING_INIT(_ring_gen_t *ring)
 {
-	odp_atomic_init_u32(&ring->w_head, 0);
-	odp_atomic_init_u32(&ring->w_tail, 0);
-	odp_atomic_init_u32(&ring->r_head, 0);
-	odp_atomic_init_u32(&ring->r_tail, 0);
+	odp_atomic_init_u32(&ring->r.w_head, 0);
+	odp_atomic_init_u32(&ring->r.w_tail, 0);
+	odp_atomic_init_u32(&ring->r.r_head, 0);
+	odp_atomic_init_u32(&ring->r.r_tail, 0);
 }
 
 /* Dequeue data from the ring head */
-static inline uint32_t ring_deq(ring_t *ring, uint32_t mask, uint32_t *data)
+static inline uint32_t _RING_DEQ(_ring_gen_t *ring, uint32_t mask,
+				 _ring_data_t *data)
 {
 	uint32_t head, tail, new_head;
 
 	/* Load/CAS acquire of r_head ensures that w_tail load happens after
 	 * r_head load, and thus head value is always behind or equal to tail
 	 * value. */
-	head = odp_atomic_load_acq_u32(&ring->r_head);
+	head = odp_atomic_load_acq_u32(&ring->r.r_head);
 
 	/* Move reader head. This thread owns data at the new head. */
 	do {
-		tail = odp_atomic_load_acq_u32(&ring->w_tail);
+		tail = odp_atomic_load_acq_u32(&ring->r.w_tail);
 
 		if (head == tail)
 			return 0;
 
 		new_head = head + 1;
 
-	} while (odp_unlikely(cas_mo_u32(&ring->r_head, &head, new_head,
+	} while (odp_unlikely(cas_mo_u32(&ring->r.r_head, &head, new_head,
 					 __ATOMIC_ACQUIRE,
 					 __ATOMIC_ACQUIRE) == 0));
 
@@ -85,29 +133,29 @@ static inline uint32_t ring_deq(ring_t *ring, uint32_t mask, uint32_t *data)
 	*data = ring->data[new_head & mask];
 
 	/* Wait until other readers have updated the tail */
-	while (odp_unlikely(odp_atomic_load_u32(&ring->r_tail) != head))
+	while (odp_unlikely(odp_atomic_load_u32(&ring->r.r_tail) != head))
 		odp_cpu_pause();
 
 	/* Update the tail. Writers acquire it. */
-	odp_atomic_store_rel_u32(&ring->r_tail, new_head);
+	odp_atomic_store_rel_u32(&ring->r.r_tail, new_head);
 
 	return 1;
 }
 
 /* Dequeue multiple data from the ring head. Num is smaller than ring size. */
-static inline uint32_t ring_deq_multi(ring_t *ring, uint32_t mask,
-				      uint32_t data[], uint32_t num)
+static inline uint32_t _RING_DEQ_MULTI(_ring_gen_t *ring, uint32_t mask,
+				       _ring_data_t data[], uint32_t num)
 {
 	uint32_t head, tail, new_head, i;
 
 	/* Load/CAS acquire of r_head ensures that w_tail load happens after
 	 * r_head load, and thus head value is always behind or equal to tail
 	 * value. */
-	head = odp_atomic_load_acq_u32(&ring->r_head);
+	head = odp_atomic_load_acq_u32(&ring->r.r_head);
 
 	/* Move reader head. This thread owns data at the new head. */
 	do {
-		tail = odp_atomic_load_acq_u32(&ring->w_tail);
+		tail = odp_atomic_load_acq_u32(&ring->r.w_tail);
 
 		/* Ring is empty */
 		if (head == tail)
@@ -119,7 +167,7 @@ static inline uint32_t ring_deq_multi(ring_t *ring, uint32_t mask,
 
 		new_head = head + num;
 
-	} while (odp_unlikely(cas_mo_u32(&ring->r_head, &head, new_head,
+	} while (odp_unlikely(cas_mo_u32(&ring->r.r_head, &head, new_head,
 					 __ATOMIC_ACQUIRE,
 					 __ATOMIC_ACQUIRE) == 0));
 
@@ -128,29 +176,30 @@ static inline uint32_t ring_deq_multi(ring_t *ring, uint32_t mask,
 		data[i] = ring->data[(head + 1 + i) & mask];
 
 	/* Wait until other readers have updated the tail */
-	while (odp_unlikely(odp_atomic_load_u32(&ring->r_tail) != head))
+	while (odp_unlikely(odp_atomic_load_u32(&ring->r.r_tail) != head))
 		odp_cpu_pause();
 
 	/* Update the tail. Writers acquire it. */
-	odp_atomic_store_rel_u32(&ring->r_tail, new_head);
+	odp_atomic_store_rel_u32(&ring->r.r_tail, new_head);
 
 	return num;
 }
 
 /* Enqueue data into the ring tail */
-static inline void ring_enq(ring_t *ring, uint32_t mask, uint32_t data)
+static inline void _RING_ENQ(_ring_gen_t *ring, uint32_t mask,
+			     _ring_data_t data)
 {
 	uint32_t old_head, new_head;
 	uint32_t size = mask + 1;
 
 	/* Reserve a slot in the ring for writing */
-	old_head = odp_atomic_fetch_inc_u32(&ring->w_head);
+	old_head = odp_atomic_fetch_inc_u32(&ring->r.w_head);
 	new_head = old_head + 1;
 
 	/* Wait for the last reader to finish. This prevents overwrite when
 	 * a reader has been left behind (e.g. due to an interrupt) and is
 	 * still reading the same slot. */
-	while (odp_unlikely(new_head - odp_atomic_load_acq_u32(&ring->r_tail)
+	while (odp_unlikely(new_head - odp_atomic_load_acq_u32(&ring->r.r_tail)
 			    >= size))
 		odp_cpu_pause();
 
@@ -158,28 +207,28 @@ static inline void ring_enq(ring_t *ring, uint32_t mask, uint32_t data)
 	ring->data[new_head & mask] = data;
 
 	/* Wait until other writers have updated the tail */
-	while (odp_unlikely(odp_atomic_load_u32(&ring->w_tail) != old_head))
+	while (odp_unlikely(odp_atomic_load_u32(&ring->r.w_tail) != old_head))
 		odp_cpu_pause();
 
 	/* Release the new writer tail, readers acquire it. */
-	odp_atomic_store_rel_u32(&ring->w_tail, new_head);
+	odp_atomic_store_rel_u32(&ring->r.w_tail, new_head);
 }
 
 /* Enqueue multiple data into the ring tail. Num is smaller than ring size. */
-static inline void ring_enq_multi(ring_t *ring, uint32_t mask, uint32_t data[],
-				  uint32_t num)
+static inline void _RING_ENQ_MULTI(_ring_gen_t *ring, uint32_t mask,
+				   _ring_data_t data[], uint32_t num)
 {
 	uint32_t old_head, new_head, i;
 	uint32_t size = mask + 1;
 
 	/* Reserve a slot in the ring for writing */
-	old_head = odp_atomic_fetch_add_u32(&ring->w_head, num);
+	old_head = odp_atomic_fetch_add_u32(&ring->r.w_head, num);
 	new_head = old_head + 1;
 
 	/* Wait for the last reader to finish. This prevents overwrite when
 	 * a reader has been left behind (e.g. due to an interrupt) and is
 	 * still reading these slots. */
-	while (odp_unlikely(new_head - odp_atomic_load_acq_u32(&ring->r_tail)
+	while (odp_unlikely(new_head - odp_atomic_load_acq_u32(&ring->r.r_tail)
 			    >= size))
 		odp_cpu_pause();
 
@@ -188,15 +237,13 @@ static inline void ring_enq_multi(ring_t *ring, uint32_t mask, uint32_t data[],
 		ring->data[(new_head + i) & mask] = data[i];
 
 	/* Wait until other writers have updated the tail */
-	while (odp_unlikely(odp_atomic_load_u32(&ring->w_tail) != old_head))
+	while (odp_unlikely(odp_atomic_load_u32(&ring->r.w_tail) != old_head))
 		odp_cpu_pause();
 
 	/* Release the new writer tail, readers acquire it. */
-	odp_atomic_store_rel_u32(&ring->w_tail, old_head + num);
+	odp_atomic_store_rel_u32(&ring->r.w_tail, old_head + num);
 }
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/platform/linux-generic/include/odp_ring_ptr_internal.h
+++ b/platform/linux-generic/include/odp_ring_ptr_internal.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2019, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_RING_PTR_INTERNAL_H_
+#define ODP_RING_PTR_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp_ring_common.h>
+
+#undef _ODP_RING_TYPE
+#define _ODP_RING_TYPE _ODP_RING_TYPE_PTR
+
+#include <odp_ring_internal.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp_ring_u32_internal.h
+++ b/platform/linux-generic/include/odp_ring_u32_internal.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2019, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_RING_U32_INTERNAL_H_
+#define ODP_RING_U32_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp_ring_common.h>
+
+#undef _ODP_RING_TYPE
+#define _ODP_RING_TYPE _ODP_RING_TYPE_U32
+
+#include <odp_ring_internal.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2016-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -18,7 +19,7 @@
 #include <odp_debug_internal.h>
 #include <odp_align_internal.h>
 #include <odp_config_internal.h>
-#include <odp_ring_internal.h>
+#include <odp_ring_u32_internal.h>
 #include <odp_timer_internal.h>
 #include <odp_queue_basic_internal.h>
 
@@ -74,7 +75,7 @@ typedef struct ODP_ALIGNED_CACHE sched_cmd_t {
 
 typedef struct ODP_ALIGNED_CACHE {
 	/* Ring header */
-	ring_t ring;
+	ring_u32_t ring;
 
 	/* Ring data: queue indexes */
 	uint32_t ring_idx[RING_SIZE];
@@ -189,7 +190,7 @@ static int init_global(void)
 
 	for (i = 0; i < NUM_GROUP; i++)
 		for (j = 0; j < NUM_PRIO; j++)
-			ring_init(&sched_global->prio_queue[i][j].ring);
+			ring_u32_init(&sched_global->prio_queue[i][j].ring);
 
 	sched_group = &sched_global->sched_group;
 	odp_ticketlock_init(&sched_group->s.lock);
@@ -411,7 +412,7 @@ static inline void add_tail(sched_cmd_t *cmd)
 	uint32_t idx = cmd->s.ring_idx;
 
 	prio_queue = &sched_global->prio_queue[group][prio];
-	ring_enq(&prio_queue->ring, RING_MASK, idx);
+	ring_u32_enq(&prio_queue->ring, RING_MASK, idx);
 }
 
 static inline sched_cmd_t *rem_head(int group, int prio)
@@ -422,7 +423,7 @@ static inline sched_cmd_t *rem_head(int group, int prio)
 
 	prio_queue = &sched_global->prio_queue[group][prio];
 
-	if (ring_deq(&prio_queue->ring, RING_MASK, &ring_idx) == 0)
+	if (ring_u32_deq(&prio_queue->ring, RING_MASK, &ring_idx) == 0)
 		return NULL;
 
 	pktio = index_from_ring_idx(&index, ring_idx);


### PR DESCRIPTION
Modify pool implementation to store buffer headers instead of indices. This removes the need for pointer <-> index conversion in buffer alloc/free functions.