### PR TITLE
[PATCH v2] api: queue context is null by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.5])
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [21])
-m4_define([odpapi_minor_version], [3])
+m4_define([odpapi_minor_version], [4])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])

--- a/include/odp/api/spec/queue.h
+++ b/include/odp/api/spec/queue.h
@@ -116,10 +116,16 @@ int odp_queue_context_set(odp_queue_t queue, void *context, uint32_t len);
 /**
  * Get queue context
  *
+ * Returns previously stored queue context pointer. The context pointer may
+ * be set with odp_queue_context_set() or during queue creation
+ * (see odp_queue_param_t). The pointer value is set to NULL by default.
+ *
  * @param queue    Queue handle
  *
  * @return pointer to the queue context
  * @retval NULL on failure
+ *
+ * @see odp_queue_context_set(), odp_queue_create()
  */
 void *odp_queue_context(odp_queue_t queue);
 

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -623,6 +623,7 @@ static void queue_test_param(void)
 	CU_ASSERT(ODP_SCHED_SYNC_PARALLEL == odp_queue_sched_type(queue));
 	CU_ASSERT(ODP_SCHED_GROUP_WORKER  == odp_queue_sched_group(queue));
 
+	CU_ASSERT(odp_queue_context(queue) == NULL);
 	CU_ASSERT(0 == odp_queue_context_set(queue, &queue_context,
 					     sizeof(queue_context)));
 
@@ -633,6 +634,7 @@ static void queue_test_param(void)
 	odp_queue_param_init(&qparams);
 	null_queue = odp_queue_create(NULL, &qparams);
 	CU_ASSERT(ODP_QUEUE_INVALID != null_queue);
+	CU_ASSERT(odp_queue_context(null_queue) == NULL);
 
 	/* Plain type queue */
 	odp_queue_param_init(&qparams);


### PR DESCRIPTION
Improve documentation and testing of queue context being NULL by default. It was already defined under odp_queue_param_t documentation.

This PR should be merged after #834 to maintain API version number increments in order.