### PR TITLE
[PATCH v3] build: simplify remote target testing

### DIFF
--- a/example/generator/Makefile.am
+++ b/example/generator/Makefile.am
@@ -11,3 +11,23 @@ TESTS = generator_null_test.sh
 TESTS_ENVIRONMENT += ODP_PLATFORM=$(with_platform)
 endif
 EXTRA_DIST = generator_null_test.sh
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/example/ipsec/Makefile.am
+++ b/example/ipsec/Makefile.am
@@ -35,3 +35,23 @@ LDADD += $(OPENSSL_LIBS)
 else
 AM_CPPFLAGS = -DNO_OPENSSL
 endif
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/example/ipsec_api/Makefile.am
+++ b/example/ipsec_api/Makefile.am
@@ -38,3 +38,23 @@ LDADD += $(OPENSSL_LIBS)
 else
 AM_CPPFLAGS = -DNO_OPENSSL
 endif
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/example/l2fwd_simple/Makefile.am
+++ b/example/l2fwd_simple/Makefile.am
@@ -10,3 +10,23 @@ TESTS = l2fwd_simple_run.sh
 endif
 endif
 EXTRA_DIST = l2fwd_simple_run.sh udp64.pcap
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/example/l3fwd/Makefile.am
+++ b/example/l3fwd/Makefile.am
@@ -15,3 +15,23 @@ TESTS = odp_l3fwd_run.sh
 endif
 endif
 EXTRA_DIST = odp_l3fwd_run.sh udp64.pcap
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/example/packet/Makefile.am
+++ b/example/packet/Makefile.am
@@ -13,3 +13,23 @@ TESTS = packet_dump_run.sh pktio_run.sh
 endif
 endif
 EXTRA_DIST = packet_dump_run.sh pktio_run.sh udp64.pcap
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/example/ping/Makefile.am
+++ b/example/ping/Makefile.am
@@ -10,3 +10,23 @@ TESTS = ping_run.sh
 endif
 endif
 EXTRA_DIST = ping_run.sh icmp_echo_req.pcap
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/example/simple_pipeline/Makefile.am
+++ b/example/simple_pipeline/Makefile.am
@@ -10,3 +10,23 @@ TESTS = simple_pipeline_run.sh
 endif
 endif
 EXTRA_DIST = simple_pipeline_run.sh udp64.pcap
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/example/switch/Makefile.am
+++ b/example/switch/Makefile.am
@@ -10,3 +10,23 @@ TESTS = switch_run.sh
 endif
 endif
 EXTRA_DIST = switch_run.sh udp64.pcap
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/helper/test/Makefile.am
+++ b/helper/test/Makefile.am
@@ -40,3 +40,23 @@ table_SOURCES = table.c
 iplookuptable_SOURCES = iplookuptable.c
 version_SOURCES = version.c
 debug_SOURCES = debug.c
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/platform/linux-generic/test/Makefile.am
+++ b/platform/linux-generic/test/Makefile.am
@@ -62,3 +62,23 @@ if test_installdir
 installcheck-local:
 	$(DESTDIR)/$(testdir)/run-test.sh $(TESTNAME)
 endif
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/platform/linux-generic/test/pktio_ipc/Makefile.am
+++ b/platform/linux-generic/test/pktio_ipc/Makefile.am
@@ -9,3 +9,23 @@ pktio_ipc2_SOURCES = pktio_ipc2.c ipc_common.c ipc_common.h
 
 dist_check_SCRIPTS = pktio_ipc_run.sh
 test_SCRIPTS = $(dist_check_SCRIPTS)
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/platform/linux-generic/test/validation/api/pktio/Makefile.am
+++ b/platform/linux-generic/test/validation/api/pktio/Makefile.am
@@ -13,3 +13,23 @@ dist_check_SCRIPTS += pktio_run_dpdk.sh
 endif
 
 test_SCRIPTS = $(dist_check_SCRIPTS)
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -61,3 +61,23 @@ example-generator:
 dist_check_SCRIPTS = $(TESTSCRIPTS)
 
 dist_check_DATA = udp64.pcap
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS) $(dist_check_DATA); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS) $(dist_check_DATA); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi


### PR DESCRIPTION
It is often beneficial to run "make check" on a remote target platform.
However in order to run it, a full build-system has to be present which
may not be efficient or possible for embedded platforms.
Alternatively autotools offer a mechanism which may be used:
LOG_COMPILER environment variable. If specified, all test invocations
are prepended with its contents. This allows injecting a wrapper script
which will ensure the test is run remotely (i.e. through ssh).

Prior to that the binaries have to be transported to the remote system.
This cannot be done in the script itself as it has no knowledge on the
dependencies of the test program, only its path. Test could be relying
on some files stored in srcdir or builddir.

An issue exists that if ODP is built in out-of-tree method (builddir !=
srcdir), only the compiled test programs are copied to the builddir.
scripts and script data files remain in srcdir and wrapper script is
called with an absolute path to the script located in srcdir.
This would require to copy the srcdir to exactly the same path on the
target as on build host. This may alias with some paths already there.

To prevent this from happening add make target wrappers which copy
scripts and script data to build directory which allows the autotools
test harness to produce a proper wrapper script invocation with a
relative path and allows to only copy the builddir to the target to a
strictly controlled location.

Signed-off-by: Stanislaw Kardach <skardach@marvell.com>