### PR TITLE
[PATCH v3] linux-gen: sched scalable: remove clearing pktin queue flag in pktio_…

### DIFF
--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -732,7 +732,6 @@ static void pktio_start(int pktio_idx,
 
 static void pktio_stop(sched_elem_t *elem)
 {
-	elem->cons_type &= ~FLAG_PKTIN; /* Clear pktin queue flag */
 	sched_pktin_rem(elem->sched_grp);
 	if (__atomic_sub_fetch(&global->poll_count[elem->pktio_idx],
 			       1, __ATOMIC_RELAXED) == 0) {


### PR DESCRIPTION
…stop()

if one CPU core A clear FLAG_PKTIN, and another core B got the elem in
_schedule() a bit time ago. then core B maybe go to wrong code flow in
_schedule(). So keep the FLAG_PKTIN, core B will try to schedq_cond_pop(),
 will fail and return normally.

Signed-off-by: Jecky Pei <jpei@sonicwall.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>