### PR TITLE
[PATCH v2] validation: packet: fix max_num expectations

### DIFF
--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -291,6 +291,7 @@ static void packet_test_alloc_free(void)
 	params.pkt.seg_len    = pool_capa.pkt.min_seg_len;
 	params.pkt.len        = pool_capa.pkt.min_seg_len;
 	params.pkt.num        = 1;
+	params.pkt.max_num    = 1;
 
 	pool = odp_pool_create("packet_pool_alloc", &params);
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
@@ -361,6 +362,7 @@ static void packet_test_alloc_free_multi(void)
 	params.pkt.seg_len    = pool_capa.pkt.min_seg_len;
 	params.pkt.len        = pool_capa.pkt.min_seg_len;
 	params.pkt.num        = num_pkt;
+	params.pkt.max_num    = num_pkt;
 
 	pool[0] = odp_pool_create("packet_pool_alloc_multi_0", &params);
 	pool[1] = odp_pool_create("packet_pool_alloc_multi_1", &params);


### PR DESCRIPTION
Some tests are missing params.pkt.max_num value and yet expect that no
more than params.pkt.num packets will be present in the pool. That is
not required by spec. Instead max_num parameter should be used for that.

Change-Id: I63901f564a634355267f1243cf7c12379945791c