### PR TITLE
[PATCH v6] api: pktio: enable reading link status information

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,8 +3,8 @@ AC_PREREQ([2.5])
 # ODP API version
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
-m4_define([odpapi_major_version], [23])
-m4_define([odpapi_minor_version], [6])
+m4_define([odpapi_major_version], [24])
+m4_define([odpapi_minor_version], [0])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2020, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -1208,6 +1209,13 @@ void odp_pktio_config_init(odp_pktio_config_t *config);
  */
 void odp_pktio_print(odp_pktio_t pktio);
 
+/** Link status */
+typedef enum odp_pktio_link_status_t {
+	ODP_PKTIO_LINK_STATUS_UNKNOWN = -1,
+	ODP_PKTIO_LINK_STATUS_DOWN = 0,
+	ODP_PKTIO_LINK_STATUS_UP = 1
+} odp_pktio_link_status_t;
+
 /**
  * Determine pktio link is up or down for a packet IO interface.
  *
@@ -1254,6 +1262,112 @@ typedef struct odp_pktio_info_t {
  * @retval <0 on failure
  */
 int odp_pktio_info(odp_pktio_t pktio, odp_pktio_info_t *info);
+
+/** @name Link speed
+ *  Packet IO link speeds in Mbps
+ *  @anchor link_speed
+ *  @{
+ */
+
+/** Link speed unknown */
+#define	ODP_PKTIO_LINK_SPEED_UNKNOWN 0
+/** Link speed 10 Mbit/s */
+#define	ODP_PKTIO_LINK_SPEED_10M     10
+/** Link speed 100 Mbit/s */
+#define	ODP_PKTIO_LINK_SPEED_100M    100
+/** Link speed 1 Gbit/s */
+#define	ODP_PKTIO_LINK_SPEED_1G      1000
+/** Link speed 2.5 Gbit/s */
+#define	ODP_PKTIO_LINK_SPEED_2_5G    2500
+/** Link speed 5 Gbit/s */
+#define	ODP_PKTIO_LINK_SPEED_5G      5000
+/** Link speed 10 Gbit/s */
+#define	ODP_PKTIO_LINK_SPEED_10G     10000
+/** Link speed 20 Gbit/s */
+#define	ODP_PKTIO_LINK_SPEED_20G     20000
+/** Link speed 25 Gbit/s */
+#define	ODP_PKTIO_LINK_SPEED_25G     25000
+/** Link speed 40 Gbit/s */
+#define	ODP_PKTIO_LINK_SPEED_40G     40000
+/** Link speed 50 Gbit/s */
+#define	ODP_PKTIO_LINK_SPEED_50G     50000
+/** Link speed 56 Gbit/s */
+#define	ODP_PKTIO_LINK_SPEED_56G     56000
+/** Link speed 100 Gbit/s */
+#define	ODP_PKTIO_LINK_SPEED_100G    100000
+/** Link speed 200 Gbit/s */
+#define	ODP_PKTIO_LINK_SPEED_200G    200000
+/** Link speed 400 Gbit/s */
+#define	ODP_PKTIO_LINK_SPEED_400G    400000
+
+/** @} */
+
+/** Autonegotiation mode */
+typedef enum odp_pktio_link_autoneg_t {
+	/** Autonegotiation state unknown */
+	ODP_PKTIO_LINK_AUTONEG_UNKNOWN = -1,
+	/** Autonegotiation disabled */
+	ODP_PKTIO_LINK_AUTONEG_OFF = 0,
+	/** Autonegotiation enabled */
+	ODP_PKTIO_LINK_AUTONEG_ON  = 1
+} odp_pktio_link_autoneg_t;
+
+/** Duplex mode */
+typedef enum odp_pktio_link_duplex_t {
+	ODP_PKTIO_LINK_DUPLEX_UNKNOWN = -1,
+	ODP_PKTIO_LINK_DUPLEX_HALF = 0,
+	ODP_PKTIO_LINK_DUPLEX_FULL = 1
+} odp_pktio_link_duplex_t;
+
+/** Ethernet pause frame (flow control) mode */
+typedef enum odp_pktio_link_pause_t {
+	ODP_PKTIO_LINK_PAUSE_UNKNOWN = -1,
+	ODP_PKTIO_LINK_PAUSE_OFF = 0,
+	ODP_PKTIO_LINK_PAUSE_ON  = 1
+} odp_pktio_link_pause_t;
+
+/**
+ * Packet IO link information
+ */
+typedef struct odp_pktio_link_info_t {
+	/** Link autonegotiation */
+	odp_pktio_link_autoneg_t autoneg;
+	/** Duplex mode */
+	odp_pktio_link_duplex_t duplex;
+	/** Link media type
+	 *
+	 * The implementation owned string describes link media type. Values are
+	 * implementation specific short names like copper, fiber, or virtual.
+	 * The value of "unknown" is used when media type cannot be determined. */
+	const char *media;
+	/** Reception of pause frames */
+	odp_pktio_link_pause_t pause_rx;
+	/** Transmission of pause frames */
+	odp_pktio_link_pause_t pause_tx;
+	/** Link speed in Mbps
+	  *
+	  * The value of zero means that the link speed is unknown.
+	  * ODP_PKTIO_LINK_SPEED_* (@ref link_speed) defines can be used to
+	  * compare the value to standard link speeds. */
+	uint32_t speed;
+	/** Link status */
+	odp_pktio_link_status_t status;
+} odp_pktio_link_info_t;
+
+/**
+ * Retrieve information about packet IO link status
+ *
+ * Fills in link information structure with the current link status values.
+ * May be called any time with a valid pktio handle. The call is not intended
+ * for fast path use. The info structure is written only on success.
+ *
+ * @param      pktio   Packet IO handle
+ * @param[out] info    Pointer to packet IO link info struct for output
+ *
+ * @retval  0 on success
+ * @retval <0 on failure
+ */
+int odp_pktio_link_info(odp_pktio_t pktio, odp_pktio_link_info_t *info);
 
 /**
  * Packet input timestamp resolution in hertz

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -1221,11 +1221,10 @@ typedef enum odp_pktio_link_status_t {
  *
  * @param pktio Packet IO handle.
  *
- * @retval  1 link is up
- * @retval  0 link is down
- * @retval <0 on failure
+ * @retval  ODP_PKTIO_LINK_STATUS_UP or ODP_PKTIO_LINK_STATUS_DOWN on success
+ * @retval  ODP_PKTIO_LINK_STATUS_UNKNOWN on failure
 */
-int odp_pktio_link_status(odp_pktio_t pktio);
+odp_pktio_link_status_t odp_pktio_link_status(odp_pktio_t pktio);
 
 /**
  * Packet IO information

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -180,6 +180,7 @@ typedef struct pktio_if_ops {
 	int (*mac_get)(pktio_entry_t *pktio_entry, void *mac_addr);
 	int (*mac_set)(pktio_entry_t *pktio_entry, const void *mac_addr);
 	int (*link_status)(pktio_entry_t *pktio_entry);
+	int (*link_info)(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *info);
 	int (*capability)(pktio_entry_t *pktio_entry,
 			  odp_pktio_capability_t *capa);
 	int (*config)(pktio_entry_t *pktio_entry,

--- a/platform/linux-generic/include/odp_socket_common.h
+++ b/platform/linux-generic/include/odp_socket_common.h
@@ -12,6 +12,8 @@
 extern "C" {
 #endif
 
+#include <odp/api/packet_io.h>
+
 #include <string.h>
 #include <linux/if_ether.h>
 
@@ -56,6 +58,11 @@ int promisc_mode_get_fd(int fd, const char *name);
  * Return link status of a packet socket (up/down)
  */
 int link_status_fd(int fd, const char *name);
+
+/**
+ * Read link information from a packet socket
+ */
+int link_info_fd(int fd, const char *name, odp_pktio_link_info_t *info);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1168,15 +1168,15 @@ int odp_pktio_mac_addr_set(odp_pktio_t hdl, const void *mac_addr, int addr_size)
 	return ret;
 }
 
-int odp_pktio_link_status(odp_pktio_t hdl)
+odp_pktio_link_status_t odp_pktio_link_status(odp_pktio_t hdl)
 {
 	pktio_entry_t *entry;
-	int ret = -1;
+	int ret = ODP_PKTIO_LINK_STATUS_UNKNOWN;
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL) {
 		ODP_DBG("pktio entry %d does not exist\n", hdl);
-		return -1;
+		return ODP_PKTIO_LINK_STATUS_UNKNOWN;
 	}
 
 	lock_entry(entry);
@@ -1184,7 +1184,7 @@ int odp_pktio_link_status(odp_pktio_t hdl)
 	if (odp_unlikely(is_free(entry))) {
 		unlock_entry(entry);
 		ODP_DBG("already freed pktio\n");
-		return -1;
+		return ODP_PKTIO_LINK_STATUS_UNKNOWN;
 	}
 
 	if (entry->s.ops->link_status)

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019, Nokia
+ * Copyright (c) 2019-2020, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -1242,6 +1242,23 @@ int odp_pktio_info(odp_pktio_t hdl, odp_pktio_info_t *info)
 	memcpy(&info->param, &entry->s.param, sizeof(odp_pktio_param_t));
 
 	return 0;
+}
+
+int odp_pktio_link_info(odp_pktio_t hdl, odp_pktio_link_info_t *info)
+{
+	pktio_entry_t *entry;
+
+	entry = get_pktio_entry(hdl);
+
+	if (entry == NULL) {
+		ODP_DBG("pktio entry %d does not exist\n", hdl);
+		return -1;
+	}
+
+	if (entry->s.ops->link_info)
+		return entry->s.ops->link_info(entry, info);
+
+	return -1;
 }
 
 uint64_t odp_pktin_ts_res(odp_pktio_t hdl)

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -2056,8 +2056,9 @@ static int dpdk_link_status(pktio_entry_t *pktio_entry)
 	memset(&link, 0, sizeof(struct rte_eth_link));
 
 	rte_eth_link_get_nowait(pkt_priv(pktio_entry)->port_id, &link);
-
-	return link.link_status;
+	if (link.link_status)
+		return ODP_PKTIO_LINK_STATUS_UP;
+	return ODP_PKTIO_LINK_STATUS_DOWN;
 }
 
 static int dpdk_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *info)

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -900,6 +900,13 @@ static int ipc_stop(pktio_entry_t *pktio_entry)
 	return 0;
 }
 
+static int ipc_link_status(pktio_entry_t *pktio_entry)
+{
+	pkt_ipc_t *pktio_ipc = pkt_priv(pktio_entry);
+
+	return odp_atomic_load_u32(&pktio_ipc->ready);
+}
+
 static int ipc_close(pktio_entry_t *pktio_entry)
 {
 	pkt_ipc_t *pktio_ipc = pkt_priv(pktio_entry);
@@ -947,6 +954,7 @@ const pktio_if_ops_t ipc_pktio_ops = {
 	.send = ipc_pktio_send,
 	.start = ipc_start,
 	.stop = ipc_stop,
+	.link_status = ipc_link_status,
 	.mtu_get = ipc_mtu_get,
 	.promisc_mode_set = NULL,
 	.promisc_mode_get = NULL,

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -904,7 +904,9 @@ static int ipc_link_status(pktio_entry_t *pktio_entry)
 {
 	pkt_ipc_t *pktio_ipc = pkt_priv(pktio_entry);
 
-	return odp_atomic_load_u32(&pktio_ipc->ready);
+	if (odp_atomic_load_u32(&pktio_ipc->ready))
+		return ODP_PKTIO_LINK_STATUS_UP;
+	return ODP_PKTIO_LINK_STATUS_DOWN;
 }
 
 static int ipc_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *info)

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -907,6 +907,26 @@ static int ipc_link_status(pktio_entry_t *pktio_entry)
 	return odp_atomic_load_u32(&pktio_ipc->ready);
 }
 
+static int ipc_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *info)
+{
+	pkt_ipc_t *pktio_ipc = pkt_priv(pktio_entry);
+
+	memset(info, 0, sizeof(odp_pktio_link_info_t));
+
+	info->autoneg = ODP_PKTIO_LINK_AUTONEG_OFF;
+	info->duplex = ODP_PKTIO_LINK_DUPLEX_FULL;
+	info->media = "virtual";
+	info->pause_rx = ODP_PKTIO_LINK_PAUSE_OFF;
+	info->pause_tx = ODP_PKTIO_LINK_PAUSE_OFF;
+	info->speed = ODP_PKTIO_LINK_SPEED_UNKNOWN;
+	if (odp_atomic_load_u32(&pktio_ipc->ready))
+		info->status = ODP_PKTIO_LINK_STATUS_UP;
+	else
+		info->status = ODP_PKTIO_LINK_STATUS_DOWN;
+
+	return 0;
+}
+
 static int ipc_close(pktio_entry_t *pktio_entry)
 {
 	pkt_ipc_t *pktio_ipc = pkt_priv(pktio_entry);
@@ -955,6 +975,7 @@ const pktio_if_ops_t ipc_pktio_ops = {
 	.start = ipc_start,
 	.stop = ipc_stop,
 	.link_status = ipc_link_status,
+	.link_info = ipc_link_info,
 	.mtu_get = ipc_mtu_get,
 	.promisc_mode_set = NULL,
 	.promisc_mode_get = NULL,

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2013, Nokia Solutions and Networks
+ * Copyright (c) 2013-2020, Nokia Solutions and Networks
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -370,6 +370,21 @@ static int loopback_link_status(pktio_entry_t *pktio_entry ODP_UNUSED)
 	return 1;
 }
 
+static int loopback_link_info(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_link_info_t *info)
+{
+	memset(info, 0, sizeof(odp_pktio_link_info_t));
+
+	info->autoneg = ODP_PKTIO_LINK_AUTONEG_OFF;
+	info->duplex = ODP_PKTIO_LINK_DUPLEX_FULL;
+	info->media = "virtual";
+	info->pause_rx = ODP_PKTIO_LINK_PAUSE_OFF;
+	info->pause_tx = ODP_PKTIO_LINK_PAUSE_OFF;
+	info->speed = ODP_PKTIO_LINK_SPEED_UNKNOWN;
+	info->status = ODP_PKTIO_LINK_STATUS_UP;
+
+	return 0;
+}
+
 static int loopback_init_capability(pktio_entry_t *pktio_entry)
 {
 	odp_pktio_capability_t *capa = &pktio_entry->s.capa;
@@ -467,6 +482,7 @@ const pktio_if_ops_t loopback_pktio_ops = {
 	.mac_get = loopback_mac_addr_get,
 	.mac_set = NULL,
 	.link_status = loopback_link_status,
+	.link_info = loopback_link_info,
 	.capability = loopback_capability,
 	.pktin_ts_res = NULL,
 	.pktin_ts_from_ns = NULL,

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -367,7 +367,7 @@ static int loopback_mac_addr_get(pktio_entry_t *pktio_entry ODP_UNUSED,
 static int loopback_link_status(pktio_entry_t *pktio_entry ODP_UNUSED)
 {
 	/* loopback interfaces are always up */
-	return 1;
+	return ODP_PKTIO_LINK_STATUS_UP;
 }
 
 static int loopback_link_info(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_link_info_t *info)

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2019, Nokia
+ * Copyright (c) 2019-2020, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -359,6 +359,27 @@ static int netmap_link_status(pktio_entry_t *pktio_entry)
 
 	return link_status_fd(pkt_priv(pktio_entry)->sockfd,
 			      pkt_priv(pktio_entry)->if_name);
+}
+
+static int netmap_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *info)
+{
+	pkt_netmap_t *pkt_nm = pkt_priv(pktio_entry);
+
+	if (pkt_nm->is_virtual) {
+		memset(info, 0, sizeof(odp_pktio_link_info_t));
+
+		info->autoneg = ODP_PKTIO_LINK_AUTONEG_OFF;
+		info->duplex = ODP_PKTIO_LINK_DUPLEX_FULL;
+		info->media = "virtual";
+		info->pause_rx = ODP_PKTIO_LINK_PAUSE_OFF;
+		info->pause_tx = ODP_PKTIO_LINK_PAUSE_OFF;
+		info->speed = ODP_PKTIO_LINK_SPEED_UNKNOWN;
+		info->status = ODP_PKTIO_LINK_STATUS_UP;
+
+		return 0;
+	}
+
+	return link_info_fd(pkt_nm->sockfd, pkt_nm->if_name, info);
 }
 
 /**
@@ -1225,6 +1246,7 @@ const pktio_if_ops_t netmap_pktio_ops = {
 	.start = netmap_start,
 	.stop = netmap_stop,
 	.link_status = netmap_link_status,
+	.link_info = netmap_link_info,
 	.stats = netmap_stats,
 	.stats_reset = netmap_stats_reset,
 	.mtu_get = netmap_mtu_get,

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -355,7 +355,7 @@ static int netmap_close(pktio_entry_t *pktio_entry)
 static int netmap_link_status(pktio_entry_t *pktio_entry)
 {
 	if (pkt_priv(pktio_entry)->is_virtual)
-		return 1;
+		return ODP_PKTIO_LINK_STATUS_UP;
 
 	return link_status_fd(pkt_priv(pktio_entry)->sockfd,
 			      pkt_priv(pktio_entry)->if_name);

--- a/platform/linux-generic/pktio/null.c
+++ b/platform/linux-generic/pktio/null.c
@@ -156,7 +156,7 @@ static int null_init_global(void)
 
 static int null_link_status(pktio_entry_t *pktio_entry ODP_UNUSED)
 {
-	return 1;
+	return ODP_PKTIO_LINK_STATUS_UP;
 }
 
 static int null_link_info(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_link_info_t *info)

--- a/platform/linux-generic/pktio/null.c
+++ b/platform/linux-generic/pktio/null.c
@@ -159,6 +159,21 @@ static int null_link_status(pktio_entry_t *pktio_entry ODP_UNUSED)
 	return 1;
 }
 
+static int null_link_info(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_link_info_t *info)
+{
+	memset(info, 0, sizeof(odp_pktio_link_info_t));
+
+	info->autoneg = ODP_PKTIO_LINK_AUTONEG_OFF;
+	info->duplex = ODP_PKTIO_LINK_DUPLEX_FULL;
+	info->media = "virtual";
+	info->pause_rx = ODP_PKTIO_LINK_PAUSE_OFF;
+	info->pause_tx = ODP_PKTIO_LINK_PAUSE_OFF;
+	info->speed = ODP_PKTIO_LINK_SPEED_UNKNOWN;
+	info->status = ODP_PKTIO_LINK_STATUS_UP;
+
+	return 0;
+}
+
 const pktio_if_ops_t null_pktio_ops = {
 	.name = "null",
 	.print = NULL,
@@ -184,5 +199,6 @@ const pktio_if_ops_t null_pktio_ops = {
 	.config = NULL,
 	.input_queues_config = null_inqueues_config,
 	.output_queues_config = null_outqueues_config,
-	.link_status = null_link_status
+	.link_status = null_link_status,
+	.link_info = null_link_info
 };

--- a/platform/linux-generic/pktio/null.c
+++ b/platform/linux-generic/pktio/null.c
@@ -154,6 +154,11 @@ static int null_init_global(void)
 	return 0;
 }
 
+static int null_link_status(pktio_entry_t *pktio_entry ODP_UNUSED)
+{
+	return 1;
+}
+
 const pktio_if_ops_t null_pktio_ops = {
 	.name = "null",
 	.print = NULL,
@@ -179,4 +184,5 @@ const pktio_if_ops_t null_pktio_ops = {
 	.config = NULL,
 	.input_queues_config = null_inqueues_config,
 	.output_queues_config = null_outqueues_config,
+	.link_status = null_link_status
 };

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -446,7 +446,7 @@ static int pcapif_init_global(void)
 
 static int pcapif_link_status(pktio_entry_t *pktio_entry ODP_UNUSED)
 {
-	return 1;
+	return ODP_PKTIO_LINK_STATUS_UP;
 }
 
 static int pcapif_link_info(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_link_info_t *info)

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -444,6 +444,11 @@ static int pcapif_init_global(void)
 	return 0;
 }
 
+static int pcapif_link_status(pktio_entry_t *pktio_entry ODP_UNUSED)
+{
+	return 1;
+}
+
 const pktio_if_ops_t pcap_pktio_ops = {
 	.name = "pcap",
 	.print = NULL,
@@ -466,4 +471,5 @@ const pktio_if_ops_t pcap_pktio_ops = {
 	.config = NULL,
 	.input_queues_config = NULL,
 	.output_queues_config = NULL,
+	.link_status = pcapif_link_status,
 };

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -449,6 +449,21 @@ static int pcapif_link_status(pktio_entry_t *pktio_entry ODP_UNUSED)
 	return 1;
 }
 
+static int pcapif_link_info(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_link_info_t *info)
+{
+	memset(info, 0, sizeof(odp_pktio_link_info_t));
+
+	info->autoneg = ODP_PKTIO_LINK_AUTONEG_OFF;
+	info->duplex = ODP_PKTIO_LINK_DUPLEX_FULL;
+	info->media = "virtual";
+	info->pause_rx = ODP_PKTIO_LINK_PAUSE_OFF;
+	info->pause_tx = ODP_PKTIO_LINK_PAUSE_OFF;
+	info->speed = ODP_PKTIO_LINK_SPEED_UNKNOWN;
+	info->status = ODP_PKTIO_LINK_STATUS_UP;
+
+	return 0;
+}
+
 const pktio_if_ops_t pcap_pktio_ops = {
 	.name = "pcap",
 	.print = NULL,
@@ -472,4 +487,5 @@ const pktio_if_ops_t pcap_pktio_ops = {
 	.input_queues_config = NULL,
 	.output_queues_config = NULL,
 	.link_status = pcapif_link_status,
+	.link_info = pcapif_link_info
 };

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -493,6 +493,11 @@ static int sock_link_status(pktio_entry_t *pktio_entry)
 			      pktio_entry->s.name);
 }
 
+static int sock_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *info)
+{
+	return link_info_fd(pkt_priv(pktio_entry)->sockfd, pktio_entry->s.name, info);
+}
+
 static int sock_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 			   odp_pktio_capability_t *capa)
 {
@@ -566,6 +571,7 @@ const pktio_if_ops_t sock_mmsg_pktio_ops = {
 	.mac_get = sock_mac_addr_get,
 	.mac_set = NULL,
 	.link_status = sock_link_status,
+	.link_info = sock_link_info,
 	.capability = sock_capability,
 	.pktin_ts_res = NULL,
 	.pktin_ts_from_ns = NULL,

--- a/platform/linux-generic/pktio/socket_common.c
+++ b/platform/linux-generic/pktio/socket_common.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2019, Nokia
+ * Copyright (c) 2019-2020, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -14,7 +14,9 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <net/if.h>
+#include <linux/ethtool.h>
 #include <linux/if_packet.h>
+#include <linux/sockios.h>
 #include <errno.h>
 #include <odp_debug_internal.h>
 #include <odp_errno_define.h>
@@ -159,4 +161,135 @@ int link_status_fd(int fd, const char *name)
 	}
 
 	return !!(ifr.ifr_flags & IFF_RUNNING);
+}
+
+int link_info_fd(int fd, const char *name, odp_pktio_link_info_t *info)
+{
+	struct ethtool_link_settings hcmd = {.cmd = ETHTOOL_GLINKSETTINGS};
+	struct ethtool_link_settings *ecmd;
+	struct ethtool_pauseparam pcmd = {.cmd = ETHTOOL_GPAUSEPARAM};
+	struct ifreq ifr;
+	int status;
+
+	status = link_status_fd(fd, name);
+	if (status < 0)
+		return -1;
+
+	snprintf(ifr.ifr_name, IF_NAMESIZE, "%s", name);
+
+	/* Link pause status */
+	ifr.ifr_data = (void *)&pcmd;
+	if (ioctl(fd, SIOCETHTOOL, &ifr) && errno != EOPNOTSUPP) {
+		__odp_errno = errno;
+		ODP_ERR("ioctl(SIOCETHTOOL): %s: \"%s\".\n", strerror(errno),
+			ifr.ifr_name);
+		return -1;
+	}
+
+	/* Try to perform handshake and fall back to old API if failed */
+	ifr.ifr_data = (void *)&hcmd;
+	if (ioctl(fd, SIOCETHTOOL, &ifr) < 0) {
+		struct ethtool_cmd ecmd_old = {.cmd = ETHTOOL_GSET};
+
+		ifr.ifr_data = (void *)&ecmd_old;
+		if (ioctl(fd, SIOCETHTOOL, &ifr) < 0) {
+			__odp_errno = errno;
+			ODP_ERR("ioctl(SIOCETHTOOL): %s: \"%s\".\n", strerror(errno), ifr.ifr_name);
+			return -1;
+		}
+
+		memset(info, 0, sizeof(odp_pktio_link_info_t));
+		info->speed = ethtool_cmd_speed(&ecmd_old);
+		if (info->speed == (uint32_t)SPEED_UNKNOWN)
+			info->speed = ODP_PKTIO_LINK_SPEED_UNKNOWN;
+
+		if (ecmd_old.autoneg == AUTONEG_ENABLE)
+			info->autoneg = ODP_PKTIO_LINK_AUTONEG_ON;
+		else if (ecmd_old.autoneg == AUTONEG_DISABLE)
+			info->autoneg = ODP_PKTIO_LINK_AUTONEG_OFF;
+		else
+			info->autoneg = ODP_PKTIO_LINK_AUTONEG_UNKNOWN;
+
+		if (ecmd_old.duplex == DUPLEX_HALF)
+			info->duplex = ODP_PKTIO_LINK_DUPLEX_HALF;
+		else if (ecmd_old.duplex == DUPLEX_FULL)
+			info->duplex = ODP_PKTIO_LINK_DUPLEX_FULL;
+		else
+			info->duplex = ODP_PKTIO_LINK_DUPLEX_UNKNOWN;
+
+		info->pause_rx = pcmd.rx_pause ? ODP_PKTIO_LINK_PAUSE_ON : ODP_PKTIO_LINK_PAUSE_OFF;
+		info->pause_tx = pcmd.tx_pause ? ODP_PKTIO_LINK_PAUSE_ON : ODP_PKTIO_LINK_PAUSE_OFF;
+
+		if (ecmd_old.port == PORT_TP)
+			info->media = "copper";
+		else if (ecmd_old.port == PORT_FIBRE)
+			info->media = "fiber";
+		else if (ecmd_old.port == PORT_OTHER)
+			info->media = "other";
+		else
+			info->media = "unknown";
+
+		info->status = status;
+
+		return 0;
+	}
+
+	if (hcmd.link_mode_masks_nwords >= 0 || hcmd.cmd != ETHTOOL_GLINKSETTINGS) {
+		ODP_ERR("ETHTOOL_GLINKSETTINGS handshake failed\n");
+		return -1;
+	}
+	/* Absolute value indicates kernel recommended 'link_mode_masks_nwords' value. */
+	hcmd.link_mode_masks_nwords = -hcmd.link_mode_masks_nwords;
+
+	/* Reserve space for the three bitmasks (map_supported, map_advertising, map_lp_advertising)
+	 * at the end of struct ethtool_link_settings. 'link_mode_masks_nwords' defines the bitmask
+	 * length in 32-bit words. */
+	uint8_t ODP_ALIGNED_CACHE data[offsetof(struct ethtool_link_settings, link_mode_masks) +
+				       (3 * sizeof(uint32_t) * hcmd.link_mode_masks_nwords)];
+
+	ecmd = (void *)data;
+	*ecmd = hcmd;
+	ifr.ifr_data = (void *)ecmd;
+	if (ioctl(fd, SIOCETHTOOL, &ifr) < 0) {
+		__odp_errno = errno;
+		ODP_ERR("ioctl(SIOCETHTOOL): %s: \"%s\".\n", strerror(errno),
+			ifr.ifr_name);
+		return -1;
+	}
+
+	memset(info, 0, sizeof(odp_pktio_link_info_t));
+	if (ecmd->speed == (uint32_t)SPEED_UNKNOWN)
+		info->speed = ODP_PKTIO_LINK_SPEED_UNKNOWN;
+	else
+		info->speed = ecmd->speed;
+
+	if (ecmd->autoneg == AUTONEG_ENABLE)
+		info->autoneg = ODP_PKTIO_LINK_AUTONEG_ON;
+	else if (ecmd->autoneg == AUTONEG_DISABLE)
+		info->autoneg = ODP_PKTIO_LINK_AUTONEG_OFF;
+	else
+		info->autoneg = ODP_PKTIO_LINK_AUTONEG_UNKNOWN;
+
+	if (ecmd->duplex == DUPLEX_HALF)
+		info->duplex = ODP_PKTIO_LINK_DUPLEX_HALF;
+	else if (ecmd->duplex == DUPLEX_FULL)
+		info->duplex = ODP_PKTIO_LINK_DUPLEX_FULL;
+	else
+		info->duplex = ODP_PKTIO_LINK_DUPLEX_UNKNOWN;
+
+	info->pause_rx = pcmd.rx_pause ? ODP_PKTIO_LINK_PAUSE_ON : ODP_PKTIO_LINK_PAUSE_OFF;
+	info->pause_tx = pcmd.tx_pause ? ODP_PKTIO_LINK_PAUSE_ON : ODP_PKTIO_LINK_PAUSE_OFF;
+
+	if (ecmd->port == PORT_TP)
+		info->media = "copper";
+	else if (ecmd->port == PORT_FIBRE)
+		info->media = "fiber";
+	else if (ecmd->port == PORT_OTHER)
+		info->media = "other";
+	else
+		info->media = "unknown";
+
+	info->status = status;
+
+	return 0;
 }

--- a/platform/linux-generic/pktio/socket_common.c
+++ b/platform/linux-generic/pktio/socket_common.c
@@ -157,10 +157,12 @@ int link_status_fd(int fd, const char *name)
 		__odp_errno = errno;
 		ODP_DBG("ioctl(SIOCGIFFLAGS): %s: \"%s\".\n", strerror(errno),
 			ifr.ifr_name);
-		return -1;
+		return ODP_PKTIO_LINK_STATUS_UNKNOWN;
 	}
 
-	return !!(ifr.ifr_flags & IFF_RUNNING);
+	if (ifr.ifr_flags & IFF_RUNNING)
+		return ODP_PKTIO_LINK_STATUS_UP;
+	return ODP_PKTIO_LINK_STATUS_DOWN;
 }
 
 int link_info_fd(int fd, const char *name, odp_pktio_link_info_t *info)

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -784,6 +784,11 @@ static int sock_mmap_link_status(pktio_entry_t *pktio_entry)
 			      pktio_entry->s.name);
 }
 
+static int sock_mmap_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *info)
+{
+	return link_info_fd(pkt_priv(pktio_entry)->sockfd, pktio_entry->s.name, info);
+}
+
 static int sock_mmap_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 				odp_pktio_capability_t *capa)
 {
@@ -860,6 +865,7 @@ const pktio_if_ops_t sock_mmap_pktio_ops = {
 	.mac_get = sock_mmap_mac_addr_get,
 	.mac_set = NULL,
 	.link_status = sock_mmap_link_status,
+	.link_info = sock_mmap_link_info,
 	.capability = sock_mmap_capability,
 	.pktin_ts_res = NULL,
 	.pktin_ts_from_ns = NULL,

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -467,6 +467,11 @@ static int tap_link_status(pktio_entry_t *pktio_entry)
 			      pktio_entry->s.name + 4);
 }
 
+static int tap_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *info)
+{
+	return link_info_fd(pkt_priv(pktio_entry)->skfd, pktio_entry->s.name + 4, info);
+}
+
 static int tap_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 			  odp_pktio_capability_t *capa)
 {
@@ -501,6 +506,7 @@ const pktio_if_ops_t tap_pktio_ops = {
 	.mac_get = tap_mac_addr_get,
 	.mac_set = tap_mac_addr_set,
 	.link_status = tap_link_status,
+	.link_info = tap_link_info,
 	.capability = tap_capability,
 	.pktin_ts_res = NULL,
 	.pktin_ts_from_ns = NULL,

--- a/test/validation/api/pktio/parser.c
+++ b/test/validation/api/pktio/parser.c
@@ -56,7 +56,7 @@ static inline void wait_linkup(odp_pktio_t pktio)
 
 	for (i = 0; i < wait_num; i++) {
 		ret = odp_pktio_link_status(pktio);
-		if (ret < 0 || ret == 1)
+		if (ret == ODP_PKTIO_LINK_STATUS_UNKNOWN || ret == ODP_PKTIO_LINK_STATUS_UP)
 			break;
 		/* link is down, call status again after delay */
 		odp_time_wait_ns(wait_ns);

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -112,7 +112,7 @@ static inline void _pktio_wait_linkup(odp_pktio_t pktio)
 
 	for (i = 0; i < wait_num; i++) {
 		ret = odp_pktio_link_status(pktio);
-		if (ret < 0 || ret == 1)
+		if (ret == ODP_PKTIO_LINK_STATUS_UNKNOWN || ret == ODP_PKTIO_LINK_STATUS_UP)
 			break;
 		/* link is down, call status again after delay */
 		odp_time_wait_ns(wait_ns);
@@ -1508,7 +1508,6 @@ static void pktio_test_link_info(void)
 		CU_ASSERT(link_info.pause_tx == ODP_PKTIO_LINK_PAUSE_UNKNOWN ||
 			  link_info.pause_tx == ODP_PKTIO_LINK_PAUSE_ON ||
 			  link_info.pause_tx == ODP_PKTIO_LINK_PAUSE_OFF);
-		CU_ASSERT(link_info.speed >= 0);
 		CU_ASSERT(link_info.status == ODP_PKTIO_LINK_STATUS_UNKNOWN ||
 			  link_info.status == ODP_PKTIO_LINK_STATUS_UP ||
 			  link_info.status == ODP_PKTIO_LINK_STATUS_DOWN);

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
+ * Copyright (c) 2020, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -1480,6 +1481,45 @@ static void pktio_test_info(void)
 	}
 }
 
+static void pktio_test_link_info(void)
+{
+	odp_pktio_t pktio;
+	odp_pktio_link_info_t link_info;
+	int i;
+
+	for (i = 0; i < num_ifaces; i++) {
+		memset(&link_info, 0, sizeof(link_info));
+
+		pktio = create_pktio(i, ODP_PKTIN_MODE_QUEUE,
+				     ODP_PKTOUT_MODE_DIRECT);
+		CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
+
+		CU_ASSERT_FATAL(odp_pktio_link_info(pktio, &link_info) == 0);
+
+		CU_ASSERT(link_info.autoneg == ODP_PKTIO_LINK_AUTONEG_UNKNOWN ||
+			  link_info.autoneg == ODP_PKTIO_LINK_AUTONEG_ON ||
+			  link_info.autoneg == ODP_PKTIO_LINK_AUTONEG_OFF);
+		CU_ASSERT(link_info.duplex == ODP_PKTIO_LINK_DUPLEX_UNKNOWN ||
+			  link_info.duplex == ODP_PKTIO_LINK_DUPLEX_HALF ||
+			  link_info.duplex == ODP_PKTIO_LINK_DUPLEX_FULL);
+		CU_ASSERT(link_info.pause_rx == ODP_PKTIO_LINK_PAUSE_UNKNOWN ||
+			  link_info.pause_rx == ODP_PKTIO_LINK_PAUSE_ON ||
+			  link_info.pause_rx == ODP_PKTIO_LINK_PAUSE_OFF);
+		CU_ASSERT(link_info.pause_tx == ODP_PKTIO_LINK_PAUSE_UNKNOWN ||
+			  link_info.pause_tx == ODP_PKTIO_LINK_PAUSE_ON ||
+			  link_info.pause_tx == ODP_PKTIO_LINK_PAUSE_OFF);
+		CU_ASSERT(link_info.speed >= 0);
+		CU_ASSERT(link_info.status == ODP_PKTIO_LINK_STATUS_UNKNOWN ||
+			  link_info.status == ODP_PKTIO_LINK_STATUS_UP ||
+			  link_info.status == ODP_PKTIO_LINK_STATUS_DOWN);
+		CU_ASSERT(link_info.media != NULL);
+
+		CU_ASSERT(odp_pktio_link_info(ODP_PKTIO_INVALID, &link_info) < 0);
+
+		CU_ASSERT(odp_pktio_close(pktio) == 0);
+	}
+}
+
 static void pktio_test_pktin_queue_config_direct(void)
 {
 	odp_pktio_t pktio;
@@ -2908,6 +2948,7 @@ odp_testinfo_t pktio_suite_unsegmented[] = {
 	ODP_TEST_INFO(pktio_test_print),
 	ODP_TEST_INFO(pktio_test_pktio_config),
 	ODP_TEST_INFO(pktio_test_info),
+	ODP_TEST_INFO(pktio_test_link_info),
 	ODP_TEST_INFO(pktio_test_pktin_queue_config_direct),
 	ODP_TEST_INFO(pktio_test_pktin_queue_config_sched),
 	ODP_TEST_INFO(pktio_test_pktin_queue_config_multi_sched),

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -456,7 +456,7 @@ static int wait_linkup(odp_pktio_t pktio)
 
 	for (i = 0; i < wait_num; i++) {
 		ret = odp_pktio_link_status(pktio);
-		if (ret < 0 || ret == 1)
+		if (ret == ODP_PKTIO_LINK_STATUS_UNKNOWN || ret == ODP_PKTIO_LINK_STATUS_UP)
 			break;
 		/* link is down, call status again after delay */
 		odp_time_wait_ns(wait_ns);


### PR DESCRIPTION
Add new function odp_pktio_link_info() and data structure
odp_pktio_link_info_t for reading current link status information:
- Autonegotiation mode (enabled/disabled)
- Duplex mode (unknown/half duplex/full duplex)
- Speed (Mbps)
- Link status (up/down)
