### PR TITLE
[PATCH v4] Fixup issues detected by doxygen 1.8.17

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.5])
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [24])
-m4_define([odpapi_minor_version], [0])
+m4_define([odpapi_minor_version], [1])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])

--- a/doc/application-api-guide/Doxyfile
+++ b/doc/application-api-guide/Doxyfile
@@ -6,5 +6,5 @@ PROJECT_LOGO = $(SRCDIR)/doc/images/ODP-Logo-HQ.svg
 INPUT = $(SRCDIR)/doc/application-api-guide \
 	include \
 	$(SRCDIR)/include
-EXAMPLE_PATH = $(SRCDIR)/example $(SRCDIR)
+EXAMPLE_PATH = $(SRCDIR)/example $(SRCDIR)/CONTRIBUTING
 WARNINGS = NO

--- a/doc/platform-api-guide/Doxyfile
+++ b/doc/platform-api-guide/Doxyfile
@@ -9,4 +9,4 @@ INPUT = $(SRCDIR)/doc/application-api-guide \
 	$(SRCDIR)/include/odp/api \
 	$(SRCDIR)/platform/$(WITH_PLATFORM)/doc \
 	$(SRCDIR)/platform/$(WITH_PLATFORM)/include/odp/api
-EXAMPLE_PATH = $(SRCDIR)/example $(SRCDIR)/platform $(SRCDIR)
+EXAMPLE_PATH = $(SRCDIR)/example $(SRCDIR)/platform $(SRCDIR)/CONTRIBUTING

--- a/helper/include/odph_list_internal.h
+++ b/helper/include/odph_list_internal.h
@@ -18,30 +18,22 @@
 extern "C" {
 #endif
 
-/** List object */
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
 typedef struct odph_list_object {
-	/** Next element in list */
 	struct odph_list_object *next;
 
-	/** Previous element in list */
 	struct odph_list_object *prev;
 } odph_list_object;
 
-/** Head of list */
 typedef odph_list_object odph_list_head;
 
-/**
- * @internal Intiailize list head element
- *
- * @param list List object to be initialized
- */
 static inline void ODPH_INIT_LIST_HEAD(odph_list_object *list)
 {
 	list->next = list;
 	list->prev = list;
 }
 
-/** @internal Inline function @param new @param prev @param next */
 static inline void __odph_list_add(odph_list_object *new,
 				   odph_list_object *prev,
 				   odph_list_object *next)
@@ -52,20 +44,17 @@ static inline void __odph_list_add(odph_list_object *new,
 	prev->next = new;
 }
 
-/** @internal Inline function @param new @param head */
 static inline void odph_list_add(odph_list_object *new, odph_list_object *head)
 {
 	__odph_list_add(new, head, head->next);
 }
 
-/** @internal Inline function @param new @param head */
 static inline void odph_list_add_tail(struct odph_list_object *new,
 				      odph_list_object *head)
 {
 	__odph_list_add(new, head->prev, head);
 }
 
-/** @internal Inline function @param prev @param next */
 static inline void __odph_list_del(struct odph_list_object *prev,
 				   odph_list_object *next)
 {
@@ -73,28 +62,26 @@ static inline void __odph_list_del(struct odph_list_object *prev,
 	prev->next = next;
 }
 
-/** @internal Inline function @param entry */
 static inline void odph_list_del(struct odph_list_object *entry)
 {
 	__odph_list_del(entry->prev, entry->next);
 	ODPH_INIT_LIST_HEAD(entry);
 }
 
-/** @internal Inline function @param head @return */
 static inline int odph_list_empty(const struct odph_list_object *head)
 {
 	return head->next == head;
 }
 
-/** @internal */
 #define container_of(ptr, type, list_node) \
 		((type *)(void *)((char *)ptr - offsetof(type, list_node)))
 
-/** @internal */
 #define ODPH_LIST_FOR_EACH(pos, list_head, type, list_node) \
 	for (pos = container_of((list_head)->next, type, list_node); \
 		&pos->list_node != (list_head); \
 		pos = container_of(pos->list_node.next, type, list_node))
+
+/** @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/odp/api/abi-default/event.h
+++ b/include/odp/api/abi-default/event.h
@@ -24,7 +24,7 @@ typedef _odp_abi_event_t *odp_event_t;
 
 #define ODP_EVENT_INVALID  ((odp_event_t)0)
 
-typedef enum odp_event_type_t {
+typedef enum {
 	ODP_EVENT_BUFFER       = 1,
 	ODP_EVENT_PACKET       = 2,
 	ODP_EVENT_TIMEOUT      = 3,
@@ -32,7 +32,7 @@ typedef enum odp_event_type_t {
 	ODP_EVENT_IPSEC_STATUS = 5
 } odp_event_type_t;
 
-typedef enum odp_event_subtype_t {
+typedef enum {
 	ODP_EVENT_NO_SUBTYPE   = 0,
 	ODP_EVENT_PACKET_BASIC = 1,
 	ODP_EVENT_PACKET_CRYPTO = 2,

--- a/include/odp/api/abi-default/packet.h
+++ b/include/odp/api/abi-default/packet.h
@@ -70,8 +70,6 @@ typedef enum {
 	ODP_PACKET_ALL_COLORS = 3,
 } odp_packet_color_t;
 
-#define ODP_NUM_PACKET_COLORS 3
-
 /** Parse result flags */
 typedef struct odp_packet_parse_result_flag_t {
 	/** Flags union */

--- a/include/odp/api/abi-default/pool.h
+++ b/include/odp/api/abi-default/pool.h
@@ -26,12 +26,6 @@ typedef _odp_abi_pool_t *odp_pool_t;
 
 #define ODP_POOL_NAME_LEN  32
 
-typedef enum odp_pool_type_t {
-	ODP_POOL_BUFFER  = ODP_EVENT_BUFFER,
-	ODP_POOL_PACKET  = ODP_EVENT_PACKET,
-	ODP_POOL_TIMEOUT = ODP_EVENT_TIMEOUT
-} odp_pool_type_t;
-
 /**
  * @}
  */

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -71,6 +71,12 @@ extern "C" {
   */
 
 /**
+ * Maximum number of packet colors which accommodates ODP_PACKET_GREEN, ODP_PACKET_YELLOW and
+ * ODP_PACKET_RED.
+ */
+#define ODP_NUM_PACKET_COLORS 3
+
+/**
  * @typedef odp_proto_l2_type_t
  * Layer 2 protocol type
  */

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -115,6 +115,11 @@ extern "C" {
  */
 
 /**
+ * @typedef odp_proto_l4_type_t
+ * Layer 4 protocol type
+ */
+
+/**
  * @def ODP_PROTO_L4_TYPE_NONE
  * Layer 4 protocol type not defined
  *

--- a/platform/linux-generic/include-abi/odp/api/abi/packet.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet.h
@@ -77,8 +77,6 @@ typedef enum {
 	ODP_PACKET_ALL_COLORS = 3,
 } odp_packet_color_t;
 
-#define ODP_NUM_PACKET_COLORS 3
-
 typedef struct odp_packet_parse_result_flag_t {
 	union {
 		uint64_t all;

--- a/platform/linux-generic/include-abi/odp/api/abi/pool.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/pool.h
@@ -31,12 +31,6 @@ typedef ODP_HANDLE_T(odp_pool_t);
 
 #define ODP_POOL_NAME_LEN  32
 
-typedef enum odp_pool_type_t {
-	ODP_POOL_BUFFER  = ODP_EVENT_BUFFER,
-	ODP_POOL_PACKET  = ODP_EVENT_PACKET,
-	ODP_POOL_TIMEOUT = ODP_EVENT_TIMEOUT,
-} odp_pool_type_t;
-
 /**
  * @}
  */


### PR DESCRIPTION
While running doxygen on Ubuntu 20.04 I've noticed some new warnings popping up. Some of them are quire benign (hiding structures in helper), some are real issues with API or documentation.

This patchset addresses all the warnings detected.