### PR TITLE
[PATCH v2] linux-gen: include only ODP defines in autogenerated header files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,11 @@ depcomp
 doc/output
 dpdk/
 install-sh
-include/odp/config.h.in
-include/odp/config.h
-include/odp/stamp-h1
+include/odp/autoheader_build.h.in
+include/odp/autoheader_build.h
+include/odp/autoheader_external.h
+include/odp/autoheader_internal.h
+include/odp/stamp-h*
 lib/
 libtool
 ltmain.sh

--- a/configure.ac
+++ b/configure.ac
@@ -281,7 +281,7 @@ AS_IF([test "${with_platform}" = "linux-generic"],
       [m4_include([./platform/linux-generic/m4/configure.m4])],
       [AC_MSG_ERROR([UNSUPPORTED PLATFORM: ${with_platform}])])
 
-AC_DEFINE_UNQUOTED([ODP_IMPLEMENTATION_NAME], ["$ODP_IMPLEMENTATION_NAME"],
+AC_DEFINE_UNQUOTED([_ODP_IMPLEMENTATION_NAME], ["$ODP_IMPLEMENTATION_NAME"],
 		   [Define to the name of the implementation])
 
 AM_CONDITIONAL([ODP_USE_CONFIG], [test "x$odp_use_config" = "xtrue"])

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AS_IF([test "$ac_cv_env_CFLAGS_set" = ""], [user_cflags=0], [user_cflags=1])
 # Initialize automake
 AM_INIT_AUTOMAKE([1.9 tar-pax subdir-objects foreign nostdinc -Wall -Werror])
 AC_CONFIG_SRCDIR([include/odp/api/spec/init.h])
-AM_CONFIG_HEADER([include/odp/config.h])
+AM_CONFIG_HEADER([include/odp/autoheader_build.h include/odp/autoheader_external.h include/odp/autoheader_internal.h])
 
 AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE

--- a/helper/include/odp/helper/odph_debug.h
+++ b/helper/include/odp/helper/odph_debug.h
@@ -15,7 +15,7 @@
 #ifndef ODPH_DEBUG_H_
 #define ODPH_DEBUG_H_
 
-#include <odp/config.h>
+#include <odp/autoheader_external.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/helper/test/debug.c
+++ b/helper/test/debug.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/config.h>
+#include <odp/autoheader_external.h>
 
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -4,7 +4,7 @@ include_HEADERS = \
 
 odpincludedir= $(includedir)/odp
 odpinclude_HEADERS = \
-		  odp/config.h \
+		  odp/autoheader_external.h \
 		  odp/visibility_begin.h \
 		  odp/visibility_end.h
 

--- a/include/odp/autoheader_external.h.in
+++ b/include/odp/autoheader_external.h.in
@@ -1,0 +1,17 @@
+
+#ifndef ODP_AUTOHEADER_EXTERNAL_H_
+#define ODP_AUTOHEADER_EXTERNAL_H_
+
+/* Define to 1 to include additional debug code */
+#undef ODP_DEBUG
+
+/* Define to 1 to display debug information */
+#undef ODP_DEBUG_PRINT
+
+/* Define to 1 to include additional helper debug code */
+#undef ODPH_DEBUG
+
+/* Define to 1 to display helper debug information */
+#undef ODPH_DEBUG_PRINT
+
+#endif

--- a/include/odp/autoheader_internal.h.in
+++ b/include/odp/autoheader_internal.h.in
@@ -3,22 +3,22 @@
 #define ODP_AUTOHEADER_INTERNAL_H_
 
 /* Define to the name of the implementation */
-#undef ODP_IMPLEMENTATION_NAME
+#undef _ODP_IMPLEMENTATION_NAME
 
 /* Define to name default scheduler */
-#undef ODP_SCHEDULE_DEFAULT
+#undef _ODP_SCHEDULE_DEFAULT
 
 /* Define to 1 if numa library is usable */
 #undef _ODP_HAVE_NUMA_LIBRARY
 
-/* Define to 1 to enable DPDK zero copy support */
-#undef ODP_DPDK_ZERO_COPY
-
-/* Define to 1 to enable netmap IO support */
-#undef ODP_NETMAP
-
 /* Define to 1 to enable DPDK packet I/O support */
-#undef ODP_PKTIO_DPDK
+#undef _ODP_PKTIO_DPDK
+
+/* Define to 1 to enable DPDK zero copy support */
+#undef _ODP_DPDK_ZERO_COPY
+
+/* Define to 1 to enable netmap packet I/O support */
+#undef _ODP_PKTIO_NETMAP
 
 /* Define to 1 to enable pcap packet I/O support */
 #undef _ODP_PKTIO_PCAP

--- a/include/odp/autoheader_internal.h.in
+++ b/include/odp/autoheader_internal.h.in
@@ -1,0 +1,29 @@
+
+#ifndef ODP_AUTOHEADER_INTERNAL_H_
+#define ODP_AUTOHEADER_INTERNAL_H_
+
+/* Define to the name of the implementation */
+#undef ODP_IMPLEMENTATION_NAME
+
+/* Define to name default scheduler */
+#undef ODP_SCHEDULE_DEFAULT
+
+/* Define to 1 if numa library is usable */
+#undef _ODP_HAVE_NUMA_LIBRARY
+
+/* Define to 1 to enable DPDK zero copy support */
+#undef ODP_DPDK_ZERO_COPY
+
+/* Define to 1 to enable netmap IO support */
+#undef ODP_NETMAP
+
+/* Define to 1 to enable DPDK packet I/O support */
+#undef ODP_PKTIO_DPDK
+
+/* Define to 1 to enable pcap packet I/O support */
+#undef _ODP_PKTIO_PCAP
+
+/* Define to 1 to enable pcapng support */
+#undef _ODP_PCAPNG
+
+#endif

--- a/m4/odp_dpdk.m4
+++ b/m4/odp_dpdk.m4
@@ -54,7 +54,7 @@ AS_IF([test "x$DPDK_SHARED" = "xyes"], [dnl
 OLD_LIBS=$LIBS
 LIBS="-lnuma"
 AC_TRY_LINK_FUNC([numa_num_configured_nodes],
-		 [AC_DEFINE([HAVE_NUMA_LIBRARY], [1],
+		 [AC_DEFINE([_ODP_HAVE_NUMA_LIBRARY], [1],
 			    [Define to 1 if numa library is usable])
 		 AS_VAR_APPEND([DPDK_LIBS_LIBODP], [" -lnuma"])])
 LIBS=$OLD_LIBS

--- a/m4/odp_pcap.m4
+++ b/m4/odp_pcap.m4
@@ -13,7 +13,8 @@ AC_CHECK_HEADER(pcap/pcap.h,
 [])
 
 if test "$have_pcap" = "yes"; then
-    AC_DEFINE([HAVE_PCAP], 1, [Define to 1 if you have pcap library])
+    AC_DEFINE([_ODP_PKTIO_PCAP], 1,
+    	      [Define to 1 to enable pcap packet I/O support])
     PCAP_LIBS="-lpcap"
 else
     PCAP_LIBS=""

--- a/m4/odp_scheduler.m4
+++ b/m4/odp_scheduler.m4
@@ -6,6 +6,6 @@ AC_ARG_ENABLE([scheduler-default],
 	      [AS_HELP_STRING([enable-scheduler-default],
 			      [Choose default scheduler (default is basic)])],
 	      [], [enable_scheduler_default=basic])
-AC_DEFINE_UNQUOTED([ODP_SCHEDULE_DEFAULT], ["$enable_scheduler_default"],
+AC_DEFINE_UNQUOTED([_ODP_SCHEDULE_DEFAULT], ["$enable_scheduler_default"],
 		   [Define to name default scheduler])
 ]) # ODP_SCHEDULER

--- a/platform/linux-generic/include/odp_debug_internal.h
+++ b/platform/linux-generic/include/odp_debug_internal.h
@@ -16,7 +16,7 @@
 #ifndef ODP_DEBUG_INTERNAL_H_
 #define ODP_DEBUG_INTERNAL_H_
 
-#include <odp/config.h>
+#include <odp/autoheader_external.h>
 #include <odp/api/debug.h>
 #include <odp_global_data.h>
 

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -54,11 +54,11 @@ extern "C" {
 /* Forward declaration */
 struct pktio_if_ops;
 
-#if defined(ODP_NETMAP)
+#if defined(_ODP_PKTIO_NETMAP)
 #define PKTIO_PRIVATE_SIZE 74752
-#elif defined(ODP_PKTIO_DPDK) && ODP_CACHE_LINE_SIZE == 128
+#elif defined(_ODP_PKTIO_DPDK) && ODP_CACHE_LINE_SIZE == 128
 #define PKTIO_PRIVATE_SIZE 10240
-#elif defined(ODP_PKTIO_DPDK)
+#elif defined(_ODP_PKTIO_DPDK)
 #define PKTIO_PRIVATE_SIZE 5632
 #else
 #define PKTIO_PRIVATE_SIZE 384

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -216,7 +216,7 @@ extern const pktio_if_ops_t dpdk_pktio_ops;
 extern const pktio_if_ops_t sock_mmsg_pktio_ops;
 extern const pktio_if_ops_t sock_mmap_pktio_ops;
 extern const pktio_if_ops_t loopback_pktio_ops;
-#ifdef HAVE_PCAP
+#ifdef _ODP_PKTIO_PCAP
 extern const pktio_if_ops_t pcap_pktio_ops;
 #endif
 extern const pktio_if_ops_t tap_pktio_ops;

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#include <odp/config.h>
+#include <odp/autoheader_internal.h>
 
 #include <odp/api/packet_io.h>
 #include <odp/api/plat/pktio_inlines.h>

--- a/platform/linux-generic/m4/odp_dpdk.m4
+++ b/platform/linux-generic/m4/odp_dpdk.m4
@@ -41,9 +41,9 @@ then
     esac
 
     ODP_CHECK_CFLAG([-Wno-error=cast-align])
-    AC_DEFINE([ODP_PKTIO_DPDK], [1],
+    AC_DEFINE([_ODP_PKTIO_DPDK], [1],
 	      [Define to 1 to enable DPDK packet I/O support])
-    AC_DEFINE_UNQUOTED([ODP_DPDK_ZERO_COPY], [$zero_copy],
+    AC_DEFINE_UNQUOTED([_ODP_DPDK_ZERO_COPY], [$zero_copy],
 	      [Define to 1 to enable DPDK zero copy support])
 else
     pktio_dpdk_support=no

--- a/platform/linux-generic/m4/odp_netmap.m4
+++ b/platform/linux-generic/m4/odp_netmap.m4
@@ -31,8 +31,8 @@ if test x$netmap_support = xyes
 then
     AC_CHECK_HEADERS([net/netmap_user.h], [],
         [AC_MSG_FAILURE(["can't find netmap header"])])
-    AC_DEFINE([ODP_NETMAP], [1],
-	      [Define to 1 to enable netmap IO support])
+    AC_DEFINE([_ODP_PKTIO_NETMAP], [1],
+	      [Define to 1 to enable netmap packet I/O support])
     AC_SUBST([NETMAP_CPPFLAGS])
 else
     netmap_support=no

--- a/platform/linux-generic/odp_impl.c
+++ b/platform/linux-generic/odp_impl.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/config.h>
+#include <odp/autoheader_internal.h>
 #include <odp/api/version.h>
 
 #define ODP_VERSION_IMPL 0

--- a/platform/linux-generic/odp_impl.c
+++ b/platform/linux-generic/odp_impl.c
@@ -9,7 +9,7 @@
 
 #define ODP_VERSION_IMPL 0
 #define ODP_VERSION_IMPL_STR \
-	ODP_IMPLEMENTATION_NAME " " \
+	_ODP_IMPLEMENTATION_NAME " " \
 	ODP_VERSION_TO_STR(ODP_VERSION_API_GENERATION) "." \
 	ODP_VERSION_TO_STR(ODP_VERSION_API_MAJOR) "." \
 	ODP_VERSION_TO_STR(ODP_VERSION_API_MINOR) "-" \
@@ -26,5 +26,5 @@ const char *odp_version_impl_str(void)
 
 const char *odp_version_impl_name(void)
 {
-	return ODP_IMPLEMENTATION_NAME;
+	return _ODP_IMPLEMENTATION_NAME;
 }

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/config.h>
+#include <odp/autoheader_external.h>
 
 #include <odp/api/packet.h>
 #include <odp/api/plat/packet_inlines.h>

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -7,7 +7,7 @@
 
 #include <odp_posix_extensions.h>
 
-#include <odp/config.h>
+#include <odp/autoheader_internal.h>
 #include <odp/api/packet_io.h>
 #include <odp/api/plat/pktio_inlines.h>
 #include <odp_packet_io_internal.h>

--- a/platform/linux-generic/odp_pcapng.c
+++ b/platform/linux-generic/odp_pcapng.c
@@ -5,7 +5,9 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/config.h>
+#include <odp_posix_extensions.h>
+
+#include <odp/autoheader_internal.h>
 
 #if defined(_ODP_PCAPNG) && _ODP_PCAPNG == 1
 

--- a/platform/linux-generic/odp_queue_if.c
+++ b/platform/linux-generic/odp_queue_if.c
@@ -101,7 +101,7 @@ int _odp_queue_init_global(void)
 	const char *sched = getenv("ODP_SCHEDULER");
 
 	if (sched == NULL || !strcmp(sched, "default"))
-		sched = ODP_SCHEDULE_DEFAULT;
+		sched = _ODP_SCHEDULE_DEFAULT;
 
 	if (!strcmp(sched, "basic") || !strcmp(sched, "sp")) {
 		queue_fn = &queue_basic_fn;

--- a/platform/linux-generic/odp_queue_if.c
+++ b/platform/linux-generic/odp_queue_if.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/config.h>
+#include <odp/autoheader_internal.h>
 
 #include <odp_queue_if.h>
 #include <odp_init_internal.h>

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/config.h>
+#include <odp/autoheader_internal.h>
 
 #include <odp_schedule_if.h>
 #include <odp_init_internal.h>

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -206,7 +206,7 @@ int _odp_schedule_init_global(void)
 	const char *sched = getenv("ODP_SCHEDULER");
 
 	if (sched == NULL || !strcmp(sched, "default"))
-		sched = ODP_SCHEDULE_DEFAULT;
+		sched = _ODP_SCHEDULE_DEFAULT;
 
 	ODP_PRINT("Using scheduler '%s'\n", sched);
 

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -6,7 +6,7 @@
 
 #include <odp/autoheader_internal.h>
 
-#ifdef ODP_PKTIO_DPDK
+#ifdef _ODP_PKTIO_DPDK
 
 #include <odp_posix_extensions.h>
 
@@ -65,7 +65,7 @@
 #define rte_log_set_global_level rte_set_log_level
 #endif
 
-#if ODP_DPDK_ZERO_COPY
+#if _ODP_DPDK_ZERO_COPY
 ODP_STATIC_ASSERT(CONFIG_PACKET_HEADROOM == RTE_PKTMBUF_HEADROOM,
 		  "ODP and DPDK headroom sizes not matching!");
 #endif
@@ -465,7 +465,7 @@ int _odp_dpdk_pool_create(pool_t *pool)
 	struct rte_mempool *pkt_pool;
 	char pool_name[RTE_MEMPOOL_NAMESIZE];
 
-	if (!ODP_DPDK_ZERO_COPY)
+	if (!_ODP_DPDK_ZERO_COPY)
 		return 0;
 
 	pool->pool_in_use = 0;
@@ -492,7 +492,7 @@ uint32_t _odp_dpdk_pool_obj_size(pool_t *pool, uint32_t block_size)
 	struct rte_mempool_objsz sz;
 	uint32_t total_size;
 
-	if (!ODP_DPDK_ZERO_COPY)
+	if (!_ODP_DPDK_ZERO_COPY)
 		return block_size;
 
 	if (odp_global_rw->dpdk_initialized == 0) {
@@ -1296,7 +1296,7 @@ static int dpdk_pktio_term(void)
 	}
 #endif
 
-	if (!ODP_DPDK_ZERO_COPY)
+	if (!_ODP_DPDK_ZERO_COPY)
 		rte_mempool_walk(dpdk_mempool_free, NULL);
 
 	return 0;
@@ -1569,7 +1569,7 @@ static int dpdk_open(odp_pktio_t id ODP_UNUSED,
 	else
 		pkt_dpdk->min_rx_burst = 0;
 
-	if (ODP_DPDK_ZERO_COPY) {
+	if (_ODP_DPDK_ZERO_COPY) {
 		pkt_pool = (struct rte_mempool *)pool_entry->ext_desc;
 	} else {
 		snprintf(pool_name, sizeof(pool_name), "pktpool_%s", netdev);
@@ -1806,7 +1806,7 @@ static int dpdk_recv(pktio_entry_t *pktio_entry, int index,
 			ts_val = odp_time_global();
 			ts = &ts_val;
 		}
-		if (ODP_DPDK_ZERO_COPY)
+		if (_ODP_DPDK_ZERO_COPY)
 			nb_rx = mbuf_to_pkt_zero(pktio_entry, pkt_table,
 						 rx_mbufs, nb_rx, ts);
 		else
@@ -1830,7 +1830,7 @@ static int dpdk_send(pktio_entry_t *pktio_entry, int index,
 	if (odp_unlikely(pktio_entry->s.state != PKTIO_STATE_STARTED))
 		return 0;
 
-	if (ODP_DPDK_ZERO_COPY)
+	if (_ODP_DPDK_ZERO_COPY)
 		mbufs = pkt_to_mbuf_zero(pktio_entry, tx_mbufs, pkt_table, num,
 					 &copy_count);
 	else
@@ -1845,7 +1845,7 @@ static int dpdk_send(pktio_entry_t *pktio_entry, int index,
 	if (!pkt_dpdk->lockless_tx)
 		odp_ticketlock_unlock(&pkt_dpdk->tx_lock[index]);
 
-	if (ODP_DPDK_ZERO_COPY) {
+	if (_ODP_DPDK_ZERO_COPY) {
 		/* Free copied packets */
 		if (odp_unlikely(copy_count)) {
 			uint16_t freed = 0;
@@ -2014,4 +2014,4 @@ int _odp_dpdk_pool_create(pool_t *pool ODP_UNUSED)
 	return 0;
 }
 
-#endif /* ODP_PKTIO_DPDK */
+#endif /* _ODP_PKTIO_DPDK */

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -55,7 +55,7 @@
 #include <rte_version.h>
 
 /* NUMA is not supported on all platforms */
-#ifdef HAVE_NUMA_LIBRARY
+#ifdef _ODP_HAVE_NUMA_LIBRARY
 #include <numa.h>
 #else
 #define numa_num_configured_nodes() 1

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/config.h>
+#include <odp/autoheader_internal.h>
 
 #ifdef ODP_PKTIO_DPDK
 

--- a/platform/linux-generic/pktio/dpdk_parse.c
+++ b/platform/linux-generic/pktio/dpdk_parse.c
@@ -6,7 +6,7 @@
 
 #include <odp/autoheader_internal.h>
 
-#ifdef ODP_PKTIO_DPDK
+#ifdef _ODP_PKTIO_DPDK
 
 #include <odp_packet_io_internal.h>
 #include <odp_packet_dpdk.h>
@@ -489,4 +489,4 @@ int _odp_dpdk_packet_parse_common(packet_parser_t *prs, const uint8_t *ptr,
 					      pktin_cfg);
 }
 
-#endif /* ODP_PKTIO_DPDK */
+#endif /* _ODP_PKTIO_DPDK */

--- a/platform/linux-generic/pktio/dpdk_parse.c
+++ b/platform/linux-generic/pktio/dpdk_parse.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/config.h>
+#include <odp/autoheader_internal.h>
 
 #ifdef ODP_PKTIO_DPDK
 

--- a/platform/linux-generic/pktio/io_ops.c
+++ b/platform/linux-generic/pktio/io_ops.c
@@ -19,7 +19,7 @@ const pktio_if_ops_t * const pktio_if_ops[]  = {
 #ifdef ODP_NETMAP
 	&netmap_pktio_ops,
 #endif
-#ifdef HAVE_PCAP
+#ifdef _ODP_PKTIO_PCAP
 	&pcap_pktio_ops,
 #endif
 	&ipc_pktio_ops,

--- a/platform/linux-generic/pktio/io_ops.c
+++ b/platform/linux-generic/pktio/io_ops.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/config.h>
+#include <odp/autoheader_internal.h>
 #include <odp_packet_io_internal.h>
 
 /* Ops for all implementation of pktio.

--- a/platform/linux-generic/pktio/io_ops.c
+++ b/platform/linux-generic/pktio/io_ops.c
@@ -13,10 +13,10 @@
  * Array must be NULL terminated */
 const pktio_if_ops_t * const pktio_if_ops[]  = {
 	&loopback_pktio_ops,
-#ifdef ODP_PKTIO_DPDK
+#ifdef _ODP_PKTIO_DPDK
 	&dpdk_pktio_ops,
 #endif
-#ifdef ODP_NETMAP
+#ifdef _ODP_PKTIO_NETMAP
 	&netmap_pktio_ops,
 #endif
 #ifdef _ODP_PKTIO_PCAP

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/config.h>
+#include <odp/autoheader_internal.h>
 
 #ifdef ODP_NETMAP
 

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -7,7 +7,7 @@
 
 #include <odp/autoheader_internal.h>
 
-#ifdef ODP_NETMAP
+#ifdef _ODP_PKTIO_NETMAP
 
 #include <odp_posix_extensions.h>
 
@@ -1253,4 +1253,4 @@ const pktio_if_ops_t netmap_pktio_ops = {
 	.fd_set = netmap_fd_set
 };
 
-#endif /* ODP_NETMAP */
+#endif /* _ODP_PKTIO_NETMAP */


### PR DESCRIPTION
The config.h file has been split into three parts:
- autoheader_build.h: should NOT be included by ANY source file
- autoheader_external.h: can be included by any source file, including public headers
- autoheader_internal.h: can be included by any internal source file, but NOT by public headers

autoheader_external.h and autoheader_internal.h are generated based on
matching template files (*.in) and include only ODP defines.
autoheader_build.h includes all build defines and should not be included
by any source file.
