### PR TITLE
[PATCH v2] example: ping: initialize len allways

### DIFF
--- a/example/ping/odp_ping.c
+++ b/example/ping/odp_ping.c
@@ -492,11 +492,11 @@ static uint16_t update_chksum(uint16_t chksum, uint16_t old, uint16_t new)
 
 static void icmp_reply(test_global_t *global, odp_packet_t pkt)
 {
-	uint32_t len;
 	uint32_t dst_ip;
 	odph_ipv4hdr_t *ip_hdr;
 	odph_ethhdr_t *eth_hdr;
 	uint16_t old, new;
+	uint32_t len = 0;
 	int index = odp_packet_input_index(pkt);
 	odp_pktout_queue_t pktout = global->pktio[index].pktout;
 	odph_ethaddr_t *eth_addr = &global->pktio[index].eth_addr;


### PR DESCRIPTION
Initialize len allways to make an older compiler happy.
It complains about potentially uninitialized variable,
but this should happen only when odp_packet_l4_ptr()
returns NULL (which is checked first).

Signed-off-by: Petri Savolainen <petri.savolainen@nokia.com>