### PR TITLE
[PATCH v2] linux-gen: pktio: enable explicit pktio type definition

### DIFF
--- a/platform/linux-generic/README
+++ b/platform/linux-generic/README
@@ -1,17 +1,43 @@
 Copyright (c) 2014-2018, Linaro Limited
+Copyright (c) 2019, Nokia
 All rights reserved.
 
 SPDX-License-Identifier:        BSD-3-Clause
 
 1. Intro
-
-OpenDataPlane implementation for Linux generic. Directory linux-generic contains ODP headers and implementation
-for linux-generic target. This drop does not target high
-performance. It is rather proof of ODP API functionality. It still uses
-linux-generic's SW scheduler.
+    OpenDataPlane API generic Linux implementation. Directory linux-generic
+    contains the header and source files and additional platform test scripts
+    for ODP linux-generic implementation.
 
 2. Build
-# To compile ODP
-./bootstrap
-./configure
-make
+    See DEPENDENCIES file about system requirements and dependencies to external
+    libraries/packages. It contains also more detailed build instructions.
+
+    Generally, ODP is built with these three steps:
+        ./bootstrap
+        ./configure
+        make
+
+3. Configuration file
+    See config/README for application runtime configuration options.
+
+4. Packet I/O
+    When passing a packet I/O device name to odp_pktio_open() one can explicitly
+    specify the used implementation internal pktio type. The pktio type can be
+    selected by adding a pktio type prefix to the device name separated by a
+    colon (<pktio_type>:<if_name>).
+
+    E.g.
+        socket:eth1
+        netmap:eth2
+
+    The supported pktio types are:
+        dpdk
+        ipc
+        loop
+        netmap
+        null
+        pcap
+        socket
+        socket_mmap
+        tap

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -93,8 +94,10 @@ struct pktio_entry {
 	odp_proto_chksums_t in_chksums; /**< Checksums validation settings */
 	pktio_stats_type_t stats_type;
 	char name[PKTIO_NAME_LEN];	/**< name of pktio provided to
-					   pktio_open() */
-
+					     internal pktio_open() calls */
+	char full_name[PKTIO_NAME_LEN];	/**< original pktio name passed to
+					     odp_pktio_open() and returned by
+					     odp_pktio_info() */
 	odp_pool_t pool;
 	odp_pktio_param_t param;
 	odp_pktio_capability_t capa;	/**< Packet IO capabilities */

--- a/platform/linux-generic/include/odp_socket_common.h
+++ b/platform/linux-generic/include/odp_socket_common.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -35,6 +36,11 @@ int mac_addr_get_fd(int fd, const char *name, unsigned char mac_dst[]);
  * Read the MTU from a packet socket
  */
 uint32_t mtu_get_fd(int fd, const char *name);
+
+/**
+ * Set a packet socket MTU
+ */
+int mtu_set_fd(int fd, const char *name, int mtu);
 
 /**
  * Enable/Disable promisc mode for a packet socket

--- a/platform/linux-generic/pktio/socket_common.c
+++ b/platform/linux-generic/pktio/socket_common.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -64,6 +65,27 @@ uint32_t mtu_get_fd(int fd, const char *name)
 		return 0;
 	}
 	return ifr.ifr_mtu + _ODP_ETHHDR_LEN;
+}
+
+/*
+ * ODP_PACKET_NETMAP:
+ */
+int mtu_set_fd(int fd, const char *name, int mtu)
+{
+	struct ifreq ifr;
+	int ret;
+
+	snprintf(ifr.ifr_name, IF_NAMESIZE, "%s", name);
+	ifr.ifr_mtu = mtu;
+
+	ret = ioctl(fd, SIOCSIFMTU, &ifr);
+	if (ret < 0) {
+		__odp_errno = errno;
+		ODP_DBG("ioctl(SIOCSIFMTU): %s: \"%s\".\n", strerror(errno),
+			ifr.ifr_name);
+		return -1;
+	}
+	return 0;
 }
 
 /*

--- a/platform/linux-generic/test/validation/api/pktio/pktio_run_dpdk.sh
+++ b/platform/linux-generic/test/validation/api/pktio/pktio_run_dpdk.sh
@@ -75,8 +75,8 @@ run()
 	if [ "$ODP_PKTIO_IF0" = "" ]; then
 		setup_pktio_env clean
 		export ODP_PKTIO_DPDK_PARAMS="--no-pci --vdev net_pcap0,iface=$IF0 --vdev net_pcap1,iface=$IF1"
-		export ODP_PKTIO_IF0=0
-		export ODP_PKTIO_IF1=1
+		export ODP_PKTIO_IF0=dpdk:0
+		export ODP_PKTIO_IF1=dpdk:1
 	fi
 
 	run_test

--- a/platform/linux-generic/test/validation/api/pktio/pktio_run_netmap.sh
+++ b/platform/linux-generic/test/validation/api/pktio/pktio_run_netmap.sh
@@ -84,8 +84,8 @@ run_test_veth()
 	fi
 
 	setup_pktio_env clean
-	export ODP_PKTIO_IF0=$IF0
-	export ODP_PKTIO_IF1=$IF1
+	export ODP_PKTIO_IF0=netmap:$IF0
+	export ODP_PKTIO_IF1=netmap:$IF1
 	run_test
 	return $?
 }


### PR DESCRIPTION
Previously, the odp_pktio_open() implementation called open() for all
implementation internal pktio types in predefined order until the call
succeeded or all pktio types failed.

Add option to explicitly define the used pktio type per device. This
enables the user to use multiple pktio types within a single application.

The pktio type is selected by adding pktio_type prefix in front of device
name separated by a colon (<pktio_type>:<if_name>).

E.g.
    socket:eth1
    netmap:eth2