### PR TITLE
[PATCH v2] API: add version and cache line round up macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.5])
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [23])
-m4_define([odpapi_minor_version], [1])
+m4_define([odpapi_minor_version], [2])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])

--- a/include/odp/api/abi-default/align.h
+++ b/include/odp/api/abi-default/align.h
@@ -45,6 +45,9 @@ extern "C" {
 
 #define ODP_ALIGNED_PAGE    ODP_ALIGNED(ODP_PAGE_SIZE)
 
+#define ODP_CACHE_LINE_ROUNDUP(x) \
+((ODP_CACHE_LINE_SIZE) * (((x) + (ODP_CACHE_LINE_SIZE) - 1) / (ODP_CACHE_LINE_SIZE)))
+
 /**
  * @}
  */

--- a/include/odp/api/spec/align.h
+++ b/include/odp/api/spec/align.h
@@ -48,12 +48,12 @@ extern "C" {
 
 /**
  * @def ODP_CACHE_LINE_SIZE
- * Cache line size
+ * Cache line size in bytes
  */
 
 /**
  * @def ODP_PAGE_SIZE
- * Page size
+ * Page size in bytes
  */
 
 /**
@@ -64,6 +64,15 @@ extern "C" {
 /**
  * @def ODP_ALIGNED_PAGE
  * Defines type/struct/variable to be page size aligned
+ */
+
+/**
+ * @def ODP_CACHE_LINE_ROUNDUP
+ * Round up to cache line size
+ *
+ * Rounds up the passed value to the next multiple of cache line size
+ * (ODP_CACHE_LINE_SIZE). Returns the original value if it is already
+ * a multiple of cache line size or zero.
  */
 
 /**

--- a/include/odp/api/spec/version.h.in
+++ b/include/odp/api/spec/version.h.in
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2020, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -54,6 +55,23 @@ extern "C" {
  * different minor numbers the two versions are backward compatible.
  */
 #define ODP_VERSION_API_MINOR @ODP_VERSION_API_MINOR@
+
+/**
+ * ODP API version number macro
+ *
+ * Macro to build a version number for comparisons
+ */
+#define ODP_VERSION_API_NUM(gen, ma, mi) ((gen) << 24 | (ma) << 16 | (mi) << 8)
+
+/**
+ * ODP API version number
+ *
+ * API version number for comparisons against ODP_VERSION_API_NUM()
+ * macro output.
+ */
+#define ODP_VERSION_API ODP_VERSION_API_NUM(ODP_VERSION_API_GENERATION, \
+					    ODP_VERSION_API_MAJOR, \
+					    ODP_VERSION_API_MINOR)
 
 /**
  * ODP API version string

--- a/test/validation/api/system/system.c
+++ b/test/validation/api/system/system.c
@@ -206,6 +206,13 @@ static void system_test_odp_sys_cache_line_size(void)
 	cache_size = odp_sys_cache_line_size();
 	CU_ASSERT(0 < cache_size);
 	CU_ASSERT(ODP_CACHE_LINE_SIZE == cache_size);
+
+	CU_ASSERT(ODP_CACHE_LINE_ROUNDUP(0) == 0);
+	CU_ASSERT(ODP_CACHE_LINE_ROUNDUP(1) == ODP_CACHE_LINE_SIZE);
+	CU_ASSERT(ODP_CACHE_LINE_ROUNDUP(ODP_CACHE_LINE_SIZE) ==
+		  ODP_CACHE_LINE_SIZE);
+	CU_ASSERT(ODP_CACHE_LINE_ROUNDUP(ODP_CACHE_LINE_SIZE + 1) ==
+		  2 * ODP_CACHE_LINE_SIZE);
 }
 
 static void system_test_odp_cpu_model_str(void)

--- a/test/validation/api/system/system.c
+++ b/test/validation/api/system/system.c
@@ -17,7 +17,7 @@
 #define GIGA_HZ 1000000000ULL
 #define KILO_HZ 1000ULL
 
-static void system_test_odp_version_numbers(void)
+static void test_version_api_str(void)
 {
 	int char_ok = 0;
 	char version_string[128];
@@ -37,6 +37,18 @@ static void system_test_odp_version_numbers(void)
 		}
 	}
 	CU_ASSERT(char_ok);
+}
+
+static void test_version_str(void)
+{
+	printf("\nAPI version:\n");
+	printf("%s\n\n", odp_version_api_str());
+
+	printf("Implementation name:\n");
+	printf("%s\n\n", odp_version_impl_name());
+
+	printf("Implementation details:\n");
+	printf("%s\n\n", odp_version_impl_str());
 }
 
 static void system_test_odp_cpu_count(void)
@@ -335,7 +347,8 @@ static void system_test_info_print(void)
 }
 
 odp_testinfo_t system_suite[] = {
-	ODP_TEST_INFO(system_test_odp_version_numbers),
+	ODP_TEST_INFO(test_version_api_str),
+	ODP_TEST_INFO(test_version_str),
 	ODP_TEST_INFO(system_test_odp_cpu_count),
 	ODP_TEST_INFO(system_test_odp_sys_cache_line_size),
 	ODP_TEST_INFO(system_test_odp_cpu_model_str),

--- a/test/validation/api/system/system.c
+++ b/test/validation/api/system/system.c
@@ -51,6 +51,28 @@ static void test_version_str(void)
 	printf("%s\n\n", odp_version_impl_str());
 }
 
+static void test_version_macro(void)
+{
+	CU_ASSERT(ODP_VERSION_API_NUM(0, 0, 0) < ODP_VERSION_API_NUM(0, 0, 1));
+	CU_ASSERT(ODP_VERSION_API_NUM(0, 0, 1) < ODP_VERSION_API_NUM(0, 1, 0));
+	CU_ASSERT(ODP_VERSION_API_NUM(0, 1, 0) < ODP_VERSION_API_NUM(1, 0, 0));
+	CU_ASSERT(ODP_VERSION_API_NUM(1, 90, 0) <
+		  ODP_VERSION_API_NUM(1, 90, 1));
+
+	CU_ASSERT(ODP_VERSION_API_NUM(ODP_VERSION_API_GENERATION,
+				      ODP_VERSION_API_MAJOR,
+				      ODP_VERSION_API_MINOR) ==
+		  ODP_VERSION_API);
+
+	CU_ASSERT(ODP_VERSION_API_NUM(ODP_VERSION_API_GENERATION,
+				      ODP_VERSION_API_MAJOR, 0) <=
+		  ODP_VERSION_API);
+
+	CU_ASSERT(ODP_VERSION_API_NUM(ODP_VERSION_API_GENERATION,
+				      ODP_VERSION_API_MAJOR + 1, 0) >
+		  ODP_VERSION_API);
+}
+
 static void system_test_odp_cpu_count(void)
 {
 	int cpus;
@@ -349,6 +371,7 @@ static void system_test_info_print(void)
 odp_testinfo_t system_suite[] = {
 	ODP_TEST_INFO(test_version_api_str),
 	ODP_TEST_INFO(test_version_str),
+	ODP_TEST_INFO(test_version_macro),
 	ODP_TEST_INFO(system_test_odp_cpu_count),
 	ODP_TEST_INFO(system_test_odp_sys_cache_line_size),
 	ODP_TEST_INFO(system_test_odp_cpu_model_str),


### PR DESCRIPTION
Added new macros into API for easier:
* API version comparison: ODP_VERSION_API_NUM, ODP_VERSION_API
* Cache line size round up in buffer size calculations, etc: ODP_CACHE_LINE_ROUNDUP()

 