### PR TITLE
[PATCH v2] test: scheduling: resume scheduling only after sync barrier

### DIFF
--- a/test/performance/odp_scheduling.c
+++ b/test/performance/odp_scheduling.c
@@ -396,12 +396,13 @@ static int test_schedule_single(const char *str, int thr,
 		}
 	}
 
-	odp_schedule_resume();
-
 	c2     = odp_cpu_cycles();
 	cycles = odp_cpu_cycles_diff(c2, c1);
 
 	odp_barrier_wait(&globals->barrier);
+
+	odp_schedule_resume();
+
 	clear_sched_queues();
 
 	cycles = cycles / tot;
@@ -469,12 +470,13 @@ static int test_schedule_many(const char *str, int thr,
 		}
 	}
 
-	odp_schedule_resume();
-
 	c2     = odp_cpu_cycles();
 	cycles = odp_cpu_cycles_diff(c2, c1);
 
 	odp_barrier_wait(&globals->barrier);
+
+	odp_schedule_resume();
+
 	clear_sched_queues();
 
 	cycles = cycles / tot;
@@ -557,12 +559,13 @@ static int test_schedule_multi(const char *str, int thr,
 		}
 	}
 
-	odp_schedule_resume();
-
 	c2     = odp_cpu_cycles();
 	cycles = odp_cpu_cycles_diff(c2, c1);
 
 	odp_barrier_wait(&globals->barrier);
+
+	odp_schedule_resume();
+
 	clear_sched_queues();
 
 	if (tot)


### PR DESCRIPTION
Prevents pre-scheduling events to finished threads.

Signed-off-by: Matias Elo <matias.elo@nokia.com>