### PR TITLE
[PATCH v9] api: ipsec: add tm_queue as parameter for inline outbound

### DIFF
--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -516,13 +516,14 @@ typedef struct odp_pktio_config_t {
 	 *  to the pktio interface for output. IPSEC configuration is done
 	 *  through the IPSEC API.
 	 *
-	 *  Outbound IPSEC inline operation cannot be combined with traffic
-	 *  manager (ODP_PKTOUT_MODE_TM).
+	 *  Support of outbound IPSEC inline operation with traffic manager
+	 *  (ODP_PKTOUT_MODE_TM) can be queried with odp_ipsec_capability().
 	 *
-	 *  0: Disable outbound IPSEC inline operation (default)
-	 *  1: Enable outbound IPSEC inline operation
+	 * * 0: Disable outbound IPSEC inline operation (default)
+	 * * 1: Enable outbound IPSEC inline operation
 	 *
 	 *  @see odp_ipsec_config(), odp_ipsec_sa_create()
+	 *  odp_ipsec_out_inline()
 	 */
 	odp_bool_t outbound_ipsec;
 

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -63,6 +63,7 @@ int odp_ipsec_capability(odp_ipsec_capability_t *capa)
 		return rc;
 
 	capa->max_queues = queue_capa.max_queues;
+	capa->inline_ipsec_tm = ODP_SUPPORT_NO;
 
 	return 0;
 }
@@ -1821,6 +1822,7 @@ int odp_ipsec_out_inline(const odp_packet_t pkt_in[], int num_in,
 	unsigned opt_inc = (param->num_opt > 1) ? 1 : 0;
 
 	ODP_ASSERT(param->num_sa != 0);
+	ODP_ASSERT(inline_param->pktio != ODP_PKTIO_INVALID);
 
 	while (in_pkt < num_in) {
 		odp_packet_t pkt = pkt_in[in_pkt];

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -760,6 +760,7 @@ static int ipsec_send_out_one(const ipsec_test_part *part,
 			memset(hdr, 0xff, hdr_len);
 		}
 		inline_param.pktio = suite_context.pktio;
+		inline_param.tm_queue = ODP_TM_INVALID;
 		inline_param.outer_hdr.ptr = hdr;
 		inline_param.outer_hdr.len = hdr_len;
 


### PR DESCRIPTION
Inline outbound requires pktio output queue to allow application to
control the traffic distribution and precedence. The option to specify
output queue is required to perform QoS post inline IPsec processing.

Signed-off-by: Anoob Joseph <anoobj@marvell.com>