### PR TITLE
[PATCH v2] API: packet length zero and packet pool align

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -62,7 +62,8 @@ pool: {
 		max_num = 262143
 
 		# Base alignment for segment data. When set to zero,
-		# cache line size is used. Use power of two values.
+		# cache line size is used. Use power of two values. This is
+		# also the maximum value for the packet pool alignment param.
 		base_align = 0
 	}
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.5])
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [23])
-m4_define([odpapi_minor_version], [2])
+m4_define([odpapi_minor_version], [3])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -318,11 +318,10 @@ void odp_packet_free_sp(const odp_packet_t pkt[], int num);
  *
  * Resets all packet metadata to their default values. Packet length is used
  * to initialize pointers and lengths. It must be less than the total buffer
- * length of the packet minus the default headroom length. Packet is not
- * modified on failure.
+ * length of the packet. Packet is not modified on failure.
  *
  * @param pkt           Packet handle
- * @param len           Packet data length
+ * @param len           Packet data length (1 ... odp_packet_buf_len())
  *
  * @retval 0 on success
  * @retval <0 on failure
@@ -724,7 +723,8 @@ int odp_packet_extend_head(odp_packet_t *pkt, uint32_t len, void **data_ptr,
  *
  * @param[in, out] pkt  Pointer to packet handle. A successful operation outputs
  *                      the new packet handle.
- * @param len           Number of bytes to truncate the head (0 ... packet_len)
+ * @param len           Number of bytes to truncate the head
+ *                      (0 ... packet_len - 1)
  * @param[out] data_ptr Pointer to output the new data pointer.
  *                      Ignored when NULL.
  * @param[out] seg_len  Pointer to output segment length at 'data_ptr' above.
@@ -797,7 +797,8 @@ int odp_packet_extend_tail(odp_packet_t *pkt, uint32_t len, void **data_ptr,
  *
  * @param[in, out] pkt  Pointer to packet handle. A successful operation outputs
  *                      the new packet handle.
- * @param len           Number of bytes to truncate the tail (0 ... packet_len)
+ * @param len           Number of bytes to truncate the tail
+ *                      (0 ... packet_len - 1)
  * @param[out] tail_ptr Pointer to output the new tail pointer.
  *                      Ignored when NULL.
  * @param[out] tailroom Pointer to output the new tailroom. Ignored when NULL.
@@ -861,7 +862,9 @@ int odp_packet_add_data(odp_packet_t *pkt, uint32_t offset, uint32_t len);
  * @param[in, out] pkt  Pointer to packet handle. A successful operation outputs
  *                      the new packet handle.
  * @param offset        Byte offset into the packet
- * @param len           Number of bytes to remove from the offset
+ * @param len           Number of bytes to remove from the offset. When offset
+ *                      is zero: 0 ... packet_len - 1 bytes, otherwise
+ *                      0 ... packet_len - offset bytes.
  *
  * @retval 0   Operation successful, old pointers remain valid
  * @retval >0  Operation successful, old pointers need to be updated
@@ -1064,6 +1067,7 @@ int odp_packet_concat(odp_packet_t *dst, odp_packet_t src);
  * @param[in, out] pkt   Pointer to packet handle. A successful operation
  *                       outputs a new packet handle for the head packet.
  * @param len            Data length remaining in the head packet
+ *                       (1 ... packet_len - 1)
  * @param tail           Pointer to output the tail packet handle
  *
  * @retval 0   Operation successful, old pointers remain valid

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -92,6 +92,12 @@ typedef struct odp_pool_capability_t {
 		 * memory size for the pool. */
 		uint32_t max_num;
 
+		/** Maximum packet data alignment in bytes
+		 *
+		 * This is the maximum value of packet pool alignment
+		 * (pkt.align) parameter. */
+		uint32_t max_align;
+
 		/** Minimum packet level headroom length in bytes
 		 *
 		 * The minimum number of headroom bytes that newly created
@@ -247,6 +253,19 @@ typedef struct odp_pool_param_t {
 		 *  pkt.max_len. Use 0 for default (the pool maximum).
 		 */
 		uint32_t max_len;
+
+		/** Minimum packet data alignment in bytes.
+		 *
+		 *  Valid values are powers of two. User allocated packets have
+		 *  start of data (@see odp_packet_data()) aligned to this or
+		 *  a higher alignment (power of two value). This parameter
+		 *  does not apply to packets that ODP allocates internally
+		 *  (e.g. packets from packet input).
+		 *
+		 *  The maximum value is defined by pool capability
+		 *  pkt.max_align. Use 0 for default alignment.
+		 */
+		uint32_t align;
 
 		/** Minimum number of packet data bytes that are stored in the
 		 *  first segment of a packet. The maximum value is defined by

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -503,6 +503,15 @@ static odp_pool_t pool_create(const char *name, odp_pool_param_t *params,
 	align = 0;
 
 	if (params->type == ODP_POOL_PACKET) {
+		uint32_t align_req = params->pkt.align;
+
+		if (align_req &&
+		    (!CHECK_IS_POWER2(align_req) ||
+		     align_req > _odp_pool_glb->config.pkt_base_align)) {
+			ODP_ERR("Bad align requirement\n");
+			return ODP_POOL_INVALID;
+		}
+
 		align = _odp_pool_glb->config.pkt_base_align;
 	} else {
 		if (params->type == ODP_POOL_BUFFER)
@@ -1106,6 +1115,7 @@ int odp_pool_capability(odp_pool_capability_t *capa)
 	capa->pkt.max_pools        = max_pools;
 	capa->pkt.max_len          = CONFIG_PACKET_MAX_LEN;
 	capa->pkt.max_num	   = _odp_pool_glb->config.pkt_max_num;
+	capa->pkt.max_align	   = _odp_pool_glb->config.pkt_base_align;
 	capa->pkt.min_headroom     = CONFIG_PACKET_HEADROOM;
 	capa->pkt.max_headroom     = CONFIG_PACKET_HEADROOM;
 	capa->pkt.min_tailroom     = CONFIG_PACKET_TAILROOM;

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -429,7 +429,7 @@ odp_packet_t ipsec_packet(const ipsec_test_packet *itp)
 {
 	odp_packet_t pkt = odp_packet_alloc(suite_context.pool, itp->len);
 
-	CU_ASSERT_NOT_EQUAL(ODP_PACKET_INVALID, pkt);
+	CU_ASSERT_NOT_EQUAL_FATAL(ODP_PACKET_INVALID, pkt);
 	if (ODP_PACKET_INVALID == pkt)
 		return pkt;
 

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -1036,7 +1036,7 @@ static void test_out_dummy_esp_null_sha256_tun_ipv4(void)
 	test.out[0].l3_type = ODP_PROTO_L3_TYPE_IPV4;
 	test.out[0].l4_type = ODP_PROTO_L4_TYPE_NO_NEXT;
 
-	test_empty.pkt_in = &pkt_test_emtpy;
+	test_empty.pkt_in = &pkt_test_empty;
 	test_empty.num_opt = 1;
 	test_empty.opt.flag.tfc_dummy = 1;
 	test_empty.opt.tfc_pad_len = 16;
@@ -1110,7 +1110,7 @@ static void test_out_dummy_esp_null_sha256_tun_ipv6(void)
 	test.out[0].l3_type = ODP_PROTO_L3_TYPE_IPV4;
 	test.out[0].l4_type = ODP_PROTO_L4_TYPE_NO_NEXT;
 
-	test_empty.pkt_in = &pkt_test_emtpy;
+	test_empty.pkt_in = &pkt_test_empty;
 	test_empty.num_opt = 1;
 	test_empty.opt.flag.tfc_dummy = 1;
 	test_empty.opt.tfc_pad_len = 16;

--- a/test/validation/api/ipsec/test_vectors.h
+++ b/test/validation/api/ipsec/test_vectors.h
@@ -1865,8 +1865,8 @@ static const ODP_UNUSED ipsec_test_packet
 	},
 };
 
-static const ipsec_test_packet pkt_test_emtpy = {
-	.len = 0,
+static const ipsec_test_packet pkt_test_empty = {
+	.len = 1,
 	.l2_offset = ODP_PACKET_OFFSET_INVALID,
 	.l3_offset = ODP_PACKET_OFFSET_INVALID,
 	.l4_offset = ODP_PACKET_OFFSET_INVALID,


### PR DESCRIPTION
Merged packet API modifications into a single patch set. Clarify that application cannot create zero length packets. Add packet pool parameter to control minimum alignment of packet data when application allocates packets from a pool.