### PR TITLE
validation: pool: honor max_align capability

### DIFF
--- a/example/time/time_global_test.c
+++ b/example/time/time_global_test.c
@@ -330,7 +330,6 @@ int main(int argc, char *argv[])
 	odp_pool_param_init(&pool_param);
 
 	pool_param.buf.size  = sizeof(timestamp_event_t);
-	pool_param.buf.align = ODP_CACHE_LINE_SIZE;
 	pool_param.buf.num   = MAX_NUM_BUF;
 	pool_param.type      = ODP_POOL_BUFFER;
 

--- a/helper/cuckootable.c
+++ b/helper/cuckootable.c
@@ -269,7 +269,8 @@ odph_cuckoo_table_create(
 	odp_pool_param_init(&param);
 	param.type = ODP_POOL_BUFFER;
 	param.buf.size = kv_entry_size;
-	param.buf.align = ODP_CACHE_LINE_SIZE;
+	if (pcapa.buf.max_align >= ODP_CACHE_LINE_SIZE)
+		param.buf.align = ODP_CACHE_LINE_SIZE;
 	param.buf.num = capacity;
 
 	pool = odp_pool_create(pool_name, &param);

--- a/helper/iplookuptable.c
+++ b/helper/iplookuptable.c
@@ -216,7 +216,8 @@ cache_alloc_new_pool(
 	/* Create new pool (new free buffers). */
 	odp_pool_param_init(&param);
 	param.type = ODP_POOL_BUFFER;
-	param.buf.align = ODP_CACHE_LINE_SIZE;
+	if (pool_capa.buf.max_align >= ODP_CACHE_LINE_SIZE)
+		param.buf.align = ODP_CACHE_LINE_SIZE;
 	if (type == CACHE_TYPE_SUBTREE) {
 		num = CACHE_NUM_SUBTREE;
 		size = ENTRY_SIZE * ENTRY_NUM_SUBTREE;

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -45,7 +45,6 @@ static void pool_test_create_destroy_buffer(void)
 
 	param.type      = ODP_POOL_BUFFER;
 	param.buf.size  = BUF_SIZE;
-	param.buf.align = ODP_CACHE_LINE_SIZE;
 	param.buf.num   = BUF_NUM;
 
 	pool_create_destroy(&param);
@@ -88,7 +87,6 @@ static void pool_test_lookup_info_print(void)
 
 	param.type      = ODP_POOL_BUFFER;
 	param.buf.size  = BUF_SIZE;
-	param.buf.align = ODP_CACHE_LINE_SIZE;
 	param.buf.num   = BUF_NUM;
 
 	pool = odp_pool_create(pool_name, &param);
@@ -630,7 +628,6 @@ static int run_pool_test_create_after_fork(void *arg ODP_UNUSED)
 
 		param.type      = ODP_POOL_BUFFER;
 		param.buf.size  = BUF_SIZE;
-		param.buf.align = ODP_CACHE_LINE_SIZE;
 		param.buf.num   = BUF_NUM;
 
 		pool = odp_pool_create(NULL, &param);

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -83,7 +83,6 @@ static int queue_suite_init(void)
 	odp_pool_param_init(&params);
 
 	params.buf.size  = 4;
-	params.buf.align = ODP_CACHE_LINE_SIZE;
 	params.buf.num   = MAX_NUM_EVENT;
 	params.type      = ODP_POOL_BUFFER;
 


### PR DESCRIPTION
Honor the odp_pool_capability_t::buf.max_align attribute while
creating the pool.

Some implementation chooses to optimize odp_buffer_t handling in
such a way that implementation-specific metadata and actual
data can be in the same cache-line as a performance optimization
while accessing the odp_buffer_t.

As a fix, except helpers, let the application uses the default
alignment from odp_pool_param_init().

Signed-off-by: Jerin Jacob <jerinj@marvell.com>
Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>
