### PR TITLE
[PATCH v4] linux-gen: pktio: always check pktio state before recv/send

### DIFF
--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -602,8 +602,8 @@ int odp_pktio_start(odp_pktio_t hdl)
 	mode = entry->s.param.in_mode;
 
 	if (mode == ODP_PKTIN_MODE_SCHED) {
-		unsigned i;
-		unsigned num = entry->s.num_in_queue;
+		unsigned int i;
+		unsigned int num = entry->s.num_in_queue;
 		int index[num];
 		odp_queue_t odpq[num];
 
@@ -928,7 +928,7 @@ int sched_cb_pktin_poll_one(int pktio_index,
 		return 0;
 	}
 
-	ODP_ASSERT((unsigned)rx_queue < entry->s.num_in_queue);
+	ODP_ASSERT((unsigned int)rx_queue < entry->s.num_in_queue);
 	num_pkts = entry->s.ops->recv(entry, rx_queue,
 				      packets, QUEUE_MULTI_MAX);
 
@@ -1433,7 +1433,7 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 	return ret;
 }
 
-unsigned odp_pktio_max_index(void)
+unsigned int odp_pktio_max_index(void)
 {
 	return ODP_CONFIG_PKTIO_ENTRIES - 1;
 }
@@ -1497,8 +1497,8 @@ int odp_pktin_queue_config(odp_pktio_t pktio,
 	pktio_entry_t *entry;
 	odp_pktin_mode_t mode;
 	odp_pktio_capability_t capa;
-	unsigned num_queues;
-	unsigned i;
+	unsigned int num_queues;
+	unsigned int i;
 	int rc;
 	odp_queue_t queue;
 	odp_pktin_queue_param_t default_param;
@@ -1621,8 +1621,8 @@ int odp_pktout_queue_config(odp_pktio_t pktio,
 	pktio_entry_t *entry;
 	odp_pktout_mode_t mode;
 	odp_pktio_capability_t capa;
-	unsigned num_queues;
-	unsigned i;
+	unsigned int num_queues;
+	unsigned int i;
 	int rc;
 	odp_pktout_queue_param_t default_param;
 
@@ -1966,11 +1966,11 @@ int odp_pktin_recv_tmo(odp_pktin_queue_t queue, odp_packet_t packets[], int num,
 	}
 }
 
-int odp_pktin_recv_mq_tmo(const odp_pktin_queue_t queues[], unsigned num_q,
-			  unsigned *from, odp_packet_t packets[], int num,
+int odp_pktin_recv_mq_tmo(const odp_pktin_queue_t queues[], unsigned int num_q,
+			  unsigned int *from, odp_packet_t packets[], int num,
 			  uint64_t wait)
 {
-	unsigned i;
+	unsigned int i;
 	int ret;
 	odp_time_t t1, t2;
 	struct timespec ts;

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1890,6 +1890,9 @@ int odp_pktin_recv(odp_pktin_queue_t queue, odp_packet_t packets[], int num)
 		return -1;
 	}
 
+	if (odp_unlikely(entry->s.state != PKTIO_STATE_STARTED))
+		return 0;
+
 	ret = entry->s.ops->recv(entry, queue.index, packets, num);
 	if (_ODP_PCAPNG)
 		_odp_dump_pcapng_pkts(entry, queue.index, packets, ret);
@@ -1915,6 +1918,9 @@ int odp_pktin_recv_tmo(odp_pktin_queue_t queue, odp_packet_t packets[], int num,
 		ODP_DBG("pktio entry %d does not exist\n", queue.pktio);
 		return -1;
 	}
+
+	if (odp_unlikely(entry->s.state != PKTIO_STATE_STARTED))
+		return 0;
 
 	if (entry->s.ops->recv_tmo && wait != ODP_PKTIN_NO_WAIT) {
 		ret = entry->s.ops->recv_tmo(entry, queue.index, packets, num,
@@ -2067,6 +2073,9 @@ int odp_pktout_send(odp_pktout_queue_t queue, const odp_packet_t packets[],
 		ODP_DBG("pktio entry %d does not exist\n", pktio);
 		return -1;
 	}
+
+	if (odp_unlikely(entry->s.state != PKTIO_STATE_STARTED))
+		return 0;
 
 	if (_ODP_PCAPNG)
 		_odp_dump_pcapng_pkts(entry, queue.index, packets, num);

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -1833,9 +1833,6 @@ static int dpdk_recv(pktio_entry_t *pktio_entry, int index,
 	int i;
 	unsigned cache_idx;
 
-	if (odp_unlikely(pktio_entry->s.state != PKTIO_STATE_STARTED))
-		return 0;
-
 	if (!pkt_dpdk->lockless_rx)
 		odp_ticketlock_lock(&pkt_dpdk->rx_lock[index]);
 	/**
@@ -1904,9 +1901,6 @@ static int dpdk_send(pktio_entry_t *pktio_entry, int index,
 	int tx_pkts;
 	int i;
 	int mbufs;
-
-	if (odp_unlikely(pktio_entry->s.state != PKTIO_STATE_STARTED))
-		return 0;
 
 	if (_ODP_DPDK_ZERO_COPY)
 		mbufs = pkt_to_mbuf_zero(pktio_entry, tx_mbufs, pkt_table, num,

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -908,9 +908,6 @@ static int netmap_fd_set(pktio_entry_t *pktio_entry, int index, fd_set *readfds)
 	int i;
 	int max_fd = 0;
 
-	if (odp_unlikely(pktio_entry->s.state != PKTIO_STATE_STARTED))
-		return 0;
-
 	if (!pkt_nm->lockless_rx)
 		odp_ticketlock_lock(&pkt_nm->rx_desc_ring[index].s.lock);
 
@@ -948,9 +945,6 @@ static int netmap_recv(pktio_entry_t *pktio_entry, int index,
 	int num_rx = 0;
 	int max_fd = 0;
 	fd_set empty_rings;
-
-	if (odp_unlikely(pktio_entry->s.state != PKTIO_STATE_STARTED))
-		return 0;
 
 	FD_ZERO(&empty_rings);
 
@@ -1073,9 +1067,6 @@ static int netmap_send(pktio_entry_t *pktio_entry, int index,
 	uint32_t pkt_len;
 	unsigned slot_id;
 	char *buf;
-
-	if (odp_unlikely(pktio_entry->s.state != PKTIO_STATE_STARTED))
-		return 0;
 
 	/* Only one netmap tx ring per pktout queue */
 	desc_id = pkt_nm->tx_desc_ring[index].s.cur;

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -231,7 +231,7 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 	odp_ticketlock_lock(&pktio_entry->s.rxl);
 
-	if (pktio_entry->s.state != PKTIO_STATE_STARTED || !pcap->rx) {
+	if (odp_unlikely(!pcap->rx)) {
 		odp_ticketlock_unlock(&pktio_entry->s.rxl);
 		return 0;
 	}
@@ -317,11 +317,6 @@ static int pcapif_send_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	int i;
 
 	odp_ticketlock_lock(&pktio_entry->s.txl);
-
-	if (pktio_entry->s.state != PKTIO_STATE_STARTED) {
-		odp_ticketlock_unlock(&pktio_entry->s.txl);
-		return 0;
-	}
 
 	for (i = 0; i < num; ++i) {
 		int pkt_len = odp_packet_len(pkts[i]);

--- a/platform/linux-generic/pktio/pktio_common.c
+++ b/platform/linux-generic/pktio/pktio_common.c
@@ -76,6 +76,12 @@ int sock_recv_mq_tmo_try_int_driven(const struct odp_pktin_queue_t queues[],
 			*trial_successful = 0;
 			return -1;
 		}
+
+		if (odp_unlikely(entry[i]->s.state != PKTIO_STATE_STARTED)) {
+			*trial_successful = 0;
+			return 0;
+		}
+
 		if (entry[i]->s.ops->recv_mq_tmo == NULL &&
 		    entry[i]->s.ops->fd_set == NULL) {
 			*trial_successful = 0;

--- a/platform/linux-generic/pktio/pktio_common.c
+++ b/platform/linux-generic/pktio/pktio_common.c
@@ -10,13 +10,13 @@
 
 static int sock_recv_mq_tmo_select(pktio_entry_t * const *entry,
 				   const int index[],
-				   unsigned num_q, unsigned *from,
+				   unsigned int num_q, unsigned int *from,
 				   odp_packet_t packets[], int num,
 				   uint64_t usecs, fd_set *readfds,
 				   int maxfd)
 {
 	struct timeval timeout;
-	unsigned i;
+	unsigned int i;
 	int ret;
 
 	for (i = 0; i < num_q; i++) {
@@ -49,17 +49,17 @@ static int sock_recv_mq_tmo_select(pktio_entry_t * const *entry,
 }
 
 int sock_recv_mq_tmo_try_int_driven(const struct odp_pktin_queue_t queues[],
-				    unsigned num_q, unsigned *from,
+				    unsigned int num_q, unsigned int *from,
 				    odp_packet_t packets[], int num,
 				    uint64_t usecs, int *trial_successful)
 {
-	unsigned i;
+	unsigned int i;
 	pktio_entry_t *entry[num_q];
 	int index[num_q];
 	fd_set readfds;
 	int maxfd = -1;
 	int (*impl)(pktio_entry_t *entry[], int index[], int num_q,
-		    odp_packet_t packets[], int num, unsigned *from,
+		    odp_packet_t packets[], int num, unsigned int *from,
 		    uint64_t wait_usecs) = NULL;
 	int impl_set = 0;
 


### PR DESCRIPTION
Previously some pktio types could recv/send packets even though the pktio
was not in started state.