### PR TITLE
[PATCH v1] travis: add em-odp build test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -332,6 +332,16 @@ jobs:
                               ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/build_${ARCH}.sh
                 - stage: test
                   canfail: yes
+                  env: TEST=em-odp
+                  install:
+                          - true
+                  script:
+                          - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
+                          - docker run -i -t -v `pwd`:/odp --shm-size 8g
+                              -e CC="${CC}"
+                              ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/build_em-odp.sh
+                - stage: test
+                  canfail: yes
                   env: TEST=checkpatch
                   compiler: gcc
                   install:

--- a/scripts/ci/build_em-odp.sh
+++ b/scripts/ci/build_em-odp.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"/../..
+./bootstrap
+./configure \
+	--host=${TARGET_ARCH} --build=x86_64-linux-gnu \
+	--prefix=/opt/odp \
+	--enable-dpdk \
+	--without-examples \
+	--without-tests \
+	${CONF}
+
+make -j $(nproc)
+make install
+
+pushd ${HOME}
+git clone --depth 1 https://github.com/openeventmachine/em-odp.git
+cd em-odp
+./bootstrap
+./configure \
+	--host=${TARGET_ARCH} --build=x86_64-linux-gnu \
+	--prefix=/opt/em-odp \
+	--with-odp-path=/opt/odp
+make -j $(nproc)
+make install
+popd


### PR DESCRIPTION
Add EM-ODP project build test. The test is allowed to fail since ODP API
changes have to be ported into EM-ODP project.

Signed-off-by: Matias Elo <matias.elo@nokia.com>