### PR TITLE
[PATCH v4] travis: add ubuntu 20.04 build test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ env:
         - CHECK=0 OS=centos_7
         - CONF="--without-openssl --without-pcap"
         - OS=ubuntu_16.04
+        - OS=ubuntu_20.04
 
 matrix:
   exclude:

--- a/platform/linux-generic/test/validation/api/pktio/pktio_run_pcap.sh
+++ b/platform/linux-generic/test/validation/api/pktio/pktio_run_pcap.sh
@@ -28,6 +28,8 @@ else
 	exit 1
 fi
 
+export ODP_PKTIO_TEST_DISABLE_START_STOP=1
+
 PCAP_FNAME=vald.pcap
 export ODP_PKTIO_IF0="pcap:out=${PCAP_FNAME}"
 export ODP_PKTIO_IF1="pcap:in=${PCAP_FNAME}"

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1181,12 +1181,7 @@ static void test_recv_tmo(recv_tmo_mode_e mode)
 
 	memset(pkt_seq, 0, sizeof(pkt_seq));
 
-	/* No packets sent yet, so should wait */
 	ns = 100 * ODP_TIME_MSEC_IN_NS;
-
-	ret = recv_packets_tmo(pktio_rx, &pkt_tbl[0], &pkt_seq[0], 1, mode,
-			       odp_pktin_wait_time(ns), ns, 1);
-	CU_ASSERT(ret == 0);
 
 	ret = create_packets(pkt_tbl, pkt_seq, test_pkt_count, pktio_tx,
 			     pktio_rx);
@@ -1757,13 +1752,6 @@ static void pktio_test_statistics_counters(void)
 	if (num_ifaces > 1) {
 		ret = odp_pktio_start(pktio_rx);
 		CU_ASSERT(ret == 0);
-	}
-
-	/* flush packets with magic number in pipes */
-	for (i = 0; i < 1000; i++) {
-		ev = odp_schedule(NULL, wait);
-		if (ev != ODP_EVENT_INVALID)
-			odp_event_free(ev);
 	}
 
 	alloc = create_packets(tx_pkt, pkt_seq, 1000, pktio_tx, pktio_rx);

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1196,7 +1196,8 @@ static void test_recv_tmo(recv_tmo_mode_e mode)
 	CU_ASSERT_FATAL(ret == test_pkt_count);
 
 	ret = recv_packets_tmo(pktio_rx, &pkt_tbl[0], &pkt_seq[0], 1, mode,
-			       odp_pktin_wait_time(UINT64_MAX), 0, 0);
+			       odp_pktin_wait_time(10 * ODP_TIME_SEC_IN_NS),
+			       0, 0);
 	CU_ASSERT_FATAL(ret == 1);
 
 	ret = recv_packets_tmo(pktio_rx, &pkt_tbl[1], &pkt_seq[1], 1, mode,

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1836,6 +1836,13 @@ static void pktio_test_statistics_counters(void)
 	}
 }
 
+static int pktio_check_start_stop(void)
+{
+	if (getenv("ODP_PKTIO_TEST_DISABLE_START_STOP"))
+		return ODP_TEST_INACTIVE;
+	return ODP_TEST_ACTIVE;
+}
+
 static void pktio_test_start_stop(void)
 {
 	odp_pktio_t pktio[MAX_NUM_IFACES];
@@ -2931,7 +2938,8 @@ odp_testinfo_t pktio_suite_unsegmented[] = {
 	ODP_TEST_INFO(pktio_test_mtu),
 	ODP_TEST_INFO(pktio_test_promisc),
 	ODP_TEST_INFO(pktio_test_mac),
-	ODP_TEST_INFO(pktio_test_start_stop),
+	ODP_TEST_INFO_CONDITIONAL(pktio_test_start_stop,
+				  pktio_check_start_stop),
 	ODP_TEST_INFO(pktio_test_recv_on_wonly),
 	ODP_TEST_INFO(pktio_test_send_on_ronly),
 	ODP_TEST_INFO(pktio_test_plain_multi_event),


### PR DESCRIPTION
Enables GCC 9.2 and Clang 9 testing.

Signed-off-by: Matias Elo <matias.elo@nokia.com>