### PR TITLE
[PATCH v5] Various build-system fixes

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,7 +1,7 @@
 #! /bin/sh
 set -x
 aclocal -I config -I m4
-libtoolize --copy
+libtoolize --copy --force
 autoheader
 automake --add-missing --copy --warnings=all
 autoconf --force

--- a/m4/odp_atomic.m4
+++ b/m4/odp_atomic.m4
@@ -126,12 +126,13 @@ AC_CACHE_CHECK([whether -latomic is needed for 64-bit atomic compare exchange],
 	       [odp_cv_atomic_needed_64bit_cmp_exc], [dnl
 AC_LINK_IFELSE(
   [AC_LANG_SOURCE([[
+    #include <stdbool.h>
     #include <stdint.h>
     static uint64_t loc;
     int main(void)
     {
         uint64_t exp = 0;
-        uint64_t = __atomic_compare_exchange_n(&loc, &exp, 1, 1,
+        bool res = __atomic_compare_exchange_8(&loc, &exp, 1, 1,
                                                __ATOMIC_ACQUIRE,
                                                __ATOMIC_RELAXED);
         return 0;
@@ -157,14 +158,14 @@ AC_CACHE_CHECK([whether -latomic is needed for 128-bit atomic compare exchange],
 	       [odp_cv_atomic_needed_128bit_cmp_exc], [dnl
 AC_LINK_IFELSE(
   [AC_LANG_SOURCE([[
-    #include <stdint.h>
+    #include <stdbool.h>
     static __int128 loc;
     int main(void)
     {
         __int128 exp = 0;
-        __int128 = __atomic_compare_exchange_n(&loc, &exp, 1, 1,
-                                               __ATOMIC_ACQUIRE,
-                                               __ATOMIC_RELAXED);
+        bool res = __atomic_compare_exchange_16(&loc, &exp, 1, 1,
+                                                __ATOMIC_ACQUIRE,
+                                                __ATOMIC_RELAXED);
         return 0;
     }
     ]])],

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -29,7 +29,7 @@ endif
 AM_CFLAGS = $(CUNIT_CFLAGS)
 
 if STATIC_APPS
-AM_LDFLAGS = -L$(LIB) -static
+AM_LDFLAGS = -L$(LIB)
 else
 AM_LDFLAGS =
 endif


### PR DESCRIPTION
While integrating our implementations with other build-systems, such as buildroot and adding automated remote hardware testing, we've noticed several minor issues with current automake files. This patchset gathers together fixes for those issues. Related to this pull request are: https://github.com/OpenDataPlane/odp/pull/924 and https://github.com/OpenDataPlane/odp/pull/956 which I think should be handled separately.