### PR TITLE
[PATCH v2] Use atomic flag variable to trigger thread exit

### DIFF
--- a/example/ping/odp_ping.c
+++ b/example/ping/odp_ping.c
@@ -32,7 +32,7 @@ typedef struct test_global_t {
 	uint64_t rx_packets;
 	uint64_t tx_replies;
 	odp_pool_t pool;
-	int stop;
+	odp_atomic_u32_t stop;
 
 	struct {
 		odph_ethaddr_t eth_addr;
@@ -50,8 +50,7 @@ static void sig_handler(int signo)
 {
 	(void)signo;
 
-	test_global.stop = 1;
-	odp_mb_full();
+	odp_atomic_store_u32(&test_global.stop, 1);
 }
 
 static void print_usage(void)
@@ -575,7 +574,7 @@ static int receive_packets(test_global_t *global)
 	odp_time_t cur = odp_time_local();
 	odp_time_t prev = cur;
 
-	while (!global->stop) {
+	while (!odp_atomic_load_u32(&global->stop)) {
 		ev = odp_schedule(NULL, wait);
 
 		cur = odp_time_local();
@@ -629,6 +628,7 @@ int main(int argc, char *argv[])
 
 	global = &test_global;
 	memset(global, 0, sizeof(test_global_t));
+	odp_atomic_init_u32(&global->stop, 0);
 
 	signal(SIGINT, sig_handler);
 

--- a/test/performance/odp_bench_packet.c
+++ b/test/performance/odp_bench_packet.c
@@ -126,7 +126,7 @@ typedef struct {
 	/** Number of benchmark functions */
 	int num_bench;
 	/** Break worker loop if set to 1 */
-	int exit_thread;
+	odp_atomic_u32_t exit_thread;
 	struct {
 		/** Test packet length */
 		uint32_t len;
@@ -168,7 +168,7 @@ static void sig_handler(int signo ODP_UNUSED)
 {
 	if (gbl_args == NULL)
 		return;
-	gbl_args->exit_thread = 1;
+	odp_atomic_store_u32(&gbl_args->exit_thread, 1);
 }
 
 /**
@@ -183,7 +183,7 @@ static void run_indef(args_t *args, int idx)
 
 	printf("Running %s() indefinitely\n", desc);
 
-	while (!gbl_args->exit_thread) {
+	while (!odp_atomic_load_u32(&gbl_args->exit_thread)) {
 		int ret;
 
 		if (args->bench[idx].init != NULL)
@@ -1789,6 +1789,7 @@ int main(int argc, char *argv[])
 	}
 
 	memset(gbl_args, 0, sizeof(args_t));
+	odp_atomic_init_u32(&gbl_args->exit_thread, 0);
 
 	gbl_args->bench = test_suite;
 	gbl_args->num_bench = sizeof(test_suite) / sizeof(test_suite[0]);


### PR DESCRIPTION
Currently various test and example apps use a normal variable without synchronization to communicate to worker threads that they should exit. Even though this is wrong (it is a data race and thus allows undefined behavior) it often works in practice unless the compiler performs so aggressive optimizations that the flag check moves away from the thread main loop. Something like this actually happened to me with GCC-10 and link time optimization, causing make check to never complete.

Some apps use volatile flag variable which probably always works in practice even though it is still wrong (it is still a data race as volatile does not imply synchronization or atomicity). The commits of this PR do not touch the volatile flags.