### PR TITLE
[PATCH v3] linux-gen: pktio: use odp atomics for in_discards counter

### DIFF
--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -93,7 +93,12 @@ struct pktio_entry {
 	} state;
 	odp_pktio_config_t config;	/**< Device configuration */
 	classifier_t cls;		/**< classifier linked with this pktio*/
-	odp_pktio_stats_t stats;	/**< statistic counters for pktio */
+	/* Driver level statistics counters */
+	odp_pktio_stats_t stats;
+	/* Statistics counters used outside drivers */
+	struct {
+		odp_atomic_u64_t in_discards;
+	} stats_extra;
 	odp_proto_chksums_t in_chksums; /**< Checksums validation settings */
 	pktio_stats_type_t stats_type;
 	char name[PKTIO_NAME_LEN];	/**< name of pktio provided to


### PR DESCRIPTION
Previously, build would fail on 32-bit systems since __atomic_fetch_add()
was called using a 64-bit variable.


V2:
- Updated commit message (Janne)
