### PR TITLE
[PATCH v2] travis: add packet and packet IO align test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -200,6 +200,19 @@ jobs:
                               -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/inline-timer.conf
                               ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/check_inline_timer.sh
                 - stage: test
+                  env: TEST=packet_align
+                  install:
+                          - true
+                  compiler: gcc
+                  script:
+                          - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
+                          - docker run --privileged -i -t
+                              -v `pwd`:/odp --shm-size 8g
+                              -e CC="${CC}"
+                              -e CONF=""
+                              -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/packet_align.conf
+                              ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/check_pktio.sh
+                - stage: test
                   env: TEST=distcheck
                   compiler: gcc
                   script:

--- a/platform/linux-generic/test/packet_align.conf
+++ b/platform/linux-generic/test/packet_align.conf
@@ -1,0 +1,21 @@
+# Mandatory fields
+odp_implementation = "linux-generic"
+config_file_version = "0.1.12"
+
+pool: {
+	pkt: {
+		# Non-zero, larger than cache line size, power of two value.
+		base_align = 128
+	}
+
+	buf: {
+		# Non-zero, larger than cache line size, power of two value.
+		min_align = 256
+	}
+}
+
+pktio: {
+	# Ethernet header offset is 2 bytes, so that Ethernet payload
+	# starts at 16 byte alignment.
+	pktin_frame_offset = 2
+}

--- a/scripts/ci/check_pktio.sh
+++ b/scripts/ci/check_pktio.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+"`dirname "$0"`"/build_x86_64.sh
+
+cd "$(dirname "$0")"/../..
+
+echo 1000 | tee /proc/sys/vm/nr_hugepages
+mkdir -p /mnt/huge
+mount -t hugetlbfs nodev /mnt/huge
+
+./platform/linux-generic/test/validation/api/pktio/pktio_run.sh
+
+umount /mnt/huge


### PR DESCRIPTION
Added new options to enable testing timer reset and log test results into a file.