### PR TITLE
[PATCH v2] travis: add ubuntu 20.04 arm64 build test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ env:
         - CHECK=0 CONF="--enable-lto"
         - CHECK=0 CONF="--enable-lto --disable-abi-compat"
         - CHECK=0 ARCH=arm64
+        - CHECK=0 ARCH=arm64 OS=ubuntu_20.04
         - CHECK=0 ARCH=armhf
         - CHECK=0 ARCH=ppc64el
         - CHECK=0 ARCH=i386


### PR DESCRIPTION
Add new arm64 build only test for Ubuntu 20.04. Uses GCC 9 and Clang 10.

Signed-off-by: Matias Elo <matias.elo@nokia.com>