### PR TITLE
[PATCH v2] linux-gen: use provided conf file for install and rebuild

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -489,6 +489,7 @@ AC_MSG_RESULT([
 	test_example:		${test_example}
 	user_guides:		${user_guides}
 	pcapng:			${have_pcapng}
+	default_config_path:    ${default_config_path}
 ])
 
 AS_IF([test "${with_openssl}" = "no"],

--- a/platform/Makefile.inc
+++ b/platform/Makefile.inc
@@ -7,8 +7,8 @@ EXTRA_DIST = doc/platform_specific.dox
 
 configdir = $(sysconfdir)/odp
 if ODP_USE_CONFIG
-config_DATA = $(top_srcdir)/config/odp-$(with_platform).conf
-EXTRA_DIST += $(top_srcdir)/config/odp-$(with_platform).conf
+config_DATA = $(top_builddir)/$(rel_default_config_path)
+EXTRA_DIST += $(top_builddir)/$(rel_default_config_path)
 endif
 
 VPATH = $(srcdir) $(builddir)

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -17,7 +17,7 @@ AM_CFLAGS +=  $(DPDK_CFLAGS)
 AM_CFLAGS +=  $(LIBCONFIG_CFLAGS)
 
 DISTCLEANFILES = include/odp_libconfig_config.h
-include/odp_libconfig_config.h: $(top_srcdir)/config/odp-$(with_platform).conf $(top_builddir)/config.status
+include/odp_libconfig_config.h: $(top_builddir)/$(rel_default_config_path) $(top_builddir)/config.status
 	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@
 
 odpapiabiarchincludedir = $(archincludedir)/odp/api/abi
@@ -148,7 +148,7 @@ noinst_HEADERS = \
 		  include/protocols/tcp.h \
 		  include/protocols/thash.h \
 		  include/protocols/udp.h
-nodist_noinst_HEADERS = \
+BUILT_SOURCES = \
 		  include/odp_libconfig_config.h
 
 __LIB__libodp_linux_la_SOURCES = \

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -20,9 +20,16 @@ AC_SUBST(_ODP_CONFIG_VERSION_MINOR)
 ##########################################################################
 default_config_path="${srcdir}/config/odp-$with_platform.conf"
 
+AC_CHECK_PROGS([REALPATH], [realpath])
+AS_IF([test -z "$REALPATH"], [AC_MSG_ERROR([Could not find 'realpath'])])
+
 AC_ARG_WITH([config-file],
 AS_HELP_STRING([--with-config-file=FILE path to the default configuration file],
                [(this file must include all configuration options).]),
             [default_config_path=$withval], [])
 
-ODP_LIBCONFIG([$with_platform], [$default_config_path])
+rel_default_config_path=`realpath --relative-to=$(pwd) ${default_config_path}`
+AC_SUBST(default_config_path)
+AC_SUBST(rel_default_config_path)
+
+ODP_LIBCONFIG([$with_platform], [$rel_default_config_path])


### PR DESCRIPTION
When providing a conf file with "--with-config-file",
- In case of change in this file, rebuild was not doing anything
- In case of change in generic conf file, rebuild was using
  generic conf file instead of provided one to regenerate / rebuild
- Generic conf file was installed

Signed-off-by: Thomas Pansiot <thomas.pansiot@nokia.com>