### PR TITLE
[PATCH v3] L2fwd pool options

### DIFF
--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1303,8 +1303,11 @@ void odp_pktio_print(odp_pktio_t hdl)
 	len += snprintf(&str[len], n - len,
 			"  index             %i\n", odp_pktio_index(hdl));
 	len += snprintf(&str[len], n - len,
-			"  handle (u64)      %" PRIu64 "\n",
+			"  handle            0x%" PRIx64 "\n",
 			odp_pktio_to_u64(hdl));
+	len += snprintf(&str[len], n - len,
+			"  pool handle       0x%" PRIx64 "\n",
+			odp_pool_to_u64(entry->s.pool));
 	len += snprintf(&str[len], n - len,
 			"  state             %s\n",
 			entry->s.state ==  PKTIO_STATE_STARTED ? "start" :

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -513,9 +513,10 @@ static odp_pool_t pool_create(const char *name, const odp_pool_param_t *params,
 	uint32_t max_len, cache_size, burst_size;
 	uint32_t ring_size;
 	uint32_t num_extra = 0;
-	int name_len;
-	const char *postfix = "_uarea";
-	char uarea_name[ODP_POOL_NAME_LEN + sizeof(postfix)];
+	const char *max_prefix = "pool_000_uarea_";
+	int max_prefix_len = strlen(max_prefix);
+	char shm_name[ODP_POOL_NAME_LEN + max_prefix_len];
+	char uarea_name[ODP_POOL_NAME_LEN + max_prefix_len];
 
 	align = 0;
 
@@ -622,9 +623,9 @@ static odp_pool_t pool_create(const char *name, const odp_pool_param_t *params,
 		pool->name[ODP_POOL_NAME_LEN - 1] = 0;
 	}
 
-	name_len = strlen(pool->name);
-	memcpy(uarea_name, pool->name, name_len);
-	strcpy(&uarea_name[name_len], postfix);
+	/* Format SHM names from prefix, pool index and pool name. */
+	sprintf(shm_name,   "pool_%03i_%s", pool->pool_idx, pool->name);
+	sprintf(uarea_name, "pool_%03i_uarea_%s", pool->pool_idx, pool->name);
 
 	pool->params = *params;
 	pool->block_offset = 0;
@@ -706,7 +707,7 @@ static odp_pool_t pool_create(const char *name, const odp_pool_param_t *params,
 		pool->burst_size = burst_size;
 	}
 
-	shm = odp_shm_reserve(pool->name, pool->shm_size, ODP_PAGE_SIZE,
+	shm = odp_shm_reserve(shm_name, pool->shm_size, ODP_PAGE_SIZE,
 			      shmflags);
 
 	pool->shm = shm;


### PR DESCRIPTION
Added new options to control number of pools (-y) and number of packets per pool (-n). Depending on implementation these settings may have performance impacts.

  -y, --pools             0: A pool per interface
                          1: A single pool for all interfaces (default)
  -n, --num_pkt <num>     Number of packets per pool. Default is 16k or
                          the maximum capability. Use 0 for the default.
