### PR TITLE
[PATCH v3] Fix compilation with GCC 10

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,15 @@ ODP_CHECK_CFLAG([-Wformat-overflow=0])
 # header structures). Generate only warnings on those, not errors.
 ODP_CHECK_CFLAG([-Wno-error=address-of-packed-member])
 
+# GCC 10 sometimes gets confused about object sizes and gives bogus warnings.
+# Make the affected warnings generate only warnings, not errors.
+AS_IF([test "$GCC" == yes],
+      AS_IF([test `$CC -dumpversion` -ge 10],
+	    ODP_CHECK_CFLAG([-Wno-error=array-bounds])
+	    ODP_CHECK_CFLAG([-Wno-error=stringop-overflow])
+      )
+)
+
 ODP_CFLAGS="$ODP_CFLAGS -std=c99"
 ODP_CXXFLAGS="$ODP_CXXFLAGS -std=c++11"
 

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -5,6 +5,14 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
+/*
+ * Suppress bounds warnings about interior zero length arrays. Such an array
+ * is used intentionally in prio_queue_t.
+ */
+#if __GNUC__ >= 10
+#pragma GCC diagnostic ignored "-Wzero-length-bounds"
+#endif
+
 #include <odp/api/schedule.h>
 #include <odp_schedule_if.h>
 #include <odp/api/align.h>
@@ -154,7 +162,7 @@ typedef struct ODP_ALIGNED_CACHE {
 	ring_u32_t ring;
 
 	/* Ring data: queue indexes */
-	uint32_t queue_index[MAX_RING_SIZE];
+	uint32_t queue_index[MAX_RING_SIZE]; /* overlaps with ring.data[] */
 
 } prio_queue_t;
 

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -5,6 +5,14 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
+/*
+ * Suppress bounds warnings about interior zero length arrays. Such an array
+ * is used intentionally in prio_queue_t.
+ */
+#if __GNUC__ >= 10
+#pragma GCC diagnostic ignored "-Wzero-length-bounds"
+#endif
+
 #include <odp/api/ticketlock.h>
 #include <odp/api/thread.h>
 #include <odp/api/plat/thread_inlines.h>
@@ -77,7 +85,7 @@ typedef struct ODP_ALIGNED_CACHE {
 	ring_u32_t ring;
 
 	/* Ring data: queue indexes */
-	uint32_t ring_idx[RING_SIZE];
+	uint32_t ring_idx[RING_SIZE]; /* overlaps with ring.data[] */
 
 } prio_queue_t;
 

--- a/platform/linux-generic/pktio/stats/ethtool_stats.c
+++ b/platform/linux-generic/pktio/stats/ethtool_stats.c
@@ -18,11 +18,19 @@
 #include <odp_debug_internal.h>
 #include <odp_errno_define.h>
 
+/*
+ * Suppress bounds warnings about interior zero length arrays. Such an array
+ * is used intentionally in sset_info.
+ */
+#if __GNUC__ >= 10
+#pragma GCC diagnostic ignored "-Wzero-length-bounds"
+#endif
+
 static struct ethtool_gstrings *get_stringset(int fd, struct ifreq *ifr)
 {
 	struct {
 		struct ethtool_sset_info hdr;
-		uint32_t buf[1];
+		uint32_t buf[1]; /* overlaps with hdr.data[] */
 	} sset_info;
 	struct ethtool_drvinfo drvinfo;
 	uint32_t len;

--- a/platform/linux-generic/test/pktio_ipc/ipc_common.c
+++ b/platform/linux-generic/test/pktio_ipc/ipc_common.c
@@ -139,10 +139,8 @@ void print_info(char *progname)
 {
 	odp_sys_info_print();
 
-	printf("Running ODP appl: \"%s\"\n"
-	       "-----------------\n"
-	       "Using IF:        %s\n",
-	       progname, pktio_name);
+	printf("Running ODP appl: \"%s\"\n",
+	       progname);
 	printf("\n\n");
 	fflush(NULL);
 }

--- a/platform/linux-generic/test/pktio_ipc/ipc_common.h
+++ b/platform/linux-generic/test/pktio_ipc/ipc_common.h
@@ -64,14 +64,11 @@ typedef struct ODP_PACKED {
 	odp_u32be_t magic;
 } pkt_tail_t;
 
-/** Application argument */
-char *pktio_name;
-
 /** Run time in seconds */
-int run_time_sec;
+extern int run_time_sec;
 
 /** PID of the master process */
-int master_pid;
+extern int master_pid;
 
 /* helper funcs */
 void parse_args(int argc, char *argv[]);

--- a/test/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/validation/api/classification/odp_classification_test_pmr.c
@@ -11,7 +11,7 @@
 
 static odp_pool_t pkt_pool;
 /** sequence number of IP packets */
-odp_atomic_u32_t seq;
+static odp_atomic_u32_t seq;
 
 static cls_packet_info_t default_pkt_info;
 static odp_cls_capability_t cls_capa;

--- a/test/validation/api/classification/odp_classification_tests.c
+++ b/test/validation/api/classification/odp_classification_tests.c
@@ -25,7 +25,7 @@ static int global_num_l2_qos;
 #define NUM_COS_PMR	1
 #define NUM_COS_COMPOSITE	1
 /** sequence number of IP packets */
-odp_atomic_u32_t seq;
+static odp_atomic_u32_t seq;
 
 /* default packet info */
 static cls_packet_info_t default_pkt_info;


### PR DESCRIPTION
GCC 10 warns if the bounds of interior zero length arrays are exceeded, but that is done intentionally in ODP in a few places. Ignore the warning in those pieces of code.

The current GCC 10 also seems to have a bug that causes bogus array-bounds and stringop-overflow warnings. As a workaround, globally exclude those warnings from -Werror. Both are in the same commit as the affected code is the same and the issue triggering the warnings appears to be the same.
