### PR TITLE
[PATCH v2] linux-gen: packet: reimplement segmentation using linked list

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.8"
+config_file_version = "0.1.9"
 
 # Shared memory options
 shm: {
@@ -69,6 +69,9 @@ pktio_dpdk: {
 	num_rx_desc = 128
 	num_tx_desc = 512
 	rx_drop_en = 0
+
+	# Store RX RSS hash result as ODP flow hash
+	set_flow_hash = 0
 
 	# Driver specific options (use PMD names from DPDK)
 	net_ixgbe: {

--- a/platform/linux-generic/include-abi/odp/api/abi/packet.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -30,22 +31,11 @@ typedef ODP_HANDLE_T(odp_packet_t);
 
 #define ODP_PACKET_OFFSET_INVALID 0xffff
 
-typedef uint8_t odp_packet_seg_t;
+typedef ODP_HANDLE_T(odp_packet_seg_t);
 
-/* or it will be provided by packet_inlines.h */
-#define _ODP_HAVE_PACKET_SEG_NDX	1
+#define ODP_PACKET_SEG_INVALID _odp_cast_scalar(odp_packet_seg_t, 0)
 
-static inline uint8_t _odp_packet_seg_to_ndx(odp_packet_seg_t seg)
-{
-	return (uint8_t)seg;
-}
-
-static inline odp_packet_seg_t _odp_packet_seg_from_ndx(uint8_t ndx)
-{
-	return (odp_packet_seg_t)ndx;
-}
-
-#define ODP_PACKET_SEG_INVALID ((odp_packet_seg_t)-1)
+#define ODP_PACKET_OFFSET_INVALID 0xffff
 
 typedef uint8_t odp_proto_l2_type_t;
 

--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -28,14 +29,14 @@ extern "C" {
 
 /* Packet header field offsets for inline functions */
 typedef struct _odp_packet_inline_offset_t {
-	uint16_t data;
+	uint16_t seg_data;
 	uint16_t seg_len;
 	uint16_t frame_len;
 	uint16_t headroom;
 	uint16_t tailroom;
 	uint16_t pool;
 	uint16_t input;
-	uint16_t segcount;
+	uint16_t seg_count;
 	uint16_t user_ptr;
 	uint16_t user_area;
 	uint16_t l2_offset;

--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -31,6 +31,7 @@ extern "C" {
 typedef struct _odp_packet_inline_offset_t {
 	uint16_t seg_data;
 	uint16_t seg_len;
+	uint16_t seg_next;
 	uint16_t frame_len;
 	uint16_t headroom;
 	uint16_t tailroom;

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -57,6 +57,9 @@
 	#define odp_packet_head __odp_packet_head
 	#define odp_packet_is_segmented __odp_packet_is_segmented
 	#define odp_packet_first_seg __odp_packet_first_seg
+	#define odp_packet_seg_data __odp_packet_seg_data
+	#define odp_packet_seg_data_len __odp_packet_seg_data_len
+	#define odp_packet_next_seg __odp_packet_next_seg
 	#define odp_packet_prefetch __odp_packet_prefetch
 	#define odp_packet_copy_from_mem __odp_packet_copy_from_mem
 	#define odp_packet_copy_to_mem __odp_packet_copy_to_mem
@@ -254,6 +257,29 @@ _ODP_INLINE int odp_packet_is_segmented(odp_packet_t pkt)
 _ODP_INLINE odp_packet_seg_t odp_packet_first_seg(odp_packet_t pkt)
 {
 	return (odp_packet_seg_t)pkt;
+}
+
+_ODP_INLINE void *odp_packet_seg_data(odp_packet_t pkt ODP_UNUSED,
+				      odp_packet_seg_t seg)
+{
+	return _odp_pkt_get((odp_packet_t)seg, void *, seg_data);
+}
+
+_ODP_INLINE uint32_t odp_packet_seg_data_len(odp_packet_t pkt ODP_UNUSED,
+					     odp_packet_seg_t seg)
+{
+	return _odp_pkt_get((odp_packet_t)seg, uint32_t, seg_len);
+}
+
+_ODP_INLINE odp_packet_seg_t odp_packet_next_seg(odp_packet_t pkt ODP_UNUSED,
+						 odp_packet_seg_t seg)
+{
+	void *next_seg = _odp_pkt_get((odp_packet_t)seg, void *, seg_next);
+
+	if (odp_unlikely(next_seg == NULL))
+		return ODP_PACKET_SEG_INVALID;
+
+	return (odp_packet_seg_t)next_seg;
 }
 
 _ODP_INLINE void odp_packet_prefetch(odp_packet_t pkt, uint32_t offset,

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2017-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -56,8 +57,6 @@
 	#define odp_packet_head __odp_packet_head
 	#define odp_packet_is_segmented __odp_packet_is_segmented
 	#define odp_packet_first_seg __odp_packet_first_seg
-	#define odp_packet_last_seg __odp_packet_last_seg
-	#define odp_packet_next_seg __odp_packet_next_seg
 	#define odp_packet_prefetch __odp_packet_prefetch
 	#define odp_packet_copy_from_mem __odp_packet_copy_from_mem
 	#define odp_packet_copy_to_mem __odp_packet_copy_to_mem
@@ -72,7 +71,7 @@
 #endif
 
 void *_odp_packet_map(void *pkt_ptr, uint32_t offset, uint32_t *seg_len,
-		      int *seg_idx);
+		      odp_packet_seg_t *seg);
 
 int _odp_packet_copy_from_mem_seg(odp_packet_t pkt, uint32_t offset,
 				  uint32_t len, const void *src);
@@ -83,22 +82,9 @@ int _odp_packet_copy_to_mem_seg(odp_packet_t pkt, uint32_t offset,
 extern const _odp_packet_inline_offset_t _odp_packet_inline;
 extern const _odp_pool_inline_offset_t   _odp_pool_inline;
 
-#ifndef _ODP_HAVE_PACKET_SEG_NDX
-#include <odp/api/plat/strong_types.h>
-static inline uint32_t _odp_packet_seg_to_ndx(odp_packet_seg_t seg)
-{
-	return _odp_typeval(seg) - 1;
-}
-
-static inline odp_packet_seg_t _odp_packet_seg_from_ndx(uint32_t ndx)
-{
-	return _odp_cast_scalar(odp_packet_seg_t, ndx + 1);
-}
-#endif
-
 _ODP_INLINE void *odp_packet_data(odp_packet_t pkt)
 {
-	return _odp_pkt_get(pkt, void *, data);
+	return _odp_pkt_get(pkt, void *, seg_data);
 }
 
 _ODP_INLINE uint32_t odp_packet_seg_len(odp_packet_t pkt)
@@ -149,7 +135,7 @@ _ODP_INLINE int odp_packet_input_index(odp_packet_t pkt)
 
 _ODP_INLINE int odp_packet_num_segs(odp_packet_t pkt)
 {
-	return _odp_pkt_get(pkt, uint8_t, segcount);
+	return _odp_pkt_get(pkt, uint8_t, seg_count);
 }
 
 _ODP_INLINE void *odp_packet_user_ptr(odp_packet_t pkt)
@@ -262,29 +248,12 @@ _ODP_INLINE void *odp_packet_head(odp_packet_t pkt)
 
 _ODP_INLINE int odp_packet_is_segmented(odp_packet_t pkt)
 {
-	return _odp_pkt_get(pkt, uint8_t, segcount) > 1;
+	return _odp_pkt_get(pkt, uint8_t, seg_count) > 1;
 }
 
 _ODP_INLINE odp_packet_seg_t odp_packet_first_seg(odp_packet_t pkt)
 {
-	(void)pkt;
-
-	return _odp_packet_seg_from_ndx(0);
-}
-
-_ODP_INLINE odp_packet_seg_t odp_packet_last_seg(odp_packet_t pkt)
-{
-	return _odp_packet_seg_from_ndx(odp_packet_num_segs(pkt) - 1);
-}
-
-_ODP_INLINE odp_packet_seg_t odp_packet_next_seg(odp_packet_t pkt,
-						    odp_packet_seg_t seg)
-{
-	if (odp_unlikely(_odp_packet_seg_to_ndx(seg) >=
-			 _odp_packet_seg_to_ndx(odp_packet_last_seg(pkt))))
-		return ODP_PACKET_SEG_INVALID;
-
-	return seg + 1;
+	return (odp_packet_seg_t)pkt;
 }
 
 _ODP_INLINE void odp_packet_prefetch(odp_packet_t pkt, uint32_t offset,

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -32,12 +33,6 @@ extern "C" {
 #include <odp_schedule_if.h>
 #include <stddef.h>
 
-typedef struct seg_entry_t {
-	void     *hdr;
-	uint8_t  *data;
-	uint32_t  len;
-} seg_entry_t;
-
 typedef union buffer_index_t {
 	uint32_t u32;
 
@@ -58,46 +53,14 @@ ODP_STATIC_ASSERT(CONFIG_POOL_MAX_NUM <= (0xFFFFFF + 1), "TOO_LARGE_POOL");
 
 /* Common buffer header */
 struct ODP_ALIGNED_CACHE odp_buffer_hdr_t {
-	/* Combined pool and buffer index */
-	buffer_index_t index;
-
-	/* Total segment count */
-	uint16_t  segcount;
-
-	/* Pool type */
-	int8_t    type;
-
-	/* Number of seg[] entries used */
-	uint8_t   num_seg;
-
-	/* Next header which continues the segment list */
-	void *next_seg;
-
-	/* Last header of the segment list */
-	void *last_seg;
-
 	/* Initial buffer data pointer */
 	uint8_t  *base_data;
 
 	/* Pool pointer */
-	void *pool_ptr;
-
-	/* --- 40 bytes --- */
-
-	/* Segments */
-	seg_entry_t seg[CONFIG_PACKET_SEGS_PER_HDR];
+	void     *pool_ptr;
 
 	/* --- Mostly read only data --- */
 	const void *user_ptr;
-
-	/* Reference count */
-	odp_atomic_u32_t ref_cnt;
-
-	/* Event type. Maybe different than pool type (crypto compl event) */
-	int8_t    event_type;
-
-	/* Event flow id */
-	uint8_t   flow_id;
 
 	/* Initial buffer tail pointer */
 	uint8_t  *buf_end;
@@ -109,12 +72,24 @@ struct ODP_ALIGNED_CACHE odp_buffer_hdr_t {
 	 * offset has to be used */
 	uint64_t ipc_data_offset;
 
+	/* Combined pool and buffer index */
+	buffer_index_t index;
+
+	/* Reference count */
+	odp_atomic_u32_t ref_cnt;
+
+	/* Pool type */
+	int8_t    type;
+
+	/* Event type. Maybe different than pool type (crypto compl event) */
+	int8_t    event_type;
+
+	/* Event flow id */
+	uint8_t   flow_id;
+
 	/* Data or next header */
 	uint8_t data[0];
 };
-
-ODP_STATIC_ASSERT(CONFIG_PACKET_SEGS_PER_HDR < 256,
-		  "CONFIG_PACKET_SEGS_PER_HDR_TOO_LARGE");
 
 odp_event_type_t _odp_buffer_event_type(odp_buffer_t buf);
 void _odp_buffer_event_type_set(odp_buffer_t buf, int ev);

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2016-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -87,21 +88,6 @@ extern "C" {
  * consider any unused portion of the last segment of a packet as tailroom
  */
 #define CONFIG_PACKET_TAILROOM 0
-
-/*
- * Maximum number of segments per packet
- */
-#define CONFIG_PACKET_MAX_SEGS 255
-
-/*
- * Packet segmentation disabled
- */
-#define CONFIG_PACKET_SEG_DISABLED (CONFIG_PACKET_MAX_SEGS == 1)
-
-/*
- * Number of segments stored in a packet header
- */
-#define CONFIG_PACKET_SEGS_PER_HDR 6
 
 /*
  * Maximum packet data length in bytes

--- a/platform/linux-generic/include/odp_packet_dpdk.h
+++ b/platform/linux-generic/include/odp_packet_dpdk.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2016-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -51,8 +52,8 @@ static inline int _odp_dpdk_packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
 					       uint32_t supported_ptypes,
 					       odp_pktin_config_opt_t pktin_cfg)
 {
-	uint32_t seg_len = pkt_hdr->buf_hdr.seg[0].len;
-	void *base = pkt_hdr->buf_hdr.seg[0].data;
+	uint32_t seg_len = pkt_hdr->seg_len;
+	void *base = pkt_hdr->seg_data;
 
 	return _odp_dpdk_packet_parse_common(&pkt_hdr->p, base,
 					     pkt_hdr->frame_len, seg_len, mbuf,

--- a/platform/linux-generic/odp_buffer.c
+++ b/platform/linux-generic/odp_buffer.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -38,7 +39,7 @@ void *odp_buffer_addr(odp_buffer_t buf)
 {
 	odp_buffer_hdr_t *hdr = buf_hdl_to_hdr(buf);
 
-	return hdr->seg[0].data;
+	return hdr->base_data;
 }
 
 uint32_t odp_buffer_size(odp_buffer_t buf)
@@ -69,7 +70,7 @@ int odp_buffer_snprint(char *str, uint32_t n, odp_buffer_t buf)
 			"  pool         %" PRIu64 "\n",
 			odp_pool_to_u64(pool->pool_hdl));
 	len += snprintf(&str[len], n - len,
-			"  addr         %p\n",          hdr->seg[0].data);
+			"  addr         %p\n",          hdr->base_data);
 	len += snprintf(&str[len], n - len,
 			"  size         %" PRIu32 "\n", odp_buffer_size(buf));
 	len += snprintf(&str[len], n - len,

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -792,11 +792,16 @@ int odp_packet_reset(odp_packet_t pkt, uint32_t len)
 	odp_packet_hdr_t *const pkt_hdr = packet_hdr(pkt);
 	pool_t *pool = pkt_hdr->buf_hdr.pool_ptr;
 	int num = pkt_hdr->seg_count;
+	int num_req;
 
 	if (odp_unlikely(len > (pool->seg_len * num)))
 		return -1;
 
-	reset_seg(pkt_hdr, num);
+	/* Free possible extra segments */
+	num_req = num_segments(len, pool->seg_len);
+	if (odp_unlikely(num_req < num))
+		free_segments(pkt_hdr, num - num_req, 0, 0, 0);
+	reset_seg(pkt_hdr, num_req);
 
 	packet_init(pkt_hdr, len);
 

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1533,6 +1533,11 @@ int odp_packet_concat(odp_packet_t *dst, odp_packet_t src)
 
 	ODP_ASSERT(odp_packet_has_ref(*dst) == 0);
 
+	if (odp_unlikely(dst_len + src_len > dst_pool->max_len)) {
+		ODP_ERR("concat would result oversized packet\n");
+		return -1;
+	}
+
 	/* Do a copy if packets are from different pools. */
 	if (odp_unlikely(dst_pool != src_pool)) {
 		if (odp_packet_extend_tail(dst, src_len, NULL, NULL) >= 0) {

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -38,6 +38,7 @@
 const _odp_packet_inline_offset_t ODP_ALIGNED_CACHE _odp_packet_inline = {
 	.seg_data       = offsetof(odp_packet_hdr_t, seg_data),
 	.seg_len        = offsetof(odp_packet_hdr_t, seg_len),
+	.seg_next       = offsetof(odp_packet_hdr_t, seg_next),
 	.frame_len      = offsetof(odp_packet_hdr_t, frame_len),
 	.headroom       = offsetof(odp_packet_hdr_t, headroom),
 	.tailroom       = offsetof(odp_packet_hdr_t, tailroom),
@@ -1194,35 +1195,9 @@ void odp_packet_ts_set(odp_packet_t pkt, odp_time_t timestamp)
  *
  */
 
-void *odp_packet_seg_data(odp_packet_t pkt ODP_UNUSED, odp_packet_seg_t seg)
-{
-	odp_packet_hdr_t *seg_hdr = packet_seg_to_hdr(seg);
-
-	return seg_hdr->seg_data;
-}
-
-uint32_t odp_packet_seg_data_len(odp_packet_t pkt ODP_UNUSED,
-				 odp_packet_seg_t seg)
-{
-	odp_packet_hdr_t *seg_hdr = packet_seg_to_hdr(seg);
-
-	return seg_hdr->seg_len;
-}
-
 odp_packet_seg_t odp_packet_last_seg(odp_packet_t pkt)
 {
 	return (odp_packet_seg_t)packet_last_seg(packet_hdr(pkt));
-}
-
-odp_packet_seg_t odp_packet_next_seg(odp_packet_t pkt ODP_UNUSED,
-				     odp_packet_seg_t seg)
-{
-	odp_packet_hdr_t *pkt_hdr = packet_seg_to_hdr(seg);
-
-	if (odp_unlikely(pkt_hdr->seg_next == NULL))
-		return ODP_PACKET_SEG_INVALID;
-
-	return (odp_packet_seg_t)pkt_hdr->seg_next;
 }
 
 /*

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -894,6 +894,9 @@ int odp_packet_extend_head(odp_packet_t *pkt, uint32_t len,
 			return -1;
 
 		num = num_segments(len - headroom, pool->seg_len);
+		if (odp_unlikely(pkt_hdr->seg_count + num > PKT_MAX_SEGS))
+			return -1;
+
 		push_head(pkt_hdr, headroom);
 		ptr = add_segments(pkt_hdr, pool, len - headroom, num, 1);
 
@@ -1000,6 +1003,9 @@ int odp_packet_extend_tail(odp_packet_t *pkt, uint32_t len,
 			return -1;
 
 		num = num_segments(len - tailroom, pool->seg_len);
+		if (odp_unlikely(pkt_hdr->seg_count + num > PKT_MAX_SEGS))
+			return -1;
+
 		push_tail(pkt_hdr, tailroom);
 		ptr = add_segments(pkt_hdr, pool, len - tailroom, num, 0);
 
@@ -1355,6 +1361,10 @@ int odp_packet_concat(odp_packet_t *dst, odp_packet_t src)
 
 		return -1;
 	}
+
+	if (odp_unlikely(dst_hdr->seg_count + src_hdr->seg_count >
+			 PKT_MAX_SEGS))
+		return -1;
 
 	add_all_segs(dst_hdr, src_hdr);
 

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -1,5 +1,5 @@
-/* Copyright (c) 2019, Nokia
- * Copyright (c) 2013-2018, Linaro Limited
+/* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -410,20 +410,19 @@ static void init_buffers(pool_t *pool)
 		buf_hdr->event_type = type;
 		buf_hdr->pool_ptr = pool;
 		buf_hdr->uarea_addr = uarea;
-		buf_hdr->segcount = 1;
-		buf_hdr->num_seg  = 1;
-		buf_hdr->next_seg = NULL;
-		buf_hdr->last_seg = buf_hdr;
 
-		/* Pointer to data start (of the first segment) */
-		buf_hdr->seg[0].hdr       = buf_hdr;
-		buf_hdr->seg[0].data      = &data[offset];
-		buf_hdr->seg[0].len       = pool->seg_len;
+		/* Initialize segmentation metadata */
+		if (type == ODP_POOL_PACKET) {
+			pkt_hdr->seg_data = &data[offset];
+			pkt_hdr->seg_len  = pool->seg_len;
+			pkt_hdr->seg_count = 1;
+			pkt_hdr->seg_next = NULL;
+		}
 
 		odp_atomic_init_u32(&buf_hdr->ref_cnt, 0);
 
 		/* Store base values for fast init */
-		buf_hdr->base_data = buf_hdr->seg[0].data;
+		buf_hdr->base_data = &data[offset];
 		buf_hdr->buf_end   = &data[offset + pool->seg_len +
 				     pool->tailroom];
 
@@ -512,9 +511,8 @@ static odp_pool_t pool_create(const char *name, odp_pool_param_t *params,
 		 * pool. */
 		if (params->pkt.max_len != 0)
 			max_len = params->pkt.max_len;
-		if ((max_len + seg_len - 1) / seg_len > CONFIG_PACKET_MAX_SEGS)
-			seg_len = (max_len + CONFIG_PACKET_MAX_SEGS - 1) /
-				CONFIG_PACKET_MAX_SEGS;
+		if ((max_len + seg_len - 1) / seg_len > PKT_MAX_SEGS)
+			seg_len = (max_len + PKT_MAX_SEGS - 1) / PKT_MAX_SEGS;
 		if (seg_len > CONFIG_PACKET_MAX_SEG_LEN) {
 			ODP_ERR("Pool unable to store 'max_len' packet");
 			return ODP_POOL_INVALID;
@@ -1068,7 +1066,7 @@ int odp_pool_capability(odp_pool_capability_t *capa)
 	capa->pkt.min_headroom     = CONFIG_PACKET_HEADROOM;
 	capa->pkt.max_headroom     = CONFIG_PACKET_HEADROOM;
 	capa->pkt.min_tailroom     = CONFIG_PACKET_TAILROOM;
-	capa->pkt.max_segs_per_pkt = CONFIG_PACKET_MAX_SEGS;
+	capa->pkt.max_segs_per_pkt = PKT_MAX_SEGS;
 	capa->pkt.min_seg_len      = CONFIG_PACKET_SEG_LEN_MIN;
 	capa->pkt.max_seg_len      = max_seg_len;
 	capa->pkt.max_uarea_size   = MAX_SIZE;

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -804,7 +804,7 @@ static inline void prefetch_pkt(struct rte_mbuf *mbuf)
 	void *data = rte_pktmbuf_mtod(mbuf, char *);
 
 	odp_prefetch(pkt_hdr);
-	odp_prefetch(&pkt_hdr->p);
+	odp_prefetch_store((uint8_t *)pkt_hdr + ODP_CACHE_LINE_SIZE);
 	odp_prefetch(data);
 }
 
@@ -920,6 +920,7 @@ static inline int pkt_to_mbuf_zero(pktio_entry_t *pktio_entry,
 	odp_pktout_config_opt_t *pktout_cfg = &pktio_entry->s.config.pktout;
 	odp_pktout_config_opt_t *pktout_capa =
 		&pktio_entry->s.capa.config.pktout;
+	uint16_t mtu = pkt_dpdk->mtu;
 	int i;
 	*copy_count = 0;
 
@@ -929,7 +930,7 @@ static inline int pkt_to_mbuf_zero(pktio_entry_t *pktio_entry,
 		struct rte_mbuf *mbuf = mbuf_from_pkt_hdr(pkt_hdr);
 		uint16_t pkt_len = odp_packet_len(pkt);
 
-		if (odp_unlikely(pkt_len > pkt_dpdk->mtu))
+		if (odp_unlikely(pkt_len > mtu))
 			goto fail;
 
 		if (odp_likely(pkt_hdr->seg_count == 1)) {

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -685,7 +685,7 @@ static int ipc_pktio_send_lockless(pktio_entry_t *pktio_entry,
 
 		offsets[i] = (uint8_t *)pkt_hdr -
 			     (uint8_t *)odp_shm_addr(pool->shm);
-		data_pool_off = (uint8_t *)pkt_hdr->buf_hdr.seg[0].data -
+		data_pool_off = (uint8_t *)pkt_hdr->seg_data -
 				(uint8_t *)odp_shm_addr(pool->shm);
 
 		/* compile all function code even if ipc disabled with config */

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -216,7 +216,7 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	odp_time_t *ts = NULL;
 	const int sockfd = pkt_sock->sockfd;
 	struct mmsghdr msgvec[num];
-	struct iovec iovecs[num][CONFIG_PACKET_MAX_SEGS];
+	struct iovec iovecs[num][PKT_MAX_SEGS];
 	int nb_rx = 0;
 	int nb_pkts;
 	int recv_msgs;
@@ -421,7 +421,7 @@ static int sock_mmsg_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 {
 	pkt_sock_t *pkt_sock = pkt_priv(pktio_entry);
 	struct mmsghdr msgvec[num];
-	struct iovec iovecs[num][CONFIG_PACKET_MAX_SEGS];
+	struct iovec iovecs[num][PKT_MAX_SEGS];
 	int ret;
 	int sockfd = pkt_sock->sockfd;
 	int i;

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.8"
+config_file_version = "0.1.9"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.8"
+config_file_version = "0.1.9"
 
 # Shared memory options
 shm: {

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:	BSD-3-Clause
@@ -1383,7 +1384,8 @@ static void packet_test_copy(void)
 	odp_packet_t pkt;
 	odp_packet_t pkt_copy, pkt_part;
 	odp_pool_t pool;
-	uint32_t i, plen, seg_len, src_offset, dst_offset;
+	uint32_t i, plen, src_offset, dst_offset;
+	uint32_t seg_len = 0;
 	void *pkt_data;
 
 	pkt = odp_packet_copy(test_packet, packet_pool_no_uarea);
@@ -1462,7 +1464,7 @@ static void packet_test_copy(void)
 
 	/* Test segment crossing if we support segments */
 	pkt_data = odp_packet_offset(pkt, 0, &seg_len, NULL);
-	CU_ASSERT(pkt_data != NULL);
+	CU_ASSERT_FATAL(pkt_data != NULL);
 
 	if (seg_len < plen) {
 		src_offset = seg_len - 15;
@@ -2166,7 +2168,8 @@ static void packet_test_extend_ref(void)
 static void packet_test_align(void)
 {
 	odp_packet_t pkt;
-	uint32_t pkt_len, seg_len, offset, aligned_seglen;
+	uint32_t pkt_len, offset;
+	uint32_t seg_len = 0, aligned_seglen = 0;
 	void *pkt_data, *aligned_data;
 	const uint32_t max_align = 32;
 
@@ -2224,7 +2227,8 @@ static void packet_test_align(void)
 static void packet_test_offset(void)
 {
 	odp_packet_t pkt = test_packet;
-	uint32_t seg_len, full_seg_len;
+	uint32_t seg_len = 0;
+	uint32_t full_seg_len;
 	uint8_t *ptr, *start_ptr;
 	uint32_t offset;
 	odp_packet_seg_t seg = ODP_PACKET_SEG_INVALID;


### PR DESCRIPTION
Packet segmentation has been reimplemented using a linked list. The new
implementation is more simple and has the added benefit of reducing
packet and buffer header sizes:
    odp_packet_hdr_t: 384B -> 256B
    odp_buffer_hdr_t: 256B -> 64B

The dynamic packet reference implementation has been temporarily downgraded
to a simple packet copy.
