### PR TITLE
[PATCH v2] linux-gen: sched scalable: remove unnecessary single VA shm flag

### DIFF
--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -1828,8 +1828,7 @@ static int schedule_init_global(void)
 		    sizeof(sched_queue_t);
 	max_alloc = min_alloc;
 	pool = _odp_ishm_pool_create("sched_shm_pool", pool_size,
-				     min_alloc, max_alloc,
-				     _ODP_ISHM_SINGLE_VA);
+				     min_alloc, max_alloc, 0);
 	if (pool == NULL) {
 		ODP_ERR("Failed to allocate shared memory pool "
 			"for sched\n");


### PR DESCRIPTION
The particular memory block is reserved during global init, so single VA
flags is not needed.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reported-by: Mikko Kurikka <mikko.kurikka@nokia.com>