### PR TITLE
[PATCH v1] Fix build with GCC 9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,7 @@ AC_TYPE_UINT64_T
 ODP_CFLAGS="$ODP_CFLAGS -W -Wall -Werror"
 ODP_CXXFLAGS="$ODP_CXXFLAGS -W -Wall -Werror"
 
+# Additional warnings:
 ODP_CHECK_CFLAG([-Wstrict-prototypes])
 ODP_CHECK_CFLAG([-Wmissing-prototypes])
 ODP_CHECK_CFLAG([-Wmissing-declarations])
@@ -126,6 +127,11 @@ ODP_CHECK_CFLAG([-Wundef])
 ODP_CHECK_CFLAG([-Wwrite-strings])
 ODP_CHECK_CFLAG([-Wformat-truncation=0])
 ODP_CHECK_CFLAG([-Wformat-overflow=0])
+
+# Suppressed warnings:
+# GCC-9 warns about taking pointers to packed structure fields (e.g. protocol
+# header structures). Generate only warnings on those, not errors.
+ODP_CHECK_CFLAG([-Wno-error=address-of-packed-member])
 
 ODP_CFLAGS="$ODP_CFLAGS -std=c99"
 ODP_CXXFLAGS="$ODP_CXXFLAGS -std=c++11"

--- a/example/ipfragreass/odp_ipfragreass.c
+++ b/example/ipfragreass/odp_ipfragreass.c
@@ -230,7 +230,7 @@ int main(void)
 	odp_pool_t fragment_pool;
 	odp_shm_t shm;
 	odp_cpumask_t cpumask;
-	odph_odpthread_t threads[MAX_WORKERS] = {};
+	odph_odpthread_t threads[MAX_WORKERS];
 	odph_odpthread_params_t thread_params;
 	odp_packet_t dequeued_pkts[NUM_PACKETS];
 	odp_event_t ev;
@@ -242,6 +242,7 @@ int main(void)
 	int num_workers = MAX_WORKERS;
 	int reassembled;
 
+	memset(&threads, 0, sizeof(threads));
 	init(&instance, &fragment_pool, &shm, &cpumask, &num_workers);
 
 	/* Packet generation & fragmentation */

--- a/test/validation/api/ipsec/Makefile.am
+++ b/test/validation/api/ipsec/Makefile.am
@@ -1,7 +1,5 @@
 include ../Makefile.inc
 
-AM_CPPFLAGS += -Wno-error=missing-field-initializers
-
 noinst_LTLIBRARIES = libtestipsec.la
 libtestipsec_la_SOURCES = \
 	test_vectors.h \

--- a/test/validation/api/ipsec/ipsec_test_in.c
+++ b/test/validation/api/ipsec/ipsec_test_in.c
@@ -42,9 +42,11 @@ static void test_in_ipv4_ah_sha256(void)
 
 static void test_in_ipv4_ah_sha256_tun_ipv4(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, true, 123, &tunnel,
@@ -75,9 +77,11 @@ static void test_in_ipv4_ah_sha256_tun_ipv4(void)
 
 static void test_in_ipv4_ah_sha256_tun_ipv6(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, true, 123, &tunnel,
@@ -335,9 +339,11 @@ static void test_in_ipv4_esp_null_sha256_lookup(void)
 
 static void test_in_ipv4_esp_null_sha256_tun_ipv4(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, false, 123, &tunnel,
@@ -368,9 +374,11 @@ static void test_in_ipv4_esp_null_sha256_tun_ipv4(void)
 
 static void test_in_ipv4_esp_null_sha256_tun_ipv6(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, false, 123, &tunnel,
@@ -966,9 +974,11 @@ static void test_in_ipv4_rfc3602_6_esp(void)
 
 static void test_in_ipv4_rfc3602_7_esp(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, false, 0x8765, &tunnel,
@@ -999,9 +1009,11 @@ static void test_in_ipv4_rfc3602_7_esp(void)
 
 static void test_in_ipv4_rfc3602_8_esp(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, false, 0x8765, &tunnel,
@@ -1032,9 +1044,11 @@ static void test_in_ipv4_rfc3602_8_esp(void)
 
 static void test_in_ipv4_mcgrew_gcm_2_esp(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, false, 0xa5f8, &tunnel,
@@ -1065,9 +1079,11 @@ static void test_in_ipv4_mcgrew_gcm_2_esp(void)
 
 static void test_in_ipv4_mcgrew_gcm_3_esp(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, false, 0x4a2cbfe3, &tunnel,
@@ -1098,9 +1114,11 @@ static void test_in_ipv4_mcgrew_gcm_3_esp(void)
 
 static void test_in_ipv4_mcgrew_gcm_4_esp(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, false, 0x00000000, &tunnel,
@@ -1131,9 +1149,11 @@ static void test_in_ipv4_mcgrew_gcm_4_esp(void)
 
 static void test_in_ipv4_mcgrew_gcm_12_esp(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	/* This test will not work properly inbound inline mode.
 	 * Packet might be dropped and we will not check for that. */
@@ -1201,9 +1221,11 @@ static void test_in_ipv4_mcgrew_gcm_12_esp_notun(void)
 
 static void test_in_ipv4_mcgrew_gcm_15_esp(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, false, 0x00004321, &tunnel,
@@ -1234,9 +1256,11 @@ static void test_in_ipv4_mcgrew_gcm_15_esp(void)
 
 static void test_in_ipv4_rfc7634_chacha(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, false, 0x01020304, &tunnel,
@@ -1363,9 +1387,11 @@ static void test_in_ipv6_ah_sha256(void)
 
 static void test_in_ipv6_ah_sha256_tun_ipv4(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, true, 123, &tunnel,
@@ -1396,9 +1422,11 @@ static void test_in_ipv6_ah_sha256_tun_ipv4(void)
 
 static void test_in_ipv6_ah_sha256_tun_ipv6(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, true, 123, &tunnel,
@@ -1461,9 +1489,11 @@ static void test_in_ipv6_esp_null_sha256(void)
 
 static void test_in_ipv6_esp_null_sha256_tun_ipv4(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, false, 123, &tunnel,
@@ -1494,9 +1524,11 @@ static void test_in_ipv6_esp_null_sha256_tun_ipv4(void)
 
 static void test_in_ipv6_esp_null_sha256_tun_ipv6(void)
 {
-	odp_ipsec_tunnel_param_t tunnel = {};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 
 	ipsec_sa_param_fill(&param,
 			    true, false, 123, &tunnel,

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -45,16 +45,17 @@ static void test_out_ipv4_ah_sha256(void)
 
 static void test_out_ipv4_ah_sha256_tun_ipv4(void)
 {
-	uint32_t src = IPV4ADDR(10, 0, 111, 2);
-	uint32_t dst = IPV4ADDR(10, 0, 222, 2);
-	odp_ipsec_tunnel_param_t tunnel = {
-		.type = ODP_IPSEC_TUNNEL_IPV4,
-		.ipv4.src_addr = &src,
-		.ipv4.dst_addr = &dst,
-		.ipv4.ttl = 64,
-	};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+	uint32_t src = IPV4ADDR(10, 0, 111, 2);
+	uint32_t dst = IPV4ADDR(10, 0, 222, 2);
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
+	tunnel.type = ODP_IPSEC_TUNNEL_IPV4;
+	tunnel.ipv4.src_addr = &src;
+	tunnel.ipv4.dst_addr = &dst;
+	tunnel.ipv4.ttl = 64;
 
 	ipsec_sa_param_fill(&param,
 			    false, true, 123, &tunnel,
@@ -83,6 +84,9 @@ static void test_out_ipv4_ah_sha256_tun_ipv4(void)
 
 static void test_out_ipv4_ah_sha256_tun_ipv6(void)
 {
+	odp_ipsec_tunnel_param_t tunnel;
+	odp_ipsec_sa_param_t param;
+	odp_ipsec_sa_t sa;
 	uint8_t src[16] = {
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 		0x02, 0x11, 0x43, 0xff, 0xfe, 0x4a, 0xd7, 0x0a,
@@ -91,14 +95,12 @@ static void test_out_ipv4_ah_sha256_tun_ipv6(void)
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16,
 	};
-	odp_ipsec_tunnel_param_t tunnel = {
-		.type = ODP_IPSEC_TUNNEL_IPV6,
-		.ipv6.src_addr = src,
-		.ipv6.dst_addr = dst,
-		.ipv6.hlimit = 64,
-	};
-	odp_ipsec_sa_param_t param;
-	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
+	tunnel.type = ODP_IPSEC_TUNNEL_IPV6;
+	tunnel.ipv6.src_addr = src;
+	tunnel.ipv6.dst_addr = dst;
+	tunnel.ipv6.hlimit = 64;
 
 	ipsec_sa_param_fill(&param,
 			    false, true, 123, &tunnel,
@@ -157,16 +159,17 @@ static void test_out_ipv4_esp_null_sha256(void)
 
 static void test_out_ipv4_esp_null_sha256_tun_ipv4(void)
 {
-	uint32_t src = IPV4ADDR(10, 0, 111, 2);
-	uint32_t dst = IPV4ADDR(10, 0, 222, 2);
-	odp_ipsec_tunnel_param_t tunnel = {
-		.type = ODP_IPSEC_TUNNEL_IPV4,
-		.ipv4.src_addr = &src,
-		.ipv4.dst_addr = &dst,
-		.ipv4.ttl = 64,
-	};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+	uint32_t src = IPV4ADDR(10, 0, 111, 2);
+	uint32_t dst = IPV4ADDR(10, 0, 222, 2);
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
+	tunnel.type = ODP_IPSEC_TUNNEL_IPV4;
+	tunnel.ipv4.src_addr = &src;
+	tunnel.ipv4.dst_addr = &dst;
+	tunnel.ipv4.ttl = 64;
 
 	ipsec_sa_param_fill(&param,
 			    false, false, 123, &tunnel,
@@ -196,6 +199,9 @@ static void test_out_ipv4_esp_null_sha256_tun_ipv4(void)
 
 static void test_out_ipv4_esp_null_sha256_tun_ipv6(void)
 {
+	odp_ipsec_tunnel_param_t tunnel;
+	odp_ipsec_sa_param_t param;
+	odp_ipsec_sa_t sa;
 	uint8_t src[16] = {
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 		0x02, 0x11, 0x43, 0xff, 0xfe, 0x4a, 0xd7, 0x0a,
@@ -204,14 +210,12 @@ static void test_out_ipv4_esp_null_sha256_tun_ipv6(void)
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16,
 	};
-	odp_ipsec_tunnel_param_t tunnel = {
-		.type = ODP_IPSEC_TUNNEL_IPV6,
-		.ipv6.src_addr = src,
-		.ipv6.dst_addr = dst,
-		.ipv6.hlimit = 64,
-	};
-	odp_ipsec_sa_param_t param;
-	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
+	tunnel.type = ODP_IPSEC_TUNNEL_IPV6;
+	tunnel.ipv6.src_addr = src;
+	tunnel.ipv6.dst_addr = dst;
+	tunnel.ipv6.hlimit = 64;
 
 	ipsec_sa_param_fill(&param,
 			    false, false, 123, &tunnel,
@@ -770,16 +774,17 @@ static void test_out_ipv6_ah_sha256(void)
 
 static void test_out_ipv6_ah_sha256_tun_ipv4(void)
 {
-	uint32_t src = IPV4ADDR(10, 0, 111, 2);
-	uint32_t dst = IPV4ADDR(10, 0, 222, 2);
-	odp_ipsec_tunnel_param_t tunnel = {
-		.type = ODP_IPSEC_TUNNEL_IPV4,
-		.ipv4.src_addr = &src,
-		.ipv4.dst_addr = &dst,
-		.ipv4.ttl = 64,
-	};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+	uint32_t src = IPV4ADDR(10, 0, 111, 2);
+	uint32_t dst = IPV4ADDR(10, 0, 222, 2);
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
+	tunnel.type = ODP_IPSEC_TUNNEL_IPV4;
+	tunnel.ipv4.src_addr = &src;
+	tunnel.ipv4.dst_addr = &dst;
+	tunnel.ipv4.ttl = 64;
 
 	ipsec_sa_param_fill(&param,
 			    false, true, 123, &tunnel,
@@ -808,6 +813,9 @@ static void test_out_ipv6_ah_sha256_tun_ipv4(void)
 
 static void test_out_ipv6_ah_sha256_tun_ipv6(void)
 {
+	odp_ipsec_tunnel_param_t tunnel;
+	odp_ipsec_sa_param_t param;
+	odp_ipsec_sa_t sa;
 	uint8_t src[16] = {
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 		0x02, 0x11, 0x43, 0xff, 0xfe, 0x4a, 0xd7, 0x0a,
@@ -816,14 +824,12 @@ static void test_out_ipv6_ah_sha256_tun_ipv6(void)
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16,
 	};
-	odp_ipsec_tunnel_param_t tunnel = {
-		.type = ODP_IPSEC_TUNNEL_IPV6,
-		.ipv6.src_addr = src,
-		.ipv6.dst_addr = dst,
-		.ipv6.hlimit = 64,
-	};
-	odp_ipsec_sa_param_t param;
-	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
+	tunnel.type = ODP_IPSEC_TUNNEL_IPV6;
+	tunnel.ipv6.src_addr = src;
+	tunnel.ipv6.dst_addr = dst;
+	tunnel.ipv6.hlimit = 64;
 
 	ipsec_sa_param_fill(&param,
 			    false, true, 123, &tunnel,
@@ -882,16 +888,17 @@ static void test_out_ipv6_esp_null_sha256(void)
 
 static void test_out_ipv6_esp_null_sha256_tun_ipv4(void)
 {
-	uint32_t src = IPV4ADDR(10, 0, 111, 2);
-	uint32_t dst = IPV4ADDR(10, 0, 222, 2);
-	odp_ipsec_tunnel_param_t tunnel = {
-		.type = ODP_IPSEC_TUNNEL_IPV4,
-		.ipv4.src_addr = &src,
-		.ipv4.dst_addr = &dst,
-		.ipv4.ttl = 64,
-	};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
+	uint32_t src = IPV4ADDR(10, 0, 111, 2);
+	uint32_t dst = IPV4ADDR(10, 0, 222, 2);
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
+	tunnel.type = ODP_IPSEC_TUNNEL_IPV4;
+	tunnel.ipv4.src_addr = &src;
+	tunnel.ipv4.dst_addr = &dst;
+	tunnel.ipv4.ttl = 64;
 
 	ipsec_sa_param_fill(&param,
 			    false, false, 123, &tunnel,
@@ -921,6 +928,9 @@ static void test_out_ipv6_esp_null_sha256_tun_ipv4(void)
 
 static void test_out_ipv6_esp_null_sha256_tun_ipv6(void)
 {
+	odp_ipsec_tunnel_param_t tunnel;
+	odp_ipsec_sa_param_t param;
+	odp_ipsec_sa_t sa;
 	uint8_t src[16] = {
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 		0x02, 0x11, 0x43, 0xff, 0xfe, 0x4a, 0xd7, 0x0a,
@@ -929,14 +939,12 @@ static void test_out_ipv6_esp_null_sha256_tun_ipv6(void)
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16,
 	};
-	odp_ipsec_tunnel_param_t tunnel = {
-		.type = ODP_IPSEC_TUNNEL_IPV6,
-		.ipv6.src_addr = &src,
-		.ipv6.dst_addr = &dst,
-		.ipv6.hlimit = 64,
-	};
-	odp_ipsec_sa_param_t param;
-	odp_ipsec_sa_t sa;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
+	tunnel.type = ODP_IPSEC_TUNNEL_IPV6;
+	tunnel.ipv6.src_addr = &src;
+	tunnel.ipv6.dst_addr = &dst;
+	tunnel.ipv6.hlimit = 64;
 
 	ipsec_sa_param_fill(&param,
 			    false, false, 123, &tunnel,
@@ -997,17 +1005,18 @@ static void test_out_ipv6_esp_udp_null_sha256(void)
 
 static void test_out_dummy_esp_null_sha256_tun_ipv4(void)
 {
-	uint32_t src = IPV4ADDR(10, 0, 111, 2);
-	uint32_t dst = IPV4ADDR(10, 0, 222, 2);
-	odp_ipsec_tunnel_param_t tunnel = {
-		.type = ODP_IPSEC_TUNNEL_IPV4,
-		.ipv4.src_addr = &src,
-		.ipv4.dst_addr = &dst,
-		.ipv4.ttl = 64,
-	};
+	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
 	odp_ipsec_sa_t sa2;
+	uint32_t src = IPV4ADDR(10, 0, 111, 2);
+	uint32_t dst = IPV4ADDR(10, 0, 222, 2);
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
+	tunnel.type = ODP_IPSEC_TUNNEL_IPV4;
+	tunnel.ipv4.src_addr = &src;
+	tunnel.ipv4.dst_addr = &dst;
+	tunnel.ipv4.ttl = 64;
 
 	/* This test will not work properly inbound inline mode.
 	 * Packet might be dropped and we will not check for that. */
@@ -1073,6 +1082,10 @@ static void test_out_dummy_esp_null_sha256_tun_ipv4(void)
 
 static void test_out_dummy_esp_null_sha256_tun_ipv6(void)
 {
+	odp_ipsec_tunnel_param_t tunnel;
+	odp_ipsec_sa_param_t param;
+	odp_ipsec_sa_t sa;
+	odp_ipsec_sa_t sa2;
 	uint8_t src[16] = {
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 		0x02, 0x11, 0x43, 0xff, 0xfe, 0x4a, 0xd7, 0x0a,
@@ -1081,15 +1094,12 @@ static void test_out_dummy_esp_null_sha256_tun_ipv6(void)
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16,
 	};
-	odp_ipsec_tunnel_param_t tunnel = {
-		.type = ODP_IPSEC_TUNNEL_IPV6,
-		.ipv6.src_addr = src,
-		.ipv6.dst_addr = dst,
-		.ipv6.hlimit = 64,
-	};
-	odp_ipsec_sa_param_t param;
-	odp_ipsec_sa_t sa;
-	odp_ipsec_sa_t sa2;
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
+	tunnel.type = ODP_IPSEC_TUNNEL_IPV6;
+	tunnel.ipv6.src_addr = src;
+	tunnel.ipv6.dst_addr = dst;
+	tunnel.ipv6.hlimit = 64;
 
 	/* This test will not work properly inbound inline mode.
 	 * Packet might be dropped and we will not check for that. */


### PR DESCRIPTION
GCC 9 includes a new warning (-Waddress-of-packed-member). Handle it only as a warning, not as an error. Enabled struct initializations warnings again and fixed some struct init issues that an old compiler complained about.