### PR TITLE
[PATCH v2] linux-gen: include config.h header in install directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,8 @@ depcomp
 doc/output
 dpdk/
 install-sh
-include/config.h.in
-include/config.h
+include/odp/config.h.in
+include/odp/config.h
 include/stamp-h1
 lib/
 libtool

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AS_IF([test "$ac_cv_env_CFLAGS_set" = ""], [user_cflags=0], [user_cflags=1])
 # Initialize automake
 AM_INIT_AUTOMAKE([1.9 tar-pax subdir-objects foreign nostdinc -Wall -Werror])
 AC_CONFIG_SRCDIR([include/odp/api/spec/init.h])
-AM_CONFIG_HEADER([include/config.h])
+AM_CONFIG_HEADER([include/odp/config.h])
 
 AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE

--- a/helper/chksum.c
+++ b/helper/chksum.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp.h>
 #include <odp/helper/ip.h>
 #include <odp/helper/udp.h>

--- a/helper/cuckootable.c
+++ b/helper/cuckootable.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 /*-
  *   BSD LICENSE
  *

--- a/helper/eth.c
+++ b/helper/eth.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/helper/eth.h>
 
 #include <stdio.h>

--- a/helper/hashtable.c
+++ b/helper/hashtable.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:   BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <stdio.h>
 #include <string.h>
 #include <malloc.h>

--- a/helper/include/odp/helper/odph_debug.h
+++ b/helper/include/odp/helper/odph_debug.h
@@ -15,7 +15,7 @@
 #ifndef ODPH_DEBUG_H_
 #define ODPH_DEBUG_H_
 
-#include "config.h"
+#include <odp/config.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/helper/ip.c
+++ b/helper/ip.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/helper/ip.h>
 
 #include <stdio.h>

--- a/helper/iplookuptable.c
+++ b/helper/iplookuptable.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <string.h>
 #include <stdint.h>
 #include <errno.h>

--- a/helper/lineartable.c
+++ b/helper/lineartable.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <stdio.h>
 #include <string.h>
 #include <malloc.h>

--- a/helper/linux/thread.c
+++ b/helper/linux/thread.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif

--- a/helper/test/chksum.c
+++ b/helper/test/chksum.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
 

--- a/helper/test/cuckootable.c
+++ b/helper/test/cuckootable.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 /*-
  *   BSD LICENSE
  *

--- a/helper/test/debug.c
+++ b/helper/test/debug.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
+#include <odp/config.h>
 
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>

--- a/helper/test/iplookuptable.c
+++ b/helper/test/iplookuptable.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>

--- a/helper/test/linux/process.c
+++ b/helper/test/linux/process.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
 #include <odp/helper/linux/pthread.h>

--- a/helper/test/linux/pthread.c
+++ b/helper/test/linux/pthread.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
 #include <odp/helper/linux/pthread.h>

--- a/helper/test/odpthreads.c
+++ b/helper/test/odpthreads.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 /*
  * This program tests the ability of the linux helper to create ODP threads,
  * either implemented as linux pthreads or as linux processes, depending on

--- a/helper/test/parse.c
+++ b/helper/test/parse.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
 

--- a/helper/test/table.c
+++ b/helper/test/table.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
 

--- a/helper/test/version.c
+++ b/helper/test/version.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
 

--- a/helper/threads.c
+++ b/helper/threads.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -4,6 +4,7 @@ include_HEADERS = \
 
 odpincludedir= $(includedir)/odp
 odpinclude_HEADERS = \
+		  odp/config.h \
 		  odp/visibility_begin.h \
 		  odp/visibility_end.h
 

--- a/platform/linux-generic/arch/aarch64/odp_global_time.c
+++ b/platform/linux-generic/arch/aarch64/odp_global_time.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 
 #include <time.h>

--- a/platform/linux-generic/arch/aarch64/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/aarch64/odp_sysinfo_parse.c
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier:     BSD-3-Clause
  */
-#include "config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/platform/linux-generic/arch/default/odp_cpu_cycles.c
+++ b/platform/linux-generic/arch/default/odp_cpu_cycles.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 
 #include <stdlib.h>

--- a/platform/linux-generic/arch/default/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/default/odp_sysinfo_parse.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_sysinfo_internal.h>
 
 int cpuinfo_parser(FILE *file ODP_UNUSED, system_info_t *sysinfo)

--- a/platform/linux-generic/arch/mips64/odp_cpu_cycles.c
+++ b/platform/linux-generic/arch/mips64/odp_cpu_cycles.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/cpu.h>
 #include <odp/api/hints.h>
 #include <odp/api/system_info.h>

--- a/platform/linux-generic/arch/mips64/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/mips64/odp_sysinfo_parse.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_sysinfo_internal.h>
 #include <string.h>
 

--- a/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_sysinfo_internal.h>
 #include <string.h>
 

--- a/platform/linux-generic/arch/x86/cpu_flags.c
+++ b/platform/linux-generic/arch/x86/cpu_flags.c
@@ -37,8 +37,6 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-
 #include "cpu_flags.h"
 #include <odp_debug_internal.h>
 #include <odp/api/abi/cpu_time.h>

--- a/platform/linux-generic/arch/x86/odp_global_time.c
+++ b/platform/linux-generic/arch/x86/odp_global_time.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 
 #include <time.h>

--- a/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_sysinfo_internal.h>
 #include "cpu_flags.h"
 #include <string.h>

--- a/platform/linux-generic/include/odp_debug_internal.h
+++ b/platform/linux-generic/include/odp_debug_internal.h
@@ -16,10 +16,13 @@
 #ifndef ODP_DEBUG_INTERNAL_H_
 #define ODP_DEBUG_INTERNAL_H_
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <odp/config.h>
 #include <odp/api/debug.h>
 #include <odp_global_data.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -18,6 +18,8 @@
 extern "C" {
 #endif
 
+#include <odp/config.h>
+
 #include <odp/api/packet_io.h>
 #include <odp/api/plat/pktio_inlines.h>
 #include <odp/api/spinlock.h>
@@ -34,6 +36,7 @@ extern "C" {
 #include <string.h>
 #include <net/if.h>
 #include <linux/if_ether.h>
+#include <sys/select.h>
 
 #define PKTIO_MAX_QUEUES 64
 

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -87,9 +87,7 @@ int sched_cb_pktin_poll_one(int pktio_index, int rx_queue, odp_event_t evts[]);
 void sched_cb_pktio_stop_finalize(int pktio_index);
 
 /* For debugging */
-#ifdef ODP_DEBUG
 extern int _odp_schedule_configured;
-#endif
 
 /* API functions */
 typedef struct {

--- a/platform/linux-generic/odp_atomic.c
+++ b/platform/linux-generic/odp_atomic.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/atomic.h>
 
 int odp_atomic_lock_free_u64(odp_atomic_op_t *atomic_op)

--- a/platform/linux-generic/odp_atomic_api.c
+++ b/platform/linux-generic/odp_atomic_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/atomic.h>
 
 /* Include non-inlined versions of API functions */

--- a/platform/linux-generic/odp_barrier.c
+++ b/platform/linux-generic/odp_barrier.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/barrier.h>
 #include <odp/api/sync.h>
 #include <odp/api/cpu.h>

--- a/platform/linux-generic/odp_bitmap.c
+++ b/platform/linux-generic/odp_bitmap.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <string.h>
 #include <unistd.h>
 #include <odp/api/std_types.h>

--- a/platform/linux-generic/odp_buffer.c
+++ b/platform/linux-generic/odp_buffer.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/buffer.h>
 #include <odp_pool_internal.h>
 #include <odp_buffer_internal.h>

--- a/platform/linux-generic/odp_byteorder_api.c
+++ b/platform/linux-generic/odp_byteorder_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/byteorder.h>
 
 /* Include non-inlined versions of API functions */

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/classification.h>
 #include <odp/api/align.h>
 #include <odp/api/queue.h>

--- a/platform/linux-generic/odp_comp.c
+++ b/platform/linux-generic/odp_comp.c
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier:     BSD-3-Clause
  */
-#include "config.h"
 
 #include <string.h>
 

--- a/platform/linux-generic/odp_cpu_api.c
+++ b/platform/linux-generic/odp_cpu_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/cpu.h>
 
 /* Non-inlined functions for ABI compat mode */

--- a/platform/linux-generic/odp_cpumask.c
+++ b/platform/linux-generic/odp_cpumask.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 
 #include <sched.h>

--- a/platform/linux-generic/odp_cpumask_task.c
+++ b/platform/linux-generic/odp_cpumask_task.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 
 #include <sched.h>

--- a/platform/linux-generic/odp_crypto_null.c
+++ b/platform/linux-generic/odp_crypto_null.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 #include <odp/api/crypto.h>
 #include <odp_init_internal.h>

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 #include <odp/api/crypto.h>
 #include <odp_init_internal.h>

--- a/platform/linux-generic/odp_errno.c
+++ b/platform/linux-generic/odp_errno.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/errno.h>
 #include <string.h>
 #include <stdio.h>

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/event.h>
 #include <odp/api/buffer.h>
 #include <odp/api/crypto.h>

--- a/platform/linux-generic/odp_event_api.c
+++ b/platform/linux-generic/odp_event_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/event.h>
 
 /* Non-inlined functions for ABI compat mode */

--- a/platform/linux-generic/odp_fdserver.c
+++ b/platform/linux-generic/odp_fdserver.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 /*
  * This file implements a file descriptor sharing server enabling
  * sharing of file descriptors between processes, regardless of fork time.

--- a/platform/linux-generic/odp_hash_crc32c.c
+++ b/platform/linux-generic/odp_hash_crc32c.c
@@ -37,8 +37,6 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-
 #include <odp/api/hash.h>
 #include <odp/api/std_types.h>
 

--- a/platform/linux-generic/odp_impl.c
+++ b/platform/linux-generic/odp_impl.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
+#include <odp/config.h>
 #include <odp/api/version.h>
 
 #define ODP_VERSION_IMPL 0

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 
 #include <odp/api/init.h>

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/ipsec.h>
 #include <odp/api/chksum.h>
 

--- a/platform/linux-generic/odp_ipsec_events.c
+++ b/platform/linux-generic/odp_ipsec_events.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/ipsec.h>
 #include <odp/api/shared_memory.h>
 

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/atomic.h>
 #include <odp/api/ipsec.h>
 #include <odp/api/random.h>

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 /* This file handles the internal shared memory: internal shared memory
  * is memory which is sharable by all ODP threads regardless of how the
  * ODP thread is implemented (pthread or process) and regardless of fork()

--- a/platform/linux-generic/odp_ishmphy.c
+++ b/platform/linux-generic/odp_ishmphy.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 /*
  * This file handles the lower end of the ishm memory allocator:
  * It performs the physical mappings.

--- a/platform/linux-generic/odp_ishmpool.c
+++ b/platform/linux-generic/odp_ishmpool.c
@@ -41,7 +41,6 @@
  * The second one regroups the functions needed by the slab allocator.
  * The third section regroups the common functions exported externally.
  */
-#include "config.h"
 
 #include <odp_posix_extensions.h>
 #include <odp/api/spinlock.h>

--- a/platform/linux-generic/odp_libconfig.c
+++ b/platform/linux-generic/odp_libconfig.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <stdlib.h>
 #include <string.h>
 #include <libconfig.h>

--- a/platform/linux-generic/odp_name_table.c
+++ b/platform/linux-generic/odp_name_table.c
@@ -6,8 +6,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <stdint.h>
 #include <string.h>
 #include <malloc.h>

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
+#include <odp/config.h>
 
 #include <odp/api/packet.h>
 #include <odp/api/plat/packet_inlines.h>

--- a/platform/linux-generic/odp_packet_api.c
+++ b/platform/linux-generic/odp_packet_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/packet.h>
 #include <odp_packet_internal.h>
 #include <odp_debug_internal.h>

--- a/platform/linux-generic/odp_packet_flags.c
+++ b/platform/linux-generic/odp_packet_flags.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/plat/packet_flag_inlines.h>
 #include <odp/api/packet_flags.h>
 #include <odp_packet_internal.h>

--- a/platform/linux-generic/odp_packet_flags_api.c
+++ b/platform/linux-generic/odp_packet_flags_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/packet_flags.h>
 #include <odp_packet_internal.h>
 

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -5,10 +5,9 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 
+#include <odp/config.h>
 #include <odp/api/packet_io.h>
 #include <odp/api/plat/pktio_inlines.h>
 #include <odp_packet_io_internal.h>

--- a/platform/linux-generic/odp_pcapng.c
+++ b/platform/linux-generic/odp_pcapng.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
+#include <odp/config.h>
 
 #if defined(_ODP_PCAPNG) && _ODP_PCAPNG == 1
 

--- a/platform/linux-generic/odp_pkt_queue.c
+++ b/platform/linux-generic/odp_pkt_queue.c
@@ -6,8 +6,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <stdint.h>
 #include <string.h>
 #include <malloc.h>

--- a/platform/linux-generic/odp_pktio_api.c
+++ b/platform/linux-generic/odp_pktio_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/packet_io.h>
 
 /* Include non-inlined versions of API functions */

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/pool.h>
 #include <odp/api/shared_memory.h>
 #include <odp/api/align.h>

--- a/platform/linux-generic/odp_queue_api.c
+++ b/platform/linux-generic/odp_queue_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/queue.h>
 
 /* Non-inlined functions for ABI compat mode */

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/queue.h>
 #include <odp_queue_basic_internal.h>
 #include <odp_queue_if.h>

--- a/platform/linux-generic/odp_queue_if.c
+++ b/platform/linux-generic/odp_queue_if.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
+#include <odp/config.h>
 
 #include <odp_queue_if.h>
 #include <odp_init_internal.h>

--- a/platform/linux-generic/odp_queue_lf.c
+++ b/platform/linux-generic/odp_queue_lf.c
@@ -12,7 +12,6 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "config.h"
 #include <odp_debug_internal.h>
 
 #define RING_LF_SIZE   32

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -5,7 +5,6 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include <config.h>
 
 #include <odp/api/hints.h>
 #include <odp/api/ticketlock.h>

--- a/platform/linux-generic/odp_queue_spsc.c
+++ b/platform/linux-generic/odp_queue_spsc.c
@@ -9,7 +9,6 @@
 #include <odp_queue_basic_internal.h>
 #include <odp_pool_internal.h>
 
-#include "config.h"
 #include <odp_debug_internal.h>
 
 static inline void buffer_index_from_buf(uint32_t buffer_index[],

--- a/platform/linux-generic/odp_random_null.c
+++ b/platform/linux-generic/odp_random_null.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/platform/linux-generic/odp_random_openssl.c
+++ b/platform/linux-generic/odp_random_openssl.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 #include <stdint.h>
 #include <odp/api/random.h>

--- a/platform/linux-generic/odp_rwlock.c
+++ b/platform/linux-generic/odp_rwlock.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <stdbool.h>
 #include <odp/api/atomic.h>
 #include <odp/api/rwlock.h>

--- a/platform/linux-generic/odp_rwlock_recursive.c
+++ b/platform/linux-generic/odp_rwlock_recursive.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/rwlock_recursive.h>
 #include <odp/api/thread.h>
 #include <odp/api/plat/thread_inlines.h>

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
-#include <string.h>
 #include <odp/api/schedule.h>
 #include <odp_schedule_if.h>
 #include <odp/api/align.h>
@@ -30,6 +27,8 @@
 #include <odp_queue_basic_internal.h>
 #include <odp_libconfig_internal.h>
 #include <odp/api/plat/queue_inlines.h>
+
+#include <string.h>
 
 /* No synchronization context */
 #define NO_SYNC_CONTEXT ODP_SCHED_SYNC_PARALLEL

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
+#include <odp/config.h>
 
 #include <odp_schedule_if.h>
 #include <odp_init_internal.h>

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -5,7 +5,6 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include <config.h>
 
 #include <odp/api/align.h>
 #include <odp/api/atomic.h>

--- a/platform/linux-generic/odp_schedule_scalable_ordered.c
+++ b/platform/linux-generic/odp_schedule_scalable_ordered.c
@@ -5,7 +5,6 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include <config.h>
 
 #include <odp/api/shared_memory.h>
 #include <odp/api/cpu.h>

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
-#include <string.h>
 #include <odp/api/ticketlock.h>
 #include <odp/api/thread.h>
 #include <odp/api/plat/thread_inlines.h>
@@ -22,6 +19,8 @@
 #include <odp_ring_u32_internal.h>
 #include <odp_timer_internal.h>
 #include <odp_queue_basic_internal.h>
+
+#include <string.h>
 
 #define NUM_THREAD        ODP_THREAD_COUNT_MAX
 #define NUM_QUEUE         CONFIG_MAX_SCHED_QUEUES

--- a/platform/linux-generic/odp_shared_memory.c
+++ b/platform/linux-generic/odp_shared_memory.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_config_internal.h>
 #include <odp/api/debug.h>
 #include <odp/api/std_types.h>

--- a/platform/linux-generic/odp_sorted_list.c
+++ b/platform/linux-generic/odp_sorted_list.c
@@ -6,8 +6,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <stdint.h>
 #include <string.h>
 #include <malloc.h>

--- a/platform/linux-generic/odp_spinlock.c
+++ b/platform/linux-generic/odp_spinlock.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/spinlock.h>
 #include <odp/api/cpu.h>
 #include <odp_atomic_internal.h>

--- a/platform/linux-generic/odp_spinlock_recursive.c
+++ b/platform/linux-generic/odp_spinlock_recursive.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/spinlock_recursive.h>
 #include <odp/api/thread.h>
 #include <odp/api/plat/thread_inlines.h>

--- a/platform/linux-generic/odp_std_clib_api.c
+++ b/platform/linux-generic/odp_std_clib_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/std_clib.h>
 
 /* Include non-inlined versions of API functions */

--- a/platform/linux-generic/odp_sync_api.c
+++ b/platform/linux-generic/odp_sync_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/sync.h>
 
 /* Include non-inlined versions of API functions */

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -11,8 +11,6 @@
  *   All rights reserved.
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 
 #include <odp/api/system_info.h>

--- a/platform/linux-generic/odp_thread.c
+++ b/platform/linux-generic/odp_thread.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 
 #include <sched.h>

--- a/platform/linux-generic/odp_thread_api.c
+++ b/platform/linux-generic/odp_thread_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/thread.h>
 #include <odp/api/cpu.h>
 

--- a/platform/linux-generic/odp_thrmask.c
+++ b/platform/linux-generic/odp_thrmask.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/thrmask.h>
 #include <odp/api/cpumask.h>
 

--- a/platform/linux-generic/odp_ticketlock_api.c
+++ b/platform/linux-generic/odp_ticketlock_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/ticketlock.h>
 #include <odp/api/plat/atomic_inlines.h>
 

--- a/platform/linux-generic/odp_time.c
+++ b/platform/linux-generic/odp_time.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 
 #include <time.h>

--- a/platform/linux-generic/odp_time_api.c
+++ b/platform/linux-generic/odp_time_api.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/time.h>
 
 /* Non-inlined functions for ABI compat mode */

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 /**
  * @file
  *

--- a/platform/linux-generic/odp_timer_wheel.c
+++ b/platform/linux-generic/odp_timer_wheel.c
@@ -6,8 +6,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <stdint.h>
 #include <string.h>
 #include <malloc.h>

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "config.h"
 #include <odp_posix_extensions.h>
 
 #include <stdint.h>

--- a/platform/linux-generic/odp_version.c
+++ b/platform/linux-generic/odp_version.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/version.h>
 
 const char *odp_version_api_str(void)

--- a/platform/linux-generic/odp_weak.c
+++ b/platform/linux-generic/odp_weak.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp/api/debug.h>
 #include <odp_debug_internal.h>
 #include <odp/api/hints.h>

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
+#include <odp/config.h>
 
 #ifdef ODP_PKTIO_DPDK
 

--- a/platform/linux-generic/pktio/dpdk_parse.c
+++ b/platform/linux-generic/pktio/dpdk_parse.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
+#include <odp/config.h>
 
 #ifdef ODP_PKTIO_DPDK
 

--- a/platform/linux-generic/pktio/ethtool_rss.c
+++ b/platform/linux-generic/pktio/ethtool_rss.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
 #include <odp_posix_extensions.h>
 
 #include <stdio.h>

--- a/platform/linux-generic/pktio/io_ops.c
+++ b/platform/linux-generic/pktio/io_ops.c
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
+#include <odp/config.h>
 #include <odp_packet_io_internal.h>
 
 /* Ops for all implementation of pktio.

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_packet_io_ipc_internal.h>
 #include <odp_debug_internal.h>
 #include <odp_packet_io_internal.h>

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_packet_internal.h>
 #include <odp_packet_io_internal.h>

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
+#include <odp/config.h>
 
 #ifdef ODP_NETMAP
 

--- a/platform/linux-generic/pktio/null.c
+++ b/platform/linux-generic/pktio/null.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_packet_io_internal.h>
 

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 /**
  * @file
  *

--- a/platform/linux-generic/pktio/pktio_common.c
+++ b/platform/linux-generic/pktio/pktio_common.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_packet_io_internal.h>
 #include <errno.h>
 

--- a/platform/linux-generic/pktio/ring.c
+++ b/platform/linux-generic/pktio/ring.c
@@ -69,8 +69,6 @@
  *
  ***************************************************************************/
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_posix_extensions.h>
 
 #include <sys/socket.h>

--- a/platform/linux-generic/pktio/socket_common.c
+++ b/platform/linux-generic/pktio/socket_common.c
@@ -4,7 +4,7 @@
  *
  * SPDX-License-Identifier:     BSD-3-Clause
  */
-#include "config.h"
+
 #include <odp_posix_extensions.h>
 
 #include <stdio.h>

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
 
 #include <odp_posix_extensions.h>
 

--- a/platform/linux-generic/pktio/stats/ethtool_stats.c
+++ b/platform/linux-generic/pktio/stats/ethtool_stats.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
 #include <odp_posix_extensions.h>
 
 #include <sys/ioctl.h>

--- a/platform/linux-generic/pktio/stats/packet_io_stats.c
+++ b/platform/linux-generic/pktio/stats/packet_io_stats.c
@@ -4,12 +4,11 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
-#include <string.h>
 #include <odp_packet_io_stats.h>
 #include <odp_ethtool_stats.h>
 #include <odp_sysfs_stats.h>
+
+#include <string.h>
 
 int sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd)
 {

--- a/platform/linux-generic/pktio/stats/sysfs_stats.c
+++ b/platform/linux-generic/pktio/stats/sysfs_stats.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_sysfs_stats.h>
 #include <odp_errno_define.h>

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 /**
  * @file
  *

--- a/platform/linux-generic/test/ring/ring_main.c
+++ b/platform/linux-generic/test/ring/ring_main.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include "ring_suites.h"
 
 int main(int argc, char *argv[])

--- a/platform/linux-generic/test/validation/api/shmem/shmem_linux.c
+++ b/platform/linux-generic/test/validation/api/shmem/shmem_linux.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 /* this test makes sure that odp shared memory created with the ODP_SHM_PROC
  * flag is visible under linux, and checks that memory created with the
  * ODP_SHM_EXPORT flag is visible by other ODP instances.

--- a/platform/linux-generic/test/validation/api/shmem/shmem_odp1.c
+++ b/platform/linux-generic/test/validation/api/shmem/shmem_odp1.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp.h>
 #include <linux/limits.h>
 #include <sys/types.h>

--- a/platform/linux-generic/test/validation/api/shmem/shmem_odp2.c
+++ b/platform/linux-generic/test/validation/api/shmem/shmem_odp2.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp.h>
 #include <linux/limits.h>
 #include <sys/types.h>

--- a/test/common/mask_common.c
+++ b/test/common/mask_common.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 
 #include "odp_cunit_common.h"

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif /* _GNU_SOURCE */

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif /* _GNU_SOURCE */

--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	 BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <malloc.h>
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>

--- a/test/validation/api/barrier/barrier.c
+++ b/test/validation/api/barrier/barrier.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	 BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <malloc.h>
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>

--- a/test/validation/api/buffer/buffer.c
+++ b/test/validation/api/buffer/buffer.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include "odp_cunit_common.h"
 

--- a/test/validation/api/classification/classification.c
+++ b/test/validation/api/classification/classification.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 #include "odp_classification_testsuites.h"

--- a/test/validation/api/classification/odp_classification_basic.c
+++ b/test/validation/api/classification/odp_classification_basic.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_cunit_common.h>
 #include "odp_classification_testsuites.h"
 #include "classification.h"

--- a/test/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/validation/api/classification/odp_classification_test_pmr.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #include "odp_classification_testsuites.h"
 #include "classification.h"
 #include <odp_cunit_common.h>

--- a/test/validation/api/classification/odp_classification_tests.c
+++ b/test/validation/api/classification/odp_classification_tests.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #include "odp_classification_testsuites.h"
 #include "classification.h"
 #include <odp_cunit_common.h>

--- a/test/validation/api/comp/comp.c
+++ b/test/validation/api/comp/comp.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 #include "test_vectors.h"

--- a/test/validation/api/cpumask/cpumask.c
+++ b/test/validation/api/cpumask/cpumask.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 
 #include "odp_cunit_common.h"

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
 #include <CUnit/Basic.h>

--- a/test/validation/api/errno/errno.c
+++ b/test/validation/api/errno/errno.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include "odp_cunit_common.h"
 

--- a/test/validation/api/event/event.c
+++ b/test/validation/api/event/event.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 

--- a/test/validation/api/hash/hash.c
+++ b/test/validation/api/hash/hash.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 

--- a/test/validation/api/init/init_main.c
+++ b/test/validation/api/init/init_main.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier:	 BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 #include <unistd.h>

--- a/test/validation/api/ipsec/ipsec_async.c
+++ b/test/validation/api/ipsec/ipsec_async.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include "ipsec.h"
 
 static int ipsec_async_init(odp_instance_t *inst)

--- a/test/validation/api/ipsec/ipsec_inline_in.c
+++ b/test/validation/api/ipsec/ipsec_inline_in.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include "ipsec.h"
 
 static int ipsec_sync_init(odp_instance_t *inst)

--- a/test/validation/api/ipsec/ipsec_inline_out.c
+++ b/test/validation/api/ipsec/ipsec_inline_out.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include "ipsec.h"
 
 static int ipsec_sync_init(odp_instance_t *inst)

--- a/test/validation/api/ipsec/ipsec_sync.c
+++ b/test/validation/api/ipsec/ipsec_sync.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include "ipsec.h"
 
 static int ipsec_sync_init(odp_instance_t *inst)

--- a/test/validation/api/ipsec/ipsec_test_in.c
+++ b/test/validation/api/ipsec/ipsec_test_in.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include "ipsec.h"
 
 #include "test_vectors.h"

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include "ipsec.h"
 
 #include "test_vectors.h"

--- a/test/validation/api/lock/lock.c
+++ b/test/validation/api/lock/lock.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	 BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <malloc.h>
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <stdlib.h>
 
 #include <odp_api.h>

--- a/test/validation/api/pktio/parser.c
+++ b/test/validation/api/pktio/parser.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 #include <test_packet_parser.h>

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:	BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include "odp_cunit_common.h"
 

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 

--- a/test/validation/api/random/random.c
+++ b/test/validation/api/random/random.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include "odp_cunit_common.h"
 #include <odp/helper/odph_api.h>

--- a/test/validation/api/shmem/shmem.c
+++ b/test/validation/api/shmem/shmem.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 #include <stdlib.h>

--- a/test/validation/api/std_clib/std_clib.c
+++ b/test/validation/api/std_clib/std_clib.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "config.h"
-
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 

--- a/test/validation/api/time/time.c
+++ b/test/validation/api/time/time.c
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "config.h"
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <time.h>
 
 #include <odp_api.h>
 #include "odp_cunit_common.h"
-#include <time.h>
 
 #define BUSY_LOOP_CNT		30000000    /* used for t > min resolution */
 #define BUSY_LOOP_CNT_LONG	6000000000  /* used for t > 4 sec */


### PR DESCRIPTION
Previously, config.h header was not included in install dir. This caused a
compilation failure when an application tried to include ODP helper
headers.

config.h has been moved to include/odp subdirectory to avoid naming
conflicts and unnecessary includes have been removed.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reported-by: Mikko Parpala <mikko.parpala@nokia.com>