### PR TITLE
[PATCH v2] Pktin data alignment configuration

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.11"
+config_file_version = "0.1.12"
 
 # Shared memory options
 shm: {
@@ -72,6 +72,16 @@ pool: {
 		# cache line size is used. Use power of two values.
 		min_align = 0
 	}
+}
+
+# General pktio options
+pktio: {
+	# Frame start offset from packet base pointer at packet input. This can
+	# be used (together with pool.pkt.base_align option) to tune packet data
+	# alignment for received frames. Currently, packet IO drivers
+	# (zero-copy DPDK, loop and ipc) that do not copy data ignore this
+	# option.
+	pktin_frame_offset = 0
 }
 
 # DPDK pktio options

--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.10"
+config_file_version = "0.1.11"
 
 # Shared memory options
 shm: {
@@ -60,6 +60,17 @@ pool: {
 		# Maximum number of packets per pool. Power of two minus one
 		# results optimal memory usage (e.g. (256 * 1024) - 1).
 		max_num = 262143
+
+		# Base alignment for segment data. When set to zero,
+		# cache line size is used. Use power of two values.
+		base_align = 0
+	}
+
+	buf: {
+		# Minimum data alignment. The alignment request in pool
+		# parameters is rounded up to this value. When set to zero,
+		# cache line size is used. Use power of two values.
+		min_align = 0
 	}
 }
 

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -235,6 +235,14 @@ static inline void copy_packet_cls_metadata(odp_packet_hdr_t *src_hdr,
 	dst_hdr->timestamp = src_hdr->timestamp;
 }
 
+static inline void pull_head(odp_packet_hdr_t *pkt_hdr, uint32_t len)
+{
+	pkt_hdr->headroom  += len;
+	pkt_hdr->frame_len -= len;
+	pkt_hdr->seg_data  += len;
+	pkt_hdr->seg_len   -= len;
+}
+
 static inline void pull_tail(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 {
 	odp_packet_hdr_t *last = packet_last_seg(pkt_hdr);

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -134,10 +134,14 @@ typedef union {
 	uint8_t pad[ROUNDUP_CACHE_LINE(sizeof(struct pktio_entry))];
 } pktio_entry_t;
 
+/* Global variables */
 typedef struct {
 	odp_spinlock_t lock;
+	odp_shm_t      shm;
+
 	pktio_entry_t entries[ODP_CONFIG_PKTIO_ENTRIES];
-} pktio_table_t;
+
+} pktio_global_t;
 
 typedef struct pktio_if_ops {
 	const char *name;

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -70,6 +70,7 @@ struct pktio_entry {
 	odp_ticketlock_t txl;		/**< TX ticketlock */
 	uint8_t cls_enabled;            /**< classifier enabled */
 	uint8_t chksum_insert_ena;      /**< pktout checksum offload enabled */
+	uint16_t pktin_frame_offset;
 	odp_pktio_t handle;		/**< pktio handle */
 	unsigned char ODP_ALIGNED_CACHE pkt_priv[PKTIO_PRIVATE_SIZE];
 	enum {

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -139,6 +139,11 @@ typedef struct {
 	odp_spinlock_t lock;
 	odp_shm_t      shm;
 
+	struct {
+		/* Frame start offset from base pointer at packet input */
+		uint16_t pktin_frame_offset;
+	} config;
+
 	pktio_entry_t entries[ODP_CONFIG_PKTIO_ENTRIES];
 
 } pktio_global_t;

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -97,6 +97,8 @@ typedef struct pool_global_t {
 		uint32_t pkt_max_num;
 		uint32_t local_cache_size;
 		uint32_t burst_size;
+		uint32_t pkt_base_align;
+		uint32_t buf_min_align;
 	} config;
 
 } pool_global_t;

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -89,7 +89,7 @@ typedef struct pool_t {
 
 } pool_t;
 
-typedef struct pool_table_t {
+typedef struct pool_global_t {
 	pool_t    pool[ODP_CONFIG_POOLS];
 	odp_shm_t shm;
 
@@ -99,18 +99,18 @@ typedef struct pool_table_t {
 		uint32_t burst_size;
 	} config;
 
-} pool_table_t;
+} pool_global_t;
 
-extern pool_table_t *pool_tbl;
+extern pool_global_t *_odp_pool_glb;
 
 static inline pool_t *pool_entry(uint32_t pool_idx)
 {
-	return &pool_tbl->pool[pool_idx];
+	return &_odp_pool_glb->pool[pool_idx];
 }
 
 static inline pool_t *pool_entry_from_hdl(odp_pool_t pool_hdl)
 {
-	return &pool_tbl->pool[_odp_typeval(pool_hdl) - 1];
+	return &_odp_pool_glb->pool[_odp_typeval(pool_hdl) - 1];
 }
 
 static inline odp_buffer_hdr_t *buf_hdl_to_hdr(odp_buffer_t buf)

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -160,14 +160,6 @@ static inline void push_head(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 	pkt_hdr->seg_len  += len;
 }
 
-static inline void pull_head(odp_packet_hdr_t *pkt_hdr, uint32_t len)
-{
-	pkt_hdr->headroom  += len;
-	pkt_hdr->frame_len -= len;
-	pkt_hdr->seg_data += len;
-	pkt_hdr->seg_len  -= len;
-}
-
 static inline void push_tail(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 {
 	odp_packet_hdr_t *last_seg = packet_last_seg(pkt_hdr);

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -285,6 +285,7 @@ static odp_pktio_t setup_pktio_entry(const char *name, odp_pool_t pool,
 	int pktio_if;
 	char pktio_type[PKTIO_NAME_LEN];
 	const char *if_name;
+	uint16_t pktin_frame_offset = pktio_global->config.pktin_frame_offset;
 
 	if (strlen(name) >= PKTIO_NAME_LEN - 1) {
 		/* ioctl names limitation */
@@ -311,6 +312,7 @@ static odp_pktio_t setup_pktio_entry(const char *name, odp_pool_t pool,
 	pktio_entry->s.pool = pool;
 	memcpy(&pktio_entry->s.param, param, sizeof(odp_pktio_param_t));
 	pktio_entry->s.handle = hdl;
+	pktio_entry->s.pktin_frame_offset = pktin_frame_offset;
 
 	odp_pktio_config_init(&pktio_entry->s.config);
 

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -44,10 +44,6 @@
 /* Define a practical limit for contiguous memory allocations */
 #define MAX_SIZE   (10 * 1024 * 1024)
 
-/* Minimum supported buffer alignment. Requests for values below this will be
- * rounded up to this value. */
-#define BUFFER_ALIGN_MIN ODP_CACHE_LINE_SIZE
-
 ODP_STATIC_ASSERT(CONFIG_PACKET_SEG_LEN_MIN >= 256,
 		  "ODP Segment size must be a minimum of 256 bytes");
 
@@ -502,11 +498,15 @@ static odp_pool_t pool_create(const char *name, odp_pool_param_t *params,
 
 	align = 0;
 
-	if (params->type == ODP_POOL_BUFFER)
-		align = params->buf.align;
+	if (params->type == ODP_POOL_PACKET) {
+		align = _odp_pool_glb->config.pkt_base_align;
+	} else {
+		if (params->type == ODP_POOL_BUFFER)
+			align = params->buf.align;
 
-	if (align < BUFFER_ALIGN_MIN)
-		align = BUFFER_ALIGN_MIN;
+		if (align < _odp_pool_glb->config.buf_min_align)
+			align = _odp_pool_glb->config.buf_min_align;
+	}
 
 	/* Validate requested buffer alignment */
 	if (align > ODP_CONFIG_BUFFER_ALIGN_MAX ||

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -261,6 +261,7 @@ int _odp_pool_init_global(void)
 
 	if (read_config_file(_odp_pool_glb)) {
 		odp_shm_free(shm);
+		_odp_pool_glb = NULL;
 		return -1;
 	}
 
@@ -285,6 +286,9 @@ int _odp_pool_term_global(void)
 	pool_t *pool;
 	int ret = 0;
 	int rc = 0;
+
+	if (_odp_pool_glb == NULL)
+		return 0;
 
 	for (i = 0; i < ODP_CONFIG_POOLS; i++) {
 		pool = pool_entry(i);

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -790,12 +790,14 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 	odp_packet_hdr_t parsed_hdr;
 	int i;
 	int num;
-	int alloc_len;
+	uint32_t max_len;
+	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
 
 	/* Allocate maximum sized packets */
-	alloc_len = pkt_priv(pktio_entry)->mtu;
+	max_len = pkt_priv(pktio_entry)->mtu;
 
-	num = packet_alloc_multi(pool, alloc_len, pkt_tbl, slot_num);
+	num = packet_alloc_multi(pool, max_len + frame_offset,
+				 pkt_tbl, slot_num);
 
 	for (i = 0; i < num; i++) {
 		netmap_slot_t slot;
@@ -815,10 +817,10 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 
 		pkt = pkt_tbl[i];
 		pkt_hdr = packet_hdr(pkt);
-		pull_tail(pkt_hdr, alloc_len - len);
+		pull_tail(pkt_hdr, max_len - len);
+		if (frame_offset)
+			pull_head(pkt_hdr, frame_offset);
 
-		/* For now copy the data in the mbuf,
-		   worry about zero-copy later */
 		if (odp_packet_copy_from_mem(pkt, 0, len, slot.buf) != 0)
 			goto fail;
 

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -221,11 +221,15 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	int nb_pkts;
 	int recv_msgs;
 	int i;
+	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
+	uint32_t alloc_len = pkt_sock->mtu + frame_offset;
 
 	memset(msgvec, 0, sizeof(msgvec));
 
-	nb_pkts = packet_alloc_multi(pool, pkt_sock->mtu, pkt_table, num);
+	nb_pkts = packet_alloc_multi(pool, alloc_len, pkt_table, num);
 	for (i = 0; i < nb_pkts; i++) {
+		if (frame_offset)
+			pull_head(packet_hdr(pkt_table[i]), frame_offset);
 		msgvec[i].msg_hdr.msg_iovlen =
 			_rx_pkt_to_iovec(pkt_table[i], iovecs[i]);
 		msgvec[i].msg_hdr.msg_iov = iovecs[i];

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.10"
+config_file_version = "0.1.11"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.11"
+config_file_version = "0.1.12"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.11"
+config_file_version = "0.1.12"
 
 # Shared memory options
 shm: {

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.10"
+config_file_version = "0.1.11"
 
 # Shared memory options
 shm: {


### PR DESCRIPTION
Add configure file options to control data alignment in packet input. Default values keep the current data alignment (frame starts at cache line align). All packet IO drivers doing data copy use this config, other drivers (dpdk-zero-copy, loop, ipc) ignore it.