### PR TITLE
[PATCH v4] linux_gen: example: ipsec: fix stream input packet allocation

### DIFF
--- a/example/ipsec/odp_ipsec.c
+++ b/example/ipsec/odp_ipsec.c
@@ -1326,6 +1326,10 @@ main(int argc, char *argv[])
 	/* If we have test streams build them before starting workers */
 	resolve_stream_db();
 	stream_count = create_stream_db_inputs();
+	if (stream_count < 0) {
+		ODPH_ERR("Error: creating input packets failed\n");
+		exit(EXIT_FAILURE);
+	}
 
 	/*
 	 * Create and init worker threads
@@ -1632,6 +1636,7 @@ static void usage(char *progname)
 	       "\n"
 	       "Optional OPTIONS\n"
 	       "  -c, --count <number> CPU count, 0=all available, default=1\n"
+	       "  -s, --stream SrcIP:DstIP:InIntf:OutIntf:Count:Length\n"
 	       "  -h, --help           Display help and exit.\n"
 	       " environment variables: ODP_IPSEC_USE_POLL_QUEUES\n"
 	       " to enable use of poll queues instead of scheduled (default)\n"

--- a/example/ipsec/odp_ipsec_stream.c
+++ b/example/ipsec/odp_ipsec_stream.c
@@ -562,7 +562,7 @@ int create_stream_db_inputs(void)
 	pkt_pool = odp_pool_lookup("packet_pool");
 	if (pkt_pool == ODP_POOL_INVALID) {
 		ODPH_ERR("Error: pkt_pool not found\n");
-		exit(EXIT_FAILURE);
+		return -1;
 	}
 	if (odp_pool_info(pkt_pool, &pool_info)) {
 		ODPH_ERR("Error: pool info failed\n");
@@ -599,13 +599,13 @@ int create_stream_db_inputs(void)
 
 			pkt = create_ipv4_packet(stream, dmac, pkt_pool, max_len);
 			if (ODP_PACKET_INVALID == pkt) {
-				printf("Packet buffers exhausted\n");
+				ODPH_ERR("Error: packet buffers exhausted\n");
 				break;
 			}
 			stream->created++;
 			if (odp_pktout_send(queue, &pkt, 1) != 1) {
 				odp_packet_free(pkt);
-				printf("Queue enqueue failed\n");
+				ODPH_ERR("Error: queue enqueue failed\n");
 				break;
 			}
 
@@ -613,6 +613,10 @@ int create_stream_db_inputs(void)
 			if (1 == stream->created)
 				created++;
 		}
+	}
+	if ((stream_db->index > 0) && created == 0) {
+		ODPH_ERR("Error: failed to create any input streams\n");
+		return -1;
 	}
 
 	return created;

--- a/example/ipsec/odp_ipsec_stream.h
+++ b/example/ipsec/odp_ipsec_stream.h
@@ -85,12 +85,14 @@ void resolve_stream_db(void);
  * @param stream    Stream DB entry
  * @param dmac      Destination MAC address to use
  * @param pkt_pool  Packet buffer pool to allocate from
+ * @param max_len   Maximum packet length
  *
  * @return packet else ODP_PACKET_INVALID
  */
 odp_packet_t create_ipv4_packet(stream_db_entry_t *stream,
 				uint8_t *dmac,
-				odp_pool_t pkt_pool);
+				odp_pool_t pkt_pool,
+				uint32_t max_len);
 
 /**
  * Verify an IPv4 packet received on a loop output queue

--- a/example/ipsec/odp_ipsec_stream.h
+++ b/example/ipsec/odp_ipsec_stream.h
@@ -110,10 +110,11 @@ odp_bool_t verify_ipv4_packet(stream_db_entry_t *stream,
  *
  * Create input packets based on the configured streams and enqueue them
  * into loop interface input queues.  Once packet processing starts these
- * packets will be remomved and processed as if they had come from a normal
+ * packets will be removed and processed as if they had come from a normal
  * packet interface.
  *
  * @return number of streams successfully processed
+ * @return <0 on failure
  */
 int create_stream_db_inputs(void);
 

--- a/example/ipsec_api/odp_ipsec.c
+++ b/example/ipsec_api/odp_ipsec.c
@@ -1020,6 +1020,10 @@ main(int argc, char *argv[])
 	/* If we have test streams build them before starting workers */
 	resolve_stream_db();
 	stream_count = create_stream_db_inputs();
+	if (stream_count < 0) {
+		ODPH_ERR("Error: creating input packets failed\n");
+		exit(EXIT_FAILURE);
+	}
 
 	/*
 	 * Create and init worker threads
@@ -1331,6 +1335,7 @@ static void usage(char *progname)
 	       "\n"
 	       "Optional OPTIONS\n"
 	       "  -c, --count <number> CPU count, 0=all available, default=1\n"
+	       "  -s, --stream SrcIP:DstIP:InIntf:OutIntf:Count:Length\n"
 	       "  -h, --help           Display help and exit.\n"
 	       " environment variables: ODP_IPSEC_USE_POLL_QUEUES\n"
 	       " to enable use of poll queues instead of scheduled (default)\n"


### PR DESCRIPTION
The application tried to allocate packets of length zero, which is not
allowed by the API.

Signed-off-by: Matias Elo <matias.elo@nokia.com>