### PR TITLE
[PATCH v2] linux-dpdk: improve dpdk linking

### DIFF
--- a/m4/odp_dpdk.m4
+++ b/m4/odp_dpdk.m4
@@ -1,9 +1,7 @@
 # ODP_DPDK_PMDS(DPDK_DRIVER_PATH)
 # -------------------------------
-# Build a list of DPDK PMD drivers in DPDK_PMDS variable.
-# Updated DPDK_LIBS to include dependencies.
+# Update DPDK_LIBS to include dependencies.
 AC_DEFUN([ODP_DPDK_PMDS], [dnl
-AS_VAR_SET([DPDK_PMDS], ["-Wl,--whole-archive,"])
 AC_MSG_NOTICE([Looking for DPDK PMDs at $1])
 for filename in "$1"/librte_pmd_*.a; do
 cur_driver=`basename "$filename" .a | sed -e 's/^lib//'`
@@ -11,11 +9,10 @@ cur_driver=`basename "$filename" .a | sed -e 's/^lib//'`
 # Match pattern is filled to 'filename' once if no matches are found
 AS_IF([test "x$cur_driver" = "xrte_pmd_*"], [break])
 
-AS_VAR_APPEND([DPDK_PMDS], [-l$cur_driver,])
 AS_CASE([$cur_driver],
     [rte_pmd_nfp], [AS_VAR_APPEND([DPDK_LIBS], [" -lm"])],
     [rte_pmd_mlx4], [AS_VAR_APPEND([DPDK_LIBS], [" -lmlx4 -libverbs"])],
-    [rte_pmd_mlx5], [AS_VAR_APPEND([DPDK_LIBS], [" -lmlx5 -libverbs"])],
+    [rte_pmd_mlx5], [AS_VAR_APPEND([DPDK_LIBS], [" -lmlx5 -libverbs -lmnl"])],
     [rte_pmd_pcap], [AS_VAR_APPEND([DPDK_LIBS], [" -lpcap"])],
     [rte_pmd_aesni_gcm], [AS_VAR_APPEND([DPDK_LIBS], [" -lIPSec_MB"])],
     [rte_pmd_aesni_mb], [AS_VAR_APPEND([DPDK_LIBS], [" -lIPSec_MB"])],
@@ -25,7 +22,6 @@ AS_CASE([$cur_driver],
     [rte_pmd_qat], [AS_VAR_APPEND([DPDK_LIBS], [" -lcrypto"])],
     [rte_pmd_openssl], [AS_VAR_APPEND([DPDK_LIBS], [" -lcrypto"])])
 done
-AS_VAR_APPEND([DPDK_PMDS], [--no-whole-archive])
 ])
 
 # _ODP_DPDK_SET_LIBS
@@ -33,11 +29,12 @@ AS_VAR_APPEND([DPDK_PMDS], [--no-whole-archive])
 # Set DPDK_LIBS/DPDK_LIBS_LT/DPDK_LIBS_LIBODP depending on DPDK setup
 AC_DEFUN([_ODP_DPDK_SET_LIBS], [dnl
 ODP_DPDK_PMDS([$DPDK_PMD_PATH])
+DPDK_LIB="-Wl,--whole-archive,-ldpdk,--no-whole-archive"
 AS_IF([test "x$DPDK_SHARED" = "xyes"], [dnl
     # applications don't need to be linked to anything, just rpath
     DPDK_LIBS_LT="$DPDK_RPATH_LT"
     # static linking flags will need -ldpdk
-    DPDK_LIBS_LT_STATIC="$DPDK_LDFLAGS $DPDK_PMDS $DPDK_LIBS"
+    DPDK_LIBS_LT_STATIC="$DPDK_LDFLAGS $DPDK_LIB $DPDK_LIBS"
     DPDK_LIBS="-Wl,--no-as-needed,-ldpdk,--as-needed,`echo $DPDK_LIBS | sed -e 's/ /,/g'`"
     DPDK_LIBS="$DPDK_LDFLAGS $DPDK_RPATH $DPDK_LIBS"
     # link libodp-linux with -ldpdk
@@ -46,10 +43,10 @@ AS_IF([test "x$DPDK_SHARED" = "xyes"], [dnl
     # build long list of libraries for applications, which should not be
     # rearranged by libtool
     DPDK_LIBS_LT="`echo $DPDK_LIBS | sed -e 's/^/-Wc,/' -e 's/ /,/g'`"
-    DPDK_LIBS_LT="$DPDK_LDFLAGS $DPDK_PMDS $DPDK_LIBS_LT $DPDK_LIBS"
+    DPDK_LIBS_LT="$DPDK_LDFLAGS $DPDK_LIB $DPDK_LIBS_LT $DPDK_LIBS"
     DPDK_LIBS_LT_STATIC="$DPDK_LIBS_LT"
     # static linking flags follow the suite
-    DPDK_LIBS="$DPDK_LDFLAGS $DPDK_PMDS $DPDK_LIBS"
+    DPDK_LIBS="$DPDK_LDFLAGS $DPDK_LIB $DPDK_LIBS"
     # link libodp-linux with libtool linking flags
     DPDK_LIBS_LIBODP="$DPDK_LIBS_LT"
 ])
@@ -83,7 +80,7 @@ LIBS="$LIBS -ldpdk $2"
 AC_MSG_CHECKING([for rte_eal_init in -ldpdk $2])
 AC_LINK_IFELSE([AC_LANG_CALL([], [rte_eal_init])],
 	       [AC_MSG_RESULT([yes])
-	        DPDK_LIBS="-ldpdk $2"],
+	        DPDK_LIBS="$2"],
 	       [AC_MSG_RESULT([no])])
 
 ##########################################################################

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -139,32 +139,6 @@ static inline pkt_dpdk_t *pkt_priv(pktio_entry_t *pktio_entry)
 
 static int disable_pktio; /** !0 this pktio disabled, 0 enabled */
 
-#ifndef RTE_BUILD_SHARED_LIB
-#define MEMPOOL_OPS(hdl) \
-extern void mp_hdlr_init_##hdl(void)
-
-MEMPOOL_OPS(ops_mp_mc);
-MEMPOOL_OPS(ops_sp_sc);
-MEMPOOL_OPS(ops_mp_sc);
-MEMPOOL_OPS(ops_sp_mc);
-MEMPOOL_OPS(ops_stack);
-
-/*
- * This function is not called from anywhere, it's only purpose is to make sure
- * that if ODP and DPDK are statically linked to an application, the GCC
- * constructors of mempool handlers are linked as well. Otherwise the linker
- * would omit them. It's not an issue with dynamic linking. */
-void refer_constructors(void);
-void refer_constructors(void)
-{
-	mp_hdlr_init_ops_mp_mc();
-	mp_hdlr_init_ops_sp_sc();
-	mp_hdlr_init_ops_mp_sc();
-	mp_hdlr_init_ops_sp_mc();
-	mp_hdlr_init_ops_stack();
-}
-#endif
-
 static int dpdk_pktio_init(void);
 
 static int pool_alloc(struct rte_mempool *mp);


### PR DESCRIPTION
Link whole dpdk library with 'whole-archive' flags instead of linking each
driver individually.

Adds missing mlx5 driver dependency.

Signed-off-by: Matias Elo <matias.elo@nokia.com>