### PR TITLE
[PATCH v2] test: sched_latency: resume scheduling only on main thread

### DIFF
--- a/test/performance/odp_sched_latency.c
+++ b/test/performance/odp_sched_latency.c
@@ -425,11 +425,10 @@ static int test_schedule(int thr, test_globals_t *globals)
 		}
 	}
 
-	odp_schedule_resume();
-
 	odp_barrier_wait(&globals->barrier);
 
 	if (thr == MAIN_THREAD) {
+		odp_schedule_resume();
 		clear_sched_queues(globals);
 		print_results(globals);
 	}


### PR DESCRIPTION
Prevent pre-scheduling events to terminating threads.

Signed-off-by: Matias Elo <matias.elo@nokia.com>