### PR TITLE
[PATCH v2] linux-gen: pool: increase max segment length

### DIFF
--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -97,7 +97,7 @@ extern "C" {
 /*
  * Maximum packet segment size including head- and tailrooms
  */
-#define CONFIG_PACKET_SEG_SIZE (8 * 1024)
+#define CONFIG_PACKET_SEG_SIZE (60 * 1024)
 
 /* Maximum data length in a segment
  *


### PR DESCRIPTION
Enable creating larger single segment packets.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Suggested-by: Jussi Kerttula <jussi.kerttula@nokia.com>