### PR TITLE
[PATCH v6] Timer and time API additions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.5])
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [21])
-m4_define([odpapi_minor_version], [5])
+m4_define([odpapi_minor_version], [6])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])

--- a/include/odp/api/spec/time.h
+++ b/include/odp/api/spec/time.h
@@ -22,10 +22,20 @@ extern "C" {
  *  @{
  */
 
-/* Time in nanoseconds */
-#define ODP_TIME_USEC_IN_NS	1000ULL       /**< Microsecond in nsec */
-#define ODP_TIME_MSEC_IN_NS	1000000ULL    /**< Millisecond in nsec */
-#define ODP_TIME_SEC_IN_NS	1000000000ULL /**< Second in nsec */
+/** A microsecond in nanoseconds */
+#define ODP_TIME_USEC_IN_NS  1000ULL
+
+/** A millisecond in nanoseconds */
+#define ODP_TIME_MSEC_IN_NS  1000000ULL
+
+/** A second in nanoseconds */
+#define ODP_TIME_SEC_IN_NS   1000000000ULL
+
+/** A minute in nanoseconds */
+#define ODP_TIME_MIN_IN_NS   60000000000ULL
+
+/** An hour in nanoseconds */
+#define ODP_TIME_HOUR_IN_NS  3600000000000ULL
 
 /**
  * @typedef odp_time_t

--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -69,26 +69,29 @@ typedef enum {
  * Return values of timer set calls.
  */
 typedef enum {
-/**
- * Timer set operation succeeded
- */
+	/**
+	 * Timer set operation succeeded
+	 */
 	ODP_TIMER_SUCCESS = 0,
-/**
- * Timer set operation failed, expiration too early.
- * Either retry with a later expiration time or process the timeout
- * immediately. */
+
+	/**
+	 * Timer set operation failed, expiration too early.
+	 * Either retry with a later expiration time or process the timeout
+	 * immediately. */
 	ODP_TIMER_TOOEARLY = -1,
 
-/**
- * Timer set operation failed, expiration too late.
- * Truncate the expiration time against the maximum timeout for the
- * timer pool. */
+	/**
+	 * Timer set operation failed, expiration too late.
+	 * Truncate the expiration time against the maximum timeout for the
+	 * timer pool. */
 	ODP_TIMER_TOOLATE = -2,
-/**
- * Timer set operation failed because no event specified and no event present
- * in the timer (timer inactive/expired).
- */
+
+	/**
+	 * Timer set operation failed because no event specified and no event
+	 * present in the timer (timer inactive/expired).
+	 */
 	ODP_TIMER_NOEVENT = -3
+
 } odp_timer_set_t;
 
 /**
@@ -96,8 +99,8 @@ typedef enum {
  * Maximum timer pool name length in chars including null char
  */
 
-/** Timer pool parameters
- * Timer pool parameters are used when creating and querying timer pools.
+/**
+ * Timer pool parameters
  */
 typedef struct {
 	/** Timeout resolution in nanoseconds. Timer pool must serve timeouts
@@ -187,9 +190,8 @@ int odp_timer_capability(odp_timer_clk_src_t clk_src,
  * @return Timer pool handle on success
  * @retval ODP_TIMER_POOL_INVALID on failure and errno set
  */
-odp_timer_pool_t
-odp_timer_pool_create(const char *name,
-		      const odp_timer_pool_param_t *params);
+odp_timer_pool_t odp_timer_pool_create(const char *name,
+				       const odp_timer_pool_param_t *params);
 
 /**
  * Start a timer pool
@@ -207,60 +209,67 @@ void odp_timer_pool_start(void);
  * Destroy a timer pool, freeing all resources.
  * All timers must have been freed.
  *
- * @param tpid  Timer pool identifier
+ * @param timer_pool  Timer pool
  */
-void odp_timer_pool_destroy(odp_timer_pool_t tpid);
+void odp_timer_pool_destroy(odp_timer_pool_t timer_pool);
 
 /**
  * Convert timer ticks to nanoseconds
  *
- * @param tpid  Timer pool identifier
- * @param ticks Timer ticks
+ * @param timer_pool  Timer pool
+ * @param ticks       Timer ticks
  *
  * @return Nanoseconds
  */
-uint64_t odp_timer_tick_to_ns(odp_timer_pool_t tpid, uint64_t ticks);
+uint64_t odp_timer_tick_to_ns(odp_timer_pool_t timer_pool, uint64_t ticks);
 
 /**
  * Convert nanoseconds to timer ticks
  *
- * @param tpid  Timer pool identifier
- * @param ns    Nanoseconds
+ * @param timer_pool  Timer pool
+ * @param ns          Nanoseconds
  *
  * @return Timer ticks
  */
-uint64_t odp_timer_ns_to_tick(odp_timer_pool_t tpid, uint64_t ns);
+uint64_t odp_timer_ns_to_tick(odp_timer_pool_t timer_pool, uint64_t ns);
 
 /**
  * Current tick value
  *
- * @param tpid Timer pool identifier
+ * @param timer_pool  Timer pool
  *
  * @return Current time in timer ticks
  */
-uint64_t odp_timer_current_tick(odp_timer_pool_t tpid);
+uint64_t odp_timer_current_tick(odp_timer_pool_t timer_pool);
 
 /**
  * ODP timer pool information and configuration
  */
-
 typedef struct {
-	odp_timer_pool_param_t param; /**< Parameters specified at creation */
-	uint32_t cur_timers; /**< Number of currently allocated timers */
-	uint32_t hwm_timers; /**< High watermark of allocated timers */
-	const char *name; /**< Name of timer pool */
+	/** Parameters specified at creation */
+	odp_timer_pool_param_t param;
+
+	/** Number of currently allocated timers */
+	uint32_t cur_timers;
+
+	/** High watermark of allocated timers */
+	uint32_t hwm_timers;
+
+	/** Name of timer pool */
+	const char *name;
+
 } odp_timer_pool_info_t;
 
 /**
  * Query timer pool configuration and current state
  *
- * @param tpid Timer pool identifier
- * @param[out] info Pointer to information buffer
+ * @param      timer_pool  Timer pool
+ * @param[out] info        Pointer to information buffer
  *
  * @retval 0 on success
  * @retval <0 on failure. Info could not be retrieved.
  */
-int odp_timer_pool_info(odp_timer_pool_t tpid,
+int odp_timer_pool_info(odp_timer_pool_t timer_pool,
 			odp_timer_pool_info_t *info);
 
 /**
@@ -270,15 +279,14 @@ int odp_timer_pool_info(odp_timer_pool_t tpid,
  * the timer pool. The user_ptr is copied to timeouts and can be retrieved
  * using the odp_timeout_user_ptr() call.
  *
- * @param tpid     Timer pool identifier
- * @param queue    Destination queue for timeout notifications
- * @param user_ptr User defined pointer or NULL to be copied to timeouts
+ * @param timer_pool  Timer pool
+ * @param queue       Destination queue for timeout notifications
+ * @param user_ptr    User defined pointer or NULL to be copied to timeouts
  *
  * @return Timer handle on success
  * @retval ODP_TIMER_INVALID on failure and errno set.
  */
-odp_timer_t odp_timer_alloc(odp_timer_pool_t tpid,
-			    odp_queue_t queue,
+odp_timer_t odp_timer_alloc(odp_timer_pool_t timer_pool, odp_queue_t queue,
 			    void *user_ptr);
 
 /**
@@ -289,11 +297,12 @@ odp_timer_t odp_timer_alloc(odp_timer_pool_t tpid,
  * The timeout event for an expired timer will not be returned. It is the
  * responsibility of the application to handle this timeout when it is received.
  *
- * @param tim      Timer handle
+ * @param timer      Timer
+ *
  * @return Event handle of timeout event
  * @retval ODP_EVENT_INVALID on failure
  */
-odp_event_t odp_timer_free(odp_timer_t tim);
+odp_event_t odp_timer_free(odp_timer_t timer);
 
 /**
  * Set (or reset) a timer with absolute expiration time
@@ -395,6 +404,7 @@ odp_event_t odp_timeout_to_event(odp_timeout_t tmo);
 
 /**
  * Check for fresh timeout
+ *
  * If the corresponding timer has been reset or cancelled since this timeout
  * was enqueued, the timeout is stale (not fresh).
  *
@@ -424,6 +434,7 @@ uint64_t odp_timeout_tick(odp_timeout_t tmo);
 
 /**
  * Return user pointer for the timeout
+ *
  * The user pointer was specified when the timer was allocated.
  *
  * @param tmo Timeout handle
@@ -456,41 +467,41 @@ void odp_timeout_free(odp_timeout_t tmo);
 /**
  * Get printable value for an odp_timer_pool_t
  *
- * @param hdl  odp_timer_pool_t handle to be printed
- * @return     uint64_t value that can be used to print/display this
- *             handle
+ * @param timer_pool  odp_timer_pool_t handle to be printed
+ *
+ * @return uint64_t value that can be used to print/display this handle
  *
  * @note This routine is intended to be used for diagnostic purposes
  * to enable applications to generate a printable value that represents
  * an odp_timer_pool_t handle.
  */
-uint64_t odp_timer_pool_to_u64(odp_timer_pool_t hdl);
+uint64_t odp_timer_pool_to_u64(odp_timer_pool_t timer_pool);
 
 /**
  * Get printable value for an odp_timer_t
  *
- * @param hdl  odp_timer_t handle to be printed
- * @return     uint64_t value that can be used to print/display this
- *             handle
+ * @param timer  odp_timer_t handle to be printed
+ *
+ * @return uint64_t value that can be used to print/display this handle
  *
  * @note This routine is intended to be used for diagnostic purposes
  * to enable applications to generate a printable value that represents
  * an odp_timer_t handle.
  */
-uint64_t odp_timer_to_u64(odp_timer_t hdl);
+uint64_t odp_timer_to_u64(odp_timer_t timer);
 
 /**
  * Get printable value for an odp_timeout_t
  *
- * @param hdl  odp_timeout_t handle to be printed
- * @return     uint64_t value that can be used to print/display this
- *             handle
+ * @param tmo  odp_timeout_t handle to be printed
+ *
+ * @return uint64_t value that can be used to print/display this handle
  *
  * @note This routine is intended to be used for diagnostic purposes
  * to enable applications to generate a printable value that represents
  * an odp_timeout_t handle.
  */
-uint64_t odp_timeout_to_u64(odp_timeout_t hdl);
+uint64_t odp_timeout_to_u64(odp_timeout_t tmo);
 
 /**
  * @}

--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -136,6 +136,21 @@ typedef struct {
 } odp_timer_pool_param_t;
 
 /**
+ * Timer resolution capability
+ */
+typedef struct {
+	/** Timeout resolution in nanoseconds */
+	uint64_t res_ns;
+
+	/** Minimum relative timeout in nanoseconds */
+	uint64_t min_tmo;
+
+	/** Maximum relative timeout in nanoseconds */
+	uint64_t max_tmo;
+
+} odp_timer_res_capability_t;
+
+/**
  * Timer capability
  */
 typedef struct {
@@ -160,8 +175,35 @@ typedef struct {
 	 *  This defines the highest resolution supported by a timer.
 	 *  It's the minimum valid value for 'res_ns' timer pool
 	 *  parameter.
+	 *
+	 *  This value is equal to 'max_res.res_ns' capability.
 	 */
 	uint64_t highest_res_ns;
+
+	/**
+	 * Maximum resolution
+	 *
+	 * This defines the highest resolution supported by a timer, with
+	 * limits to min/max timeout values. The highest resolution for a timer
+	 * pool is defined by 'max_res.res_ns', therefore it's the minimum value
+	 * for 'res_ns' timer pool parameter. When this resolution is used:
+	 * - 'min_tmo' parameter value must be in minimum 'max_res.min_tmo'
+	 * - 'max_tmo' parameter value must be in maximum 'max_res.max_tmo'
+	 */
+	odp_timer_res_capability_t max_res;
+
+	/**
+	 * Maximum timeout length
+	 *
+	 * This defines the maximum relative timeout value supported by a timer,
+	 * with limits to min timeout and max resolution values. The maximum
+	 * value for 'max_tmo' timer pool parameter is defined by
+	 * 'max_tmo.max_tmo'. When this max timeout value is used:
+	 * - 'min_tmo' parameter value must be in minimum 'max_tmo.min_tmo'
+	 * - 'res_ns'  parameter value must be in minimum 'max_tmo.res_ns'
+	 */
+	odp_timer_res_capability_t max_tmo;
+
 } odp_timer_capability_t;
 
 /**
@@ -177,6 +219,28 @@ typedef struct {
  */
 int odp_timer_capability(odp_timer_clk_src_t clk_src,
 			 odp_timer_capability_t *capa);
+
+/**
+ * Timer resolution capability
+ *
+ * This function fills in capability limits for timer pool resolution and
+ * min/max timeout values, based on either resolution or maximum timeout.
+ * Set the required value to 'res_ns' or 'max_tmo', and set other fields to
+ * zero. A successful call fills in the other two fields. The call returns
+ * a failure, if the user defined value ('res_ns' or 'max_tmo)' exceeds
+ * capability limits. Outputted values are minimums for 'res_ns' and 'min_tmo',
+ * and a maximum for 'max_tmo'.
+ *
+ * @param         clk_src  Clock source for timers
+ * @param[in,out] res_capa Resolution capability pointer for input/output.
+ *                         Set either 'res_ns' or 'max_tmo', a successful call
+ *                         fills in other fields.
+ *
+ * @retval 0 on success
+ * @retval <0 on failure
+ */
+int odp_timer_res_capability(odp_timer_clk_src_t clk_src,
+			     odp_timer_res_capability_t *res_capa);
 
 /**
  * Create a timer pool

--- a/test/validation/api/time/time.c
+++ b/test/validation/api/time/time.c
@@ -28,6 +28,17 @@ static void time_test_constants(void)
 {
 	uint64_t ns;
 
+	CU_ASSERT(ODP_TIME_USEC_IN_NS == 1000);
+
+	ns = ODP_TIME_HOUR_IN_NS;
+	CU_ASSERT(ns == 60 * ODP_TIME_MIN_IN_NS);
+	ns = ODP_TIME_MIN_IN_NS;
+	CU_ASSERT(ns == 60 * ODP_TIME_SEC_IN_NS);
+	ns = ODP_TIME_SEC_IN_NS;
+	CU_ASSERT(ns == 1000 * ODP_TIME_MSEC_IN_NS);
+	ns = ODP_TIME_MSEC_IN_NS;
+	CU_ASSERT(ns == 1000 * ODP_TIME_USEC_IN_NS);
+
 	ns = ODP_TIME_SEC_IN_NS / 1000;
 	CU_ASSERT(ns == ODP_TIME_MSEC_IN_NS);
 	ns /= 1000;

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -181,6 +181,43 @@ static int timer_global_term(odp_instance_t inst)
 	return 0;
 }
 
+static void timer_test_capa(void)
+{
+	odp_timer_capability_t capa;
+	odp_timer_res_capability_t res_capa;
+	int ret;
+
+	memset(&capa, 0, sizeof(capa));
+	ret = odp_timer_capability(ODP_CLOCK_CPU, &capa);
+	CU_ASSERT_FATAL(ret == 0);
+
+	CU_ASSERT(capa.highest_res_ns == capa.max_res.res_ns);
+	CU_ASSERT(capa.max_res.res_ns  < capa.max_res.max_tmo);
+	CU_ASSERT(capa.max_res.min_tmo < capa.max_res.max_tmo);
+	CU_ASSERT(capa.max_tmo.res_ns  < capa.max_tmo.max_tmo);
+	CU_ASSERT(capa.max_tmo.min_tmo < capa.max_tmo.max_tmo);
+
+	/* Set max resolution */
+	memset(&res_capa, 0, sizeof(res_capa));
+	res_capa.res_ns = capa.max_res.res_ns;
+
+	ret = odp_timer_res_capability(ODP_CLOCK_CPU, &res_capa);
+	CU_ASSERT_FATAL(ret == 0);
+	CU_ASSERT(res_capa.res_ns  == capa.max_res.res_ns);
+	CU_ASSERT(res_capa.min_tmo == capa.max_res.min_tmo);
+	CU_ASSERT(res_capa.max_tmo == capa.max_res.max_tmo);
+
+	/* Set max timeout */
+	memset(&res_capa, 0, sizeof(res_capa));
+	res_capa.max_tmo = capa.max_tmo.max_tmo;
+
+	ret = odp_timer_res_capability(ODP_CLOCK_CPU, &res_capa);
+	CU_ASSERT_FATAL(ret == 0);
+	CU_ASSERT(res_capa.max_tmo == capa.max_tmo.max_tmo);
+	CU_ASSERT(res_capa.min_tmo == capa.max_tmo.min_tmo);
+	CU_ASSERT(res_capa.res_ns  == capa.max_tmo.res_ns);
+}
+
 static void timer_test_timeout_pool_alloc(void)
 {
 	odp_pool_t pool;
@@ -1193,6 +1230,7 @@ static void timer_test_odp_timer_all(void)
 }
 
 odp_testinfo_t timer_suite[] = {
+	ODP_TEST_INFO(timer_test_capa),
 	ODP_TEST_INFO(timer_test_timeout_pool_alloc),
 	ODP_TEST_INFO(timer_test_timeout_pool_free),
 	ODP_TEST_INFO(timer_pool_create_destroy),


### PR DESCRIPTION
Clarifies current timer API functionality (set/reset operation and event type), adds timer resolution capability and adds time defines for minute/hour.

Timer validation test of minimum timeout needed fixing posix timer overrun issue in timer pool start. It seems Linux (scheduler) has about 15ms latency before the first posix timer signal is received on the timer pthread.