### PR TITLE
[PATCH v7] api: packet input set function

### DIFF
--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1508,6 +1508,22 @@ odp_pool_t odp_packet_pool(odp_packet_t pkt);
 odp_pktio_t odp_packet_input(odp_packet_t pkt);
 
 /**
+ * Set packet input interface
+ *
+ * Set packet input interface to a valid packet IO handle or ODP_PKTIO_INVALID.
+ * An application may use this for testing or other purposes, when perception
+ * of the packet input interface need to be changed. The call updates both
+ * input interface handle (odp_packet_input()) and index
+ * (odp_packet_input_index()).
+ *
+ * @param pkt   Packet handle
+ * @param pktio Handle to a valid packet input interface or ODP_PKTIO_INVALID.
+ *              ODP_PKTIO_INVALID indicates that the packet was not received by
+ *              any packet IO interface.
+ */
+void odp_packet_input_set(odp_packet_t pkt, odp_pktio_t pktio);
+
+/**
  * Packet input interface index
  *
  * Returns the index of the packet I/O interface that received the packet, or

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -267,7 +267,18 @@ int packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
 		       odp_proto_chksums_t chksums);
 
 /* Reset parser metadata for a new parse */
-void packet_parse_reset(odp_packet_hdr_t *pkt_hdr);
+static inline void packet_parse_reset(odp_packet_hdr_t *pkt_hdr, int all)
+{
+	pkt_hdr->p.input_flags.all  = 0;
+	pkt_hdr->p.l2_offset        = ODP_PACKET_OFFSET_INVALID;
+	pkt_hdr->p.l3_offset        = ODP_PACKET_OFFSET_INVALID;
+	pkt_hdr->p.l4_offset        = ODP_PACKET_OFFSET_INVALID;
+
+	if (all)
+		pkt_hdr->p.flags.all_flags = 0;
+	else /* Keep user ptr and pktout flags */
+		pkt_hdr->p.flags.all.error = 0;
+}
 
 static inline int packet_hdr_has_l2(odp_packet_hdr_t *pkt_hdr)
 {

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -1415,7 +1415,7 @@ int cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 	uint32_t hash;
 
 	if (parse) {
-		packet_parse_reset(pkt_hdr);
+		packet_parse_reset(pkt_hdr, 1);
 		packet_set_len(pkt_hdr, pkt_len);
 
 		packet_parse_common(&pkt_hdr->p, base, pkt_len, seg_len,

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -778,7 +778,7 @@ static ipsec_sa_t *ipsec_in_single(odp_packet_t pkt,
 	    ODP_IPSEC_MODE_TUNNEL == ipsec_sa->mode) {
 		odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
-		packet_parse_reset(pkt_hdr);
+		packet_parse_reset(pkt_hdr, 0);
 		pkt_hdr->p.l3_offset = state.ip_offset;
 	} else {
 		odp_packet_parse_param_t parse_param;

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -308,16 +308,6 @@ int _odp_packet_copy_to_mem_seg(odp_packet_t pkt, uint32_t offset,
 
 #include <odp/visibility_end.h>
 
-void packet_parse_reset(odp_packet_hdr_t *pkt_hdr)
-{
-	/* Reset parser metadata before new parse */
-	pkt_hdr->p.input_flags.all  = 0;
-	pkt_hdr->p.flags.all.error  = 0;
-	pkt_hdr->p.l2_offset        = ODP_PACKET_OFFSET_INVALID;
-	pkt_hdr->p.l3_offset        = ODP_PACKET_OFFSET_INVALID;
-	pkt_hdr->p.l4_offset        = ODP_PACKET_OFFSET_INVALID;
-}
-
 static inline void link_segments(odp_packet_hdr_t *pkt_hdr[], int num)
 {
 	int cur = 0;
@@ -2633,7 +2623,8 @@ int odp_packet_parse(odp_packet_t pkt, uint32_t offset,
 	if (data == NULL)
 		return -1;
 
-	packet_parse_reset(pkt_hdr);
+	/* Reset parser flags, keep other flags */
+	packet_parse_reset(pkt_hdr, 0);
 
 	if (proto == ODP_PROTO_ETH) {
 		/* Assume valid L2 header, no CRC/FCS check in SW */

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1093,6 +1093,13 @@ void odp_packet_user_ptr_set(odp_packet_t pkt, const void *ptr)
 	pkt_hdr->p.flags.user_ptr_set = 1;
 }
 
+void odp_packet_input_set(odp_packet_t pkt, odp_pktio_t pktio)
+{
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
+
+	pkt_hdr->input = pktio;
+}
+
 int odp_packet_l2_offset_set(odp_packet_t pkt, uint32_t offset)
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -575,7 +575,7 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 		if (pktio_cls_enabled(pktio_entry)) {
 			uint32_t supported_ptypes = pkt_dpdk->supported_ptypes;
 
-			packet_parse_reset(&parsed_hdr);
+			packet_parse_reset(&parsed_hdr, 1);
 			packet_set_len(&parsed_hdr, pkt_len);
 			if (_odp_dpdk_packet_parse_common(&parsed_hdr.p, data,
 							  pkt_len, pkt_len,
@@ -859,7 +859,7 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 		if (pktio_cls_enabled(pktio_entry)) {
 			uint32_t supported_ptypes = pkt_dpdk->supported_ptypes;
 
-			packet_parse_reset(&parsed_hdr);
+			packet_parse_reset(&parsed_hdr, 1);
 			packet_set_len(&parsed_hdr, pkt_len);
 			if (_odp_dpdk_packet_parse_common(&parsed_hdr.p, data,
 							  pkt_len, pkt_len,

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -121,7 +121,7 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 		pkt_len = odp_packet_len(pkt);
 		pkt_hdr = packet_hdr(pkt);
 
-		packet_parse_reset(pkt_hdr);
+		packet_parse_reset(pkt_hdr, 1);
 		if (pktio_cls_enabled(pktio_entry)) {
 			odp_packet_t new_pkt;
 			odp_pool_t new_pool;

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -161,7 +161,9 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 					failed++;
 					continue;
 				}
+
 				pkt = new_pkt;
+				pkt_hdr = packet_hdr(new_pkt);
 			}
 		} else {
 			packet_parse_layer(pkt_hdr,

--- a/test/validation/api/classification/odp_classification_common.c
+++ b/test/validation/api/classification/odp_classification_common.c
@@ -193,8 +193,9 @@ void enqueue_pktio_interface(odp_packet_t pkt, odp_pktio_t pktio)
 odp_packet_t receive_packet(odp_queue_t *queue, uint64_t ns)
 {
 	odp_event_t ev;
+	uint64_t wait = odp_schedule_wait_time(ns);
 
-	ev = odp_schedule(queue, ns);
+	ev = odp_schedule(queue, wait);
 	return odp_packet_from_event(ev);
 }
 

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -879,6 +879,14 @@ static void pktio_txrx_multi(pktio_info_t *pktio_info_a,
 
 		CU_ASSERT(odp_packet_user_ptr(pkt) == NULL);
 
+		odp_packet_input_set(pkt, ODP_PKTIO_INVALID);
+		CU_ASSERT(odp_packet_input(pkt) == ODP_PKTIO_INVALID);
+		CU_ASSERT(odp_packet_input_index(pkt) < 0);
+
+		odp_packet_input_set(pkt, pktio_b);
+		CU_ASSERT(odp_packet_input(pkt) == pktio_b);
+		CU_ASSERT(odp_packet_input_index(pkt) == pktio_index_b);
+
 		/* Dummy read to ones complement in case pktio has set it */
 		sum = odp_packet_ones_comp(pkt, &range);
 		if (range.length > 0)

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -491,6 +491,9 @@ static int create_packets_udp(odp_packet_t pkt_tbl[],
 
 		pktio_pkt_set_macs(pkt_tbl[i], pktio_src, pktio_dst);
 
+		/* Set user pointer. It should be NULL on receive side. */
+		odp_packet_user_ptr_set(pkt_tbl[i], (void *)1);
+
 		if (fix_cs)
 			ret = pktio_fixup_checksums(pkt_tbl[i]);
 		else
@@ -873,6 +876,8 @@ static void pktio_txrx_multi(pktio_info_t *pktio_info_a,
 			CU_ASSERT(odp_packet_has_l4(pkt));
 			CU_ASSERT(odp_packet_has_udp(pkt));
 		}
+
+		CU_ASSERT(odp_packet_user_ptr(pkt) == NULL);
 
 		/* Dummy read to ones complement in case pktio has set it */
 		sum = odp_packet_ones_comp(pkt, &range);


### PR DESCRIPTION
An application may use this for testing or other purposes, 
when perception of the packet input interface need to be 
changed.

v4: few bugs fixed that were found during testing the patch set