### PR TITLE
[PATCH v2] configure: add option to disable pcap pktio support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ env:
         - CONF="--disable-host-optimization --disable-abi-compat"
         - CHECK=0 ARCH="x86_64" CONF="--enable-pcapng-support"
         - CHECK=0 ARCH="x86_64" OS="centos_7"
-        - CONF="--without-openssl"
+        - CONF="--without-openssl --without-pcap"
         - OS="ubuntu_18.04"
 
 matrix:

--- a/m4/odp_pcap.m4
+++ b/m4/odp_pcap.m4
@@ -1,3 +1,7 @@
+# ODP_PCAP([ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+# --------------------------------------------------
+AC_DEFUN([ODP_PCAP],
+[dnl
 #########################################################################
 # Check for libpcap availability
 #########################################################################
@@ -11,10 +15,15 @@ AC_CHECK_HEADER(pcap/pcap.h,
 if test "$have_pcap" = "yes"; then
     AC_DEFINE([HAVE_PCAP], 1, [Define to 1 if you have pcap library])
     PCAP_LIBS="-lpcap"
+else
+    PCAP_LIBS=""
 fi
 
 AC_SUBST([PCAP_LIBS])
 
-AC_CONFIG_COMMANDS_PRE([dnl
-AM_CONDITIONAL([HAVE_PCAP], [test x$have_pcap = xyes])
-])
+if test "x$have_pcap" = "xyes" ; then
+	m4_default([$1], [:])
+else
+	m4_default([$2], [:])
+fi
+]) # ODP_PCAP

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -13,8 +13,17 @@ AC_ARG_WITH([openssl],
 AS_IF([test "$with_openssl" != "no"],
       [ODP_OPENSSL])
 AM_CONDITIONAL([WITH_OPENSSL], [test x$with_openssl != xno])
+
+AC_ARG_WITH([pcap],
+	    [AS_HELP_STRING([--without-pcap],
+			    [compile without PCAP])],
+	    [],
+	    [with_pcap=yes])
+AS_IF([test "x$with_pcap" != xno],
+      [ODP_PCAP([with_pcap=yes]‚[with_pcap=no])])
+AM_CONDITIONAL([HAVE_PCAP], [test x$have_pcap = xyes])
+
 ODP_LIBCONFIG([linux-generic])
-m4_include([platform/linux-generic/m4/odp_pcap.m4])
 m4_include([platform/linux-generic/m4/odp_pcapng.m4])
 m4_include([platform/linux-generic/m4/odp_netmap.m4])
 m4_include([platform/linux-generic/m4/odp_dpdk.m4])


### PR DESCRIPTION
Add '--without-pcap' option to explicitly build ODP without PCAP pktio
regardless of if the library is available on the build host.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Suggested-by: Risto Reittinen <risto.teittinen@nokia-bell-labs.com>