### PR TITLE
[PATCH v2] api: ipsec: extended stats framework for IPsec.

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -33,6 +33,11 @@ extern "C" {
  * IPSEC Security Association (SA)
  */
 
+/**
+ * Maximum length for extended statistics names
+ */
+#define ODP_IPSEC_XSTATS_NAME_MAX_LEN 64
+
  /**
  * @def ODP_IPSEC_SA_INVALID
  * Invalid IPSEC SA
@@ -255,6 +260,15 @@ typedef struct odp_ipsec_capability_t {
 
 	/** Maximum anti-replay window size. */
 	uint32_t max_antireplay_ws;
+
+	/** Maximum extended stats supported by the platform.
+	 * odp_ipsec_xstats() and odp_ipsec_xstats_names() will return
+	 * this many number of extended stats.
+	 *
+	 * 0: Extended stats is not supported by the platform.
+	 * @see odp_ipsec_xstats(), odp_ipsec_xstats_names()
+	 */
+	uint32_t max_xstats;
 
 	/** Supported cipher algorithms */
 	odp_crypto_cipher_algos_t ciphers;
@@ -1262,6 +1276,52 @@ typedef struct odp_ipsec_status_t {
 	odp_ipsec_warn_t warn;
 
 } odp_ipsec_status_t;
+
+/**
+ * Extended statistics of IPsec
+ */
+typedef struct odp_ipsec_xstats_t {
+	/** Index of the counter in the extended statistics name array */
+	uint64_t index;
+
+	/** Value of the extended statistics counter */
+	uint64_t value;
+} odp_ipsec_xstats_t;
+
+/**
+ * Names for extended statistics of IPsec
+ */
+typedef struct odp_ipsec_xstats_name_t {
+	/** Name of the extended statistics counter */
+	char name[ODP_IPSEC_XSTATS_NAME_MAX_LEN];
+} odp_ipsec_xstats_name_t;
+
+/**
+ * Get extended statistics of an SA
+ *
+ * @param          sa       SA handle.
+ * @param[out]     xstats   Pointer to an array of type odp_ipsec_xstats_t.
+ * @param          len      Size of xstats array.
+ */
+
+void odp_ipsec_xstats(odp_ipsec_sa_t sa, odp_ipsec_xstats_t *xstats, int len);
+
+/**
+ * Get names of extended statistics of an SA.
+ *
+ * @param          sa             SA handle.
+ * @param[out]     xstats_names   Pointer to an array of xstats names.
+ * @param          len            Size of xstats_names array.
+ */
+void odp_ipsec_xstats_names(odp_ipsec_sa_t sa,
+			    odp_ipsec_xstats_name_t *xstats_names, int len);
+
+/**
+ * Clear extended statistics of an SA.
+ *
+ * @param          sa             SA handle.
+ */
+void odp_ipsec_xstats_clear(odp_ipsec_sa_t sa);
 
 /**
  * Inbound synchronous IPSEC operation


### PR DESCRIPTION
New framework to get and clear complete stats for an IPsec SA.
Platforms can maintain various stats corresponding to an SA.
These stats or counters may differ from platform to platform.
This framework helps application to get the stats agnostick of platform
implimentation.

The framework provide two APIs. odp_ipsec_xstats_names() will return
an array of all the names of supported stats. odp_ipsec_xstats() will
return an array of values for all supported stats. Both arrays are
matched by array index. i.e: xstats[i].value is correspond to the
xstat_names[i].name.

IPsec capability exposes the number of extended stats supported by the
platform. The value 0 indicates the platform does not support the
extended cpabilities.

Application need to allocate the memmory for the array of names and
values before invoking the APIs. Application can invoke these APIs
in any order. The preferred order of invoking is:
odp_ipsec_xstats_names() followed by odp_ipsec_xstats().

Signed-off-by: Vidya Velumuri <vvelumuri@marvell.com>