### PR TITLE
[PATCH v12] New object stash API 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.5])
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [23])
-m4_define([odpapi_minor_version], [3])
+m4_define([odpapi_minor_version], [4])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -44,6 +44,7 @@ odpapiinclude_HEADERS = \
 	odp/api/shared_memory.h \
 	odp/api/spinlock.h \
 	odp/api/spinlock_recursive.h \
+	odp/api/stash.h \
 	odp/api/std_clib.h \
 	odp/api/std_types.h \
 	odp/api/support.h \
@@ -94,6 +95,7 @@ odpapispecinclude_HEADERS = \
 		  odp/api/spec/shared_memory.h \
 		  odp/api/spec/spinlock.h \
 		  odp/api/spec/spinlock_recursive.h \
+		  odp/api/spec/stash.h \
 		  odp/api/spec/std_clib.h \
 		  odp/api/spec/std_types.h \
 		  odp/api/spec/support.h \
@@ -140,6 +142,7 @@ odpapiabidefaultinclude_HEADERS = \
 	odp/api/abi-default/shared_memory.h \
 	odp/api/abi-default/spinlock.h \
 	odp/api/abi-default/spinlock_recursive.h \
+	odp/api/abi-default/stash.h \
 	odp/api/abi-default/std_clib.h \
 	odp/api/abi-default/std_types.h \
 	odp/api/abi-default/sync.h \
@@ -151,7 +154,7 @@ odpapiabidefaultinclude_HEADERS = \
 	odp/api/abi-default/traffic_mngr.h \
 	odp/api/abi-default/version.h
 
-# Insall ABI headers only if required
+# Install ABI headers only if required
 if ODP_ABI_COMPAT
 
 odpapiabiarchincludedir = $(archincludedir)/odp/api/abi
@@ -183,6 +186,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm32-linux/odp/api/abi/shared_memory.h \
 	odp/arch/arm32-linux/odp/api/abi/spinlock.h \
 	odp/arch/arm32-linux/odp/api/abi/spinlock_recursive.h \
+	odp/arch/arm32-linux/odp/api/abi/stash.h \
 	odp/arch/arm32-linux/odp/api/abi/std_clib.h \
 	odp/arch/arm32-linux/odp/api/abi/std_types.h \
 	odp/arch/arm32-linux/odp/api/abi/sync.h \
@@ -222,6 +226,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm64-linux/odp/api/abi/shared_memory.h \
 	odp/arch/arm64-linux/odp/api/abi/spinlock.h \
 	odp/arch/arm64-linux/odp/api/abi/spinlock_recursive.h \
+	odp/arch/arm64-linux/odp/api/abi/stash.h \
 	odp/arch/arm64-linux/odp/api/abi/std_clib.h \
 	odp/arch/arm64-linux/odp/api/abi/std_types.h \
 	odp/arch/arm64-linux/odp/api/abi/sync.h \
@@ -261,6 +266,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/default-linux/odp/api/abi/shared_memory.h \
 	odp/arch/default-linux/odp/api/abi/spinlock.h \
 	odp/arch/default-linux/odp/api/abi/spinlock_recursive.h \
+	odp/arch/default-linux/odp/api/abi/stash.h \
 	odp/arch/default-linux/odp/api/abi/std_clib.h \
 	odp/arch/default-linux/odp/api/abi/std_types.h \
 	odp/arch/default-linux/odp/api/abi/sync.h \
@@ -300,6 +306,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/mips64-linux/odp/api/abi/shared_memory.h \
 	odp/arch/mips64-linux/odp/api/abi/spinlock.h \
 	odp/arch/mips64-linux/odp/api/abi/spinlock_recursive.h \
+	odp/arch/mips64-linux/odp/api/abi/stash.h \
 	odp/arch/mips64-linux/odp/api/abi/std_clib.h \
 	odp/arch/mips64-linux/odp/api/abi/std_types.h \
 	odp/arch/mips64-linux/odp/api/abi/sync.h \
@@ -339,6 +346,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/power64-linux/odp/api/abi/shared_memory.h \
 	odp/arch/power64-linux/odp/api/abi/spinlock.h \
 	odp/arch/power64-linux/odp/api/abi/spinlock_recursive.h \
+	odp/arch/power64-linux/odp/api/abi/stash.h \
 	odp/arch/power64-linux/odp/api/abi/std_clib.h \
 	odp/arch/power64-linux/odp/api/abi/std_types.h \
 	odp/arch/power64-linux/odp/api/abi/sync.h \
@@ -378,6 +386,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_32-linux/odp/api/abi/shared_memory.h \
 	odp/arch/x86_32-linux/odp/api/abi/spinlock.h \
 	odp/arch/x86_32-linux/odp/api/abi/spinlock_recursive.h \
+	odp/arch/x86_32-linux/odp/api/abi/stash.h \
 	odp/arch/x86_32-linux/odp/api/abi/std_clib.h \
 	odp/arch/x86_32-linux/odp/api/abi/std_types.h \
 	odp/arch/x86_32-linux/odp/api/abi/sync.h \
@@ -417,6 +426,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_64-linux/odp/api/abi/shared_memory.h \
 	odp/arch/x86_64-linux/odp/api/abi/spinlock.h \
 	odp/arch/x86_64-linux/odp/api/abi/spinlock_recursive.h \
+	odp/arch/x86_64-linux/odp/api/abi/stash.h \
 	odp/arch/x86_64-linux/odp/api/abi/std_clib.h \
 	odp/arch/x86_64-linux/odp/api/abi/std_types.h \
 	odp/arch/x86_64-linux/odp/api/abi/sync.h \

--- a/include/odp/api/abi-default/stash.h
+++ b/include/odp/api/abi-default/stash.h
@@ -1,0 +1,35 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_ABI_STASH_H_
+#define ODP_ABI_STASH_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @internal Dummy type for strong typing */
+typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_stash_t;
+
+/** @ingroup odp_stash
+ *  @{
+ */
+
+typedef _odp_abi_stash_t *odp_stash_t;
+
+#define ODP_STASH_INVALID   ((odp_stash_t)0)
+
+#define ODP_STASH_NAME_LEN  32
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/api/spec/atomic.h
+++ b/include/odp/api/spec/atomic.h
@@ -20,6 +20,8 @@ extern "C" {
 
 /**
  * @defgroup odp_atomic ODP ATOMIC
+ * Atomic variables.
+ *
  * @details
  * <b> Atomic integers using relaxed memory ordering </b>
  *

--- a/include/odp/api/spec/buffer.h
+++ b/include/odp/api/spec/buffer.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif
 
 /** @defgroup odp_buffer ODP BUFFER
- *  Operations on a buffer.
+ *  Buffer event metadata and operations.
  *  @{
  */
 

--- a/include/odp/api/spec/chksum.h
+++ b/include/odp/api/spec/chksum.h
@@ -7,7 +7,7 @@
 /**
  * @file
  *
- * ODP Hash functions
+ * ODP checksum functions.
  */
 
 #ifndef ODP_API_SPEC_CHKSUM_H_
@@ -21,7 +21,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 
 /** @defgroup odp_chksum ODP CHECKSUM
- *  ODP checksum functions
+ *  Checksum functions.
  *  @{
  */
 

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -22,7 +22,7 @@ extern "C" {
 #include <odp/api/support.h>
 #include <odp/api/threshold.h>
 /** @defgroup odp_classification ODP CLASSIFICATION
- *  Classification operations.
+ *  Packet input classification.
  *  @{
  */
 

--- a/include/odp/api/spec/comp.h
+++ b/include/odp/api/spec/comp.h
@@ -22,9 +22,9 @@ extern "C" {
 #endif
 
 /** @defgroup odp_compression ODP COMP
- *  Operations for Compression and Decompression API.
- *  Hash calculation may be combined with de-/compression operations
+ *  Data compression and decompression.
  *
+ *  Hash calculation may be combined with de-/compression operations.
  *  @{
  */
 

--- a/include/odp/api/spec/cpu.h
+++ b/include/odp/api/spec/cpu.h
@@ -21,6 +21,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 
 /** @defgroup odp_cpu ODP CPU
+ *  CPU cycle count, frequency, etc. information.
  *  @{
  */
 

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -24,7 +24,7 @@ extern "C" {
 #include <odp/api/packet.h>
 
 /** @defgroup odp_crypto ODP CRYPTO
- *  Macros, enums, types and operations to utilise crypto.
+ *  Data ciphering and authentication.
  *  @{
  */
 

--- a/include/odp/api/spec/errno.h
+++ b/include/odp/api/spec/errno.h
@@ -20,6 +20,8 @@ extern "C" {
 
 /**
  * @defgroup odp_errno ODP ERRNO
+ * Error number.
+ *
  * @details
  * <b> ODP errno </b>
  *

--- a/include/odp/api/spec/event.h
+++ b/include/odp/api/spec/event.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <odp/api/packet.h>
 
 /** @defgroup odp_event ODP EVENT
- *  Operations on an event.
+ *  Generic event metadata and operations.
  *  @{
  */
 

--- a/include/odp/api/spec/feature.h
+++ b/include/odp/api/spec/feature.h
@@ -23,7 +23,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 
 /** @defgroup odp_features ODP_FEATURE
- *  ODP feature definitions
+ *  List of ODP features.
  *  @{
  */
 

--- a/include/odp/api/spec/feature.h
+++ b/include/odp/api/spec/feature.h
@@ -49,7 +49,10 @@ typedef union odp_feature_t {
 		/** Scheduler APIs, e.g., odp_schedule_xxx() */
 		uint32_t schedule:1;
 
-		/** Time APIs are, e.g., odp_time_xxx() */
+		/** Stash APIs, e.g., odp_stash_xxx() */
+		uint32_t stash:1;
+
+		/** Time APIs, e.g., odp_time_xxx() */
 		uint32_t time:1;
 
 		/** Timer APIs, e.g., odp_timer_xxx(), odp_timeout_xxx()  */

--- a/include/odp/api/spec/hash.h
+++ b/include/odp/api/spec/hash.h
@@ -20,8 +20,8 @@ extern "C" {
 
 #include <odp/api/std_types.h>
 
-/** @defgroup odp_hash ODP HASH FUNCTIONS
- *  ODP Hash functions
+/** @defgroup odp_hash ODP HASH
+ *  Hash functions.
  *  @{
  */
 

--- a/include/odp/api/spec/init.h
+++ b/include/odp/api/spec/init.h
@@ -24,7 +24,7 @@ extern "C" {
 #include <odp/api/cpumask.h>
 
 /** @defgroup odp_initialization ODP INITIALIZATION
- *  Initialisation operations.
+ *  ODP instance initialization and termination.
  *  @{
  */
 

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -24,7 +24,7 @@ extern "C" {
 #include <odp/api/classification.h>
 
 /** @defgroup odp_ipsec ODP IPSEC
- *  Operations of IPSEC API.
+ *  IPSEC protocol offload.
  *  @{
  */
 

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <odp/api/time.h>
 
 /** @defgroup odp_packet ODP PACKET
- *  Operations on a packet.
+ *  Packet event metadata and operations.
  *  @{
  */
 

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -25,7 +25,7 @@ extern "C" {
 #include <odp/api/packet.h>
 
 /** @defgroup odp_packet_io ODP PACKET IO
- *  Operations on a packet Input/Output interface.
+ *  Packet IO interfaces.
  *
  * Packet IO is the Ingress and Egress interface to ODP processing. It
  * allows manipulation of the interface for setting such attributes as

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 
 /** @defgroup odp_pool ODP POOL
- *  Operations on a pool.
+ *  Packet and buffer (event) pools.
  *  @{
  */
 

--- a/include/odp/api/spec/queue.h
+++ b/include/odp/api/spec/queue.h
@@ -22,7 +22,7 @@ extern "C" {
 #include <odp/api/spec/queue_types.h>
 
 /** @defgroup odp_queue ODP QUEUE
- *  Macros and operation on a queue.
+ *  Queues for event passing and scheduling.
  *  @{
  */
 

--- a/include/odp/api/spec/random.h
+++ b/include/odp/api/spec/random.h
@@ -19,6 +19,7 @@ extern "C" {
 #endif
 
 /** @defgroup odp_random ODP RANDOM
+ *  Random number generation.
  *  @{
  */
 

--- a/include/odp/api/spec/rwlock.h
+++ b/include/odp/api/spec/rwlock.h
@@ -20,6 +20,8 @@ extern "C" {
 
 /**
  * @defgroup odp_locks ODP LOCKS
+ * Various types of locks for thread synchronization.
+ *
  * @details
  * <b> Reader / writer lock (odp_rwlock_t) </b>
  *

--- a/include/odp/api/spec/schedule.h
+++ b/include/odp/api/spec/schedule.h
@@ -25,7 +25,7 @@ extern "C" {
 #include <odp/api/thrmask.h>
 
 /** @defgroup odp_scheduler ODP SCHEDULER
- *  Operations on the scheduler.
+ *  Event scheduler for work load balancing and prioritization.
  *  @{
  */
 

--- a/include/odp/api/spec/shared_memory.h
+++ b/include/odp/api/spec/shared_memory.h
@@ -21,7 +21,7 @@ extern "C" {
 #endif
 
 /** @defgroup odp_shared_memory ODP SHARED MEMORY
- *  Operations on shared memory.
+ *  Shared memory blocks.
  *  @{
  */
 

--- a/include/odp/api/spec/stash.h
+++ b/include/odp/api/spec/stash.h
@@ -1,0 +1,355 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP stash
+ */
+
+#ifndef ODP_API_SPEC_STASH_H_
+#define ODP_API_SPEC_STASH_H_
+#include <odp/visibility_begin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/std_types.h>
+
+/** @defgroup odp_stash ODP STASH
+ *  Stash for storing object handles
+ *  @{
+ */
+
+/**
+ * @typedef odp_stash_t
+ * Stash handle
+ */
+
+/**
+ * @def ODP_STASH_INVALID
+ * Invalid stash handle
+ */
+
+/**
+ * @def ODP_STASH_NAME_LEN
+ * Maximum stash name length in chars including null char
+ */
+
+/**
+ * Stash types
+ */
+typedef enum odp_stash_type_t {
+	/** The default stash type
+	 *
+	 *  It is implementation specific in which order odp_stash_get() calls
+	 *  return object handles from the stash. The order may be FIFO, LIFO
+	 *  or something else. Use this for the best performance when any
+	 *  particular ordering is not required.
+	 */
+	ODP_STASH_TYPE_DEFAULT = 0,
+
+	/** Stash type FIFO
+	 *
+	 *  Stash is implemented as a FIFO. A stash maintains object handle
+	 *  order of consecutive odp_stash_put() calls. Object handles stored
+	 *  first in the stash are received first by following odp_stash_get()
+	 *  calls. To maintain (strict) FIFO ordering of object handles,
+	 *  application needs to ensure that odp_stash_put()
+	 *  (or odp_stash_get()) operations are not performed concurrently from
+	 *  multiple threads. When multiple threads put (or get) object handles
+	 *  concurrently in the stash, object handles from different threads
+	 *  may be interleaved on output.
+	 */
+	ODP_STASH_TYPE_FIFO
+
+} odp_stash_type_t;
+
+/**
+ * Stash operation mode
+ */
+typedef enum odp_stash_op_mode_t {
+	/** Multi-thread safe operation
+	 *
+	 *  Multiple threads operate on the stash. A stash operation
+	 *  (odp_stash_put() or odp_stash_get()) may be performed concurrently
+	 *  from multiple threads.
+	 */
+	ODP_STASH_OP_MT = 0,
+
+	/** Single thread operation
+	 *
+	 *  Multiple threads operate on the stash, but application ensures that
+	 *  a stash operation (odp_stash_put() or odp_stash_get()) is not
+	 *  performed concurrently from multiple threads.
+	 */
+	ODP_STASH_OP_ST,
+
+	/** Thread local operation
+	 *
+	 *  Only a single thread operates on the stash. Both stash operations
+	 *  (odp_stash_put() and odp_stash_get()) are always performed from the
+	 *  same thread.
+	 */
+	ODP_STASH_OP_LOCAL
+
+} odp_stash_op_mode_t;
+
+/**
+ * Stash capabilities (per stash type)
+ */
+typedef struct odp_stash_capability_t {
+	/** Maximum number of stashes of any type */
+	uint32_t max_stashes_any_type;
+
+	/** Maximum number of stashes of this type
+	 *
+	 *  The value of zero means that the requested stash type is not
+	 *  supported.
+	 */
+	uint32_t max_stashes;
+
+	/** Maximum number of object handles per stash
+	 *
+	 *  The value of zero means that limited only by the available
+	 *  memory size.
+	 */
+	uint64_t max_num_obj;
+
+	/** Maximum object handle size in bytes
+	 *
+	 *  At least 4 byte object handle size is always supported.
+	 */
+	uint32_t max_obj_size;
+
+	/** Maximum size of thread local cache */
+	uint32_t max_cache_size;
+
+} odp_stash_capability_t;
+
+/**
+ * Stash parameters
+ */
+typedef struct odp_stash_param_t {
+	/** Stash type
+	 *
+	 *  Select type of the stash to be created. The default value is
+	 *  ODP_STASH_TYPE_DEFAULT. Use stash capability to check if additional
+	 *  types are supported.
+	 */
+	odp_stash_type_t type;
+
+	/** Put operation mode
+	 *
+	 *  The default value is ODP_STASH_OP_MT. Usage of ODP_STASH_OP_ST or
+	 *  ODP_STASH_OP_LOCAL mode may improve performance when applicable.
+	 *  If ODP_STASH_OP_LOCAL is used, it must be set to both put_mode and
+	 *  get_mode.
+	 */
+	odp_stash_op_mode_t put_mode;
+
+	/** Get operation mode
+	 *
+	 *  The default value is ODP_STASH_OP_MT. Usage of ODP_STASH_OP_ST or
+	 *  ODP_STASH_OP_LOCAL mode may improve performance when applicable.
+	 *  If ODP_STASH_OP_LOCAL is used, it must be set to both put_mode and
+	 *  get_mode.
+	 */
+	odp_stash_op_mode_t get_mode;
+
+	/** Maximum number of object handles
+	 *
+	 *  This is the maximum number of object handles application will store
+	 *  in the stash. The value must not exceed 'max_num_obj' capability.
+	 */
+	uint64_t num_obj;
+
+	/** Object handle size in bytes
+	 *
+	 *  Application uses object handles of this size in put and get
+	 *  operations. Valid values are powers of two (1, 2, 4, 8, ... bytes)
+	 *  and must not exceed 'max_obj_size' capability.
+	 */
+	uint32_t obj_size;
+
+	/** Maximum number of object handles cached locally per thread
+	 *
+	 *  A non-zero value allows implementation to cache object handles
+	 *  locally per each thread. Thread local caching may improve
+	 *  performance, but requires application to take into account that
+	 *  some object handles may be stored locally per thread and thus are
+	 *  not available to odp_stash_get() calls from other threads.
+	 *
+	 *  Strict FIFO ordering of object handles cannot be maintained with
+	 *  thread local caching. If application does not require strict
+	 *  ordering, it may allow caching also with ODP_STASH_TYPE_FIFO type
+	 *  stashes.
+	 *
+	 *  This is the maximum number of handles to be cached per thread. The
+	 *  actual cache size and how it is divided between put and get
+	 *  operations is implementation specific. The value must not exceed
+	 *  'max_cache_size' capability. The default value is 0.
+	 *
+	 *  Thread local cache may be emptied with odp_stash_flush_cache().
+	 */
+	uint32_t cache_size;
+
+} odp_stash_param_t;
+
+/**
+ * Query stash capabilities
+ *
+ * Outputs capabilities of the given stash type on success. The stash type
+ * is not supported if 'max_stashes' capability is zero. The default stash
+ * type (ODP_STASH_TYPE_DEFAULT) is always supported. The function returns
+ * failure if the given stash type is unknown to the implementation.
+ *
+ * @param[out] capa   Pointer to capability structure for output
+ * @param      type   Stash type
+ *
+ * @retval 0 on success
+ * @retval <0 on failure
+ */
+int odp_stash_capability(odp_stash_capability_t *capa, odp_stash_type_t type);
+
+/**
+ * Initialize stash params
+ *
+ * Initialize an odp_stash_param_t to its default values for all fields.
+ *
+ * @param param   Parameter structure to be initialized
+ */
+void odp_stash_param_init(odp_stash_param_t *param);
+
+/**
+ * Create a stash
+ *
+ * This routine is used to create a stash for object handles. Object handle
+ * values are opaque data to ODP implementation. Application may use a stash
+ * to store e.g. pointers, offsets or indexes to arbitrary objects which are
+ * allocated and freed frequently (e.g. per packet) during application
+ * processing. Object handle size is specified in stash parameters.
+ *
+ * It is optional to give a name. Names do not have to be unique. However,
+ * odp_stash_lookup() returns only a single matching stash.
+ *
+ * @param name     Name of the stash or NULL. Maximum string length is
+ *                 ODP_STASH_NAME_LEN.
+ * @param param    Stash creation parameters
+ *
+ * @return Handle of the created stash
+ * @retval ODP_STASH_INVALID  Stash could not be created
+ */
+odp_stash_t odp_stash_create(const char *name, const odp_stash_param_t *param);
+
+/**
+ * Destroy a stash
+ *
+ * Destroy a previously created stash. Stash must be empty before it is
+ * destroyed. Results are undefined if an attempt is made to destroy a stash
+ * that contains object handles.
+ *
+ * @param stash    The stash to be destroyed
+ *
+ * @retval  0 Success
+ * @retval <0 Failure
+ */
+int odp_stash_destroy(odp_stash_t stash);
+
+/**
+ * Find a stash by name
+ *
+ * @param name      Name of the stash
+ *
+ * @return Handle of the first matching stash
+ * @retval ODP_STASH_INVALID  Stash could not be found
+ */
+odp_stash_t odp_stash_lookup(const char *name);
+
+/**
+ * Get printable value for a stash handle
+ *
+ * @param stash  Handle to be converted for debugging
+ * @return uint64_t value that can be used for debugging (e.g. printed)
+ */
+uint64_t odp_stash_to_u64(odp_stash_t stash);
+
+/**
+ * Put object handles into a stash
+ *
+ * Store object handles into the stash. Handle values are opaque data to
+ * ODP implementation and may be e.g. pointers or indexes to arbitrary objects.
+ * Application specifies object handle size and maximum number of handles to be
+ * stored in stash creation parameters. Application must not attempt to store
+ * more handles into the stash than it specifies in the creation parameters.
+ *
+ * A successful operation returns the actual number of object handles stored.
+ * If the return value is less than 'num', the remaining handles at the end of
+ * 'obj' array are not stored.
+ *
+ * In case of ODP_STASH_TYPE_FIFO, object handles are stored into the stash in
+ * the order they are in the array.
+ *
+ * @param stash  Stash handle
+ * @param obj    Points to an array of object handles to be stored.
+ *               Object handle size is specified by 'obj_size' in stash
+ *               creation parameters. The array must be 'obj_size' aligned
+ *               in memory.
+ * @param num    Number of object handles to store
+ *
+ * @return Number of object handles actually stored (0 ... num)
+ * @retval <0 on failure
+ */
+int32_t odp_stash_put(odp_stash_t stash, const void *obj, int32_t num);
+
+/**
+ * Get object handles from a stash
+ *
+ * Get previously stored object handles from the stash. Application specifies
+ * object handle size in stash creation parameters.
+ *
+ * @param      stash  Stash handle
+ * @param[out] obj    Points to an array of object handles for output.
+ *                    Object handle size is specified by 'obj_size' in stash
+ *                    creation parameters. The array must be 'obj_size' aligned
+ *                    in memory.
+ * @param      num    Maximum number of object handles to get from the stash
+ *
+ * @return Number of object handles actually output (0 ... num) to 'obj' array
+ * @retval <0 on failure
+ */
+int32_t odp_stash_get(odp_stash_t stash, void *obj, int32_t num);
+
+/**
+ * Flush object handles from the thread local cache
+ *
+ * Flushes all object handles from the thread local cache into the stash, so
+ * that those are available to odp_stash_get() calls from other threads. This
+ * call may be used to ensure that thread local cache is empty e.g. before
+ * the calling thread stops using the stash.
+ *
+ * Flush and put operations share 'put_mode' setting in stash creation
+ * parameters. So, application must ensure that flush and put operations are not
+ * used concurrently, when ODP_STASH_OP_ST is selected.
+ *
+ * @param stash  Stash handle
+ *
+ * @retval  0 on success
+ * @retval <0 on failure
+ */
+int odp_stash_flush_cache(odp_stash_t stash);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <odp/visibility_end.h>
+#endif

--- a/include/odp/api/spec/std_clib.h
+++ b/include/odp/api/spec/std_clib.h
@@ -20,6 +20,8 @@ extern "C" {
 
 /**
  * @defgroup odp_std_clib ODP STD CLIB
+ * Performance optimized versions of selected C library functions.
+ *
  * @details
  * ODP version of often used C library calls
  * @{

--- a/include/odp/api/spec/support.h
+++ b/include/odp/api/spec/support.h
@@ -18,8 +18,8 @@
 extern "C" {
 #endif
 
-/** @defgroup odp_support ODP support
- *  Common API
+/** @defgroup odp_support ODP SUPPORT
+ *  Feature support levels.
  *  @{
  */
 

--- a/include/odp/api/spec/system_info.h
+++ b/include/odp/api/spec/system_info.h
@@ -19,6 +19,7 @@ extern "C" {
 #endif
 
 /** @defgroup odp_system ODP SYSTEM
+ *  System information.
  *  @{
  */
 

--- a/include/odp/api/spec/thread.h
+++ b/include/odp/api/spec/thread.h
@@ -19,6 +19,7 @@ extern "C" {
 #endif
 
 /** @defgroup odp_thread ODP THREAD
+ *  Thread types, masks and IDs.
  *  @{
  */
 

--- a/include/odp/api/spec/time.h
+++ b/include/odp/api/spec/time.h
@@ -19,6 +19,7 @@ extern "C" {
 #endif
 
 /** @defgroup odp_time ODP TIME
+ *  Chip and CPU level wall clock time.
  *  @{
  */
 

--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -21,6 +21,7 @@ extern "C" {
 #endif
 
 /** @defgroup odp_timer ODP TIMER
+ *  Timer generating timeout events.
  *  @{
  */
 

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -23,7 +23,7 @@ extern "C" {
 /** @defgroup odp_traffic_mngr ODP TRAFFIC MNGR
  * @{
  *
- * An API for configuring and using Traffic Management systems
+ * Traffic management on packet output.
  *
  * This file forms a simple interface for creating, configuring and using
  * Traffic Management (TM) subsystems.  By TM subsystem it is meant a general

--- a/include/odp/api/stash.h
+++ b/include/odp/api/stash.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP stash
+ */
+
+#ifndef ODP_API_STASH_H_
+#define ODP_API_STASH_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/abi/stash.h>
+
+#include <odp/api/spec/stash.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/arch/arm32-linux/odp/api/abi/stash.h
+++ b/include/odp/arch/arm32-linux/odp/api/abi/stash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/stash.h>

--- a/include/odp/arch/arm64-linux/odp/api/abi/stash.h
+++ b/include/odp/arch/arm64-linux/odp/api/abi/stash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/stash.h>

--- a/include/odp/arch/default-linux/odp/api/abi/stash.h
+++ b/include/odp/arch/default-linux/odp/api/abi/stash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/stash.h>

--- a/include/odp/arch/mips64-linux/odp/api/abi/stash.h
+++ b/include/odp/arch/mips64-linux/odp/api/abi/stash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/stash.h>

--- a/include/odp/arch/power64-linux/odp/api/abi/stash.h
+++ b/include/odp/arch/power64-linux/odp/api/abi/stash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/stash.h>

--- a/include/odp/arch/x86_32-linux/odp/api/abi/stash.h
+++ b/include/odp/arch/x86_32-linux/odp/api/abi/stash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/stash.h>

--- a/include/odp/arch/x86_64-linux/odp/api/abi/stash.h
+++ b/include/odp/arch/x86_64-linux/odp/api/abi/stash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/stash.h>

--- a/include/odp_api.h
+++ b/include/odp_api.h
@@ -62,6 +62,7 @@ extern "C" {
 #include <odp/api/std_clib.h>
 #include <odp/api/support.h>
 #include <odp/api/ipsec.h>
+#include <odp/api/stash.h>
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -201,6 +201,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_sorted_list.c \
 			   odp_spinlock.c \
 			   odp_spinlock_recursive.c \
+			   odp_stash.c \
 			   odp_system_info.c \
 			   odp_pcapng.c \
 			   odp_thread.c \

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -72,6 +72,7 @@ odpapiabiarchinclude_HEADERS += \
 		  include-abi/odp/api/abi/shared_memory.h \
 		  include-abi/odp/api/abi/spinlock.h \
 		  include-abi/odp/api/abi/spinlock_recursive.h \
+		  include-abi/odp/api/abi/stash.h \
 		  include-abi/odp/api/abi/std_clib.h \
 		  include-abi/odp/api/abi/std_types.h \
 		  include-abi/odp/api/abi/sync.h \

--- a/platform/linux-generic/include-abi/odp/api/abi/stash.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/stash.h
@@ -1,0 +1,38 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ */
+
+#ifndef ODP_API_ABI_STASH_H_
+#define ODP_API_ABI_STASH_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/plat/strong_types.h>
+
+/** @ingroup odp_stash
+ *  @{
+ */
+
+typedef ODP_HANDLE_T(odp_stash_t);
+
+#define ODP_STASH_INVALID _odp_cast_scalar(odp_stash_t, 0)
+
+#define ODP_STASH_NAME_LEN  32
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp_init_internal.h
+++ b/platform/linux-generic/include/odp_init_internal.h
@@ -96,6 +96,9 @@ int _odp_cpu_cycles_init_global(void);
 int _odp_hash_init_global(void);
 int _odp_hash_term_global(void);
 
+int _odp_stash_init_global(void);
+int _odp_stash_term_global(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -29,6 +29,7 @@ enum init_stage {
 	HASH_INIT,
 	THREAD_INIT,
 	POOL_INIT,
+	STASH_INIT,
 	QUEUE_INIT,
 	SCHED_INIT,
 	PKTIO_INIT,
@@ -203,6 +204,13 @@ static int term_global(enum init_stage stage)
 		}
 		/* Fall through */
 
+	case STASH_INIT:
+		if (_odp_stash_term_global()) {
+			ODP_ERR("ODP stash term failed.\n");
+			rc = -1;
+		}
+		/* Fall through */
+
 	case POOL_INIT:
 		if (_odp_pool_term_global()) {
 			ODP_ERR("ODP buffer pool term failed.\n");
@@ -372,6 +380,12 @@ int odp_init_global(odp_instance_t *instance,
 		goto init_failed;
 	}
 	stage = POOL_INIT;
+
+	if (_odp_stash_init_global()) {
+		ODP_ERR("ODP stash init failed.\n");
+		goto init_failed;
+	}
+	stage = STASH_INIT;
 
 	if (_odp_queue_init_global()) {
 		ODP_ERR("ODP queue init failed.\n");

--- a/platform/linux-generic/odp_stash.c
+++ b/platform/linux-generic/odp_stash.c
@@ -1,0 +1,400 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <odp/api/ticketlock.h>
+#include <odp/api/shared_memory.h>
+#include <odp/api/stash.h>
+#include <odp/api/plat/strong_types.h>
+
+#include <odp_debug_internal.h>
+#include <odp_init_internal.h>
+#include <odp_ring_ptr_internal.h>
+#include <odp_ring_u32_internal.h>
+
+#define MAX_STASHES   32
+#define MAX_RING_SIZE (1024 * 1024)
+#define MIN_RING_SIZE 64
+
+typedef struct stash_t {
+	char      name[ODP_STASH_NAME_LEN];
+	odp_shm_t shm;
+	int       index;
+	uint32_t  ring_mask;
+	uint32_t  obj_size;
+
+	/* Ring header followed by variable sized data (object handles) */
+	union {
+		struct ODP_ALIGNED_CACHE {
+			ring_ptr_t hdr;
+			uintptr_t  data[0];
+		} ring_ptr;
+
+		struct ODP_ALIGNED_CACHE {
+			ring_u32_t hdr;
+			uint32_t   data[0];
+		} ring_u32;
+	};
+
+} stash_t;
+
+typedef struct stash_global_t {
+	odp_ticketlock_t  lock;
+	odp_shm_t         shm;
+	uint8_t           stash_reserved[MAX_STASHES];
+	stash_t           *stash[MAX_STASHES];
+
+} stash_global_t;
+
+static stash_global_t *stash_global;
+
+int _odp_stash_init_global(void)
+{
+	odp_shm_t shm;
+
+	shm = odp_shm_reserve("_odp_stash_table", sizeof(stash_global_t),
+			      ODP_CACHE_LINE_SIZE, 0);
+
+	stash_global = odp_shm_addr(shm);
+
+	if (stash_global == NULL) {
+		ODP_ERR("SHM reserve of stash global data failed\n");
+		return -1;
+	}
+
+	memset(stash_global, 0, sizeof(stash_global_t));
+	stash_global->shm = shm;
+	odp_ticketlock_init(&stash_global->lock);
+
+	return 0;
+}
+
+int _odp_stash_term_global(void)
+{
+	if (stash_global == NULL)
+		return 0;
+
+	if (odp_shm_free(stash_global->shm)) {
+		ODP_ERR("SHM free failed\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+int odp_stash_capability(odp_stash_capability_t *capa, odp_stash_type_t type)
+{
+	(void)type;
+	memset(capa, 0, sizeof(odp_stash_capability_t));
+
+	capa->max_stashes_any_type = MAX_STASHES;
+	capa->max_stashes          = MAX_STASHES;
+	capa->max_num_obj          = MAX_RING_SIZE;
+	capa->max_obj_size         = sizeof(uintptr_t);
+
+	return 0;
+}
+
+void odp_stash_param_init(odp_stash_param_t *param)
+{
+	memset(param, 0, sizeof(odp_stash_param_t));
+	param->type     = ODP_STASH_TYPE_DEFAULT;
+	param->put_mode = ODP_STASH_OP_MT;
+	param->get_mode = ODP_STASH_OP_MT;
+}
+
+static int reserve_index(void)
+{
+	int i;
+	int index = -1;
+
+	odp_ticketlock_lock(&stash_global->lock);
+
+	for (i = 0; i < MAX_STASHES; i++) {
+		if (stash_global->stash_reserved[i] == 0) {
+			index = i;
+			stash_global->stash_reserved[i] = 1;
+			break;
+		}
+	}
+
+	odp_ticketlock_unlock(&stash_global->lock);
+
+	return index;
+}
+
+static void free_index(int i)
+{
+	odp_ticketlock_lock(&stash_global->lock);
+
+	stash_global->stash[i] = NULL;
+	stash_global->stash_reserved[i] = 0;
+
+	odp_ticketlock_unlock(&stash_global->lock);
+}
+
+odp_stash_t odp_stash_create(const char *name, const odp_stash_param_t *param)
+{
+	odp_shm_t shm;
+	stash_t *stash;
+	uint64_t i, ring_size, shm_size;
+	int ring_ptr, index;
+	char shm_name[ODP_STASH_NAME_LEN + 8];
+
+	if (param->obj_size > sizeof(uintptr_t)) {
+		ODP_ERR("Too large object handle.\n");
+		return ODP_STASH_INVALID;
+	}
+
+	if (param->num_obj > MAX_RING_SIZE) {
+		ODP_ERR("Too many objects.\n");
+		return ODP_STASH_INVALID;
+	}
+
+	if (name && strlen(name) >= ODP_STASH_NAME_LEN) {
+		ODP_ERR("Too long name.\n");
+		return ODP_STASH_INVALID;
+	}
+
+	index = reserve_index();
+
+	if (index < 0) {
+		ODP_ERR("Maximum number of stashes created already.\n");
+		return ODP_STASH_INVALID;
+	}
+
+	ring_ptr = 0;
+	if (param->obj_size > sizeof(uint32_t))
+		ring_ptr = 1;
+
+	ring_size = param->num_obj;
+
+	/* Ring size must be larger than the number of items stored */
+	if (ring_size + 1 <= MIN_RING_SIZE)
+		ring_size = MIN_RING_SIZE;
+	else
+		ring_size = ROUNDUP_POWER2_U32(ring_size + 1);
+
+	memset(shm_name, 0, sizeof(shm_name));
+	snprintf(shm_name, sizeof(shm_name) - 1, "_stash_%s", name);
+
+	if (ring_ptr)
+		shm_size = sizeof(stash_t) + (ring_size * sizeof(uintptr_t));
+	else
+		shm_size = sizeof(stash_t) + (ring_size * sizeof(uint32_t));
+
+	shm = odp_shm_reserve(shm_name, shm_size, ODP_CACHE_LINE_SIZE, 0);
+
+	if (shm == ODP_SHM_INVALID) {
+		ODP_ERR("SHM reserve failed.\n");
+		free_index(index);
+		return ODP_STASH_INVALID;
+	}
+
+	stash = odp_shm_addr(shm);
+	memset(stash, 0, sizeof(stash_t));
+
+	if (ring_ptr) {
+		ring_ptr_init(&stash->ring_ptr.hdr);
+
+		for (i = 0; i < ring_size; i++)
+			stash->ring_ptr.data[i] = 0;
+	} else {
+		ring_u32_init(&stash->ring_u32.hdr);
+
+		for (i = 0; i < ring_size; i++)
+			stash->ring_u32.data[i] = 0;
+	}
+
+	if (name)
+		strcpy(stash->name, name);
+
+	stash->index        = index;
+	stash->shm          = shm;
+	stash->obj_size     = param->obj_size;
+	stash->ring_mask    = ring_size - 1;
+
+	/* This makes stash visible to lookups */
+	odp_ticketlock_lock(&stash_global->lock);
+	stash_global->stash[index] = stash;
+	odp_ticketlock_unlock(&stash_global->lock);
+
+	return (odp_stash_t)stash;
+}
+
+int odp_stash_destroy(odp_stash_t st)
+{
+	stash_t *stash;
+	int index;
+	odp_shm_t shm;
+
+	if (st == ODP_STASH_INVALID)
+		return -1;
+
+	stash = (stash_t *)(uintptr_t)st;
+	index = stash->index;
+	shm   = stash->shm;
+
+	free_index(index);
+
+	if (odp_shm_free(shm)) {
+		ODP_ERR("SHM free failed.\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+uint64_t odp_stash_to_u64(odp_stash_t st)
+{
+	return _odp_pri(st);
+}
+
+odp_stash_t odp_stash_lookup(const char *name)
+{
+	int i;
+	stash_t *stash;
+
+	if (name == NULL)
+		return ODP_STASH_INVALID;
+
+	odp_ticketlock_lock(&stash_global->lock);
+
+	for (i = 0; i < MAX_STASHES; i++) {
+		stash = stash_global->stash[i];
+
+		if (stash && strcmp(stash->name, name) == 0) {
+			odp_ticketlock_unlock(&stash_global->lock);
+			return (odp_stash_t)stash;
+		}
+	}
+
+	odp_ticketlock_unlock(&stash_global->lock);
+
+	return ODP_STASH_INVALID;
+}
+
+int32_t odp_stash_put(odp_stash_t st, const void *obj, int32_t num)
+{
+	stash_t *stash;
+	uint32_t obj_size;
+	int32_t i;
+
+	stash = (stash_t *)(uintptr_t)st;
+
+	if (odp_unlikely(st == ODP_STASH_INVALID))
+		return -1;
+
+	obj_size = stash->obj_size;
+
+	if (obj_size == sizeof(uintptr_t)) {
+		ring_ptr_t *ring_ptr = &stash->ring_ptr.hdr;
+
+		ring_ptr_enq_multi(ring_ptr, stash->ring_mask,
+				   (void *)(uintptr_t)obj, num);
+		return num;
+	}
+
+	if (obj_size == sizeof(uint32_t)) {
+		ring_u32_t *ring_u32 = &stash->ring_u32.hdr;
+
+		ring_u32_enq_multi(ring_u32, stash->ring_mask,
+				   (uint32_t *)(uintptr_t)obj, num);
+		return num;
+	}
+
+	if (obj_size == sizeof(uint16_t)) {
+		const uint16_t *u16_ptr = obj;
+		ring_u32_t *ring_u32 = &stash->ring_u32.hdr;
+		uint32_t u32[num];
+
+		for (i = 0; i < num; i++)
+			u32[i] = u16_ptr[i];
+
+		ring_u32_enq_multi(ring_u32, stash->ring_mask, u32, num);
+		return num;
+	}
+
+	if (obj_size == sizeof(uint8_t)) {
+		const uint8_t *u8_ptr = obj;
+		ring_u32_t *ring_u32 = &stash->ring_u32.hdr;
+		uint32_t u32[num];
+
+		for (i = 0; i < num; i++)
+			u32[i] = u8_ptr[i];
+
+		ring_u32_enq_multi(ring_u32, stash->ring_mask, u32, num);
+		return num;
+	}
+
+	return -1;
+}
+
+int32_t odp_stash_get(odp_stash_t st, void *obj, int32_t num)
+{
+	stash_t *stash;
+	uint32_t obj_size;
+	uint32_t i, num_deq;
+
+	stash = (stash_t *)(uintptr_t)st;
+
+	if (odp_unlikely(st == ODP_STASH_INVALID))
+		return -1;
+
+	obj_size = stash->obj_size;
+
+	if (obj_size == sizeof(uintptr_t)) {
+		ring_ptr_t *ring_ptr = &stash->ring_ptr.hdr;
+
+		return ring_ptr_deq_multi(ring_ptr, stash->ring_mask, obj, num);
+	}
+
+	if (obj_size == sizeof(uint32_t)) {
+		ring_u32_t *ring_u32 = &stash->ring_u32.hdr;
+
+		return ring_u32_deq_multi(ring_u32, stash->ring_mask, obj, num);
+	}
+
+	if (obj_size == sizeof(uint16_t)) {
+		uint16_t *u16_ptr = obj;
+		ring_u32_t *ring_u32 = &stash->ring_u32.hdr;
+		uint32_t u32[num];
+
+		num_deq = ring_u32_deq_multi(ring_u32, stash->ring_mask,
+					     u32, num);
+
+		for (i = 0; i < num_deq; i++)
+			u16_ptr[i] = u32[i];
+
+		return num_deq;
+	}
+
+	if (obj_size == sizeof(uint8_t)) {
+		uint8_t *u8_ptr = obj;
+		ring_u32_t *ring_u32 = &stash->ring_u32.hdr;
+		uint32_t u32[num];
+
+		num_deq = ring_u32_deq_multi(ring_u32, stash->ring_mask,
+					     u32, num);
+
+		for (i = 0; i < num_deq; i++)
+			u8_ptr[i] = u32[i];
+
+		return num_deq;
+	}
+
+	return -1;
+}
+
+int odp_stash_flush_cache(odp_stash_t st)
+{
+	if (odp_unlikely(st == ODP_STASH_INVALID))
+		return -1;
+
+	return 0;
+}

--- a/test/m4/configure.m4
+++ b/test/m4/configure.m4
@@ -39,6 +39,7 @@ AC_CONFIG_FILES([test/Makefile
 		 test/validation/api/random/Makefile
 		 test/validation/api/scheduler/Makefile
 		 test/validation/api/shmem/Makefile
+		 test/validation/api/stash/Makefile
 		 test/validation/api/std_clib/Makefile
 		 test/validation/api/system/Makefile
 		 test/validation/api/thread/Makefile

--- a/test/validation/api/Makefile.am
+++ b/test/validation/api/Makefile.am
@@ -18,6 +18,7 @@ ODP_MODULES = atomic \
 	      pool \
 	      random \
 	      scheduler \
+	      stash \
 	      std_clib \
 	      thread \
 	      time \
@@ -59,6 +60,7 @@ TESTS = \
 	queue/queue_main$(EXEEXT) \
 	random/random_main$(EXEEXT) \
 	scheduler/scheduler_main$(EXEEXT) \
+	stash/stash_main$(EXEEXT) \
 	std_clib/std_clib_main$(EXEEXT) \
 	thread/thread_main$(EXEEXT) \
 	time/time_main$(EXEEXT) \

--- a/test/validation/api/init/init_main.c
+++ b/test/validation/api/init/init_main.c
@@ -138,6 +138,7 @@ static void init_test_feature(int disable)
 		param.not_used.feat.crypto   = 1;
 		param.not_used.feat.ipsec    = 1;
 		param.not_used.feat.schedule = 1;
+		param.not_used.feat.stash    = 1;
 		param.not_used.feat.time     = 1;
 		param.not_used.feat.timer    = 1;
 		param.not_used.feat.tm       = 1;

--- a/test/validation/api/stash/.gitignore
+++ b/test/validation/api/stash/.gitignore
@@ -1,0 +1,1 @@
+stash_main

--- a/test/validation/api/stash/Makefile.am
+++ b/test/validation/api/stash/Makefile.am
@@ -1,0 +1,4 @@
+include ../Makefile.inc
+
+test_PROGRAMS = stash_main
+stash_main_SOURCES = stash.c

--- a/test/validation/api/stash/stash.c
+++ b/test/validation/api/stash/stash.c
@@ -1,0 +1,735 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <odp_api.h>
+#include "odp_cunit_common.h"
+
+#define MAGIC_U64  0x8b7438fa56c82e96
+#define MAGIC_U32  0x74a13b94
+#define MAGIC_U16  0x25bf
+#define MAGIC_U8   0xab
+
+#define NUM_U64    1024
+#define NUM_U32    1024
+#define NUM_U16    1024
+#define NUM_U8     256
+
+#define CACHE_SIZE 8
+#define BURST      32
+#define MAX_RETRY  1024
+#define RETRY_MSEC 100
+
+typedef struct num_obj_t {
+	uint32_t u64;
+	uint32_t u32;
+	uint32_t u16;
+	uint32_t u8;
+
+} num_obj_t;
+
+typedef struct global_t {
+	odp_stash_capability_t capa_default;
+	odp_stash_capability_t capa_fifo;
+	int fifo_supported;
+	num_obj_t num_default;
+	num_obj_t num_fifo;
+	uint32_t  cache_size_default;
+
+} global_t;
+
+static global_t global;
+
+static int stash_suite_init(void)
+{
+	odp_stash_capability_t *capa_default = &global.capa_default;
+	odp_stash_capability_t *capa_fifo = &global.capa_fifo;
+
+	if (odp_stash_capability(capa_default, ODP_STASH_TYPE_DEFAULT)) {
+		printf("stash capability failed for the default type\n");
+		return -1;
+	}
+
+	global.num_default.u64 = NUM_U64;
+	global.num_default.u32 = NUM_U32;
+	global.num_default.u16 = NUM_U16;
+	global.num_default.u8  = NUM_U8;
+
+	if (global.num_default.u64 > capa_default->max_num_obj)
+		global.num_default.u64 = capa_default->max_num_obj;
+	if (global.num_default.u32 > capa_default->max_num_obj)
+		global.num_default.u32 = capa_default->max_num_obj;
+	if (global.num_default.u16 > capa_default->max_num_obj)
+		global.num_default.u16 = capa_default->max_num_obj;
+	if (global.num_default.u8 > capa_default->max_num_obj)
+		global.num_default.u8 = capa_default->max_num_obj;
+
+	global.cache_size_default = CACHE_SIZE;
+	if (global.cache_size_default > capa_default->max_cache_size)
+		global.cache_size_default = capa_default->max_cache_size;
+
+	global.fifo_supported = 0;
+	if (odp_stash_capability(capa_fifo, ODP_STASH_TYPE_FIFO) == 0) {
+		if (capa_fifo->max_stashes)
+			global.fifo_supported = 1;
+	}
+
+	if (global.fifo_supported) {
+		global.num_fifo.u64 = NUM_U64;
+		global.num_fifo.u32 = NUM_U32;
+		global.num_fifo.u16 = NUM_U16;
+		global.num_fifo.u8  = NUM_U8;
+
+		if (global.num_fifo.u64 > capa_fifo->max_num_obj)
+			global.num_fifo.u64 = capa_fifo->max_num_obj;
+		if (global.num_fifo.u32 > capa_fifo->max_num_obj)
+			global.num_fifo.u32 = capa_fifo->max_num_obj;
+		if (global.num_fifo.u16 > capa_fifo->max_num_obj)
+			global.num_fifo.u16 = capa_fifo->max_num_obj;
+		if (global.num_fifo.u8 > capa_fifo->max_num_obj)
+			global.num_fifo.u8 = capa_fifo->max_num_obj;
+	}
+
+	return 0;
+}
+
+static void stash_capability(void)
+{
+	odp_stash_capability_t capa;
+	int ret;
+
+	memset(&capa, 0, sizeof(odp_stash_capability_t));
+	CU_ASSERT(odp_stash_capability(&capa, ODP_STASH_TYPE_DEFAULT) == 0);
+	CU_ASSERT(capa.max_stashes_any_type > 0);
+	CU_ASSERT(capa.max_stashes > 0);
+	CU_ASSERT(capa.max_num_obj > 0);
+	CU_ASSERT(capa.max_obj_size >= sizeof(uint32_t));
+
+	memset(&capa, 0, sizeof(odp_stash_capability_t));
+	ret = odp_stash_capability(&capa, ODP_STASH_TYPE_FIFO);
+	CU_ASSERT(ret == 0);
+	CU_ASSERT(capa.max_stashes_any_type > 0);
+	if (ret == 0 && capa.max_stashes) {
+		CU_ASSERT(capa.max_num_obj > 0);
+		CU_ASSERT(capa.max_obj_size >= sizeof(uint32_t));
+	}
+}
+
+static void stash_param_defaults(void)
+{
+	odp_stash_param_t param;
+
+	memset(&param, 0xff, sizeof(odp_stash_param_t));
+	odp_stash_param_init(&param);
+	CU_ASSERT(param.type == ODP_STASH_TYPE_DEFAULT);
+	CU_ASSERT(param.put_mode == ODP_STASH_OP_MT);
+	CU_ASSERT(param.get_mode == ODP_STASH_OP_MT);
+	CU_ASSERT(param.cache_size == 0);
+}
+
+static void stash_create_u64(void)
+{
+	odp_stash_t stash, lookup;
+	odp_stash_param_t param;
+	uint32_t num = global.num_default.u64;
+
+	odp_stash_param_init(&param);
+	param.num_obj  = num;
+	param.obj_size = sizeof(uint64_t);
+
+	stash = odp_stash_create("test_stash_u64", &param);
+
+	CU_ASSERT_FATAL(stash != ODP_STASH_INVALID);
+
+	printf("\n    Stash handle: 0x%" PRIx64 "\n", odp_stash_to_u64(stash));
+
+	lookup = odp_stash_lookup("test_stash_u64");
+	CU_ASSERT(lookup != ODP_STASH_INVALID);
+	CU_ASSERT(stash == lookup);
+	CU_ASSERT(odp_stash_lookup("foo") == ODP_STASH_INVALID);
+
+	CU_ASSERT_FATAL(odp_stash_destroy(stash) == 0);
+}
+
+static void stash_create_u32(void)
+{
+	odp_stash_t stash, lookup;
+	odp_stash_param_t param;
+	uint32_t num = global.num_default.u32;
+
+	odp_stash_param_init(&param);
+	param.num_obj  = num;
+	param.obj_size = sizeof(uint32_t);
+
+	stash = odp_stash_create("test_stash_u32", &param);
+
+	CU_ASSERT_FATAL(stash != ODP_STASH_INVALID);
+
+	printf("\n    Stash handle: 0x%" PRIx64 "\n", odp_stash_to_u64(stash));
+
+	lookup = odp_stash_lookup("test_stash_u32");
+	CU_ASSERT(lookup != ODP_STASH_INVALID);
+	CU_ASSERT(stash == lookup);
+	CU_ASSERT(odp_stash_lookup("foo") == ODP_STASH_INVALID);
+
+	CU_ASSERT_FATAL(odp_stash_destroy(stash) == 0);
+}
+
+static void stash_create_u64_all(void)
+{
+	odp_stash_param_t param;
+	uint64_t input, output;
+	uint32_t i, retry;
+	int32_t ret;
+	uint32_t num_obj = global.num_default.u32;
+	uint32_t num_stash = global.capa_default.max_stashes;
+	odp_stash_t stash[num_stash];
+
+	CU_ASSERT_FATAL(num_stash > 0);
+
+	odp_stash_param_init(&param);
+	param.num_obj  = num_obj;
+	param.obj_size = sizeof(uint64_t);
+
+	for (i = 0; i < num_stash; i++) {
+		stash[i] = odp_stash_create("test_stash_u64_all", &param);
+		CU_ASSERT_FATAL(stash[i] != ODP_STASH_INVALID);
+		CU_ASSERT_FATAL(odp_stash_get(stash[i], &output, 1) == 0);
+
+		input = i;
+		CU_ASSERT(odp_stash_put(stash[i], &input, 1) == 1);
+	}
+
+	for (i = 0; i < num_stash; i++) {
+		ret = 0;
+
+		for (retry = 0; retry < RETRY_MSEC; retry++) {
+			/* Extra delay allows HW latency from put() to get() */
+			odp_time_wait_ns(ODP_TIME_MSEC_IN_NS);
+			ret = odp_stash_get(stash[i], &output, 1);
+			if (ret)
+				break;
+		}
+
+		CU_ASSERT(ret == 1);
+		CU_ASSERT(output == i);
+	}
+
+	for (i = 0; i < num_stash; i++)
+		CU_ASSERT_FATAL(odp_stash_destroy(stash[i]) == 0);
+}
+
+static void stash_create_u32_all(void)
+{
+	odp_stash_param_t param;
+	uint32_t i, retry, input, output;
+	int32_t ret;
+	uint32_t num_obj = global.num_default.u32;
+	uint32_t num_stash = global.capa_default.max_stashes;
+	odp_stash_t stash[num_stash];
+
+	CU_ASSERT_FATAL(num_stash > 0);
+
+	odp_stash_param_init(&param);
+	param.num_obj  = num_obj;
+	param.obj_size = sizeof(uint32_t);
+
+	for (i = 0; i < num_stash; i++) {
+		stash[i] = odp_stash_create("test_stash_u32_all", &param);
+		CU_ASSERT_FATAL(stash[i] != ODP_STASH_INVALID);
+		CU_ASSERT_FATAL(odp_stash_get(stash[i], &output, 1) == 0);
+
+		input = i;
+		CU_ASSERT(odp_stash_put(stash[i], &input, 1) == 1);
+	}
+
+	for (i = 0; i < num_stash; i++) {
+		ret = 0;
+
+		for (retry = 0; retry < RETRY_MSEC; retry++) {
+			/* Extra delay allows HW latency from put() to get() */
+			odp_time_wait_ns(ODP_TIME_MSEC_IN_NS);
+			ret = odp_stash_get(stash[i], &output, 1);
+			if (ret)
+				break;
+		}
+
+		CU_ASSERT(ret == 1);
+		CU_ASSERT(output == i);
+	}
+
+	for (i = 0; i < num_stash; i++)
+		CU_ASSERT_FATAL(odp_stash_destroy(stash[i]) == 0);
+}
+
+static void stash_create_fifo_u64_all(void)
+{
+	odp_stash_param_t param;
+	uint64_t input, output;
+	uint32_t i, retry;
+	int32_t ret;
+	uint32_t num_obj = global.num_fifo.u64;
+	uint32_t num_stash = global.capa_fifo.max_stashes;
+	odp_stash_t stash[num_stash];
+
+	CU_ASSERT_FATAL(num_stash > 0);
+
+	odp_stash_param_init(&param);
+	param.type     = ODP_STASH_TYPE_FIFO;
+	param.num_obj  = num_obj;
+	param.obj_size = sizeof(uint64_t);
+
+	for (i = 0; i < num_stash; i++) {
+		stash[i] = odp_stash_create(NULL, &param);
+		CU_ASSERT_FATAL(stash[i] != ODP_STASH_INVALID);
+		CU_ASSERT_FATAL(odp_stash_get(stash[i], &output, 1) == 0);
+
+		input = i;
+		CU_ASSERT(odp_stash_put(stash[i], &input, 1) == 1);
+	}
+
+	for (i = 0; i < num_stash; i++) {
+		ret = 0;
+
+		for (retry = 0; retry < RETRY_MSEC; retry++) {
+			/* Extra delay allows HW latency from put() to get() */
+			odp_time_wait_ns(ODP_TIME_MSEC_IN_NS);
+			ret = odp_stash_get(stash[i], &output, 1);
+			if (ret)
+				break;
+		}
+
+		CU_ASSERT(ret == 1);
+		CU_ASSERT(output == i);
+	}
+
+	for (i = 0; i < num_stash; i++)
+		CU_ASSERT_FATAL(odp_stash_destroy(stash[i]) == 0);
+}
+
+static void stash_create_fifo_u32_all(void)
+{
+	odp_stash_param_t param;
+	uint32_t i, retry, input, output;
+	int32_t ret;
+	uint32_t num_obj = global.num_fifo.u32;
+	uint32_t num_stash = global.capa_fifo.max_stashes;
+	odp_stash_t stash[num_stash];
+
+	CU_ASSERT_FATAL(num_stash > 0);
+
+	odp_stash_param_init(&param);
+	param.type     = ODP_STASH_TYPE_FIFO;
+	param.num_obj  = num_obj;
+	param.obj_size = sizeof(uint32_t);
+
+	for (i = 0; i < num_stash; i++) {
+		stash[i] = odp_stash_create(NULL, &param);
+		CU_ASSERT_FATAL(stash[i] != ODP_STASH_INVALID);
+		CU_ASSERT_FATAL(odp_stash_get(stash[i], &output, 1) == 0);
+
+		input = i;
+		CU_ASSERT(odp_stash_put(stash[i], &input, 1) == 1);
+	}
+
+	for (i = 0; i < num_stash; i++) {
+		ret = 0;
+
+		for (retry = 0; retry < RETRY_MSEC; retry++) {
+			/* Extra delay allows HW latency from put() to get() */
+			odp_time_wait_ns(ODP_TIME_MSEC_IN_NS);
+			ret = odp_stash_get(stash[i], &output, 1);
+			if (ret)
+				break;
+		}
+
+		CU_ASSERT(ret == 1);
+		CU_ASSERT(output == i);
+	}
+
+	for (i = 0; i < num_stash; i++)
+		CU_ASSERT_FATAL(odp_stash_destroy(stash[i]) == 0);
+}
+
+static void stash_default_put(uint32_t size, int32_t burst)
+{
+	odp_stash_t stash;
+	odp_stash_param_t param;
+	int32_t i, ret, retry, num_left;
+	int32_t num;
+	void *input, *output;
+	uint64_t input_u64[burst];
+	uint64_t output_u64[burst];
+	uint32_t input_u32[burst];
+	uint32_t output_u32[burst];
+	uint16_t input_u16[burst];
+	uint16_t output_u16[burst];
+	uint8_t input_u8[burst];
+	uint8_t output_u8[burst];
+
+	if (size == sizeof(uint64_t)) {
+		num    = global.num_default.u64;
+		input  = input_u64;
+		output = output_u64;
+	} else if (size == sizeof(uint32_t)) {
+		num    = global.num_default.u32;
+		input  = input_u32;
+		output = output_u32;
+	} else if (size == sizeof(uint16_t)) {
+		num    = global.num_default.u16;
+		input  = input_u16;
+		output = output_u16;
+	} else {
+		num    = global.num_default.u8;
+		input  = input_u8;
+		output = output_u8;
+	}
+
+	for (i = 0; i < burst; i++) {
+		input_u64[i] = MAGIC_U64;
+		input_u32[i] = MAGIC_U32;
+		input_u16[i] = MAGIC_U16;
+		input_u8[i]  = MAGIC_U8;
+	}
+
+	odp_stash_param_init(&param);
+	param.num_obj    = num;
+	param.obj_size   = size;
+	param.cache_size = global.cache_size_default;
+
+	stash = odp_stash_create("test_stash_default", &param);
+
+	CU_ASSERT_FATAL(stash != ODP_STASH_INVALID);
+
+	/* Stash is empty */
+	CU_ASSERT_FATAL(odp_stash_get(stash, output, 1) == 0);
+
+	retry = MAX_RETRY;
+	num_left = num;
+	while (num_left) {
+		ret = odp_stash_put(stash, input, burst);
+		CU_ASSERT_FATAL(ret >= 0);
+		CU_ASSERT_FATAL(ret <= burst);
+
+		if (ret) {
+			num_left -= ret;
+			retry = MAX_RETRY;
+		} else {
+			retry--;
+			CU_ASSERT_FATAL(retry > 0);
+		}
+	}
+
+	retry = MAX_RETRY;
+	num_left = num;
+	while (num_left) {
+		memset(output, 0, burst * size);
+
+		ret = odp_stash_get(stash, output, burst);
+		CU_ASSERT_FATAL(ret >= 0);
+		CU_ASSERT_FATAL(ret <= burst);
+
+		if (ret) {
+			for (i = 0; i < ret; i++) {
+				if (size == sizeof(uint64_t)) {
+					/* CU_ASSERT needs brackets around it */
+					CU_ASSERT(output_u64[i] == MAGIC_U64);
+				} else if (size == sizeof(uint32_t)) {
+					CU_ASSERT(output_u32[i] == MAGIC_U32);
+				} else if (size == sizeof(uint16_t)) {
+					CU_ASSERT(output_u16[i] == MAGIC_U16);
+				} else {
+					CU_ASSERT(output_u8[i] == MAGIC_U8);
+				}
+			}
+
+			num_left -= ret;
+			retry = MAX_RETRY;
+		} else {
+			retry--;
+			CU_ASSERT_FATAL(retry > 0);
+		}
+	}
+
+	/* Stash is empty again */
+	CU_ASSERT(odp_stash_get(stash, output, 1) == 0);
+	CU_ASSERT(odp_stash_flush_cache(stash) == 0);
+
+	CU_ASSERT_FATAL(odp_stash_destroy(stash) == 0);
+}
+
+static void stash_fifo_put(uint32_t size, int32_t burst)
+{
+	odp_stash_t stash;
+	odp_stash_param_t param;
+	int32_t i, ret, retry, num_left;
+	int32_t num;
+	void *input, *output;
+	uint64_t input_u64[burst];
+	uint64_t output_u64[burst];
+	uint32_t input_u32[burst];
+	uint32_t output_u32[burst];
+	uint16_t input_u16[burst];
+	uint16_t output_u16[burst];
+	uint8_t input_u8[burst];
+	uint8_t output_u8[burst];
+
+	if (size == sizeof(uint64_t)) {
+		num    = global.num_fifo.u64;
+		input  = input_u64;
+		output = output_u64;
+	} else if (size == sizeof(uint32_t)) {
+		num    = global.num_fifo.u32;
+		input  = input_u32;
+		output = output_u32;
+	} else if (size == sizeof(uint16_t)) {
+		num    = global.num_fifo.u16;
+		input  = input_u16;
+		output = output_u16;
+	} else {
+		num    = global.num_fifo.u8;
+		input  = input_u8;
+		output = output_u8;
+	}
+
+	odp_stash_param_init(&param);
+	param.type     = ODP_STASH_TYPE_FIFO;
+	param.num_obj  = num;
+	param.obj_size = size;
+
+	stash = odp_stash_create("test_stash_fifo", &param);
+
+	CU_ASSERT_FATAL(stash != ODP_STASH_INVALID);
+
+	/* Stash is empty */
+	CU_ASSERT_FATAL(odp_stash_get(stash, output, 1) == 0);
+
+	retry = MAX_RETRY;
+	num_left = num;
+	while (num_left) {
+		for (i = 0; i < burst; i++) {
+			if (size == sizeof(uint64_t))
+				input_u64[i] = MAGIC_U64 + num_left - i;
+			else if (size == sizeof(uint32_t))
+				input_u32[i] = MAGIC_U32 + num_left - i;
+			else if (size == sizeof(uint16_t))
+				input_u16[i] = MAGIC_U16 + num_left - i;
+			else
+				input_u8[i] = MAGIC_U8 + num_left - i;
+		}
+
+		ret = odp_stash_put(stash, input, burst);
+		CU_ASSERT_FATAL(ret >= 0);
+
+		if (ret) {
+			CU_ASSERT_FATAL(ret <= burst);
+			num_left -= ret;
+			retry = MAX_RETRY;
+		} else {
+			retry--;
+			CU_ASSERT_FATAL(retry > 0);
+		}
+	}
+
+	retry = MAX_RETRY;
+	num_left = num;
+	while (num_left) {
+		memset(output, 0, burst * size);
+
+		ret = odp_stash_get(stash, output, burst);
+		CU_ASSERT_FATAL(ret >= 0);
+
+		if (ret) {
+			CU_ASSERT_FATAL(ret <= burst);
+			for (i = 0; i < ret; i++) {
+				if (size == sizeof(uint64_t)) {
+					uint64_t val = MAGIC_U64 + num_left - i;
+
+					CU_ASSERT(output_u64[i] == val);
+				} else if (size == sizeof(uint32_t)) {
+					uint32_t val = MAGIC_U32 + num_left - i;
+
+					CU_ASSERT(output_u32[i] == val);
+				} else if (size == sizeof(uint16_t)) {
+					uint16_t val = MAGIC_U16 + num_left - i;
+
+					CU_ASSERT(output_u16[i] == val);
+				} else {
+					uint8_t val = MAGIC_U8 + num_left - i;
+
+					CU_ASSERT(output_u8[i] == val);
+				}
+			}
+
+			num_left -= ret;
+			retry = MAX_RETRY;
+		} else {
+			retry--;
+			CU_ASSERT_FATAL(retry > 0);
+		}
+	}
+
+	/* Stash is empty again */
+	CU_ASSERT(odp_stash_get(stash, output, 1) == 0);
+	CU_ASSERT(odp_stash_flush_cache(stash) == 0);
+
+	CU_ASSERT_FATAL(odp_stash_destroy(stash) == 0);
+}
+
+static int check_support_64(void)
+{
+	if (global.capa_default.max_obj_size >= sizeof(uint64_t))
+		return ODP_TEST_ACTIVE;
+
+	return ODP_TEST_INACTIVE;
+}
+
+static int check_support_fifo_64(void)
+{
+	if (global.fifo_supported &&
+	    global.capa_fifo.max_obj_size >= sizeof(uint64_t))
+		return ODP_TEST_ACTIVE;
+
+	return ODP_TEST_INACTIVE;
+}
+
+static int check_support_fifo(void)
+{
+	if (global.fifo_supported)
+		return ODP_TEST_ACTIVE;
+
+	return ODP_TEST_INACTIVE;
+}
+
+static void stash_default_put_u64_1(void)
+{
+	stash_default_put(sizeof(uint64_t), 1);
+}
+
+static void stash_default_put_u64_n(void)
+{
+	stash_default_put(sizeof(uint64_t), BURST);
+}
+
+static void stash_default_put_u32_1(void)
+{
+	stash_default_put(sizeof(uint32_t), 1);
+}
+
+static void stash_default_put_u32_n(void)
+{
+	stash_default_put(sizeof(uint32_t), BURST);
+}
+
+static void stash_default_put_u16_1(void)
+{
+	stash_default_put(sizeof(uint16_t), 1);
+}
+
+static void stash_default_put_u16_n(void)
+{
+	stash_default_put(sizeof(uint16_t), BURST);
+}
+
+static void stash_default_put_u8_1(void)
+{
+	stash_default_put(sizeof(uint8_t), 1);
+}
+
+static void stash_default_put_u8_n(void)
+{
+	stash_default_put(sizeof(uint8_t), BURST);
+}
+
+static void stash_fifo_put_u64_1(void)
+{
+	stash_fifo_put(sizeof(uint64_t), 1);
+}
+
+static void stash_fifo_put_u64_n(void)
+{
+	stash_fifo_put(sizeof(uint64_t), BURST);
+}
+
+static void stash_fifo_put_u32_1(void)
+{
+	stash_fifo_put(sizeof(uint32_t), 1);
+}
+
+static void stash_fifo_put_u32_n(void)
+{
+	stash_fifo_put(sizeof(uint32_t), BURST);
+}
+
+static void stash_fifo_put_u16_1(void)
+{
+	stash_fifo_put(sizeof(uint16_t), 1);
+}
+
+static void stash_fifo_put_u16_n(void)
+{
+	stash_fifo_put(sizeof(uint16_t), BURST);
+}
+
+static void stash_fifo_put_u8_1(void)
+{
+	stash_fifo_put(sizeof(uint8_t), 1);
+}
+
+static void stash_fifo_put_u8_n(void)
+{
+	stash_fifo_put(sizeof(uint8_t), BURST);
+}
+
+odp_testinfo_t stash_suite[] = {
+	ODP_TEST_INFO(stash_capability),
+	ODP_TEST_INFO(stash_param_defaults),
+	ODP_TEST_INFO_CONDITIONAL(stash_create_u64, check_support_64),
+	ODP_TEST_INFO(stash_create_u32),
+	ODP_TEST_INFO_CONDITIONAL(stash_default_put_u64_1, check_support_64),
+	ODP_TEST_INFO_CONDITIONAL(stash_default_put_u64_n, check_support_64),
+	ODP_TEST_INFO(stash_default_put_u32_1),
+	ODP_TEST_INFO(stash_default_put_u32_n),
+	ODP_TEST_INFO(stash_default_put_u16_1),
+	ODP_TEST_INFO(stash_default_put_u16_n),
+	ODP_TEST_INFO(stash_default_put_u8_1),
+	ODP_TEST_INFO(stash_default_put_u8_n),
+	ODP_TEST_INFO_CONDITIONAL(stash_create_u64_all, check_support_64),
+	ODP_TEST_INFO(stash_create_u32_all),
+	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u64_1, check_support_fifo_64),
+	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u64_n, check_support_fifo_64),
+	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u32_1, check_support_fifo),
+	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u32_n, check_support_fifo),
+	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u16_1, check_support_fifo),
+	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u16_n, check_support_fifo),
+	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u8_1,  check_support_fifo),
+	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u8_n,  check_support_fifo),
+	ODP_TEST_INFO_CONDITIONAL(stash_create_fifo_u64_all,
+				  check_support_fifo_64),
+	ODP_TEST_INFO_CONDITIONAL(stash_create_fifo_u32_all,
+				  check_support_fifo),
+	ODP_TEST_INFO_NULL
+};
+
+odp_suiteinfo_t stash_suites[] = {
+		{"Stash", stash_suite_init, NULL, stash_suite},
+		ODP_SUITE_INFO_NULL
+};
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	/* parse common options: */
+	if (odp_cunit_parse_options(argc, argv))
+		return -1;
+
+	ret = odp_cunit_register(stash_suites);
+
+	if (ret == 0)
+		ret = odp_cunit_run();
+
+	return ret;
+}


### PR DESCRIPTION
Application may use stash API to store object handles (pointers or indexes) for later usage. Pools and queues are designed for events, and not optimal/suitable for storing opaque handles.