### PR TITLE
[PATCH v2] Timer control thread poll configure option

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.9"
+config_file_version = "0.1.10"
 
 # Shared memory options
 shm: {
@@ -148,18 +148,21 @@ timer: {
 	# Use inline timer implementation
 	#
 	# By default, timer processing is done in background threads (thread per
-	# timer pool). With inline implementation timers are processed on worker
-	# cores instead. When using inline timers the application has to call
-	# odp_schedule() or odp_queue_deq() to actuate timer processing.
+	# timer pool). With inline implementation timers are processed by ODP
+	# application threads instead. When using inline timers the application
+	# has to call odp_schedule() or odp_queue_deq() regularly to actuate
+	# timer processing.
 	#
-	# Set to 1 to enable
+	# 0: Use POSIX timer and background threads to process timers
+	# 1: Use inline timer implementation and application threads to process
+	#    timers
 	inline = 0
 
 	# Inline timer poll interval
 	#
 	# When set to 1 inline timers are polled during every schedule round.
 	# Increasing the value reduces timer processing overhead while
-	# decreasing accuracy. Ignored when inline timer is not enabled.
+	# decreasing accuracy. Ignored when inline timer is not used.
 	inline_poll_interval = 10
 
 	# Inline timer poll interval in nanoseconds
@@ -168,6 +171,18 @@ timer: {
 	# inline timer polling rate in nanoseconds. By default, this defines the
 	# maximum rate a thread may poll timers. If a timer pool is created with
 	# a higher resolution than this, the polling rate is increased
-	# accordingly.
+	# accordingly. Ignored when inline timer is not used.
 	inline_poll_interval_nsec = 500000
+
+	# Inline timer use of threads
+	#
+	# Select which thread types process non-private timer pools in inline
+	# timer implementation. Thread type does not affect private timer
+	# pool procesessing, those are always processed by the thread which
+	# created the pool. Ignored when inline timer is not used.
+	#
+	# 0: Both control and worker threads process non-private timer pools
+	# 1: Only worker threads process non-private timer pools
+	# 2: Only control threads process non-private timer pools
+	inline_thread_type = 0
 }

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -226,6 +226,7 @@ typedef struct timer_global_t {
 	odp_bool_t use_inline_timers;
 	int poll_interval;
 	int highest_tp_idx;
+	uint8_t thread_type;
 
 } timer_global_t;
 
@@ -1511,28 +1512,32 @@ int _odp_timer_init_global(const odp_init_t *params)
 	conf_str =  "timer.inline";
 	if (!_odp_libconfig_lookup_int(conf_str, &val)) {
 		ODP_ERR("Config option '%s' not found.\n", conf_str);
-		odp_shm_free(shm);
-		return -1;
+		goto error;
 	}
 	timer_global->use_inline_timers = val;
 
 	conf_str =  "timer.inline_poll_interval";
 	if (!_odp_libconfig_lookup_int(conf_str, &val)) {
 		ODP_ERR("Config option '%s' not found.\n", conf_str);
-		odp_shm_free(shm);
-		return -1;
+		goto error;
 	}
 	timer_global->poll_interval = val;
 
 	conf_str =  "timer.inline_poll_interval_nsec";
 	if (!_odp_libconfig_lookup_int(conf_str, &val)) {
 		ODP_ERR("Config option '%s' not found.\n", conf_str);
-		odp_shm_free(shm);
-		return -1;
+		goto error;
 	}
 	timer_global->poll_interval_nsec = val;
 	timer_global->poll_interval_time =
 		odp_time_global_from_ns(timer_global->poll_interval_nsec);
+
+	conf_str =  "timer.inline_thread_type";
+	if (!_odp_libconfig_lookup_int(conf_str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", conf_str);
+		goto error;
+	}
+	timer_global->thread_type = val;
 
 	if (!timer_global->use_inline_timers) {
 		timer_res_init();
@@ -1540,6 +1545,10 @@ int _odp_timer_init_global(const odp_init_t *params)
 	}
 
 	return 0;
+
+error:
+	odp_shm_free(shm);
+	return -1;
 }
 
 int _odp_timer_term_global(void)

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.9"
+config_file_version = "0.1.10"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.9"
+config_file_version = "0.1.10"
 
 # Shared memory options
 shm: {


### PR DESCRIPTION
Added configure file option for inline timer (inline_thread_type) to select if control threads poll shared timer pools or not. When control threads still poll their private pools. With this user can configure control and worker threads to use separate timer pools. 