### PR TITLE
[PATCH v2] Test and validation fixes that also make GCC-10 happier

### DIFF
--- a/platform/linux-generic/test/pktio_ipc/pktio_ipc2.c
+++ b/platform/linux-generic/test/pktio_ipc/pktio_ipc2.c
@@ -73,6 +73,7 @@ static int ipc_second_process(int master_pid)
 		return -1;
 	}
 
+	memset(&pktin, 0, sizeof(pktin)); /* not needed but makes GCC happy */
 	if (odp_pktin_queue(ipc_pktio, &pktin, 1) != 1) {
 		odp_pool_destroy(pool);
 		ODPH_ERR("no input queue\n");

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1745,7 +1745,7 @@ static void pktio_test_statistics_counters(void)
 	pktio_tx = pktio[0];
 	pktio_rx = (num_ifaces > 1) ? pktio[1] : pktio_tx;
 
-	CU_ASSERT(odp_pktout_queue(pktio_tx, &pktout, 1) == 1);
+	CU_ASSERT_FATAL(odp_pktout_queue(pktio_tx, &pktout, 1) == 1);
 
 	ret = odp_pktio_start(pktio_tx);
 	CU_ASSERT(ret == 0);
@@ -1849,7 +1849,7 @@ static void pktio_test_start_stop(void)
 		CU_ASSERT_FATAL(pktio[i] != ODP_PKTIO_INVALID);
 	}
 
-	CU_ASSERT(odp_pktout_queue(pktio[0], &pktout, 1) == 1);
+	CU_ASSERT_FATAL(odp_pktout_queue(pktio[0], &pktout, 1) == 1);
 
 	/* Interfaces are stopped by default,
 	 * Check that stop when stopped generates an error */

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -2127,6 +2127,7 @@ static void check_shaper_profile(char *shaper_name, uint32_t shaper_idx)
 {
 	odp_tm_shaper_params_t shaper_params;
 	odp_tm_shaper_t        profile;
+	int		       rc;
 
 	profile = odp_tm_shaper_lookup(shaper_name);
 	CU_ASSERT(profile != ODP_TM_INVALID);
@@ -2134,7 +2135,9 @@ static void check_shaper_profile(char *shaper_name, uint32_t shaper_idx)
 	if (profile != shaper_profiles[shaper_idx - 1])
 		return;
 
-	odp_tm_shaper_params_read(profile, &shaper_params);
+	memset(&shaper_params, 0, sizeof(shaper_params));
+	rc = odp_tm_shaper_params_read(profile, &shaper_params);
+	CU_ASSERT(rc == 0);
 	CU_ASSERT(approx_eq64(shaper_params.commit_bps,
 			      shaper_idx * MIN_COMMIT_BW));
 	CU_ASSERT(approx_eq64(shaper_params.peak_bps,


### PR DESCRIPTION
Make the compiler know that CU_ASSERT_FATAL does not return if the assertion fails. This gets rid of bogus warnings from subsequent code.

Change a couple of CU_ASSERTs to CU_ASSERT_FATAL to prevent the test continuing with an uninitialized handle.

Fix shaper profile validation check by clearing the param struct before reading into it and validating the content.

Get rid of a bogus maybe-uninitialized warning in pktio test by initializing the variable.