### PR TITLE
[PATCH v4] Fix various LTO compile errors

### DIFF
--- a/platform/linux-generic/test/pktio_ipc/ipc_common.c
+++ b/platform/linux-generic/test/pktio_ipc/ipc_common.c
@@ -22,6 +22,7 @@ int ipc_odp_packet_send_or_free(odp_pktio_t pktio,
 	odp_pktout_queue_t pktout;
 	int i;
 
+	memset(&pktout, 0, sizeof(pktout));
 	start_time = odp_time_local();
 	wait = odp_time_local_from_ns(ODP_TIME_SEC_IN_NS);
 	end_time = odp_time_sum(start_time, wait);

--- a/test/performance/odp_packet_gen.c
+++ b/test/performance/odp_packet_gen.c
@@ -896,6 +896,9 @@ static int init_packets(test_global_t *global, int pktio,
 	uint32_t udp_src_cnt = 0;
 	uint32_t udp_dst_cnt = 0;
 
+	if (num_vlan > MAX_VLANS)
+		num_vlan = MAX_VLANS;
+
 	for (i = 0; i < num; i++) {
 		pkt = packet[i];
 		pkt_len = odp_packet_len(pkt);

--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -1426,7 +1426,7 @@ int main(int argc, char *argv[])
 	odp_instance_t instance;
 	odp_init_t init;
 	odp_shm_t shm;
-	odp_time_t t1, t2;
+	odp_time_t t1 = ODP_TIME_NULL, t2 = ODP_TIME_NULL;
 	odph_helper_options_t helper_options;
 	odph_odpthread_t thread[MAX_WORKERS];
 	test_options_t test_options;

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -862,7 +862,7 @@ static void _verify_headroom_shift(odp_packet_t *pkt,
 	uint32_t room = odp_packet_headroom(*pkt);
 	uint32_t seg_data_len = odp_packet_seg_len(*pkt);
 	uint32_t pkt_data_len = odp_packet_len(*pkt);
-	void *data;
+	void *data = NULL;
 	char *data_orig = odp_packet_data(*pkt);
 	char *head_orig = odp_packet_head(*pkt);
 	uint32_t seg_len;
@@ -1571,7 +1571,7 @@ static void packet_test_concatsplit(void)
 {
 	odp_packet_t pkt, pkt2;
 	uint32_t pkt_len;
-	odp_packet_t splits[4];
+	odp_packet_t splits[4] = {ODP_PACKET_INVALID};
 	odp_pool_t pool;
 
 	pool = odp_packet_pool(test_packet);

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -649,7 +649,7 @@ static int recv_packets_tmo(odp_pktio_t pktio, odp_packet_t pkt_tbl[],
 	int num_q;
 	int i;
 	int n;
-	unsigned from_val;
+	unsigned int from_val = 0;
 	unsigned *from = NULL;
 
 	if (mode == RECV_MQ_TMO)

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -83,6 +83,7 @@ static void pool_test_lookup_info_print(void)
 	odp_pool_info_t info;
 	odp_pool_param_t param;
 
+	memset(&info, 0, sizeof(info));
 	odp_pool_param_init(&param);
 
 	param.type      = ODP_POOL_BUFFER;
@@ -321,6 +322,7 @@ static void pool_test_info_packet(void)
 	odp_pool_param_t param;
 	const char pool_name[] = "test_pool_name";
 
+	memset(&info, 0, sizeof(info));
 	odp_pool_param_init(&param);
 
 	param.type     = ODP_POOL_PACKET;
@@ -351,6 +353,7 @@ static void pool_test_info_data_range(void)
 	uint32_t i, num;
 	uintptr_t pool_len;
 
+	memset(&info, 0, sizeof(info));
 	odp_pool_param_init(&param);
 
 	param.type     = ODP_POOL_PACKET;

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -580,8 +580,8 @@ static void queue_test_pair_lf_spsc(void)
 static void queue_test_param(void)
 {
 	odp_queue_t queue, null_queue;
-	odp_event_t enev[BURST_SIZE];
-	odp_event_t deev[BURST_SIZE];
+	odp_event_t enev[BURST_SIZE] = {ODP_EVENT_INVALID};
+	odp_event_t deev[BURST_SIZE] = {ODP_EVENT_INVALID};
 	odp_buffer_t buf;
 	odp_event_t ev;
 	odp_pool_t msg_pool;


### PR DESCRIPTION
This patchset fixes several LTO related compile errors which I've noticed when building an empty platform skeleton.