### PR TITLE
[PATCH v1] api: ipsec: add ipsec operating mode to sa

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -647,6 +647,20 @@ typedef enum odp_ipsec_ip_version_t {
  * IPSEC Security Association (SA) parameters
  */
 typedef struct odp_ipsec_sa_param_t {
+	/** IPsec operation mode of SA
+	 *
+	 * When the IPsec mode in global config is: ODP_IPSEC_OP_MODE_INLINE,
+	 * this value takes precedence over the global config value.
+	 * In all other cases, IPsec mode in global config will take
+	 * precedence over this value.
+	 *
+	 * With IPsec mode in global config set to ODP_IPSEC_OP_MODE_INLINE,
+	 * value for this can be set to either ODP_IPSEC_OP_MODE_INLINE
+	 * or ODP_IPSEC_OP_MODE_ASYNC.
+	 *
+	 */
+	odp_ipsec_op_mode_t op_mode;
+
 	/** IPSEC SA direction: inbound or outbound */
 	odp_ipsec_dir_t dir;
 


### PR DESCRIPTION
With the IPsec mode in global config set to inline, packets can be
processed in inline mode or in asynchronous mode. When a platform has
the ability to support both inline and asynchronous modes in parallel,
application can choose to process some SAs in inline mode and some in
asynchronous mode.

This change set adds the provision to configure the IPsec mode for an SA.
With this provision application can configure the SA to either inline or
asynchronous mode when global IPsec mode is inline.

Signed-off-by: Vidya Velumuri <vvelumuri@marvell.com>