### PR TITLE
[PATCH v3] linux-gen: add configure option for setting path to the default config file

### DIFF
--- a/m4/odp_libconfig.m4
+++ b/m4/odp_libconfig.m4
@@ -20,6 +20,12 @@ AS_IF([test -z "$OD"], [AC_MSG_ERROR([Could not find 'od'])])
 AS_IF([test -z "$2"] || [test ! -f $2],
       [AC_MSG_ERROR([Default configuration file not found])], [])
 
+conf_ver=$_ODP_CONFIG_VERSION_GENERATION.$_ODP_CONFIG_VERSION_MAJOR.$_ODP_CONFIG_VERSION_MINOR
+file_ver=`$SED 's/ //g' $2 | $GREP -oP '(?<=config_file_version=").*?(?=")'`
+
+AS_IF([test "x$conf_ver" = "x$file_ver"], [],
+      [AC_MSG_ERROR([Configuration file version mismatch (_ODP_CONFIG_VERSION=$conf_ver config_file_version=$file_ver)])])
+
 odp_use_config=true
 ##########################################################################
 # Create a header file odp_libconfig_config.h which containins null

--- a/m4/odp_libconfig.m4
+++ b/m4/odp_libconfig.m4
@@ -1,5 +1,5 @@
-# ODP_LIBCONFIG(PLATFORM)
-# -----------------------
+# ODP_LIBCONFIG(PLATFORM, CONFIG-FILE-PATH)
+# -----------------------------------------
 AC_DEFUN([ODP_LIBCONFIG],
 [dnl
 ##########################################################################
@@ -14,6 +14,12 @@ AC_CHECK_PROGS([OD], [od])
 AC_PROG_SED
 AS_IF([test -z "$OD"], [AC_MSG_ERROR([Could not find 'od'])])
 
+##########################################################################
+# Check default configuration file
+##########################################################################
+AS_IF([test -z "$2"] || [test ! -f $2],
+      [AC_MSG_ERROR([Default configuration file not found])], [])
+
 odp_use_config=true
 ##########################################################################
 # Create a header file odp_libconfig_config.h which containins null
@@ -22,9 +28,9 @@ odp_use_config=true
 AC_CONFIG_COMMANDS([platform/$1/include/odp_libconfig_config.h],
 [mkdir -p platform/$1/include
    (echo "static const char config_builtin[[]] = {"; \
-     $OD -An -v -tx1 < ${srcdir}/config/odp-$1.conf | \
+     $OD -An -v -tx1 < $CONFIG_FILE | \
      $SED -e 's/[[0-9a-f]]\+/0x\0,/g' ; \
      echo "0x00 };") > \
    platform/$1/include/odp_libconfig_config.h],
- [with_platform=$with_platform OD=$OD SED=$SED])
+ [with_platform=$1 OD=$OD SED=$SED CONFIG_FILE=$2])
 ]) # ODP_LIBCONFIG

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -23,7 +23,7 @@ AS_IF([test "x$with_pcap" != xno],
       [ODP_PCAP([with_pcap=yes]‚[with_pcap=no])])
 AM_CONDITIONAL([HAVE_PCAP], [test x$have_pcap = xyes])
 
-ODP_LIBCONFIG([linux-generic])
+m4_include([platform/linux-generic/m4/odp_libconfig.m4])
 m4_include([platform/linux-generic/m4/odp_pcapng.m4])
 m4_include([platform/linux-generic/m4/odp_netmap.m4])
 m4_include([platform/linux-generic/m4/odp_dpdk.m4])

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -1,0 +1,18 @@
+##########################################################################
+# Configuration file version
+##########################################################################
+m4_define([_odp_config_version_generation], [0])
+m4_define([_odp_config_version_major], [1])
+m4_define([_odp_config_version_minor], [13])
+
+m4_define([_odp_config_version],
+          [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])
+
+_ODP_CONFIG_VERSION_GENERATION=_odp_config_version_generation
+AC_SUBST(_ODP_CONFIG_VERSION_GENERATION)
+_ODP_CONFIG_VERSION_MAJOR=_odp_config_version_major
+AC_SUBST(_ODP_CONFIG_VERSION_MAJOR)
+_ODP_CONFIG_VERSION_MINOR=_odp_config_version_minor
+AC_SUBST(_ODP_CONFIG_VERSION_MINOR)
+
+ODP_LIBCONFIG([$with_platform])

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -15,4 +15,14 @@ AC_SUBST(_ODP_CONFIG_VERSION_MAJOR)
 _ODP_CONFIG_VERSION_MINOR=_odp_config_version_minor
 AC_SUBST(_ODP_CONFIG_VERSION_MINOR)
 
-ODP_LIBCONFIG([$with_platform])
+##########################################################################
+# Set optional path for the default configuration file
+##########################################################################
+default_config_path="${srcdir}/config/odp-$with_platform.conf"
+
+AC_ARG_WITH([config-file],
+AS_HELP_STRING([--with-config-file=FILE path to the default configuration file],
+               [(this file must include all configuration options).]),
+            [default_config_path=$withval], [])
+
+ODP_LIBCONFIG([$with_platform], [$default_config_path])


### PR DESCRIPTION
Add '--with-config=FILE' configuration option for setting path to the default configuration file. The default configuration file has to include all configuration options.

V2:
- Renamed `--with-config` to `--with-config-file`. (Petri)