### PR TITLE
[PATCH v2] linux-gen: shm: increase amount of pre-reserved single va memory

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -40,7 +40,7 @@ shm: {
 	huge_page_limit_kb = 64
 
  	# Amount of memory pre-reserved for ODP_SHM_SINGLE_VA usage in kilobytes
-	single_va_size_kb = 131072
+	single_va_size_kb = 262144
 }
 
 # Pool options

--- a/scripts/ci/check.sh
+++ b/scripts/ci/check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-echo 1000 | tee /proc/sys/vm/nr_hugepages
+echo 1500 | tee /proc/sys/vm/nr_hugepages
 mkdir -p /mnt/huge
 mount -t hugetlbfs nodev /mnt/huge
 


### PR DESCRIPTION
Due to changes in pool implementation (linux-gen: pool: use pointer ring to
store buffer headers) additional single va memory is required for process
mode operation.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reported-by: Carl Wallen <carl.wallen@nokia.com>