### PR TITLE
[PATCH v2] linux-gen: queue: configure max number of plain/scheduled queues

### DIFF
--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -22,14 +22,28 @@ extern "C" {
 #define ODP_CONFIG_POOLS 64
 
 /*
- * Maximum number of queues
- */
-#define ODP_CONFIG_QUEUES 1024
-
-/*
  * Queues reserved for ODP internal use
  */
-#define NUM_INTERNAL_QUEUES 64
+#define CONFIG_INTERNAL_QUEUES 64
+
+/*
+ * Maximum number of plain ODP queues
+ */
+#define CONFIG_MAX_PLAIN_QUEUES 1024
+
+/*
+ * Maximum number of scheduled ODP queues
+ *
+ * Must be a power of two.
+ */
+#define CONFIG_MAX_SCHED_QUEUES 1024
+
+/*
+ * Maximum number of queues
+ */
+#define CONFIG_MAX_QUEUES (CONFIG_INTERNAL_QUEUES + \
+			   CONFIG_MAX_PLAIN_QUEUES + \
+			   CONFIG_MAX_SCHED_QUEUES)
 
 /*
  * Maximum number of ordered locks per queue

--- a/platform/linux-generic/include/odp_queue_basic_internal.h
+++ b/platform/linux-generic/include/odp_queue_basic_internal.h
@@ -72,7 +72,7 @@ union queue_entry_u {
 };
 
 typedef struct queue_global_t {
-	queue_entry_t   queue[ODP_CONFIG_QUEUES];
+	queue_entry_t   queue[CONFIG_MAX_QUEUES];
 	uint32_t        *ring_data;
 	uint32_t        queue_lf_num;
 	uint32_t        queue_lf_size;

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -52,13 +52,13 @@ static int queue_capa(odp_queue_capability_t *capa, int sched ODP_UNUSED)
 	memset(capa, 0, sizeof(odp_queue_capability_t));
 
 	/* Reserve some queues for internal use */
-	capa->max_queues        = ODP_CONFIG_QUEUES - NUM_INTERNAL_QUEUES;
-	capa->plain.max_num     = capa->max_queues;
+	capa->max_queues        = CONFIG_MAX_QUEUES - CONFIG_INTERNAL_QUEUES;
+	capa->plain.max_num     = CONFIG_MAX_PLAIN_QUEUES;
 	capa->plain.max_size    = queue_glb->config.max_queue_size;
 	capa->plain.lockfree.max_num  = queue_glb->queue_lf_num;
 	capa->plain.lockfree.max_size = queue_glb->queue_lf_size;
 #if ODP_DEPRECATED_API
-	capa->sched.max_num     = capa->max_queues;
+	capa->sched.max_num     = CONFIG_MAX_SCHED_QUEUES;
 	capa->sched.max_size    = queue_glb->config.max_queue_size;
 
 	if (sched) {
@@ -145,7 +145,7 @@ static int queue_init_global(void)
 
 	memset(queue_glb, 0, sizeof(queue_global_t));
 
-	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
+	for (i = 0; i < CONFIG_MAX_QUEUES; i++) {
 		/* init locks */
 		queue_entry_t *queue = qentry_from_index(i);
 		LOCK_INIT(queue);
@@ -159,7 +159,7 @@ static int queue_init_global(void)
 	}
 
 	queue_glb->queue_gbl_shm = shm;
-	mem_size = sizeof(uint32_t) * ODP_CONFIG_QUEUES *
+	mem_size = sizeof(uint32_t) * CONFIG_MAX_QUEUES *
 		   (uint64_t)queue_glb->config.max_queue_size;
 
 	shm = odp_shm_reserve("_odp_queue_rings", mem_size,
@@ -206,7 +206,7 @@ static int queue_term_global(void)
 	queue_entry_t *queue;
 	int i;
 
-	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
+	for (i = 0; i < CONFIG_MAX_QUEUES; i++) {
 		queue = qentry_from_index(i);
 		LOCK(queue);
 		if (queue->s.status != QUEUE_STATUS_FREE) {
@@ -268,6 +268,7 @@ static odp_queue_t queue_create(const char *name,
 				const odp_queue_param_t *param)
 {
 	uint32_t i;
+	uint32_t max_idx;
 	queue_entry_t *queue;
 	void *queue_lf;
 	odp_queue_type_t type;
@@ -303,7 +304,18 @@ static odp_queue_t queue_create(const char *name,
 		return ODP_QUEUE_INVALID;
 	}
 
-	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
+	if (type == ODP_QUEUE_TYPE_SCHED) {
+		/* Start scheduled queue indices from zero to enable direct
+		 * mapping to scheduler implementation indices. */
+		i = 0;
+		max_idx = CONFIG_MAX_SCHED_QUEUES;
+	} else {
+		i = CONFIG_MAX_SCHED_QUEUES;
+		/* All internal queues are of type plain */
+		max_idx = CONFIG_MAX_QUEUES;
+	}
+
+	for (; i < max_idx; i++) {
 		queue = qentry_from_index(i);
 
 		if (queue->s.status != QUEUE_STATUS_FREE)
@@ -446,7 +458,7 @@ static odp_queue_t queue_lookup(const char *name)
 {
 	uint32_t i;
 
-	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
+	for (i = 0; i < CONFIG_MAX_QUEUES; i++) {
 		queue_entry_t *queue = qentry_from_index(i);
 
 		if (queue->s.status == QUEUE_STATUS_FREE ||
@@ -634,7 +646,7 @@ static int queue_info(odp_queue_t handle, odp_queue_info_t *info)
 
 	queue_id = queue_to_index(handle);
 
-	if (odp_unlikely(queue_id >= ODP_CONFIG_QUEUES)) {
+	if (odp_unlikely(queue_id >= CONFIG_MAX_QUEUES)) {
 		ODP_ERR("Invalid queue handle: 0x%" PRIx64 "\n",
 			odp_queue_to_u64(handle));
 		return -1;

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -67,10 +67,10 @@
 /* Maximum priority queue ring size. A ring must be large enough to store all
  * queues in the worst case (all queues are scheduled, have the same priority
  * and no spreading). */
-#define MAX_RING_SIZE ODP_CONFIG_QUEUES
+#define MAX_RING_SIZE CONFIG_MAX_SCHED_QUEUES
 
 /* For best performance, the number of queues should be a power of two. */
-ODP_STATIC_ASSERT(CHECK_IS_POWER2(ODP_CONFIG_QUEUES),
+ODP_STATIC_ASSERT(CHECK_IS_POWER2(CONFIG_MAX_SCHED_QUEUES),
 		  "Number_of_queues_is_not_power_of_two");
 
 /* Ring size must be power of two, so that mask can be used. */
@@ -197,7 +197,7 @@ typedef struct {
 		uint8_t poll_pktin;
 		uint8_t pktio_index;
 		uint8_t pktin_index;
-	} queue[ODP_CONFIG_QUEUES];
+	} queue[CONFIG_MAX_SCHED_QUEUES];
 
 	/* Scheduler priority queues */
 	prio_queue_t prio_q[NUM_SCHED_GRPS][NUM_PRIO][MAX_SPREAD];
@@ -218,7 +218,7 @@ typedef struct {
 	} pktio[NUM_PKTIO];
 	odp_spinlock_t pktio_lock;
 
-	order_context_t order[ODP_CONFIG_QUEUES];
+	order_context_t order[CONFIG_MAX_SCHED_QUEUES];
 
 	/* Scheduler interface config options (not used in fast path) */
 	schedule_config_t config_if;
@@ -807,7 +807,7 @@ static int schedule_term_local(void)
 
 static void schedule_config_init(odp_schedule_config_t *config)
 {
-	config->num_queues = ODP_CONFIG_QUEUES - NUM_INTERNAL_QUEUES;
+	config->num_queues = CONFIG_MAX_SCHED_QUEUES;
 	config->queue_size = queue_glb->config.max_queue_size;
 }
 
@@ -1585,7 +1585,7 @@ static int schedule_capability(odp_schedule_capability_t *capa)
 	capa->max_ordered_locks = schedule_max_ordered_locks();
 	capa->max_groups = schedule_num_grps();
 	capa->max_prios = schedule_num_prio();
-	capa->max_queues = ODP_CONFIG_QUEUES - NUM_INTERNAL_QUEUES;
+	capa->max_queues = CONFIG_MAX_SCHED_QUEUES;
 	capa->max_queue_size = queue_glb->config.max_queue_size;
 	capa->max_flow_id = BUF_HDR_MAX_FLOW_ID;
 

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -46,7 +46,7 @@
 
 #define FLAG_PKTIN 0x80
 
-ODP_STATIC_ASSERT(CHECK_IS_POWER2(ODP_CONFIG_QUEUES),
+ODP_STATIC_ASSERT(CHECK_IS_POWER2(CONFIG_MAX_SCHED_QUEUES),
 		  "Number_of_queues_is_not_power_of_two");
 
 #define SCHED_GROUP_JOIN 0
@@ -1996,7 +1996,7 @@ static int schedule_term_local(void)
 
 static void schedule_config_init(odp_schedule_config_t *config)
 {
-	config->num_queues = ODP_CONFIG_QUEUES - NUM_INTERNAL_QUEUES;
+	config->num_queues = CONFIG_MAX_SCHED_QUEUES;
 	config->queue_size = 0; /* FIXME ? */
 }
 
@@ -2128,7 +2128,7 @@ static int schedule_capability(odp_schedule_capability_t *capa)
 	capa->max_ordered_locks = schedule_max_ordered_locks();
 	capa->max_groups = num_grps();
 	capa->max_prios = schedule_num_prio();
-	capa->max_queues = ODP_CONFIG_QUEUES - NUM_INTERNAL_QUEUES;
+	capa->max_queues = CONFIG_MAX_SCHED_QUEUES;
 	capa->max_queue_size = 0;
 
 	return 0;

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -24,7 +24,7 @@
 #include <odp_queue_basic_internal.h>
 
 #define NUM_THREAD        ODP_THREAD_COUNT_MAX
-#define NUM_QUEUE         ODP_CONFIG_QUEUES
+#define NUM_QUEUE         CONFIG_MAX_SCHED_QUEUES
 #define NUM_PKTIO         ODP_CONFIG_PKTIO_ENTRIES
 #define NUM_ORDERED_LOCKS 1
 #define NUM_STATIC_GROUP  3
@@ -260,7 +260,7 @@ static int term_local(void)
 
 static void schedule_config_init(odp_schedule_config_t *config)
 {
-	config->num_queues = ODP_CONFIG_QUEUES - NUM_INTERNAL_QUEUES;
+	config->num_queues = CONFIG_MAX_SCHED_QUEUES;
 	config->queue_size = queue_glb->config.max_queue_size;
 }
 
@@ -951,7 +951,7 @@ static int schedule_capability(odp_schedule_capability_t *capa)
 	capa->max_ordered_locks = max_ordered_locks();
 	capa->max_groups = num_grps();
 	capa->max_prios = schedule_num_prio();
-	capa->max_queues = ODP_CONFIG_QUEUES - NUM_INTERNAL_QUEUES;
+	capa->max_queues = CONFIG_MAX_SCHED_QUEUES;
 	capa->max_queue_size = queue_glb->config.max_queue_size;
 
 	return 0;


### PR DESCRIPTION
Add separate defines (CONFIG_MAX_PLAIN_QUEUES, CONFIG_MAX_SCHED_QUEUES) for
configuring the maximum number of plain and scheduled queues.

ODP_CONFIG_QUEUES define has been renamed to CONFIG_MAX_QUEUES to clearly
separate it from API defines.

Queue IDs are now allocated consecutively per queue type (scheduled queues
[0, CONFIG_MAX_SCHED_QUEUES[ and plain queues[CONFIG_MAX_SCHED_QUEUES,
CONFIG_MAX_QUEUES[). This makes scheduler load balancing more predictable
since allocating plain queues won't affect to scheduler internal queue
mappings.

Signed-off-by: Matias Elo <matias.elo@nokia.com>