### PR TITLE
[PATCH v9] build: explicitly list dependency libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -272,31 +272,6 @@ AC_SUBST(ODP_LTO_FLAGS)
 ODP_CFLAGS="$ODP_CFLAGS $ODP_LTO_FLAGS"
 
 ##########################################################################
-# Determine which platform to build for
-##########################################################################
-AC_ARG_WITH([platform],
-    [AS_HELP_STRING([--with-platform=platform],
-	[select platform to be used, default linux-generic])],
-    [],
-    [with_platform=linux-generic
-    ])
-
-AC_SUBST([with_platform])
-
-##########################################################################
-# Run platform specific checks and settings
-##########################################################################
-AS_IF([test "${with_platform}" = "linux-generic"],
-      [m4_include([./platform/linux-generic/m4/configure.m4])],
-      [AC_MSG_ERROR([UNSUPPORTED PLATFORM: ${with_platform}])])
-
-AC_DEFINE_UNQUOTED([_ODP_IMPLEMENTATION_NAME], ["$ODP_IMPLEMENTATION_NAME"],
-		   [Define to the name of the implementation])
-
-AM_CONDITIONAL([ODP_USE_CONFIG], [test "x$odp_use_config" = "xtrue"])
-AC_SUBST([ODP_LIB_NAME])
-
-##########################################################################
 # Build examples/tests dynamically
 ##########################################################################
 AC_ARG_ENABLE([static-applications],
@@ -350,22 +325,6 @@ AM_CONDITIONAL([ARCH_IS_POWERPC], [test "x${ARCH_DIR}" = "xpowerpc"])
 AM_CONDITIONAL([ARCH_IS_X86], [test "x${ARCH_DIR}" = "xx86"])
 AM_CONDITIONAL([ARCH_IS_X86_32], [test "x${ARCH_ABI}" = "xx86_32-linux"])
 AM_CONDITIONAL([ARCH_IS_X86_64], [test "x${ARCH_ABI}" = "xx86_64-linux"])
-
-##########################################################################
-# Setup doxygen documentation
-##########################################################################
-DX_HTML_FEATURE(ON)
-DX_PDF_FEATURE(OFF)
-DX_PS_FEATURE(OFF)
-DX_ENV_APPEND(WITH_PLATFORM, $with_platform)
-
-DX_INIT_DOXYGEN($PACKAGE_NAME,
-		${srcdir}/doc/application-api-guide/Doxyfile,
-		${builddir}/doc/application-api-guide/output,
-		${srcdir}/doc/helper-guide/Doxyfile,
-		${builddir}/doc/helper-guide/output,
-		${srcdir}/doc/platform-api-guide/Doxyfile,
-		${builddir}/doc/platform-api-guide/output)
 
 ##########################################################################
 # Enable/disable ODP_DEBUG
@@ -427,6 +386,54 @@ AC_ARG_ENABLE([deprecated],
 AC_SUBST(ODP_DEPRECATED_API)
 
 ##########################################################################
+# Determine which platform to build for
+##########################################################################
+AC_ARG_WITH([platform],
+    [AS_HELP_STRING([--with-platform=platform],
+	[select platform to be used, default linux-generic])],
+    [],
+    [with_platform=linux-generic
+    ])
+
+AC_SUBST([with_platform])
+
+##########################################################################
+# Run platform specific checks and settings
+##########################################################################
+# Placeholder for platform dependency libraries which might come from custom
+# paths. Platform should fill it in configure.m4 with AS_VAR_APPEND.
+# This works around a bug in libtool.m4 on some systems:
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=297726
+PLAT_DEP_LIBS=
+AC_SUBST([PLAT_DEP_LIBS])
+
+AS_IF([test "${with_platform}" = "linux-generic"],
+      [m4_include([./platform/linux-generic/m4/configure.m4])],
+      [AC_MSG_ERROR([UNSUPPORTED PLATFORM: ${with_platform}])])
+
+AC_DEFINE_UNQUOTED([_ODP_IMPLEMENTATION_NAME], ["$ODP_IMPLEMENTATION_NAME"],
+		   [Define to the name of the implementation])
+
+AM_CONDITIONAL([ODP_USE_CONFIG], [test "x$odp_use_config" = "xtrue"])
+AC_SUBST([ODP_LIB_NAME])
+
+##########################################################################
+# Setup doxygen documentation
+##########################################################################
+DX_HTML_FEATURE(ON)
+DX_PDF_FEATURE(OFF)
+DX_PS_FEATURE(OFF)
+DX_ENV_APPEND(WITH_PLATFORM, $with_platform)
+
+DX_INIT_DOXYGEN($PACKAGE_NAME,
+		${srcdir}/doc/application-api-guide/Doxyfile,
+		${builddir}/doc/application-api-guide/output,
+		${srcdir}/doc/helper-guide/Doxyfile,
+		${builddir}/doc/helper-guide/output,
+		${srcdir}/doc/platform-api-guide/Doxyfile,
+		${builddir}/doc/platform-api-guide/output)
+
+##########################################################################
 # Default include setup
 ##########################################################################
 CFLAGS="$CFLAGS $ODP_CFLAGS"
@@ -482,6 +489,7 @@ AC_MSG_RESULT([
 	ld:			${LD}
 	ldflags:		${LDFLAGS}
 	libs:			${LIBS}
+	dependency libs:	${PLAT_DEP_LIBS}
 	defs:			${DEFS}
 	static libraries:	${enable_static}
 	shared libraries:	${enable_shared}

--- a/example/Makefile.inc
+++ b/example/Makefile.inc
@@ -4,13 +4,6 @@ TESTS_ENVIRONMENT = EXEEXT=${EXEEXT}
 
 LDADD = $(LIB)/libodphelper.la $(LIB)/lib$(ODP_LIB_NAME).la
 
-# Do not link to DPDK twice in case of dynamic linking with ODP
-if STATIC_APPS
-LDADD += $(DPDK_LIBS_LT_STATIC)
-else
-LDADD += $(DPDK_LIBS_LT)
-endif
-
 AM_CFLAGS = \
 	-I$(srcdir) \
 	-I$(top_srcdir)/example \
@@ -22,3 +15,5 @@ AM_LDFLAGS = -L$(LIB) -static
 else
 AM_LDFLAGS =
 endif
+
+AM_LDFLAGS += $(PLAT_DEP_LIBS)

--- a/m4/odp_dpdk.m4
+++ b/m4/odp_dpdk.m4
@@ -31,10 +31,13 @@ AC_DEFUN([_ODP_DPDK_SET_LIBS], [dnl
 ODP_DPDK_PMDS([$DPDK_PMD_PATH])
 DPDK_LIB="-Wl,--whole-archive,-ldpdk,--no-whole-archive"
 AS_IF([test "x$DPDK_SHARED" = "xyes"], [dnl
-    # applications don't need to be linked to anything, just rpath
-    DPDK_LIBS_LT="$DPDK_RPATH_LT"
-    # static linking flags will need -ldpdk
-    DPDK_LIBS_LT_STATIC="$DPDK_LDFLAGS $DPDK_LIB $DPDK_LIBS"
+    if test x$enable_static_applications != xyes; then
+      # applications don't need to be linked to anything, just rpath
+      DPDK_LIBS_LT="$DPDK_RPATH_LT"
+    else
+      # static linking flags will need -ldpdk
+      DPDK_LIBS_LT="$DPDK_LDFLAGS $DPDK_LIB $DPDK_LIBS"
+    fi
     DPDK_LIBS="-Wl,--no-as-needed,-ldpdk,--as-needed,`echo $DPDK_LIBS | sed -e 's/ /,/g'`"
     DPDK_LIBS="$DPDK_LDFLAGS $DPDK_RPATH $DPDK_LIBS"
     # link libodp-linux with -ldpdk
@@ -44,7 +47,6 @@ AS_IF([test "x$DPDK_SHARED" = "xyes"], [dnl
     # rearranged by libtool
     DPDK_LIBS_LT="`echo $DPDK_LIBS | sed -e 's/^/-Wc,/' -e 's/ /,/g'`"
     DPDK_LIBS_LT="$DPDK_LDFLAGS $DPDK_LIB $DPDK_LIBS_LT $DPDK_LIBS"
-    DPDK_LIBS_LT_STATIC="$DPDK_LIBS_LT"
     # static linking flags follow the suite
     DPDK_LIBS="$DPDK_LDFLAGS $DPDK_LIB $DPDK_LIBS"
     # link libodp-linux with libtool linking flags
@@ -62,7 +64,6 @@ LIBS=$OLD_LIBS
 AC_SUBST([DPDK_LIBS])
 AC_SUBST([DPDK_LIBS_LIBODP])
 AC_SUBST([DPDK_LIBS_LT])
-AC_SUBST([DPDK_LIBS_LT_STATIC])
 ])
 
 # _ODP_DPDK_CHECK_LIB(LDFLAGS, [LIBS])
@@ -189,8 +190,6 @@ DPDK_PKG=", libdpdk"
 AC_SUBST([DPDK_PKG])
 # applications don't need to be linked to anything, just rpath
 DPDK_LIBS_LT=""
-# compile all static flags into single argument to fool libtool
-DPDK_LIBS_LT_STATIC="-pthread -Wl,`echo $DPDK_STATIC_LIBS | sed -e 's/-pthread//g' -e 's/ \+/,/g' -e 's/-Wl,//g'`"
 # FIXME: this might need to be changed to DPDK_LIBS_STATIC
 DPDK_LIBS_LIBODP="$DPDK_LIBS"
 DPDK_LIBS=""

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -30,6 +30,8 @@ m4_include([platform/linux-generic/m4/odp_netmap.m4])
 m4_include([platform/linux-generic/m4/odp_dpdk.m4])
 ODP_SCHEDULER
 
+AS_VAR_APPEND([PLAT_DEP_LIBS], ["${LIBCONFIG_LIBS} ${OPENSSL_LIBS} ${DPDK_LIBS_LT}"])
+
 AC_CONFIG_COMMANDS_PRE([dnl
 AM_CONDITIONAL([PLATFORM_IS_LINUX_GENERIC],
 	       [test "${with_platform}" = "linux-generic"])

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -19,13 +19,6 @@ AM_CPPFLAGS = \
 	$(HELPER_INCLUDES) \
 	-I$(top_srcdir)/test/common
 
-# Do not link to DPDK twice in case of dynamic linking with ODP
-if STATIC_APPS
-LDADD += $(DPDK_LIBS_LT_STATIC)
-else
-LDADD += $(DPDK_LIBS_LT)
-endif
-
 AM_CFLAGS = $(CUNIT_CFLAGS)
 
 if STATIC_APPS
@@ -33,6 +26,8 @@ AM_LDFLAGS = -L$(LIB)
 else
 AM_LDFLAGS =
 endif
+
+AM_LDFLAGS += $(PLAT_DEP_LIBS)
 
 @VALGRIND_CHECK_RULES@
 


### PR DESCRIPTION
build: explicitly list dependency libraries

Debian-based Linux distributions have introduced a while ago a very
specific patch to libtool generation which disables libtool generating
dependent libraries list to the linker (distribution libtool.m4 has
link_all_deplibs forced to no). This causes issues when cross-compiling
while using dependent libraries compiled and installed manually to
non-sysroot location (see [1]).

To reproduce the issue, one has to fetch a toolchain which does not
contain pkg-config in it. Debian/Ubuntu aarch64 toolchains do contain
version of that tool (aarch64-linux-gnu-pkg-config) which does not have
the change in question.

Reproduction steps:

1. Set env variables used throughout other steps:
```
   # Cross-compiler without modified pkg-config -> using system one.
   CROSS_COMPILE=aarch64-marvell-linux-gnu
   LIBCONFIG_DIR=/tmp/odp/libconfig
   DEPS_DIR=/tmp/odp/deps-prefix
   ODP_DIR=`pwd`
   BUILD_DIR=/tmp/odp/odp-build
   PREFIX=/tmp/odp/prefix
```
2. Build libconfig in separate dir:
```
   mkdir -p $LIBCONFIG_DIR
   cd $LIBCONFIG_DIR
   wget https://hyperrealm.github.io/libconfig/dist/libconfig-1.7.2.tar.gz
   tar -zxvf libconfig-1.7.2.tar.gz --strip-components=1
   ./configure --host=${CROSS_COMPILE} --prefix=${DEPS_DIR}
   make -j4 all
   make install
```
3. Cross-compile ODP linux-generic with shared libraries enabled:
```
   cd $ODP_DIR
   ./bootstrap
   mkdir -p $BUILD_DIR
   cd $BUILD_DIR
   PKG_CONFIG_PATH=$DEPS_DIR/lib/pkgconfig \
     $ODP_DIR/configure \
       --with-platform=linux-generic \
       --host=${CROSS_COMPILE} \
       --build=x86_64-linux-gnu \
       --enable-shared \
       --disable-static \
       --prefix=$PREFIX \
       --without-openssl \
       --disable-test-vald
   make all -j4 V=1
```
This will fail at odp_classifier linking with the following error::
```
  make[2]: Entering directory '/tmp/odp-build/example/classifier'
    CC       odp_classifier.o
    CCLD     odp_classifier
  /opt/marvell-tools/.../ld: warning: libconfig.so.11,
     needed by ../../lib/.libs/libodp-linux.so, not found
     (try using -rpath or -rpath-link)
  ../../lib/.libs/libodp-linux.so: undefined reference to `config_init'
  ../../lib/.libs/libodp-linux.so: undefined reference to `config_read_file'
  ../../lib/.libs/libodp-linux.so: undefined reference to `config_lookup'
  ../../lib/.libs/libodp-linux.so: undefined reference to `config_lookup_int'
  ../../lib/.libs/libodp-linux.so: undefined reference to `config_lookup_string'
  ../../lib/.libs/libodp-linux.so: undefined reference to `config_setting_get_int_elem'
  ../../lib/.libs/libodp-linux.so: undefined reference to `config_read_string'
  ../../lib/.libs/libodp-linux.so: undefined reference to `config_setting_length'
  ../../lib/.libs/libodp-linux.so: undefined reference to `config_destroy'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:533: odp_classifier] Error 1
make[2]: Leaving directory '/tmp/odp-build/example/classifier'
make[1]: *** [Makefile:468: all-recursive] Error 1
make[1]: Leaving directory '/tmp/odp-build/example'
make: *** [Makefile:551: all-recursive] Error 1
```
There are several solutions to fix this:
1. Live-patch `libtool.m4` in configure stage.
2. Explicitly add dependent libraries to examples and tests.
3. Commit a pre-patched `m4/libtool.m4` to the repository.

First approach causes configure to be run twice (due to live patching).
Third approach requires locking `libtool.m4` to a specific version which
may result in issues with some older autotools as well as produces a
large blob-like patch.
This patch implements the second approach by adding `PLAT_DEP_LIBS`
variable which platform should fill with libraries that can be added
from non-standard locations (such as `libconfig` and `libcrypto` for
linux-generic).

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=297726

Signed-off-by: Stanislaw Kardach <skardach@marvell.com>