### PR TITLE
[PATCH v3] GCC10 LTO compilation fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,7 +136,7 @@ ODP_CHECK_CFLAG([-Wno-error=address-of-packed-member])
 # GCC 10 sometimes gets confused about object sizes and gives bogus warnings.
 # Make the affected warnings generate only warnings, not errors.
 AS_IF([test "$GCC" == yes],
-      AS_IF([test `$CC -dumpversion` -ge 10],
+      AS_IF([test `$CC -dumpversion | cut -d '.' -f 1` -ge 10],
 	    ODP_CHECK_CFLAG([-Wno-error=array-bounds])
 	    ODP_CHECK_CFLAG([-Wno-error=stringop-overflow])
       )

--- a/test/performance/odp_pktio_perf.c
+++ b/test/performance/odp_pktio_perf.c
@@ -822,7 +822,7 @@ static int test_init(void)
 
 static int empty_inq(odp_pktio_t pktio)
 {
-	odp_queue_t queue;
+	odp_queue_t queue = ODP_QUEUE_INVALID;
 	odp_event_t ev;
 	odp_queue_type_t q_type;
 

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -514,16 +514,17 @@ static void check_alg(odp_crypto_op_t op,
 	int rc, i;
 	int cipher_num = odp_crypto_cipher_capability(cipher_alg, NULL, 0);
 	int auth_num = odp_crypto_auth_capability(auth_alg, NULL, 0);
-	odp_crypto_cipher_capability_t cipher_capa[cipher_num];
-	odp_crypto_auth_capability_t auth_capa[auth_num];
-	odp_bool_t cipher_tested[cipher_num];
-	odp_bool_t auth_tested[auth_num];
 	odp_bool_t cipher_ok = false;
 	odp_bool_t auth_ok = false;
 	size_t idx;
 
 	CU_ASSERT_FATAL(cipher_num > 0);
 	CU_ASSERT_FATAL(auth_num > 0);
+
+	odp_crypto_cipher_capability_t cipher_capa[cipher_num];
+	odp_crypto_auth_capability_t auth_capa[auth_num];
+	odp_bool_t cipher_tested[cipher_num];
+	odp_bool_t auth_tested[auth_num];
 
 	rc = odp_crypto_capability(&capa);
 	CU_ASSERT(!rc);

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -3292,6 +3292,7 @@ static int test_query_functions(const char *shaper_name,
 	expected_pkt_cnt  = num_pkts - 2;
 	expected_byte_cnt = expected_pkt_cnt * PKT_BUF_SIZE;
 
+	memset(&query_info, 0, sizeof(query_info));
 	rc = odp_tm_queue_query(tm_queue,
 				ODP_TM_QUERY_PKT_CNT | ODP_TM_QUERY_BYTE_CNT,
 				&query_info);
@@ -3301,6 +3302,7 @@ static int test_query_functions(const char *shaper_name,
 	CU_ASSERT(query_info.total_byte_cnt_valid);
 	CU_ASSERT(expected_byte_cnt < query_info.total_byte_cnt);
 
+	memset(&query_info, 0, sizeof(query_info));
 	rc = odp_tm_priority_query(odp_tm_systems[0], priority,
 				   ODP_TM_QUERY_PKT_CNT | ODP_TM_QUERY_BYTE_CNT,
 				   &query_info);
@@ -3310,6 +3312,7 @@ static int test_query_functions(const char *shaper_name,
 	CU_ASSERT(query_info.total_byte_cnt_valid);
 	CU_ASSERT(expected_byte_cnt < query_info.total_byte_cnt);
 
+	memset(&query_info, 0, sizeof(query_info));
 	rc = odp_tm_total_query(odp_tm_systems[0],
 				ODP_TM_QUERY_PKT_CNT | ODP_TM_QUERY_BYTE_CNT,
 				&query_info);


### PR DESCRIPTION
While testing compilation against gcc 10.0.1 I've noticed several issues which this patchset is trying to address:

1. GCC 10 version detection is done improperly.
2. Some tests have odp_pktout_queue_t and odp_queue_t left uninitialized in some paths detected by the compiler. For safety initialize them to known invalid values.