### PR TITLE
[PATCH v2] example: timer: fix LTO compilation

### DIFF
--- a/example/timer/odp_timer_simple.c
+++ b/example/timer/odp_timer_simple.c
@@ -69,6 +69,7 @@ int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 		ret += 1;
 		goto err_tp;
 	}
+	memset(&tparams, 0, sizeof(tparams));
 	tparams.res_ns = MAX(10 * ODP_TIME_MSEC_IN_NS,
 			     timer_capa.highest_res_ns);
 	tparams.min_tmo = 10 * ODP_TIME_MSEC_IN_NS;


### PR DESCRIPTION
GCC7.3 warns about uninitialized members of timer pool parameters.
Application should take care to ensure clean parameter initialization.

Signed-off-by: Stanislaw Kardach <skardach@marvell.com>