### PR TITLE
[PATCH v3] validation: scheduler: add new stress test

### DIFF
--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -685,7 +685,7 @@ static void scheduler_test_groups(void)
 	CU_ASSERT(lookup == ODP_SCHED_GROUP_INVALID);
 
 	/* Now create it and verify we can find it */
-	mygrp2 = odp_schedule_group_create("Test Group 2", &zeromask);
+	mygrp2 = odp_schedule_group_create("Test Group 2", &mymask);
 	CU_ASSERT_FATAL(mygrp2 != ODP_SCHED_GROUP_INVALID);
 
 	lookup = odp_schedule_group_lookup("Test Group 2");
@@ -694,15 +694,7 @@ static void scheduler_test_groups(void)
 	/* Destroy group with no name */
 	CU_ASSERT_FATAL(odp_schedule_group_destroy(null_grp) == 0);
 
-	/* Verify we're not part of it */
-	rc = odp_schedule_group_thrmask(mygrp2, &testmask);
-	CU_ASSERT(rc == 0);
-	CU_ASSERT(!odp_thrmask_isset(&testmask, thr_id));
-
-	/* Now join the group and verify we're part of it */
-	rc = odp_schedule_group_join(mygrp2, &mymask);
-	CU_ASSERT(rc == 0);
-
+	/* Verify we're part of group 2 */
 	rc = odp_schedule_group_thrmask(mygrp2, &testmask);
 	CU_ASSERT(rc == 0);
 	CU_ASSERT(odp_thrmask_isset(&testmask, thr_id));
@@ -710,6 +702,11 @@ static void scheduler_test_groups(void)
 	/* Leave group 2 */
 	rc = odp_schedule_group_leave(mygrp2, &mymask);
 	CU_ASSERT(rc == 0);
+
+	/* Verify we're not part of group 2 anymore */
+	rc = odp_schedule_group_thrmask(mygrp2, &testmask);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT(!odp_thrmask_isset(&testmask, thr_id));
 
 	/* Now verify scheduler adherence to groups */
 	odp_pool_param_init(&params);


### PR DESCRIPTION
New scheduler stress test creates the maximum number of scheduled queues
returned by odp_schedule_config_init(), fills them with events, and runs a
number of test scheduling rounds. The test is repeated for all scheduled
queue types.

Signed-off-by: Matias Elo <matias.elo@nokia.com>


V2:
- Fixed Petri's comments
- Added odp_schedule_group_create() test improvement commit
