### PR TITLE
[PATCH v3] New helpers for thread create and join

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.5])
 ##########################################################################
-# Set correct API version
+# ODP API version
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [21])
@@ -16,6 +16,24 @@ ODP_VERSION_API_MAJOR=odpapi_major_version
 AC_SUBST(ODP_VERSION_API_MAJOR)
 ODP_VERSION_API_MINOR=odpapi_minor_version
 AC_SUBST(ODP_VERSION_API_MINOR)
+
+##########################################################################
+# Helper library version
+##########################################################################
+m4_define([odph_version_generation], [1])
+m4_define([odph_version_major], [0])
+m4_define([odph_version_minor], [0])
+
+m4_define([odph_version],
+    [odph_version_generation.odph_version_major.odph_version_minor])
+
+ODPH_VERSION_GENERATION=odph_version_generation
+AC_SUBST(ODPH_VERSION_GENERATION)
+ODPH_VERSION_MAJOR=odph_version_major
+AC_SUBST(ODPH_VERSION_MAJOR)
+ODPH_VERSION_MINOR=odph_version_minor
+AC_SUBST(ODPH_VERSION_MINOR)
+
 AM_INIT_AUTOMAKE([1.9 tar-pax subdir-objects foreign nostdinc -Wall -Werror])
 AC_CONFIG_SRCDIR([include/odp/api/spec/init.h])
 AM_CONFIG_HEADER([include/config.h])
@@ -360,6 +378,7 @@ AC_CONFIG_FILES([include/Makefile
 		 include/odp/api/spec/version.h
 		 include/odp/api/spec/deprecated.h])
 
+AC_CONFIG_FILES([helper/include/odp/helper/version.h])
 
 ##########################################################################
 # distribute the changed variables among the Makefiles

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ AC_SUBST(ODP_VERSION_API_MINOR)
 ##########################################################################
 m4_define([odph_version_generation], [1])
 m4_define([odph_version_major], [0])
-m4_define([odph_version_minor], [0])
+m4_define([odph_version_minor], [1])
 
 m4_define([odph_version],
     [odph_version_generation.odph_version_major.odph_version_minor])

--- a/example/time/time_global_test.c
+++ b/example/time/time_global_test.c
@@ -255,10 +255,11 @@ int main(int argc, char *argv[])
 	odp_shm_t shm_log = ODP_SHM_INVALID;
 	int log_size, log_enries_num;
 	odph_helper_options_t helper_options;
-	odph_odpthread_t thread_tbl[MAX_WORKERS];
+	odph_thread_t thread_tbl[MAX_WORKERS];
 	odp_instance_t instance;
 	odp_init_t init_param;
-	odph_odpthread_params_t thr_params;
+	odph_thread_common_param_t thr_common;
+	odph_thread_param_t thr_param;
 
 	printf("\nODP global time test starts\n");
 
@@ -330,17 +331,22 @@ int main(int argc, char *argv[])
 		goto err;
 	}
 
-	memset(&thr_params, 0, sizeof(thr_params));
-	thr_params.start    = run_thread;
-	thr_params.arg      = gbls;
-	thr_params.thr_type = ODP_THREAD_WORKER;
-	thr_params.instance = instance;
+	memset(&thr_common, 0, sizeof(thr_common));
+	memset(&thr_param, 0, sizeof(thr_param));
+
+	thr_param.start    = run_thread;
+	thr_param.arg      = gbls;
+	thr_param.thr_type = ODP_THREAD_WORKER;
+
+	thr_common.instance = instance;
+	thr_common.cpumask = &cpumask;
+	thr_common.share_param = 1;
 
 	/* Create and launch worker threads */
-	odph_odpthreads_create(thread_tbl, &cpumask, &thr_params);
+	odph_thread_create(thread_tbl, &thr_common, &thr_param, num_workers);
 
 	/* Wait for worker threads to exit */
-	odph_odpthreads_join(thread_tbl);
+	odph_thread_join(thread_tbl, num_workers);
 
 	print_log(gbls);
 

--- a/helper/Makefile.am
+++ b/helper/Makefile.am
@@ -27,7 +27,8 @@ helperinclude_HEADERS = \
 		  include/odp/helper/tcp.h\
 		  include/odp/helper/table.h\
 		  include/odp/helper/threads.h \
-		  include/odp/helper/udp.h
+		  include/odp/helper/udp.h \
+		  include/odp/helper/version.h
 
 if helper_linux
 helperinclude_HEADERS += \
@@ -51,7 +52,8 @@ __LIB__libodphelper_la_SOURCES = \
 					lineartable.c \
 					cuckootable.c \
 					iplookuptable.c \
-					threads.c
+					threads.c \
+					version.c
 
 if helper_linux
 __LIB__libodphelper_la_SOURCES += \

--- a/helper/include/odp/helper/.gitignore
+++ b/helper/include/odp/helper/.gitignore
@@ -1,0 +1,1 @@
+version.h

--- a/helper/include/odp/helper/odph_api.h
+++ b/helper/include/odp/helper/odph_api.h
@@ -33,6 +33,7 @@ extern "C" {
 #include <odp/helper/table.h>
 #include <odp/helper/threads.h>
 #include <odp/helper/udp.h>
+#include <odp/helper/version.h>
 
 #ifdef __cplusplus
 }

--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -70,17 +71,34 @@ typedef struct {
 
 } odph_thread_param_t;
 
-/** The odpthread starting arguments, used both in process or thread mode */
+/** Helper internal thread start arguments. Used both in process and thread
+ *  mode */
 typedef struct {
-	odp_mem_model_t mem_model;          /**< process or thread */
-	odph_thread_param_t thr_params; /**< odpthread start parameters */
-} odph_odpthread_start_args_t;
+	/** Atomic variable to sync status */
+	odp_atomic_u32_t status;
 
-/** Linux odpthread state information, used both in process or thread mode */
+	/** Process or thread */
+	odp_mem_model_t mem_model;
+
+	/** ODP instance handle */
+	odp_instance_t instance;
+
+	/** Thread parameters */
+	odph_thread_param_t thr_params;
+
+} odph_thread_start_args_t;
+
+/** Thread state information. Used both in process and thread mode */
 typedef struct {
-	odph_odpthread_start_args_t	start_args; /**< start arguments */
-	int				cpu;	/**< CPU ID */
-	int				last;   /**< true if last table entry */
+	/** Start arguments */
+	odph_thread_start_args_t start_args;
+
+	/** CPU ID */
+	int cpu;
+
+	/** 1: last table entry */
+	uint8_t last;
+
 	/** Variant field mappings for thread/process modes */
 	union {
 		/** For thread implementation */
@@ -88,12 +106,14 @@ typedef struct {
 			pthread_t	thread_id; /**< Pthread ID */
 			pthread_attr_t	attr;	/**< Pthread attributes */
 		} thread;
+
 		/** For process implementation */
 		struct {
 			pid_t		pid;	/**< Process ID */
 			int		status;	/**< Process state chge status*/
 		} proc;
 	};
+
 } odph_thread_t;
 
 /** Linux helper options */

--- a/helper/include/odp/helper/version.h.in
+++ b/helper/include/odp/helper/version.h.in
@@ -1,0 +1,72 @@
+/* Copyright (c) 2019, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+
+/**
+ * @file
+ *
+ * ODP helper version
+ */
+
+#ifndef ODPH_VERSION_H_
+#define ODPH_VERSION_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup odph_version VERSION
+ * @{
+ */
+
+/**
+ * ODP helper generation version
+ *
+ * Introduction of major new features or changes that make very significant
+ * changes to the helper library.
+ */
+#define ODPH_VERSION_GENERATION @ODPH_VERSION_GENERATION@
+
+/**
+ * ODP helper major version
+ *
+ * Introduction of major new features or changes. Helper libraries with common
+ * generation, but with different major version numbers are likely not backward
+ * compatible.
+ */
+#define  ODPH_VERSION_MAJOR @ODPH_VERSION_MAJOR@
+
+/**
+ * ODP helper minor version
+ *
+ * Minor version is incremented when introducing backward compatible changes.
+ * Helper libraries with common generation and major version, but with
+ * different minor version numbers are backward compatible.
+ */
+#define ODPH_VERSION_MINOR @ODPH_VERSION_MINOR@
+
+/**
+ * ODP helper version string
+ *
+ * The version string defines the helper library version in this format:
+ * @verbatim <generation>.<major>.<minor> @endverbatim
+ *
+ * The string is null terminated.
+ *
+ * @return Pointer to helper library version string
+ */
+const char *odph_version_str(void);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/helper/test/.gitignore
+++ b/helper/test/.gitignore
@@ -9,3 +9,4 @@ process
 table
 thread
 pthread
+version

--- a/helper/test/Makefile.am
+++ b/helper/test/Makefile.am
@@ -1,6 +1,7 @@
 include $(top_srcdir)/test/Makefile.inc
 
-EXECUTABLES = chksum \
+EXECUTABLES = version \
+	      chksum \
               cuckootable \
               parse\
               table \
@@ -36,3 +37,4 @@ odpthreads_SOURCES = odpthreads.c
 parse_SOURCES = parse.c
 table_SOURCES = table.c
 iplookuptable_SOURCES = iplookuptable.c
+version_SOURCES = version.c

--- a/helper/test/version.c
+++ b/helper/test/version.c
@@ -1,0 +1,22 @@
+/* Copyright (c) 2019, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include <odph_debug.h>
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+	printf("\nHelper library versions is: %s\n\n", odph_version_str());
+
+	return 0;
+}

--- a/helper/threads.c
+++ b/helper/threads.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -23,24 +24,32 @@
 
 #define FAILED_CPU -1
 
+/* Thread status codes */
+#define NOT_STARTED 0
+#define SYNC_INIT   1
+#define INIT_DONE   2
+#define STARTED     3
+
 static odph_helper_options_t helper_options;
 
 /*
- * wrapper for odpthreads, either implemented as linux threads or processes.
- * (in process mode, if start_routine returns NULL, the process return FAILURE).
+ * Run a thread, either as Linux pthread or process.
+ * In process mode, if start_routine returns NULL, the process return FAILURE.
  */
-static void *_odph_thread_run_start_routine(void *arg)
+static void *run_thread(void *arg)
 {
 	int status;
 	int ret;
+	odp_instance_t instance;
 	odph_odpthread_params_t *thr_params;
 
-	odph_odpthread_start_args_t *start_args = arg;
+	odph_thread_start_args_t *start_args = arg;
 
 	thr_params = &start_args->thr_params;
+	instance   = start_args->instance;
 
 	/* ODP thread local init */
-	if (odp_init_local(thr_params->instance, thr_params->thr_type)) {
+	if (odp_init_local(instance, thr_params->thr_type)) {
 		ODPH_ERR("Local init failed\n");
 		if (start_args->mem_model == ODP_MEM_MODEL_PROCESS)
 			_exit(EXIT_FAILURE);
@@ -53,6 +62,9 @@ static void *_odph_thread_run_start_routine(void *arg)
 		 (start_args->mem_model == ODP_MEM_MODEL_THREAD) ?
 		 "pthread" : "process",
 		 (int)getpid());
+
+	if (odp_atomic_load_u32(&start_args->status) == SYNC_INIT)
+		odp_atomic_store_rel_u32(&start_args->status, INIT_DONE);
 
 	status = thr_params->start(thr_params->arg);
 	ret = odp_term_local();
@@ -69,11 +81,9 @@ static void *_odph_thread_run_start_routine(void *arg)
 }
 
 /*
- * Create a single ODPthread as a linux process
+ * Create a single linux process
  */
-static int _odph_linux_process_create(odph_odpthread_t *thread_tbl,
-				      int cpu,
-				      const odph_odpthread_params_t *thr_params)
+static int create_process(odph_thread_t *thread, int cpu)
 {
 	cpu_set_t cpu_set;
 	pid_t pid;
@@ -81,20 +91,19 @@ static int _odph_linux_process_create(odph_odpthread_t *thread_tbl,
 	CPU_ZERO(&cpu_set);
 	CPU_SET(cpu, &cpu_set);
 
-	thread_tbl->start_args.thr_params = *thr_params; /* copy */
-	thread_tbl->start_args.mem_model = ODP_MEM_MODEL_PROCESS;
-	thread_tbl->cpu = cpu;
+	thread->start_args.mem_model = ODP_MEM_MODEL_PROCESS;
+	thread->cpu = cpu;
 
 	pid = fork();
 	if (pid < 0) {
 		ODPH_ERR("fork() failed\n");
-		thread_tbl->cpu = FAILED_CPU;
+		thread->cpu = FAILED_CPU;
 		return -1;
 	}
 
 	/* Parent continues to fork */
 	if (pid > 0) {
-		thread_tbl->proc.pid  = pid;
+		thread->proc.pid  = pid;
 		return 0;
 	}
 
@@ -111,17 +120,49 @@ static int _odph_linux_process_create(odph_odpthread_t *thread_tbl,
 		return -2;
 	}
 
-	_odph_thread_run_start_routine(&thread_tbl->start_args);
+	run_thread(&thread->start_args);
 
 	return 0; /* never reached */
 }
 
 /*
- * Create a single ODPthread as a linux thread
+ * Wait single process to exit
  */
-static int odph_linux_thread_create(odph_odpthread_t *thread_tbl,
-				    int cpu,
-				    const odph_odpthread_params_t *thr_params)
+static int wait_process(odph_thread_t *thread)
+{
+	pid_t pid;
+	int status = 0;
+
+	pid = waitpid(thread->proc.pid, &status, 0);
+
+	if (pid < 0) {
+		ODPH_ERR("waitpid() failed\n");
+		return -1;
+	}
+
+	/* Examine the child process' termination status */
+	if (WIFEXITED(status) &&
+	    WEXITSTATUS(status) != EXIT_SUCCESS) {
+		ODPH_ERR("Child exit status:%d (pid:%d)\n",
+			 WEXITSTATUS(status), (int)pid);
+		return -1;
+	}
+
+	if (WIFSIGNALED(status)) {
+		int signo = WTERMSIG(status);
+
+		ODPH_ERR("Child term signo:%d - %s (pid:%d)\n",
+			 signo, strsignal(signo), (int)pid);
+		return -1;
+	}
+
+	return 0;
+}
+
+/*
+ * Create a single linux pthread
+ */
+static int create_pthread(odph_thread_t *thread, int cpu)
 {
 	int ret;
 	cpu_set_t cpu_set;
@@ -129,27 +170,175 @@ static int odph_linux_thread_create(odph_odpthread_t *thread_tbl,
 	CPU_ZERO(&cpu_set);
 	CPU_SET(cpu, &cpu_set);
 
-	pthread_attr_init(&thread_tbl->thread.attr);
+	pthread_attr_init(&thread->thread.attr);
 
-	thread_tbl->cpu = cpu;
+	thread->cpu = cpu;
 
-	pthread_attr_setaffinity_np(&thread_tbl->thread.attr,
+	pthread_attr_setaffinity_np(&thread->thread.attr,
 				    sizeof(cpu_set_t), &cpu_set);
 
-	thread_tbl->start_args.thr_params = *thr_params; /* copy */
-	thread_tbl->start_args.mem_model = ODP_MEM_MODEL_THREAD;
+	thread->start_args.mem_model = ODP_MEM_MODEL_THREAD;
 
-	ret = pthread_create(&thread_tbl->thread.thread_id,
-			     &thread_tbl->thread.attr,
-			     _odph_thread_run_start_routine,
-			     &thread_tbl->start_args);
+	ret = pthread_create(&thread->thread.thread_id,
+			     &thread->thread.attr,
+			     run_thread,
+			     &thread->start_args);
 	if (ret != 0) {
 		ODPH_ERR("Failed to start thread on cpu #%d\n", cpu);
-		thread_tbl->cpu = FAILED_CPU;
+		thread->cpu = FAILED_CPU;
 		return ret;
 	}
 
 	return 0;
+}
+
+/*
+ * Wait single pthread to exit
+ */
+static int wait_pthread(odph_thread_t *thread)
+{
+	int ret;
+	void *thread_ret = NULL;
+
+	/* Wait thread to exit */
+	ret = pthread_join(thread->thread.thread_id, &thread_ret);
+
+	if (ret) {
+		ODPH_ERR("pthread_join failed (%i) from cpu #%i\n",
+			 ret, thread->cpu);
+		return -1;
+	}
+
+	if (thread_ret) {
+		ODPH_ERR("Bad exit status cpu #%i %p\n",
+			 thread->cpu, thread_ret);
+		return -1;
+	}
+
+	ret = pthread_attr_destroy(&thread->thread.attr);
+
+	if (ret) {
+		ODPH_ERR("pthread_attr_destroy failed (%i) from cpu #%i\n",
+			 ret, thread->cpu);
+		return -1;
+	}
+
+	return 0;
+}
+
+int odph_thread_create(odph_thread_t thread[],
+		       const odph_thread_common_param_t *param,
+		       const odph_thread_param_t thr_param[],
+		       int num)
+{
+	int i, num_cpu, cpu;
+	const odp_cpumask_t *cpumask = param->cpumask;
+	int use_pthread = 1;
+
+	if (param->thread_model == 1)
+		use_pthread = 0;
+
+	if (helper_options.mem_model == ODP_MEM_MODEL_PROCESS)
+		use_pthread = 0;
+
+	if (num < 1) {
+		ODPH_ERR("Bad number of threads (%i)\n", num);
+		return -1;
+	}
+
+	num_cpu = odp_cpumask_count(cpumask);
+
+	if (num_cpu != num) {
+		ODPH_ERR("Number of threads (%i) and CPUs (%i) does not match"
+			 "\n", num, num_cpu);
+		return -1;
+	}
+
+	memset(thread, 0, num * sizeof(odph_thread_t));
+
+	cpu = odp_cpumask_first(cpumask);
+	for (i = 0; i < num; i++) {
+		odph_thread_start_args_t *start_args = &thread[i].start_args;
+
+		/* Copy thread parameters */
+		if (param->share_param)
+			start_args->thr_params = thr_param[0];
+		else
+			start_args->thr_params = thr_param[i];
+
+		start_args->instance   = param->instance;
+
+		if (param->sync)
+			odp_atomic_init_u32(&start_args->status, SYNC_INIT);
+		else
+			odp_atomic_init_u32(&start_args->status, NOT_STARTED);
+
+		if (use_pthread) {
+			if (create_pthread(&thread[i], cpu))
+				break;
+		} else {
+			if (create_process(&thread[i], cpu))
+				break;
+		}
+
+		/* Wait newly created thread to update status */
+		if (param->sync) {
+			odp_time_t t1, t2;
+			uint64_t diff_ns;
+			uint32_t status;
+			int timeout = 0;
+			odp_atomic_u32_t *atomic = &start_args->status;
+
+			t1 = odp_time_local();
+
+			do {
+				odp_cpu_pause();
+				t2 = odp_time_local();
+				diff_ns = odp_time_diff_ns(t2, t1);
+				timeout = diff_ns > ODP_TIME_SEC_IN_NS;
+				status = odp_atomic_load_acq_u32(atomic);
+
+			} while (status != INIT_DONE && timeout == 0);
+
+			if (timeout) {
+				ODPH_ERR("Thread (i:%i) start up timeout\n", i);
+				break;
+			}
+		}
+
+		odp_atomic_store_u32(&start_args->status, STARTED);
+
+		cpu = odp_cpumask_next(cpumask, cpu);
+	}
+
+	return i;
+}
+
+int odph_thread_join(odph_thread_t thread[], int num)
+{
+	odph_thread_start_args_t *start_args;
+	int i;
+
+	for (i = 0; i < num; i++) {
+		start_args = &thread[i].start_args;
+
+		if (odp_atomic_load_u32(&start_args->status) != STARTED) {
+			ODPH_DBG("Thread (i:%i) not started.\n", i);
+			break;
+		}
+
+		if (thread[i].start_args.mem_model == ODP_MEM_MODEL_THREAD) {
+			if (wait_pthread(&thread[i]))
+				break;
+		} else {
+			if (wait_process(&thread[i]))
+				break;
+		}
+
+		odp_atomic_store_u32(&start_args->status, NOT_STARTED);
+	}
+
+	return i;
 }
 
 /*
@@ -179,15 +368,19 @@ int odph_odpthreads_create(odph_odpthread_t *thread_tbl,
 
 	cpu = odp_cpumask_first(mask);
 	for (i = 0; i < num; i++) {
+		odph_thread_start_args_t *start_args;
+
+		start_args = &thread_tbl[i].start_args;
+
+		/* Copy thread parameters */
+		start_args->thr_params = *thr_params;
+		start_args->instance   = thr_params->instance;
+
 		if (helper_options.mem_model == ODP_MEM_MODEL_THREAD) {
-			if (odph_linux_thread_create(&thread_tbl[i],
-						     cpu,
-						     thr_params))
+			if (create_pthread(&thread_tbl[i], cpu))
 				break;
 		 } else {
-			if (_odph_linux_process_create(&thread_tbl[i],
-						       cpu,
-						       thr_params))
+			if (create_process(&thread_tbl[i], cpu))
 				break;
 		}
 

--- a/helper/version.c
+++ b/helper/version.c
@@ -1,0 +1,20 @@
+/* Copyright (c) 2019, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/helper/version.h>
+
+#define VERSION_STR_EXPAND(x)  #x
+#define VERSION_TO_STR(x)      VERSION_STR_EXPAND(x)
+
+#define VERSION_STR \
+VERSION_TO_STR(ODPH_VERSION_GENERATION) "." \
+VERSION_TO_STR(ODPH_VERSION_MAJOR) "." \
+VERSION_TO_STR(ODPH_VERSION_MINOR)
+
+const char *odph_version_str(void)
+{
+	return VERSION_STR;
+}

--- a/test/performance/odp_scheduling.c
+++ b/test/performance/odp_scheduling.c
@@ -796,7 +796,7 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 int main(int argc, char *argv[])
 {
 	odph_helper_options_t helper_options;
-	odph_odpthread_t *thread_tbl;
+	odph_thread_t *thread_tbl;
 	test_args_t args;
 	int num_workers;
 	odp_cpumask_t cpumask;
@@ -810,7 +810,8 @@ int main(int argc, char *argv[])
 	int ret = 0;
 	odp_instance_t instance;
 	odp_init_t init_param;
-	odph_odpthread_params_t thr_params;
+	odph_thread_common_param_t thr_common;
+	odph_thread_param_t thr_param;
 	odp_queue_capability_t capa;
 	odp_pool_capability_t pool_capa;
 	odp_schedule_config_t schedule_config;
@@ -857,7 +858,7 @@ int main(int argc, char *argv[])
 	printf("first CPU:          %i\n", odp_cpumask_first(&cpumask));
 	printf("cpu mask:           %s\n", cpumaskstr);
 
-	thread_tbl = calloc(sizeof(odph_odpthread_t), num_workers);
+	thread_tbl = calloc(sizeof(odph_thread_t), num_workers);
 	if (!thread_tbl) {
 		LOG_ERR("no memory for thread_tbl\n");
 		return -1;
@@ -997,15 +998,21 @@ int main(int argc, char *argv[])
 	globals->first_thr = -1;
 
 	/* Create and launch worker threads */
-	memset(&thr_params, 0, sizeof(thr_params));
-	thr_params.thr_type = ODP_THREAD_WORKER;
-	thr_params.instance = instance;
-	thr_params.start = run_thread;
-	thr_params.arg   = NULL;
-	odph_odpthreads_create(thread_tbl, &cpumask, &thr_params);
+	memset(&thr_common, 0, sizeof(thr_common));
+	memset(&thr_param, 0, sizeof(thr_param));
+
+	thr_param.thr_type = ODP_THREAD_WORKER;
+	thr_param.start    = run_thread;
+	thr_param.arg      = NULL;
+
+	thr_common.instance = instance;
+	thr_common.cpumask  = &cpumask;
+	thr_common.share_param = 1;
+
+	odph_thread_create(thread_tbl, &thr_common, &thr_param, num_workers);
 
 	/* Wait for worker threads to terminate */
-	odph_odpthreads_join(thread_tbl);
+	odph_thread_join(thread_tbl, num_workers);
 	free(thread_tbl);
 
 	printf("ODP example complete\n\n");


### PR DESCRIPTION
Current thread create and join helpers are not easy to use when threads are created/joined in multiple steps. API does not specify if it's possible and implementation is based on cpu count in cpumask and hidden "last" flag.

Added new implementations, with improved specification, parameter set and new features. Added also version number support for helper library, so that helper API changes are easy to track from application.

Old create/join helpers are not modified. Some test applications (incl. all validation test) was already moved to use the new functions, the rest will be moved soon.
