### PR TITLE
[PATCH v2] validation: packet: prevent test trying to allocate zero length packets

### DIFF
--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -341,7 +341,7 @@ static int packet_alloc_multi(odp_pool_t pool, uint32_t pkt_len,
 		CU_ASSERT(ret >= 0);
 		CU_ASSERT(ret <= num - total);
 		total += ret;
-	} while (total < num && ret);
+	} while (total < num && ret > 0);
 
 	return total;
 }
@@ -430,7 +430,7 @@ static void packet_test_free_sp(void)
 	odp_pool_param_t params;
 	uint32_t len = packet_len;
 
-	if (pool_capa.pkt.max_len < len)
+	if (pool_capa.pkt.max_len && pool_capa.pkt.max_len < len)
 		len = pool_capa.pkt.max_len;
 
 	odp_pool_param_init(&params);


### PR DESCRIPTION
Test packet_test_free_sp() would end up trying to allocate invalid zero
length packets if pool_capa.pkt.max_len was zero.

The following packet_alloc_multi() call would then loop indefinitely since
error return value was not checked.

Signed-off-by: Matias Elo <matias.elo@nokia.com>