### PR TITLE
[PATCH v2] Compile with -O3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,8 @@ env:
         - CHECK=1
         - NETMAP=0
     matrix:
-        - CONF=""
-        - CONF="--disable-abi-compat"
-        - NETMAP=1 CONF=""
+        - CHECK=0 CONF="CFLAGS=-O3"
+        - CHECK=0 CONF="CFLAGS=-O0 --enable-debug --enable-debug-print"
         - CHECK=0 ARCH="arm64"
         - CHECK=0 ARCH="armhf"
         - CHECK=0 ARCH="powerpc"
@@ -65,8 +64,11 @@ env:
         - CHECK=0 ARCH="armhf" CONF="--disable-abi-compat"
         - CHECK=0 ARCH="powerpc" CONF="--disable-abi-compat"
         - CHECK=0 ARCH="i386" CONF="--disable-abi-compat"
+        - CONF=""
+        - CONF="--disable-abi-compat"
         - CONF="--enable-deprecated"
         - CONF="--enable-dpdk-zero-copy --disable-static-applications"
+        - NETMAP=1 CONF=""
         - NETMAP=1 CONF="--disable-static-applications"
         - CONF="--disable-host-optimization"
         - CONF="--disable-host-optimization --disable-abi-compat"

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ env:
         # repo.
         - CODECOV_TOKEN=a733c34c-5f5c-4ff1-af4b-e9f5edb1ab5e
         - OS="ubuntu_16.04"
+        - ARCH=x86_64
         - CHECK=1
         - NETMAP=0
     matrix:
@@ -69,8 +70,8 @@ env:
         - NETMAP=1 CONF="--disable-static-applications"
         - CONF="--disable-host-optimization"
         - CONF="--disable-host-optimization --disable-abi-compat"
-        - CHECK=0 ARCH="x86_64" CONF="--enable-pcapng-support"
-        - CHECK=0 ARCH="x86_64" OS="centos_7"
+        - CHECK=0 CONF="--enable-pcapng-support"
+        - CHECK=0 OS="centos_7"
         - CONF="--without-openssl --without-pcap"
         - OS="ubuntu_18.04"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ env:
     matrix:
         - CHECK=0 CONF="CFLAGS=-O3"
         - CHECK=0 CONF="CFLAGS=-O0 --enable-debug --enable-debug-print"
+        - CHECK=0 OS=ubuntu_18.04 CONF="CFLAGS=-O3"
+        - CHECK=0 OS=ubuntu_18.04 CONF="CFLAGS=-O0 --enable-debug --enable-debug-print"
         - CHECK=0 ARCH=arm64
         - CHECK=0 ARCH=armhf
         - CHECK=0 ARCH=powerpc

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,21 +49,21 @@ env:
         # you need to generate a new one at https://codecov.io specific for your
         # repo.
         - CODECOV_TOKEN=a733c34c-5f5c-4ff1-af4b-e9f5edb1ab5e
-        - OS="ubuntu_16.04"
+        - OS=ubuntu_16.04
         - ARCH=x86_64
         - CHECK=1
         - NETMAP=0
     matrix:
         - CHECK=0 CONF="CFLAGS=-O3"
         - CHECK=0 CONF="CFLAGS=-O0 --enable-debug --enable-debug-print"
-        - CHECK=0 ARCH="arm64"
-        - CHECK=0 ARCH="armhf"
-        - CHECK=0 ARCH="powerpc"
-        - CHECK=0 ARCH="i386"
-        - CHECK=0 ARCH="arm64" CONF="--disable-abi-compat"
-        - CHECK=0 ARCH="armhf" CONF="--disable-abi-compat"
-        - CHECK=0 ARCH="powerpc" CONF="--disable-abi-compat"
-        - CHECK=0 ARCH="i386" CONF="--disable-abi-compat"
+        - CHECK=0 ARCH=arm64
+        - CHECK=0 ARCH=armhf
+        - CHECK=0 ARCH=powerpc
+        - CHECK=0 ARCH=i386
+        - CHECK=0 ARCH=arm64 CONF="--disable-abi-compat"
+        - CHECK=0 ARCH=armhf CONF="--disable-abi-compat"
+        - CHECK=0 ARCH=powerpc CONF="--disable-abi-compat"
+        - CHECK=0 ARCH=i386 CONF="--disable-abi-compat"
         - CONF=""
         - CONF="--disable-abi-compat"
         - CONF="--enable-deprecated"
@@ -73,16 +73,16 @@ env:
         - CONF="--disable-host-optimization"
         - CONF="--disable-host-optimization --disable-abi-compat"
         - CHECK=0 CONF="--enable-pcapng-support"
-        - CHECK=0 OS="centos_7"
+        - CHECK=0 OS=centos_7
         - CONF="--without-openssl --without-pcap"
-        - OS="ubuntu_18.04"
+        - OS=ubuntu_18.04
 
 matrix:
   exclude:
   - compiler: gcc
-    env: CHECK=0 ARCH="arm64"
+    env: CHECK=0 ARCH=arm64
   - compiler: gcc
-    env: CHECK=0 ARCH="i386"
+    env: CHECK=0 ARCH=i386
 
 install:
         - if [ ${NETMAP} -eq 1 ] ; then

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -297,6 +297,12 @@ static void remove_group(sched_group_t *sched_group, int thr, int group)
 
 	num = thr_group->num_group;
 
+	/* Extra array bounds check to suppress warning on GCC 7.4 with -O3 */
+	if (num >= NUM_GROUP) {
+		ODP_ERR("Too many groups");
+		return;
+	}
+
 	for (i = 0; i < num; i++) {
 		if (thr_group->group[i] == group) {
 			found = 1;


### PR DESCRIPTION
Build with -O3 in Ubuntu 18.04 fails. Fix the warning and add -O3 and -O0 jobs into Travis to avoid build breaking again in future.