### PR TITLE
[PATCH v2] Fix potential segfaults on app termination

### DIFF
--- a/example/generator/odp_generator.c
+++ b/example/generator/odp_generator.c
@@ -172,7 +172,8 @@ static void print_global_stats(int num_workers);
 static void sig_handler(int signo ODP_UNUSED)
 {
 	int i;
-
+	if (args == NULL)
+		return;
 	for (i = 0; i < args->thread_cnt; i++)
 		args->thread[i].stop = 1;
 }
@@ -1408,6 +1409,8 @@ int main(int argc, char *argv[])
 	free(ifs);
 	free(args->appl.if_names);
 	free(args->appl.if_str);
+	args = NULL;
+	odp_mb_full();
 	if (0 != odp_pool_destroy(pool))
 		fprintf(stderr, "unable to destroy pool \"pool\"\n");
 	if (0 != odp_shm_free(shm))

--- a/example/l2fwd_simple/odp_l2fwd_simple.c
+++ b/example/l2fwd_simple/odp_l2fwd_simple.c
@@ -32,6 +32,8 @@ static global_data_t *global;
 static void sig_handler(int signo ODP_UNUSED)
 {
 	printf("sig_handler!\n");
+	if (global == NULL)
+		return;
 	global->exit_thr = 1;
 }
 
@@ -281,7 +283,9 @@ int main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	if (odp_shm_free(global->shm)) {
+	global = NULL;
+	odp_mb_full();
+	if (odp_shm_free(shm)) {
 		printf("Error: shm free global data\n");
 		exit(EXIT_FAILURE);
 	}

--- a/test/performance/odp_bench_packet.c
+++ b/test/performance/odp_bench_packet.c
@@ -171,6 +171,8 @@ static args_t *gbl_args;
 
 static void sig_handler(int signo ODP_UNUSED)
 {
+	if (gbl_args == NULL)
+		return;
 	gbl_args->exit_thread = 1;
 }
 
@@ -1661,6 +1663,8 @@ int main(int argc, char *argv[])
 		LOG_ERR("Error: pool destroy\n");
 		exit(EXIT_FAILURE);
 	}
+	gbl_args = NULL;
+	odp_mb_full();
 
 	if (odp_shm_free(shm)) {
 		LOG_ERR("Error: shm free\n");

--- a/test/performance/odp_cpu_bench.c
+++ b/test/performance/odp_cpu_bench.c
@@ -177,6 +177,8 @@ static const uint8_t test_udp_packet[] = {
 
 static void sig_handler(int signo ODP_UNUSED)
 {
+	if (gbl_args == NULL)
+		return;
 	gbl_args->exit_threads = 1;
 }
 
@@ -799,6 +801,9 @@ int main(int argc, char *argv[])
 			}
 		}
 	}
+	gbl_args = NULL;
+	odp_mb_full();
+
 	if (odp_pool_destroy(pool)) {
 		LOG_ERR("Error: pool destroy\n");
 		exit(EXIT_FAILURE);

--- a/test/performance/odp_l2fwd.c
+++ b/test/performance/odp_l2fwd.c
@@ -178,6 +178,8 @@ static args_t *gbl_args;
 
 static void sig_handler(int signo ODP_UNUSED)
 {
+	if (gbl_args == NULL)
+		return;
 	gbl_args->exit_threads = 1;
 }
 
@@ -1724,6 +1726,8 @@ int main(int argc, char *argv[])
 
 	free(gbl_args->appl.if_names);
 	free(gbl_args->appl.if_str);
+	gbl_args = NULL;
+	odp_mb_full();
 
 	if (odp_pool_destroy(pool)) {
 		LOG_ERR("Error: pool destroy\n");

--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -1544,6 +1544,8 @@ quit:
 		if (test_global->tx_pkt_sum > TEST_PASSED_LIMIT)
 			ret += 2;
 	}
+	test_global = NULL;
+	odp_mb_full();
 
 	if (odp_shm_free(shm)) {
 		printf("Error: shm free failed.\n");


### PR DESCRIPTION
Some apps and tests use SHM to hold a flag for thread termination updated by a SIGINT signal handler. This fixes a potential SEGFAULT that can happen if user sends a SIGINT after SHM is freed.