### PR TITLE
[PATCH v2] Recreate vlan header in socket_mmap

### DIFF
--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -235,6 +235,19 @@ static inline void copy_packet_cls_metadata(odp_packet_hdr_t *src_hdr,
 	dst_hdr->timestamp = src_hdr->timestamp;
 }
 
+static inline void *packet_data(odp_packet_hdr_t *pkt_hdr)
+{
+	return pkt_hdr->seg_data;
+}
+
+static inline void push_head(odp_packet_hdr_t *pkt_hdr, uint32_t len)
+{
+	pkt_hdr->headroom  -= len;
+	pkt_hdr->frame_len += len;
+	pkt_hdr->seg_data -= len;
+	pkt_hdr->seg_len  += len;
+}
+
 static inline void pull_head(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 {
 	pkt_hdr->headroom  += len;

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -123,11 +123,6 @@ static inline uint32_t packet_first_seg_len(odp_packet_hdr_t *pkt_hdr)
 	return pkt_hdr->seg_len;
 }
 
-static inline void *packet_data(odp_packet_hdr_t *pkt_hdr)
-{
-	return pkt_hdr->seg_data;
-}
-
 static inline void *packet_tail(odp_packet_hdr_t *pkt_hdr)
 {
 	odp_packet_hdr_t *last_seg = packet_last_seg(pkt_hdr);
@@ -150,14 +145,6 @@ static inline uint32_t seg_tailroom(odp_packet_hdr_t *pkt_seg)
 	uint8_t *tail         = pkt_seg->seg_data + pkt_seg->seg_len;
 
 	return hdr->buf_end - tail;
-}
-
-static inline void push_head(odp_packet_hdr_t *pkt_hdr, uint32_t len)
-{
-	pkt_hdr->headroom  -= len;
-	pkt_hdr->frame_len += len;
-	pkt_hdr->seg_data -= len;
-	pkt_hdr->seg_len  += len;
 }
 
 static inline void push_tail(odp_packet_hdr_t *pkt_hdr, uint32_t len)


### PR DESCRIPTION
Socket may remove VLAN header in packet reception and record it into tpacket2_hdr structure. Insert VLAN header back into the packet when this happens.