### PR TITLE
[PATCH v2] test: correct getopt short option usage

### DIFF
--- a/example/packet/odp_pktio.c
+++ b/example/packet/odp_pktio.c
@@ -600,7 +600,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 		{NULL, 0, NULL, 0}
 	};
 
-	static const char *shortopts = "+c:i:+m:t:h";
+	static const char *shortopts = "+c:i:m:t:h";
 
 	appl_args->cpu_count = 1; /* use one worker by default */
 	appl_args->mode = APPL_MODE_PKT_SCHED;

--- a/example/switch/odp_switch.c
+++ b/example/switch/odp_switch.c
@@ -756,7 +756,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 		{NULL, 0, NULL, 0}
 	};
 
-	static const char *shortopts = "+c:+t:+a:i:h";
+	static const char *shortopts = "+c:t:a:i:h";
 
 	appl_args->cpu_count = 1; /* use one worker by default */
 	appl_args->time = 0; /* loop forever if time to run is 0 */

--- a/test/performance/odp_cpu_bench.c
+++ b/test/performance/odp_cpu_bench.c
@@ -382,7 +382,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 		{NULL, 0, NULL, 0}
 	};
 
-	static const char *shortopts = "+a:+c:+l:+t:h";
+	static const char *shortopts = "+a:c:l:t:h";
 
 	appl_args->accuracy = 1; /* Get and print pps stats second */
 	appl_args->cpu_count = 1;

--- a/test/performance/odp_pktio_ordered.c
+++ b/test/performance/odp_pktio_ordered.c
@@ -864,7 +864,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 		{NULL, 0, NULL, 0}
 	};
 
-	static const char *shortopts =  "+c:+t:+a:i:m:d:r:f:e:h";
+	static const char *shortopts =  "+c:t:a:i:m:d:r:f:e:h";
 
 	appl_args->time = 0; /* loop forever if time to run is 0 */
 	appl_args->accuracy = DEF_STATS_INT;


### PR DESCRIPTION
Remove extra plus characters from short option string.

Only the first char needs to be '+' char: "If the first character
of option string is '+' then option processing stops as soon as
a nonoption argument is encountered."

Signed-off-by: Petri Savolainen <petri.savolainen@nokia.com>