### PR TITLE
[PATCH v2] Classifier and validation test clean up

### DIFF
--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -155,6 +156,12 @@ int odp_cls_capability(odp_cls_capability_t *capability)
 	capability->max_cos = CLS_COS_MAX_ENTRY;
 	capability->pmr_range_supported = false;
 	capability->supported_terms.all_bits = 0;
+	capability->supported_terms.bit.len = 1;
+	capability->supported_terms.bit.ethtype_0 = 1;
+	capability->supported_terms.bit.ethtype_x = 1;
+	capability->supported_terms.bit.vlan_id_0 = 1;
+	capability->supported_terms.bit.vlan_id_x = 1;
+	capability->supported_terms.bit.dmac = 1;
 	capability->supported_terms.bit.ip_proto = 1;
 	capability->supported_terms.bit.udp_dport = 1;
 	capability->supported_terms.bit.udp_sport = 1;
@@ -162,6 +169,8 @@ int odp_cls_capability(odp_cls_capability_t *capability)
 	capability->supported_terms.bit.tcp_sport = 1;
 	capability->supported_terms.bit.sip_addr = 1;
 	capability->supported_terms.bit.dip_addr = 1;
+	capability->supported_terms.bit.sip6_addr = 1;
+	capability->supported_terms.bit.dip6_addr = 1;
 	capability->random_early_detection = ODP_SUPPORT_NO;
 	capability->back_pressure = ODP_SUPPORT_NO;
 	capability->threshold_red.all_bits = 0;

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -476,7 +476,7 @@ int odp_pktio_skip_set(odp_pktio_t pktio_in, uint32_t offset)
 	pktio_entry_t *entry = get_pktio_entry(pktio_in);
 
 	if (entry == NULL) {
-		ODP_ERR("Invalid odp_cos_t handle");
+		ODP_ERR("Invalid odp_pktio_t handle\n");
 		return -1;
 	}
 
@@ -650,7 +650,7 @@ odp_pmr_t odp_cls_pmr_create(const odp_pmr_param_t *terms, int num_terms,
 	cos_t *cos_dst = get_cos_entry(dst_cos);
 
 	if (NULL == cos_src || NULL == cos_dst) {
-		ODP_ERR("Invalid input handle");
+		ODP_ERR("Invalid odp_cos_t handle\n");
 		return ODP_PMR_INVALID;
 	}
 

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -121,7 +121,7 @@ int odp_classification_init_global(void)
 int odp_classification_term_global(void)
 {
 	if (cls_global && odp_shm_free(cls_global->shm)) {
-		ODP_ERR("shm free failed");
+		ODP_ERR("shm free failed\n");
 		return -1;
 	}
 
@@ -260,7 +260,7 @@ odp_cos_t odp_cls_cos_create(const char *name, odp_cls_cos_param_t *param)
 		UNLOCK(&cos->s.lock);
 	}
 
-	ODP_ERR("CLS_COS_MAX_ENTRY reached");
+	ODP_ERR("CLS_COS_MAX_ENTRY reached\n");
 	return ODP_COS_INVALID;
 }
 
@@ -284,7 +284,7 @@ odp_pmr_t alloc_pmr(pmr_t **pmr)
 		}
 		UNLOCK(&pmr_tbl->pmr[i].s.lock);
 	}
-	ODP_ERR("CLS_PMR_MAX_ENTRY reached");
+	ODP_ERR("CLS_PMR_MAX_ENTRY reached\n");
 	return ODP_PMR_INVALID;
 }
 
@@ -318,7 +318,7 @@ int odp_cos_destroy(odp_cos_t cos_id)
 	cos_t *cos = get_cos_entry(cos_id);
 
 	if (NULL == cos) {
-		ODP_ERR("Invalid odp_cos_t handle");
+		ODP_ERR("Invalid odp_cos_t handle\n");
 		return -1;
 	}
 
@@ -331,12 +331,12 @@ int odp_cos_queue_set(odp_cos_t cos_id, odp_queue_t queue_id)
 	cos_t *cos = get_cos_entry(cos_id);
 
 	if (cos == NULL) {
-		ODP_ERR("Invalid odp_cos_t handle");
+		ODP_ERR("Invalid odp_cos_t handle\n");
 		return -1;
 	}
 
 	if (cos->s.num_queue != 1) {
-		ODP_ERR("Hashing enabled, cannot set queue");
+		ODP_ERR("Hashing enabled, cannot set queue\n");
 		return -1;
 	}
 
@@ -351,7 +351,7 @@ odp_queue_t odp_cos_queue(odp_cos_t cos_id)
 	cos_t *cos = get_cos_entry(cos_id);
 
 	if (!cos) {
-		ODP_ERR("Invalid odp_cos_t handle");
+		ODP_ERR("Invalid odp_cos_t handle\n");
 		return ODP_QUEUE_INVALID;
 	}
 
@@ -363,7 +363,7 @@ uint32_t odp_cls_cos_num_queue(odp_cos_t cos_id)
 	cos_t *cos = get_cos_entry(cos_id);
 
 	if (!cos) {
-		ODP_ERR("Invalid odp_cos_t handle");
+		ODP_ERR("Invalid odp_cos_t handle\n");
 		return 0;
 	}
 
@@ -380,7 +380,7 @@ uint32_t odp_cls_cos_queues(odp_cos_t cos_id, odp_queue_t queue[],
 
 	cos  = get_cos_entry(cos_id);
 	if (!cos) {
-		ODP_ERR("Invalid odp_cos_t handle");
+		ODP_ERR("Invalid odp_cos_t handle\n");
 		return 0;
 	}
 
@@ -409,7 +409,7 @@ int odp_cos_drop_set(odp_cos_t cos_id, odp_cls_drop_t drop_policy)
 	cos_t *cos = get_cos_entry(cos_id);
 
 	if (!cos) {
-		ODP_ERR("Invalid odp_cos_t handle");
+		ODP_ERR("Invalid odp_cos_t handle\n");
 		return -1;
 	}
 
@@ -423,7 +423,7 @@ odp_cls_drop_t odp_cos_drop(odp_cos_t cos_id)
 	cos_t *cos = get_cos_entry(cos_id);
 
 	if (!cos) {
-		ODP_ERR("Invalid odp_cos_t handle");
+		ODP_ERR("Invalid odp_cos_t handle\n");
 		return -1;
 	}
 
@@ -437,12 +437,12 @@ int odp_pktio_default_cos_set(odp_pktio_t pktio_in, odp_cos_t default_cos)
 
 	entry = get_pktio_entry(pktio_in);
 	if (entry == NULL) {
-		ODP_ERR("Invalid odp_pktio_t handle");
+		ODP_ERR("Invalid odp_pktio_t handle\n");
 		return -1;
 	}
 	cos = get_cos_entry(default_cos);
 	if (cos == NULL) {
-		ODP_ERR("Invalid odp_cos_t handle");
+		ODP_ERR("Invalid odp_cos_t handle\n");
 		return -1;
 	}
 
@@ -457,13 +457,13 @@ int odp_pktio_error_cos_set(odp_pktio_t pktio_in, odp_cos_t error_cos)
 
 	entry = get_pktio_entry(pktio_in);
 	if (entry == NULL) {
-		ODP_ERR("Invalid odp_pktio_t handle");
+		ODP_ERR("Invalid odp_pktio_t handle\n");
 		return -1;
 	}
 
 	cos = get_cos_entry(error_cos);
 	if (cos == NULL) {
-		ODP_ERR("Invalid odp_cos_t handle");
+		ODP_ERR("Invalid odp_cos_t handle\n");
 		return -1;
 	}
 
@@ -489,7 +489,7 @@ int odp_pktio_headroom_set(odp_pktio_t pktio_in, uint32_t headroom)
 	pktio_entry_t *entry = get_pktio_entry(pktio_in);
 
 	if (entry == NULL) {
-		ODP_ERR("Invalid odp_pktio_t handle");
+		ODP_ERR("Invalid odp_pktio_t handle\n");
 		return -1;
 	}
 	entry->s.cls.headroom = headroom;
@@ -507,7 +507,7 @@ int odp_cos_with_l2_priority(odp_pktio_t pktio_in,
 	pktio_entry_t *entry = get_pktio_entry(pktio_in);
 
 	if (entry == NULL) {
-		ODP_ERR("Invalid odp_pktio_t handle");
+		ODP_ERR("Invalid odp_pktio_t handle\n");
 		return -1;
 	}
 	l2_cos = &entry->s.cls.l2_cos_table;
@@ -537,7 +537,7 @@ int odp_cos_with_l3_qos(odp_pktio_t pktio_in,
 	cos_t *cos;
 
 	if (entry == NULL) {
-		ODP_ERR("Invalid odp_pktio_t handle");
+		ODP_ERR("Invalid odp_pktio_t handle\n");
 		return -1;
 	}
 
@@ -655,7 +655,7 @@ odp_pmr_t odp_cls_pmr_create(const odp_pmr_param_t *terms, int num_terms,
 	}
 
 	if (num_terms > CLS_PMRTERM_MAX) {
-		ODP_ERR("no of terms greater than supported CLS_PMRTERM_MAX");
+		ODP_ERR("no of terms greater than supported CLS_PMRTERM_MAX\n");
 		return ODP_PMR_INVALID;
 	}
 
@@ -696,7 +696,7 @@ int odp_cls_cos_pool_set(odp_cos_t cos_id, odp_pool_t pool)
 
 	cos = get_cos_entry(cos_id);
 	if (cos == NULL) {
-		ODP_ERR("Invalid odp_cos_t handle");
+		ODP_ERR("Invalid odp_cos_t handle\n");
 		return -1;
 	}
 
@@ -711,7 +711,7 @@ odp_pool_t odp_cls_cos_pool(odp_cos_t cos_id)
 
 	cos = get_cos_entry(cos_id);
 	if (cos == NULL) {
-		ODP_ERR("Invalid odp_cos_t handle");
+		ODP_ERR("Invalid odp_cos_t handle\n");
 		return ODP_POOL_INVALID;
 	}
 

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -832,6 +832,9 @@ int verify_pmr(pmr_t *pmr, const uint8_t *pkt_addr, odp_packet_hdr_t *pkt_hdr)
 			break;
 		case ODP_PMR_INNER_HDR_OFF:
 			break;
+		default:
+			pmr_failure = 1;
+			break;
 		}
 
 		if (pmr_failure)

--- a/test/common/odp_cunit_common.h
+++ b/test/common/odp_cunit_common.h
@@ -103,5 +103,6 @@ void odp_cunit_register_global_init(int (*func_init_ptr)(odp_instance_t *inst));
 void odp_cunit_register_global_term(int (*func_term_ptr)(odp_instance_t inst));
 
 int odp_cunit_ret(int val);
+int odp_cunit_print_inactive(void);
 
 #endif /* ODP_CUNICT_COMMON_H */

--- a/test/validation/api/classification/odp_classification_tests.c
+++ b/test/validation/api/classification/odp_classification_tests.c
@@ -137,6 +137,9 @@ int classification_suite_term(void)
 			odp_pool_destroy(pool_list[i]);
 	}
 
+	if (odp_cunit_print_inactive())
+		retcode = -1;
+
 	return retcode;
 }
 

--- a/test/validation/api/comp/comp.c
+++ b/test/validation/api/comp/comp.c
@@ -455,33 +455,15 @@ static odp_testinfo_t comp_suite[] = {
 	ODP_TEST_INFO_NULL,
 };
 
-static int comp_suite_term(void)
-{
-	int i;
-	int first = 1;
-
-	for (i = 0; comp_suite[i].name; i++) {
-		if (comp_suite[i].check_active &&
-		    comp_suite[i].check_active() == ODP_TEST_INACTIVE) {
-			if (first) {
-				first = 0;
-				printf("\n\n  Inactive tests:\n");
-			}
-			printf("    %s\n", comp_suite[i].name);
-		}
-	}
-	return 0;
-}
-
 /* Suite names */
 #define ODP_COMP_SYNC_TEST	"Comp/decomp sync test"
 #define ODP_COMP_ASYNC_TEST	"Comp/decomp async test"
 
 static odp_suiteinfo_t comp_suites[] = {
 	{ODP_COMP_SYNC_TEST, comp_suite_sync_init,
-	 comp_suite_term, comp_suite},
+	 NULL, comp_suite},
 	{ODP_COMP_ASYNC_TEST, comp_suite_async_init,
-	 comp_suite_term, comp_suite},
+	 NULL, comp_suite},
 	ODP_SUITE_INFO_NULL,
 };
 

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -2664,24 +2664,6 @@ odp_testinfo_t crypto_suite[] = {
 	ODP_TEST_INFO_NULL,
 };
 
-static int crypto_suite_term(void)
-{
-	int i;
-	int first = 1;
-
-	for (i = 0; crypto_suite[i].name; i++) {
-		if (crypto_suite[i].check_active &&
-		    crypto_suite[i].check_active() == ODP_TEST_INACTIVE) {
-			if (first) {
-				first = 0;
-				printf("\n\n  Inactive tests:\n");
-			}
-			printf("    %s\n", crypto_suite[i].name);
-		}
-	}
-	return 0;
-}
-
 /* Suite names */
 #define ODP_CRYPTO_SYNC_INP         "odp_crypto_sync_inp"
 #define ODP_CRYPTO_ASYNC_INP        "odp_crypto_async_inp"
@@ -2690,13 +2672,13 @@ static int crypto_suite_term(void)
 
 odp_suiteinfo_t crypto_suites[] = {
 	{ODP_CRYPTO_SYNC_INP, crypto_suite_sync_init,
-	 crypto_suite_term, crypto_suite},
+	 NULL, crypto_suite},
 	{ODP_CRYPTO_ASYNC_INP, crypto_suite_async_init,
-	 crypto_suite_term, crypto_suite},
+	 NULL, crypto_suite},
 	{ODP_CRYPTO_PACKET_SYNC_INP, crypto_suite_packet_sync_init,
-	 crypto_suite_term, crypto_suite},
+	 NULL, crypto_suite},
 	{ODP_CRYPTO_PACKET_ASYNC_INP, crypto_suite_packet_async_init,
-	 crypto_suite_term, crypto_suite},
+	 NULL, crypto_suite},
 	ODP_SUITE_INFO_NULL,
 };
 

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -883,36 +883,25 @@ int ipsec_suite_init(void)
 	return rc < 0 ? -1 : 0;
 }
 
-static int ipsec_suite_term(odp_testinfo_t *suite)
+static int ipsec_suite_term(void)
 {
-	int i;
-	int first = 1;
-
 	if (suite_context.pktio != ODP_PKTIO_INVALID)
 		pktio_stop(suite_context.pktio);
 
-	for (i = 0; suite[i].name; i++) {
-		if (suite[i].check_active &&
-		    suite[i].check_active() == ODP_TEST_INACTIVE) {
-			if (first) {
-				first = 0;
-				printf("\n\n  Inactive tests:\n");
-			}
-			printf("    %s\n", suite[i].name);
-		}
-	}
+	if (odp_cunit_print_inactive())
+		return -1;
 
 	return 0;
 }
 
 int ipsec_in_term(void)
 {
-	return ipsec_suite_term(ipsec_in_suite);
+	return ipsec_suite_term();
 }
 
 int ipsec_out_term(void)
 {
-	return ipsec_suite_term(ipsec_out_suite);
+	return ipsec_suite_term();
 }
 
 int ipsec_init(odp_instance_t *inst)

--- a/test/validation/api/pktio/parser.c
+++ b/test/validation/api/pktio/parser.c
@@ -577,6 +577,9 @@ int parser_suite_term(void)
 		ret = -1;
 	}
 
+	if (odp_cunit_print_inactive())
+		ret = -1;
+
 	return ret;
 }
 

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -2830,6 +2830,9 @@ static int pktio_suite_term(void)
 	}
 	default_pkt_pool = ODP_POOL_INVALID;
 
+	if (odp_cunit_print_inactive())
+		ret = -1;
+
 	return ret;
 }
 

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -2135,6 +2135,9 @@ static int scheduler_suite_term(void)
 	if (odp_shm_free(shm) != 0)
 		fprintf(stderr, "error: failed to free shm\n");
 
+	if (odp_cunit_print_inactive())
+		return -1;
+
 	return 0;
 }
 

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -2104,6 +2104,9 @@ static int traffic_mngr_suite_term(void)
 			return -1;
 	}
 
+	if (odp_cunit_print_inactive())
+		return -1;
+
 	return 0;
 }
 


### PR DESCRIPTION
Clean up classifier and validation test code before adding new CUSTOM_L3 PMR rule into API. Classifier implementation missed reporting some capabilities, tests didn't check those capabilities and they were tested. Source IPv4 term test was missing. Also improved test result output when some tests are inactive (skipped due to missing capability). Now inactive tests are listed by default in test suite results.