### PR TITLE
[PATCH v3] linux-gen: system: read default cpu frequency values from config file

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,20 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.12"
+config_file_version = "0.1.13"
+
+# System options
+system: {
+	# CPU frequency value returned by odp_cpu_hz() and odp_cpu_hz_id()
+	# calls on platforms where frequency isn't available using standard
+	# Linux methods.
+	cpu_mhz = 0
+
+	# CPU max frequency value returned by odp_cpu_hz_max() and
+	# odp_cpu_hz_max_id() calls on platforms where max frequency isn't
+	# available using standard Linux methods.
+	cpu_mhz_max = 1400
+}
 
 # Shared memory options
 shm: {

--- a/platform/linux-generic/arch/aarch64/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/aarch64/odp_sysinfo_parse.c
@@ -8,6 +8,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include <odp/api/hints.h>
+#include <odp_global_data.h>
 #include <odp_sysinfo_internal.h>
 #include <odp_debug_internal.h>
 
@@ -184,10 +186,11 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 			/* Some CPUs do not support cpufreq, use a dummy
 			 * max freq. */
 			if (sysinfo->cpu_hz_max[id] == 0) {
-				uint64_t hz = DUMMY_MAX_MHZ * 1000000;
+				uint64_t hz = sysinfo->default_cpu_hz_max;
 
-				ODP_PRINT("WARN: cpu[%i] uses dummy max frequency %u MHz\n",
-					  id, DUMMY_MAX_MHZ);
+				ODP_PRINT("WARN: cpu[%i] uses default max "
+					  "frequency of %" PRIu64 " Hz from "
+					  "config file\n", id, hz);
 				sysinfo->cpu_hz_max[id] = hz;
 			}
 
@@ -272,9 +275,7 @@ void sys_info_print_arch(void)
 	printf("\n");
 }
 
-uint64_t odp_cpu_arch_hz_current(int id)
+uint64_t odp_cpu_arch_hz_current(int id ODP_UNUSED)
 {
-	(void)id;
-
-	return 0;
+	return odp_global_ro.system_info.default_cpu_hz;
 }

--- a/platform/linux-generic/arch/default/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/default/odp_sysinfo_parse.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
+#include <odp_global_data.h>
 #include <odp_sysinfo_internal.h>
 
 int cpuinfo_parser(FILE *file ODP_UNUSED, system_info_t *sysinfo)
@@ -17,5 +18,5 @@ void sys_info_print_arch(void)
 
 uint64_t odp_cpu_arch_hz_current(int id ODP_UNUSED)
 {
-	return 0;
+	return odp_global_ro.system_info.default_cpu_hz;
 }

--- a/platform/linux-generic/arch/mips64/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/mips64/odp_sysinfo_parse.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
+#include <odp_global_data.h>
 #include <odp_sysinfo_internal.h>
 #include <string.h>
 
@@ -64,5 +65,5 @@ void sys_info_print_arch(void)
 
 uint64_t odp_cpu_arch_hz_current(int id ODP_UNUSED)
 {
-	return 0;
+	return odp_global_ro.system_info.default_cpu_hz;
 }

--- a/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
+#include <odp_global_data.h>
 #include <odp_sysinfo_internal.h>
 #include <string.h>
 
@@ -63,5 +64,5 @@ void sys_info_print_arch(void)
 
 uint64_t odp_cpu_arch_hz_current(int id ODP_UNUSED)
 {
-	return 0;
+	return odp_global_ro.system_info.default_cpu_hz;
 }

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -25,6 +25,8 @@ extern "C" {
 
 typedef struct {
 	uint64_t cpu_hz_max[CONFIG_NUM_CPU];
+	uint64_t default_cpu_hz_max;
+	uint64_t default_cpu_hz;
 	uint64_t page_size;
 	int      cache_line_size;
 	int      cpu_count;

--- a/platform/linux-generic/include/odp_sysinfo_internal.h
+++ b/platform/linux-generic/include/odp_sysinfo_internal.h
@@ -13,9 +13,8 @@ extern "C" {
 
 #include <odp_global_data.h>
 #include <odp_debug_internal.h>
+#include <inttypes.h>
 #include <string.h>
-
-#define DUMMY_MAX_MHZ 1400
 
 int cpuinfo_parser(FILE *file, system_info_t *sysinfo);
 uint64_t odp_cpu_hz_current(int id);
@@ -24,13 +23,14 @@ void sys_info_print_arch(void);
 
 static inline int _odp_dummy_cpuinfo(system_info_t *sysinfo)
 {
+	uint64_t cpu_hz_max = sysinfo->default_cpu_hz_max;
 	int i;
 
 	ODP_DBG("Warning: use dummy values for freq and model string\n");
 	for (i = 0; i < CONFIG_NUM_CPU; i++) {
-		ODP_PRINT("WARN: cpu[%i] uses dummy max frequency %u MHz\n",
-			  i, DUMMY_MAX_MHZ);
-		sysinfo->cpu_hz_max[i] = DUMMY_MAX_MHZ * 1000000;
+		ODP_PRINT("WARN: cpu[%i] uses default max frequency of "
+			  "%" PRIu64 " Hz from config file\n", i, cpu_hz_max);
+		sysinfo->cpu_hz_max[i] = cpu_hz_max;
 		strcpy(sysinfo->model_str[i], "UNKNOWN");
 	}
 

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.12"
+config_file_version = "0.1.13"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/packet_align.conf
+++ b/platform/linux-generic/test/packet_align.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.12"
+config_file_version = "0.1.13"
 
 pool: {
 	pkt: {

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.12"
+config_file_version = "0.1.13"
 
 # Shared memory options
 shm: {

--- a/test/validation/api/system/system.c
+++ b/test/validation/api/system/system.c
@@ -284,7 +284,8 @@ static void system_test_odp_sys_huge_page_size_all(void)
 static int system_check_odp_cpu_hz(void)
 {
 	if (odp_cpu_hz() == 0) {
-		fprintf(stderr, "odp_cpu_hz is not supported, skipping\n");
+		fprintf(stderr, "odp_cpu_hz() is not supported, skipping "
+			"test\n");
 		return ODP_TEST_INACTIVE;
 	}
 
@@ -314,9 +315,8 @@ static int system_check_odp_cpu_hz_id(void)
 	for (i = 0; i < num; i++) {
 		hz = odp_cpu_hz_id(cpu);
 		if (hz == 0) {
-			fprintf(stderr, "cpu %d does not support"
-				" odp_cpu_hz_id(),"
-				"skip that test\n", cpu);
+			fprintf(stderr, "odp_cpu_hz_id() is not supported by "
+				"CPU %d, skipping test\n", cpu);
 			return ODP_TEST_INACTIVE;
 		}
 		cpu = odp_cpumask_next(&mask, cpu);
@@ -344,12 +344,45 @@ static void system_test_odp_cpu_hz_id(void)
 	}
 }
 
+static int system_check_odp_cpu_hz_max(void)
+{
+	if (odp_cpu_hz_max() == 0) {
+		fprintf(stderr, "odp_cpu_hz_max() is not supported, skipping "
+			"test\n");
+		return ODP_TEST_INACTIVE;
+	}
+	return ODP_TEST_ACTIVE;
+}
+
 static void system_test_odp_cpu_hz_max(void)
 {
-	uint64_t hz;
+	uint64_t hz = odp_cpu_hz_max();
 
-	hz = odp_cpu_hz_max();
-	CU_ASSERT(0 < hz);
+	/* Sanity check value */
+	CU_ASSERT(hz > 1 * KILO_HZ);
+	CU_ASSERT(hz < 20 * GIGA_HZ);
+}
+
+static int system_check_odp_cpu_hz_max_id(void)
+{
+	uint64_t hz;
+	odp_cpumask_t mask;
+	int i, num, cpu;
+
+	num = odp_cpumask_all_available(&mask);
+	cpu = odp_cpumask_first(&mask);
+
+	for (i = 0; i < num; i++) {
+		hz = odp_cpu_hz_max_id(cpu);
+		if (hz == 0) {
+			fprintf(stderr, "odp_cpu_hz_max_id() is not supported "
+			"by CPU %d, skipping test\n", cpu);
+			return ODP_TEST_INACTIVE;
+		}
+		cpu = odp_cpumask_next(&mask, cpu);
+	}
+
+	return ODP_TEST_ACTIVE;
 }
 
 static void system_test_odp_cpu_hz_max_id(void)
@@ -363,7 +396,9 @@ static void system_test_odp_cpu_hz_max_id(void)
 
 	for (i = 0; i < num; i++) {
 		hz = odp_cpu_hz_max_id(cpu);
-		CU_ASSERT(0 < hz);
+		/* Sanity check value */
+		CU_ASSERT(hz > 1 * KILO_HZ);
+		CU_ASSERT(hz < 20 * GIGA_HZ);
 		cpu = odp_cpumask_next(&mask, cpu);
 	}
 }
@@ -390,8 +425,10 @@ odp_testinfo_t system_suite[] = {
 				  system_check_odp_cpu_hz),
 	ODP_TEST_INFO_CONDITIONAL(system_test_odp_cpu_hz_id,
 				  system_check_odp_cpu_hz_id),
-	ODP_TEST_INFO(system_test_odp_cpu_hz_max),
-	ODP_TEST_INFO(system_test_odp_cpu_hz_max_id),
+	ODP_TEST_INFO_CONDITIONAL(system_test_odp_cpu_hz_max,
+				  system_check_odp_cpu_hz_max),
+	ODP_TEST_INFO_CONDITIONAL(system_test_odp_cpu_hz_max_id,
+				  system_check_odp_cpu_hz_max_id),
 	ODP_TEST_INFO(system_test_odp_cpu_cycles),
 	ODP_TEST_INFO(system_test_odp_cpu_cycles_max),
 	ODP_TEST_INFO(system_test_odp_cpu_cycles_resolution),


### PR DESCRIPTION
Enable setting odp_cpu_hz() and odp_cpu_hz_max() values manually usinge the
config file on platforms where frequencies aren't available using standard
Linux methods.

Signed-off-by: Matias Elo <matias.elo@nokia.com>