### PR TITLE
example: hello: remove -c option

### DIFF
--- a/example/hello/odp_hello.c
+++ b/example/hello/odp_hello.c
@@ -10,43 +10,29 @@
  * anything else than the ODP API header file.
  */
 
-/* Linux CPU affinity */
-#define _GNU_SOURCE
-#include <sched.h>
-
-/* Linux PID */
-#include <sys/types.h>
-#include <unistd.h>
-
 #include <stdio.h>
 #include <string.h>
 
 #include <odp_api.h>
 
 typedef struct {
-	int cpu;
 	int num;
 } options_t;
 
 static int parse_args(int argc, char *argv[], options_t *opt)
 {
-	static const char * const args[] = {"-c", "-n"};
+	static const char * const args[] = {"-n"};
 	int i, tmp;
 
 	for (i = 1; i < argc; i++) {
-		if ((strcmp(argv[i], args[0]) == 0) &&
+		if ((strcmp(argv[i], args[0]) == 0) && argv[i + 1] &&
 		    (sscanf(argv[i + 1], "%i", &tmp) == 1)) {
-			opt->cpu = tmp;
-			i++;
-		} else if ((strcmp(argv[i], args[1]) == 0) &&
-			   (sscanf(argv[i + 1], "%i", &tmp) == 1)) {
 			opt->num = tmp;
 			i++;
 		} else {
 			printf("\nUsage:\n"
-			       "  %s  CPU number\n"
-			       "  %s  Number of iterations\n\n",
-			       args[0], args[1]);
+			       "  [%s  Number of iterations]\n\n",
+			       args[0]);
 			return -1;
 		}
 	}
@@ -58,33 +44,16 @@ int main(int argc, char *argv[])
 {
 	odp_instance_t inst;
 	options_t opt;
-	pid_t pid;
-	cpu_set_t cpu_set;
 	int i;
-	odp_cpumask_t mask;
 
 	memset(&opt, 0, sizeof(opt));
-	opt.cpu = 0;
 	opt.num = 1;
 
 	if (parse_args(argc, argv, &opt))
 		return -1;
 
-	pid = getpid();
-
 	if (odp_init_global(&inst, NULL, NULL)) {
 		printf("Global init failed.\n");
-		return -1;
-	}
-
-	odp_cpumask_default_control(&mask, 0);
-	opt.cpu = odp_cpumask_first(&mask);
-
-	CPU_ZERO(&cpu_set);
-	CPU_SET(opt.cpu, &cpu_set);
-
-	if (sched_setaffinity(pid, sizeof(cpu_set_t), &cpu_set)) {
-		printf("Set CPU affinity failed.\n");
 		return -1;
 	}
 


### PR DESCRIPTION
In the existing application, -c is not honored, instead, it picks the
first available CPU from odp_cpumask_default_control().

https://github.com/OpenDataPlane/odp/pull/955 fixes the above-mentioned
problem, but hello world does not have to demonstrate CPU pinning,
instead it should demonstrate a minimum functionality application.

User can run the application with taskset command if it needs to run
on a particular CPU.

To simplify and fix the existing bug, this patch removes the -c option.

Also, it fixes a segfault issue if -n provided without any argument.

Suggested-by: Petri Savolainen <petri.savolainen@nokia.com>
Signed-off-by: Jerin Jacob <jerinj@marvell.com>
Reviewed-by: Petri Savolainen <petri.savolainen@nokia.com>
