### PR TITLE
[PATCH v3] Allow inlining of hash and errno APIs

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -127,6 +127,7 @@ odpapiabidefaultinclude_HEADERS = \
 	odp/api/abi-default/cpumask.h \
 	odp/api/abi-default/crypto.h \
 	odp/api/abi-default/debug.h \
+	odp/api/abi-default/errno.h \
 	odp/api/abi-default/event.h \
 	odp/api/abi-default/init.h \
 	odp/api/abi-default/ipsec.h \
@@ -171,6 +172,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm32-linux/odp/api/abi/cpumask.h \
 	odp/arch/arm32-linux/odp/api/abi/crypto.h \
 	odp/arch/arm32-linux/odp/api/abi/debug.h \
+	odp/arch/arm32-linux/odp/api/abi/errno.h \
 	odp/arch/arm32-linux/odp/api/abi/event.h \
 	odp/arch/arm32-linux/odp/api/abi/init.h \
 	odp/arch/arm32-linux/odp/api/abi/ipsec.h \
@@ -211,6 +213,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm64-linux/odp/api/abi/cpumask.h \
 	odp/arch/arm64-linux/odp/api/abi/crypto.h \
 	odp/arch/arm64-linux/odp/api/abi/debug.h \
+	odp/arch/arm64-linux/odp/api/abi/errno.h \
 	odp/arch/arm64-linux/odp/api/abi/event.h \
 	odp/arch/arm64-linux/odp/api/abi/init.h \
 	odp/arch/arm64-linux/odp/api/abi/ipsec.h \
@@ -251,6 +254,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/default-linux/odp/api/abi/cpumask.h \
 	odp/arch/default-linux/odp/api/abi/crypto.h \
 	odp/arch/default-linux/odp/api/abi/debug.h \
+	odp/arch/default-linux/odp/api/abi/errno.h \
 	odp/arch/default-linux/odp/api/abi/event.h \
 	odp/arch/default-linux/odp/api/abi/init.h \
 	odp/arch/default-linux/odp/api/abi/ipsec.h \
@@ -291,6 +295,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/mips64-linux/odp/api/abi/cpumask.h \
 	odp/arch/mips64-linux/odp/api/abi/crypto.h \
 	odp/arch/mips64-linux/odp/api/abi/debug.h \
+	odp/arch/mips64-linux/odp/api/abi/errno.h \
 	odp/arch/mips64-linux/odp/api/abi/event.h \
 	odp/arch/mips64-linux/odp/api/abi/init.h \
 	odp/arch/mips64-linux/odp/api/abi/ipsec.h \
@@ -331,6 +336,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/power64-linux/odp/api/abi/cpumask.h \
 	odp/arch/power64-linux/odp/api/abi/crypto.h \
 	odp/arch/power64-linux/odp/api/abi/debug.h \
+	odp/arch/power64-linux/odp/api/abi/errno.h \
 	odp/arch/power64-linux/odp/api/abi/event.h \
 	odp/arch/power64-linux/odp/api/abi/init.h \
 	odp/arch/power64-linux/odp/api/abi/ipsec.h \
@@ -371,6 +377,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_32-linux/odp/api/abi/cpumask.h \
 	odp/arch/x86_32-linux/odp/api/abi/crypto.h \
 	odp/arch/x86_32-linux/odp/api/abi/debug.h \
+	odp/arch/x86_32-linux/odp/api/abi/errno.h \
 	odp/arch/x86_32-linux/odp/api/abi/event.h \
 	odp/arch/x86_32-linux/odp/api/abi/init.h \
 	odp/arch/x86_32-linux/odp/api/abi/ipsec.h \
@@ -411,6 +418,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_64-linux/odp/api/abi/cpumask.h \
 	odp/arch/x86_64-linux/odp/api/abi/crypto.h \
 	odp/arch/x86_64-linux/odp/api/abi/debug.h \
+	odp/arch/x86_64-linux/odp/api/abi/errno.h \
 	odp/arch/x86_64-linux/odp/api/abi/event.h \
 	odp/arch/x86_64-linux/odp/api/abi/init.h \
 	odp/arch/x86_64-linux/odp/api/abi/ipsec.h \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -129,6 +129,7 @@ odpapiabidefaultinclude_HEADERS = \
 	odp/api/abi-default/debug.h \
 	odp/api/abi-default/errno.h \
 	odp/api/abi-default/event.h \
+	odp/api/abi-default/hash.h \
 	odp/api/abi-default/init.h \
 	odp/api/abi-default/ipsec.h \
 	odp/api/abi-default/packet.h \
@@ -174,6 +175,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm32-linux/odp/api/abi/debug.h \
 	odp/arch/arm32-linux/odp/api/abi/errno.h \
 	odp/arch/arm32-linux/odp/api/abi/event.h \
+	odp/arch/arm32-linux/odp/api/abi/hash.h \
 	odp/arch/arm32-linux/odp/api/abi/init.h \
 	odp/arch/arm32-linux/odp/api/abi/ipsec.h \
 	odp/arch/arm32-linux/odp/api/abi/packet.h \
@@ -215,6 +217,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm64-linux/odp/api/abi/debug.h \
 	odp/arch/arm64-linux/odp/api/abi/errno.h \
 	odp/arch/arm64-linux/odp/api/abi/event.h \
+	odp/arch/arm64-linux/odp/api/abi/hash.h \
 	odp/arch/arm64-linux/odp/api/abi/init.h \
 	odp/arch/arm64-linux/odp/api/abi/ipsec.h \
 	odp/arch/arm64-linux/odp/api/abi/packet.h \
@@ -256,6 +259,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/default-linux/odp/api/abi/debug.h \
 	odp/arch/default-linux/odp/api/abi/errno.h \
 	odp/arch/default-linux/odp/api/abi/event.h \
+	odp/arch/default-linux/odp/api/abi/hash.h \
 	odp/arch/default-linux/odp/api/abi/init.h \
 	odp/arch/default-linux/odp/api/abi/ipsec.h \
 	odp/arch/default-linux/odp/api/abi/packet.h \
@@ -297,6 +301,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/mips64-linux/odp/api/abi/debug.h \
 	odp/arch/mips64-linux/odp/api/abi/errno.h \
 	odp/arch/mips64-linux/odp/api/abi/event.h \
+	odp/arch/mips64-linux/odp/api/abi/hash.h \
 	odp/arch/mips64-linux/odp/api/abi/init.h \
 	odp/arch/mips64-linux/odp/api/abi/ipsec.h \
 	odp/arch/mips64-linux/odp/api/abi/packet.h \
@@ -338,6 +343,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/power64-linux/odp/api/abi/debug.h \
 	odp/arch/power64-linux/odp/api/abi/errno.h \
 	odp/arch/power64-linux/odp/api/abi/event.h \
+	odp/arch/power64-linux/odp/api/abi/hash.h \
 	odp/arch/power64-linux/odp/api/abi/init.h \
 	odp/arch/power64-linux/odp/api/abi/ipsec.h \
 	odp/arch/power64-linux/odp/api/abi/packet.h \
@@ -379,6 +385,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_32-linux/odp/api/abi/debug.h \
 	odp/arch/x86_32-linux/odp/api/abi/errno.h \
 	odp/arch/x86_32-linux/odp/api/abi/event.h \
+	odp/arch/x86_32-linux/odp/api/abi/hash.h \
 	odp/arch/x86_32-linux/odp/api/abi/init.h \
 	odp/arch/x86_32-linux/odp/api/abi/ipsec.h \
 	odp/arch/x86_32-linux/odp/api/abi/packet.h \
@@ -420,6 +427,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_64-linux/odp/api/abi/debug.h \
 	odp/arch/x86_64-linux/odp/api/abi/errno.h \
 	odp/arch/x86_64-linux/odp/api/abi/event.h \
+	odp/arch/x86_64-linux/odp/api/abi/hash.h \
 	odp/arch/x86_64-linux/odp/api/abi/init.h \
 	odp/arch/x86_64-linux/odp/api/abi/ipsec.h \
 	odp/arch/x86_64-linux/odp/api/abi/packet.h \

--- a/include/odp/api/abi-default/errno.h
+++ b/include/odp/api/abi-default/errno.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP errno
+ */
+
+#ifndef ODP_ABI_ERRNO_H_
+#define ODP_ABI_ERRNO_H_
+
+/* Empty header to allow platforms to override inlining
+ * of errno functions.
+ */
+
+#endif

--- a/include/odp/api/abi-default/hash.h
+++ b/include/odp/api/abi-default/hash.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP hash
+ */
+
+#ifndef ODP_ABI_HASH_H_
+#define ODP_ABI_HASH_H_
+
+/* Empty header to allow platforms to override inlining
+ * of hash functions.
+ */
+
+#endif

--- a/include/odp/api/errno.h
+++ b/include/odp/api/errno.h
@@ -17,6 +17,8 @@
 extern "C" {
 #endif
 
+#include <odp/api/abi/errno.h>
+
 #include <odp/api/spec/errno.h>
 
 #ifdef __cplusplus

--- a/include/odp/api/hash.h
+++ b/include/odp/api/hash.h
@@ -17,6 +17,8 @@
 extern "C" {
 #endif
 
+#include <odp/api/abi/hash.h>
+
 #include <odp/api/spec/hash.h>
 
 #ifdef __cplusplus

--- a/include/odp/arch/arm32-linux/odp/api/abi/errno.h
+++ b/include/odp/arch/arm32-linux/odp/api/abi/errno.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/errno.h>

--- a/include/odp/arch/arm32-linux/odp/api/abi/hash.h
+++ b/include/odp/arch/arm32-linux/odp/api/abi/hash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/hash.h>

--- a/include/odp/arch/arm64-linux/odp/api/abi/errno.h
+++ b/include/odp/arch/arm64-linux/odp/api/abi/errno.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/errno.h>

--- a/include/odp/arch/arm64-linux/odp/api/abi/hash.h
+++ b/include/odp/arch/arm64-linux/odp/api/abi/hash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/hash.h>

--- a/include/odp/arch/default-linux/odp/api/abi/errno.h
+++ b/include/odp/arch/default-linux/odp/api/abi/errno.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/errno.h>

--- a/include/odp/arch/default-linux/odp/api/abi/hash.h
+++ b/include/odp/arch/default-linux/odp/api/abi/hash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/hash.h>

--- a/include/odp/arch/mips64-linux/odp/api/abi/errno.h
+++ b/include/odp/arch/mips64-linux/odp/api/abi/errno.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/errno.h>

--- a/include/odp/arch/mips64-linux/odp/api/abi/hash.h
+++ b/include/odp/arch/mips64-linux/odp/api/abi/hash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/hash.h>

--- a/include/odp/arch/power64-linux/odp/api/abi/errno.h
+++ b/include/odp/arch/power64-linux/odp/api/abi/errno.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/errno.h>

--- a/include/odp/arch/power64-linux/odp/api/abi/hash.h
+++ b/include/odp/arch/power64-linux/odp/api/abi/hash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/hash.h>

--- a/include/odp/arch/x86_32-linux/odp/api/abi/errno.h
+++ b/include/odp/arch/x86_32-linux/odp/api/abi/errno.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/errno.h>

--- a/include/odp/arch/x86_32-linux/odp/api/abi/hash.h
+++ b/include/odp/arch/x86_32-linux/odp/api/abi/hash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/hash.h>

--- a/include/odp/arch/x86_64-linux/odp/api/abi/errno.h
+++ b/include/odp/arch/x86_64-linux/odp/api/abi/errno.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/errno.h>

--- a/include/odp/arch/x86_64-linux/odp/api/abi/hash.h
+++ b/include/odp/arch/x86_64-linux/odp/api/abi/hash.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/hash.h>

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -57,6 +57,7 @@ odpapiabiarchinclude_HEADERS += \
 		  include-abi/odp/api/abi/cpumask.h \
 		  include-abi/odp/api/abi/crypto.h \
 		  include-abi/odp/api/abi/debug.h \
+		  include-abi/odp/api/abi/errno.h \
 		  include-abi/odp/api/abi/event.h \
 		  include-abi/odp/api/abi/init.h \
 		  include-abi/odp/api/abi/ipsec.h \

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -59,6 +59,7 @@ odpapiabiarchinclude_HEADERS += \
 		  include-abi/odp/api/abi/debug.h \
 		  include-abi/odp/api/abi/errno.h \
 		  include-abi/odp/api/abi/event.h \
+		  include-abi/odp/api/abi/hash.h \
 		  include-abi/odp/api/abi/init.h \
 		  include-abi/odp/api/abi/ipsec.h \
 		  include-abi/odp/api/abi/packet.h \

--- a/platform/linux-generic/include-abi/odp/api/abi/errno.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/errno.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP errno
+ */
+
+#ifndef ODP_API_ABI_ERRNO_H_
+#define ODP_API_ABI_ERRNO_H_
+
+#include <odp/api/abi-default/errno.h>
+
+#endif

--- a/platform/linux-generic/include-abi/odp/api/abi/hash.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/hash.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP hash
+ */
+
+#ifndef ODP_API_ABI_HASH_H_
+#define ODP_API_ABI_HASH_H_
+
+#include <odp/api/abi-default/hash.h>
+
+#endif


### PR DESCRIPTION
Both APIs are missing respective ABI files where inline implementation could be placed.