### PR TITLE
[PATCH v4] Create missing TM print APIs

### DIFF
--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -1952,6 +1952,97 @@ odp_bool_t odp_tm_is_idle(odp_tm_t odp_tm);
 void odp_tm_stats_print(odp_tm_t odp_tm);
 
 /**
+ * Get printable value for an odp_tm_t
+ *
+ * @param hdl  odp_tm_t handle to be printed
+ * @return     uint64_t value that can be used to print/display this
+ *             handle
+ *
+ * @note This routine is intended to be used for diagnostic purposes
+ * to enable applications to generate a printable value that represents
+ * an odp_tm_t handle.
+ */
+uint64_t odp_tm_to_u64(odp_tm_t hdl);
+
+/**
+ * Get printable value for an odp_tm_queue_t
+ *
+ * @param hdl  odp_tm_queue_t handle to be printed
+ * @return     uint64_t value that can be used to print/display this
+ *             handle
+ *
+ * @note This routine is intended to be used for diagnostic purposes
+ * to enable applications to generate a printable value that represents
+ * an odp_tm_queue_t handle.
+ */
+uint64_t odp_tm_queue_to_u64(odp_tm_queue_t hdl);
+
+/**
+ * Get printable value for an odp_tm_node_t
+ *
+ * @param hdl  odp_tm_node_t handle to be printed
+ * @return     uint64_t value that can be used to print/display this
+ *             handle
+ *
+ * @note This routine is intended to be used for diagnostic purposes
+ * to enable applications to generate a printable value that represents
+ * an odp_tm_node_t handle.
+ */
+uint64_t odp_tm_node_to_u64(odp_tm_node_t hdl);
+
+/**
+ * Get printable value for an odp_tm_shaper_t
+ *
+ * @param hdl  odp_tm_shaper_t handle to be printed
+ * @return     uint64_t value that can be used to print/display this
+ *             handle
+ *
+ * @note This routine is intended to be used for diagnostic purposes
+ * to enable applications to generate a printable value that represents
+ * an odp_tm_shaper_t handle.
+ */
+uint64_t odp_tm_shaper_to_u64(odp_tm_shaper_t hdl);
+
+/**
+ * Get printable value for an odp_tm_sched_t
+ *
+ * @param hdl  odp_tm_sched_t handle to be printed
+ * @return     uint64_t value that can be used to print/display this
+ *             handle
+ *
+ * @note This routine is intended to be used for diagnostic purposes
+ * to enable applications to generate a printable value that represents
+ * an odp_tm_sched_t handle.
+ */
+uint64_t odp_tm_sched_to_u64(odp_tm_sched_t hdl);
+
+/**
+ * Get printable value for an odp_tm_threshold_t
+ *
+ * @param hdl  odp_tm_threshold_t handle to be printed
+ * @return     uint64_t value that can be used to print/display this
+ *             handle
+ *
+ * @note This routine is intended to be used for diagnostic purposes
+ * to enable applications to generate a printable value that represents
+ * an odp_tm_threshold_t handle.
+ */
+uint64_t odp_tm_threshold_to_u64(odp_tm_threshold_t hdl);
+
+/**
+ * Get printable value for an odp_tm_wred_t
+ *
+ * @param hdl  odp_tm_wred_t handle to be printed
+ * @return     uint64_t value that can be used to print/display this
+ *             handle
+ *
+ * @note This routine is intended to be used for diagnostic purposes
+ * to enable applications to generate a printable value that represents
+ * an odp_tm_wred_t handle.
+ */
+uint64_t odp_tm_wred_to_u64(odp_tm_wred_t hdl);
+
+/**
  * @}
  */
 

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -4722,6 +4722,41 @@ void odp_tm_stats_print(odp_tm_t odp_tm)
 	}
 }
 
+uint64_t odp_tm_to_u64(odp_tm_t hdl)
+{
+	return _odp_pri(hdl);
+}
+
+uint64_t odp_tm_queue_to_u64(odp_tm_queue_t hdl)
+{
+	return _odp_pri(hdl);
+}
+
+uint64_t odp_tm_node_to_u64(odp_tm_node_t hdl)
+{
+	return _odp_pri(hdl);
+}
+
+uint64_t odp_tm_shaper_to_u64(odp_tm_shaper_t hdl)
+{
+	return _odp_pri(hdl);
+}
+
+uint64_t odp_tm_sched_to_u64(odp_tm_sched_t hdl)
+{
+	return _odp_pri(hdl);
+}
+
+uint64_t odp_tm_threshold_to_u64(odp_tm_threshold_t hdl)
+{
+	return _odp_pri(hdl);
+}
+
+uint64_t odp_tm_wred_to_u64(odp_tm_wred_t hdl)
+{
+	return _odp_pri(hdl);
+}
+
 int _odp_tm_init_global(void)
 {
 	odp_shm_t shm;


### PR DESCRIPTION
Various Traffic Manager objects are defined in spec as separate types defined by the implementation. However while printing in unit-tests, handles are directly printed as `PRIx64` forcing implementations to utilize uint64_t (or related) type to be used for TM handles.
This patchset proposes new APIs to introduce TM debug print APIs to allow more freedom for implementation in choosing types for TM handles.

What remains to be discussed is ODP_TM_INVALID which according to spec indicates an invalid handle for each of Traffic Manager types.