### PR TITLE
[PATCH v4] build: do not define libodp as part of helper

### DIFF
--- a/example/Makefile.inc
+++ b/example/Makefile.inc
@@ -2,7 +2,7 @@ include $(top_srcdir)/Makefile.inc
 
 TESTS_ENVIRONMENT = EXEEXT=${EXEEXT}
 
-LDADD = $(LIB)/libodp-linux.la $(LIB)/libodphelper.la
+LDADD = $(LIB)/libodphelper.la $(LIB)/libodp-linux.la
 
 # Do not link to DPDK twice in case of dynamic linking with ODP
 if STATIC_APPS

--- a/helper/Makefile.am
+++ b/helper/Makefile.am
@@ -60,6 +60,6 @@ __LIB__libodphelper_la_SOURCES += \
 				linux/thread.c
 endif
 
-__LIB__libodphelper_la_LIBADD = $(PTHREAD_LIBS) $(LIB)/libodp-linux.la
+__LIB__libodphelper_la_LIBADD = $(PTHREAD_LIBS)
 
 lib_LTLIBRARIES = $(LIB)/libodphelper.la


### PR DESCRIPTION
This prevents multiple inclusion of libodp-linux during builds, once as part of libodphelper and then directly by the application. This causes problems when linking statically with LTO enabled. On tested compiler (9.2.1-9ubuntu2) such duplication causes constructor symbols to be defined multiple times. This means that constructors will be run multiple times which leads to unexpected behavior.
To fix this, remove libodp from helper link list. This works when compiling applications because there is no point in using libodphelper without libodp-linux, therefore both libraries have to be provided.
After removing library order in example/Makefile.inc is required to ensure the proper linking.

Reproduction steps:

1. Add a constructor in platform/linux-generic/odp_init.c, i.e.:
```diff
diff --git a/platform/linux-generic/odp_init.c b/platform/linux-generic/odp_init.c
index 0341eb318..bcd70bcd4 100644
--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -290,6 +290,15 @@ static int term_global(enum init_stage stage)
 	return rc;
 }

+uint64_t init_once;
+
+static void __attribute__((constructor(65535), used)) test_constructor(void)
+{
+	if (init_once)
+		abort();
+	init_once++;
+}
+
 int odp_init_global(odp_instance_t *instance,
 		    const odp_init_t *params,
 		    const odp_platform_init_t *platform_params ODP_UNUSED)
@@ -297,6 +306,8 @@ int odp_init_global(odp_instance_t *instance,
 	memset(&odp_global_ro, 0, sizeof(odp_global_data_ro_t));
 	odp_global_ro.main_pid = getpid();

+	printf("init_once %lu\n", init_once);
+
 	enum init_stage stage = NO_INIT;
 	odp_global_ro.log_fn = odp_override_log;
 	odp_global_ro.abort_fn = odp_override_abort;
```
2. Build with LTO and without shared libraries:
```bash
$ ./bootstrap
$ ./configure --disable-shared --disable-lto --without-openssl
$ make all -j4
```
3. Notice multiple definitions of the constructor:
```bash
$ objdump -t ./example/hello/odp_hello | grep test_constructor
0000000000005870 l F .text 0000000000000022 test_constructor.lto_priv.1
00000000000057e5 l F .text 0000000000000005 test_constructor.lto_priv.1.cold
0000000000005838 l F .text 0000000000000005 test_constructor.lto_priv.0.cold
00000000000058a0 g F .text 0000000000000022 .hidden test_constructor.lto_priv.0
```
4. Finally odp_hello aborts which means that constructors were called multiple
   times:
```bash
$ ./example/hello/odp_hello
Aborted (core dumped)
```