### PR TITLE
[PATCH v1] Disable features from config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -200,6 +200,18 @@ jobs:
                               -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/inline-timer.conf
                               ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/check_inline_timer.sh
                 - stage: test
+                  env: TEST=feature_disable
+                  install:
+                          - true
+                  compiler: gcc
+                  script:
+                          - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
+                          - docker run --privileged -i -t
+                              -v `pwd`:/odp --shm-size 8g
+                              -e CC="${CC}"
+                              -e CONF=""
+                              ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/feature_disable.sh
+                - stage: test
                   env: TEST=distcheck
                   compiler: gcc
                   script:

--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,22 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.10"
+config_file_version = "0.1.11"
+
+# Global init options
+global_init: {
+	# Feature disable flags. Overlapping flags are ignored, if
+	# application uses odp_init_t (not_used.feat flags) parameter. When
+	# application does not pass init parameter to odp_init_global(), or
+	# a flag is not overlapping, a feature is disabled during global init
+	# when set to 1.
+	disable: {
+		compress    = 0
+		crypto      = 0
+		ipsec       = 0
+		traffic_mng = 0
+	}
+}
 
 # Shared memory options
 shm: {

--- a/example/sysinfo/odp_sysinfo.c
+++ b/example/sysinfo/odp_sysinfo.c
@@ -243,6 +243,7 @@ int main(void)
 	char ava_mask_str[ODP_CPUMASK_STR_SIZE];
 	char work_mask_str[ODP_CPUMASK_STR_SIZE];
 	char ctrl_mask_str[ODP_CPUMASK_STR_SIZE];
+	int crypto_ret;
 
 	printf("\n");
 	printf("ODP system info example\n");
@@ -304,10 +305,9 @@ int main(void)
 		return -1;
 	}
 
-	if (odp_crypto_capability(&crypto_capa)) {
+	crypto_ret = odp_crypto_capability(&crypto_capa);
+	if (crypto_ret < 0)
 		printf("crypto capability failed\n");
-		return -1;
-	}
 
 	printf("\n");
 	printf("S Y S T E M    I N F O R M A T I O N\n");
@@ -417,22 +417,25 @@ int main(void)
 	       timer_capa.highest_res_ns);
 
 	printf("\n");
-	printf("  CRYPTO\n");
-	printf("    max sessions:         %" PRIu32 "\n",
-	       crypto_capa.max_sessions);
-	printf("    sync mode support:    %s\n",
-	       support_level(crypto_capa.sync_mode));
-	printf("    async mode support:   %s\n",
-	       support_level(crypto_capa.async_mode));
-	printf("    cipher algorithms:    ");
-	print_cipher_algos(crypto_capa.ciphers);
-	printf("\n");
-	print_cipher_caps(crypto_capa.ciphers);
-	printf("    auth algorithms:      ");
-	print_auth_algos(crypto_capa.auths);
-	printf("\n");
-	print_auth_caps(crypto_capa.auths);
-	printf("\n");
+
+	if (crypto_ret == 0) {
+		printf("  CRYPTO\n");
+		printf("    max sessions:         %" PRIu32 "\n",
+		       crypto_capa.max_sessions);
+		printf("    sync mode support:    %s\n",
+		       support_level(crypto_capa.sync_mode));
+		printf("    async mode support:   %s\n",
+		       support_level(crypto_capa.async_mode));
+		printf("    cipher algorithms:    ");
+		print_cipher_algos(crypto_capa.ciphers);
+		printf("\n");
+		print_cipher_caps(crypto_capa.ciphers);
+		printf("    auth algorithms:      ");
+		print_auth_algos(crypto_capa.auths);
+		printf("\n");
+		print_auth_caps(crypto_capa.auths);
+		printf("\n");
+	}
 
 	printf("  SHM MEMORY BLOCKS:\n");
 	odp_shm_print_all();

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -61,6 +61,15 @@ typedef struct odp_global_data_ro_t {
 	config_t libconfig_runtime;
 	odp_random_kind_t ipsec_rand_kind;
 
+	/* Disabled features during global init */
+	struct {
+		uint8_t compress;
+		uint8_t crypto;
+		uint8_t ipsec;
+		uint8_t traffic_mng;
+
+	} disable;
+
 } odp_global_data_ro_t;
 
 /* Modifiable global data. Memory region is shared and synchronized amongst all

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -39,7 +39,7 @@ typedef struct {
 
 /* Read-only global data. Members should not be modified after global init
  * to enable process more support. */
-struct odp_global_data_ro_t {
+typedef struct odp_global_data_ro_t {
 	odp_init_t init_param;
 	/* directory for odp mmaped files */
 	char *shm_dir;
@@ -60,17 +60,19 @@ struct odp_global_data_ro_t {
 	config_t libconfig_default;
 	config_t libconfig_runtime;
 	odp_random_kind_t ipsec_rand_kind;
-};
+
+} odp_global_data_ro_t;
 
 /* Modifiable global data. Memory region is shared and synchronized amongst all
  * worker processes. */
-struct odp_global_data_rw_t {
+typedef struct odp_global_data_rw_t {
 	odp_bool_t dpdk_initialized;
 	odp_bool_t inline_timers;
-};
 
-extern struct odp_global_data_ro_t odp_global_ro;
-extern struct odp_global_data_rw_t *odp_global_rw;
+} odp_global_data_rw_t;
+
+extern odp_global_data_ro_t odp_global_ro;
+extern odp_global_data_rw_t *odp_global_rw;
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/odp_comp.c
+++ b/platform/linux-generic/odp_comp.c
@@ -610,11 +610,17 @@ int _odp_comp_init_global(void)
 	odp_shm_t shm;
 	int idx;
 
+	if (odp_global_ro.disable.compress) {
+		ODP_PRINT("\nODP compress is DISABLED\n");
+		return 0;
+	}
+
 	/* Calculate the memory size we need */
 	mem_size = sizeof(*global);
 
 	/* Allocate our globally shared memory */
-	shm = odp_shm_reserve("comp_pool", mem_size, ODP_CACHE_LINE_SIZE, 0);
+	shm = odp_shm_reserve("_odp_comp_pool", mem_size,
+			      ODP_CACHE_LINE_SIZE, 0);
 
 	global = odp_shm_addr(shm);
 
@@ -638,6 +644,9 @@ int _odp_comp_term_global(void)
 	int ret;
 	int count = 0;
 	odp_comp_generic_session_t *session;
+
+	if (odp_global_ro.disable.compress)
+		return 0;
 
 	for (session = global->free; session != NULL; session = session->next)
 		count++;

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -45,8 +45,8 @@ enum init_stage {
 	ALL_INIT      /* All init stages completed */
 };
 
-struct odp_global_data_ro_t odp_global_ro;
-struct odp_global_data_rw_t *odp_global_rw;
+odp_global_data_ro_t odp_global_ro;
+odp_global_data_rw_t *odp_global_rw;
 
 void odp_init_param_init(odp_init_t *param)
 {
@@ -58,7 +58,7 @@ static int global_rw_data_init(void)
 	odp_shm_t shm;
 
 	shm = odp_shm_reserve("_odp_global_rw_data",
-			      sizeof(struct odp_global_data_rw_t),
+			      sizeof(odp_global_data_rw_t),
 			      ODP_CACHE_LINE_SIZE, 0);
 
 	odp_global_rw = odp_shm_addr(shm);
@@ -67,7 +67,7 @@ static int global_rw_data_init(void)
 		return -1;
 	}
 
-	memset(odp_global_rw, 0, sizeof(struct odp_global_data_rw_t));
+	memset(odp_global_rw, 0, sizeof(odp_global_data_rw_t));
 
 	return 0;
 }
@@ -266,7 +266,7 @@ int odp_init_global(odp_instance_t *instance,
 		    const odp_init_t *params,
 		    const odp_platform_init_t *platform_params ODP_UNUSED)
 {
-	memset(&odp_global_ro, 0, sizeof(struct odp_global_data_ro_t));
+	memset(&odp_global_ro, 0, sizeof(odp_global_data_ro_t));
 	odp_global_ro.main_pid = getpid();
 
 	enum init_stage stage = NO_INIT;

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -33,6 +33,11 @@ int odp_ipsec_capability(odp_ipsec_capability_t *capa)
 	odp_crypto_capability_t crypto_capa;
 	odp_queue_capability_t queue_capa;
 
+	if (odp_global_ro.disable.ipsec) {
+		ODP_ERR("IPSec is disabled\n");
+		return -1;
+	}
+
 	memset(capa, 0, sizeof(odp_ipsec_capability_t));
 
 	capa->op_mode_sync = ODP_SUPPORT_PREFERRED;
@@ -1775,6 +1780,9 @@ int _odp_ipsec_try_inline(odp_packet_t *pkt)
 	odp_ipsec_packet_result_t *result;
 	odp_packet_hdr_t *pkt_hdr;
 
+	if (odp_global_ro.disable.ipsec)
+		return -1;
+
 	memset(&status, 0, sizeof(status));
 
 	ipsec_sa = ipsec_in_single(*pkt, ODP_IPSEC_SA_INVALID, pkt, &status);
@@ -1937,6 +1945,9 @@ int _odp_ipsec_init_global(void)
 {
 	odp_shm_t shm;
 
+	if (odp_global_ro.disable.ipsec)
+		return 0;
+
 	shm = odp_shm_reserve("_odp_ipsec", sizeof(odp_ipsec_config_t),
 			      ODP_CACHE_LINE_SIZE, 0);
 
@@ -1960,7 +1971,12 @@ int _odp_ipsec_init_global(void)
 
 int _odp_ipsec_term_global(void)
 {
-	odp_shm_t shm = odp_shm_lookup("_odp_ipsec");
+	odp_shm_t shm;
+
+	if (odp_global_ro.disable.ipsec)
+		return 0;
+
+	shm = odp_shm_lookup("_odp_ipsec");
 
 	if (shm == ODP_SHM_INVALID || odp_shm_free(shm)) {
 		ODP_ERR("Shm free failed for odp_ipsec");

--- a/platform/linux-generic/odp_ipsec_events.c
+++ b/platform/linux-generic/odp_ipsec_events.c
@@ -12,6 +12,7 @@
 #include <odp_debug_internal.h>
 #include <odp_ipsec_internal.h>
 #include <odp_pool_internal.h>
+#include <odp_global_data.h>
 
 /* Inlined API functions */
 #include <odp/api/plat/event_inlines.h>
@@ -31,6 +32,11 @@ static odp_pool_t ipsec_status_pool = ODP_POOL_INVALID;
 int _odp_ipsec_events_init_global(void)
 {
 	odp_pool_param_t param;
+
+	if (odp_global_ro.disable.ipsec) {
+		ODP_PRINT("\nODP IPSec is DISABLED\n");
+		return 0;
+	}
 
 	odp_pool_param_init(&param);
 
@@ -54,6 +60,9 @@ err_status:
 int _odp_ipsec_events_term_global(void)
 {
 	int ret;
+
+	if (odp_global_ro.disable.ipsec)
+		return 0;
 
 	ret = odp_pool_destroy(ipsec_status_pool);
 	if (ret < 0) {

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -13,6 +13,7 @@
 #include <odp_debug_internal.h>
 #include <odp_ipsec_internal.h>
 #include <odp_ring_mpmc_internal.h>
+#include <odp_global_data.h>
 
 #include <odp/api/plat/atomic_inlines.h>
 #include <odp/api/plat/cpu_inlines.h>
@@ -135,6 +136,9 @@ int _odp_ipsec_sad_init_global(void)
 	odp_shm_t shm;
 	unsigned i;
 
+	if (odp_global_ro.disable.ipsec)
+		return 0;
+
 	shm = odp_shm_reserve("_odp_ipsec_sa_table",
 			      sizeof(ipsec_sa_table_t),
 			      ODP_CACHE_LINE_SIZE,
@@ -190,6 +194,9 @@ int _odp_ipsec_sad_term_global(void)
 	ipsec_sa_t *ipsec_sa;
 	int ret = 0;
 	int rc = 0;
+
+	if (odp_global_ro.disable.ipsec)
+		return 0;
 
 	for (i = 0; i < ODP_CONFIG_IPSEC_SAS; i++) {
 		ipsec_sa = ipsec_sa_entry(i);

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2918,7 +2918,7 @@ odp_tm_t odp_tm_create(const char            *name,
 	uint32_t max_tm_queues, max_sorted_lists;
 	int rc;
 
-	if (odp_global_ro.init_param.not_used.feat.tm) {
+	if (odp_global_ro.disable.traffic_mng) {
 		ODP_ERR("TM has been disabled\n");
 		return ODP_TM_INVALID;
 	}
@@ -4724,8 +4724,8 @@ int _odp_tm_init_global(void)
 {
 	odp_shm_t shm;
 
-	if (odp_global_ro.init_param.not_used.feat.tm) {
-		ODP_DBG("TM disabled\n");
+	if (odp_global_ro.disable.traffic_mng) {
+		ODP_PRINT("\nODP traffic manager is DISABLED\n");
 		return 0;
 	}
 
@@ -4758,7 +4758,7 @@ int _odp_tm_init_global(void)
 
 int _odp_tm_term_global(void)
 {
-	if (odp_global_ro.init_param.not_used.feat.tm)
+	if (odp_global_ro.disable.traffic_mng)
 		return 0;
 
 	if (odp_shm_free(tm_glb->shm)) {

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -17,6 +17,7 @@
 #include <odp/api/plat/byteorder_inlines.h>
 #include <odp_queue_if.h>
 #include <odp/api/plat/queue_inlines.h>
+#include <odp_global_data.h>
 
 #include <protocols/eth.h>
 #include <protocols/ip.h>
@@ -388,8 +389,11 @@ static int loopback_init_capability(pktio_entry_t *pktio_entry)
 	capa->config.pktout.bit.tcp_chksum = 1;
 	capa->config.pktout.bit.udp_chksum = 1;
 	capa->config.pktout.bit.sctp_chksum = 1;
-	capa->config.inbound_ipsec = 1;
-	capa->config.outbound_ipsec = 1;
+
+	if (odp_global_ro.disable.ipsec == 0) {
+		capa->config.inbound_ipsec = 1;
+		capa->config.outbound_ipsec = 1;
+	}
 
 	capa->config.pktout.bit.ipv4_chksum_ena =
 		capa->config.pktout.bit.ipv4_chksum;

--- a/platform/linux-generic/test/feature_disable.conf
+++ b/platform/linux-generic/test/feature_disable.conf
@@ -1,0 +1,14 @@
+# Mandatory fields
+odp_implementation = "linux-generic"
+config_file_version = "0.1.11"
+
+# Global init options
+global_init: {
+	# Disable unused features.
+	disable: {
+		compress    = 1
+		crypto      = 1
+		ipsec       = 1
+		traffic_mng = 1
+	}
+}

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.10"
+config_file_version = "0.1.11"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.10"
+config_file_version = "0.1.11"
 
 # Shared memory options
 shm: {

--- a/scripts/ci/feature_disable.sh
+++ b/scripts/ci/feature_disable.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+"`dirname "$0"`"/build_x86_64.sh
+
+cd "$(dirname "$0")"/../..
+
+echo 1000 | tee /proc/sys/vm/nr_hugepages
+mkdir -p /mnt/huge
+mount -t hugetlbfs nodev /mnt/huge
+
+# Run with the default config
+./example/sysinfo/odp_sysinfo
+
+# Run with unused features disabled
+ODP_CONFIG_FILE=/odp/platform/linux-generic/test/feature_disable.conf ./example/sysinfo/odp_sysinfo
+
+umount /mnt/huge
+


### PR DESCRIPTION
Disabling unused features saves SHM memory. E.g. SHM memory usage of sysinfo example is 144MB (18 blocks) by default and 118MB (11 blocks) when all four features are disabled through config file.

