### PR TITLE
[PATCH v3] api: packet vector producer support

### DIFF
--- a/include/odp/api/abi-default/event.h
+++ b/include/odp/api/abi-default/event.h
@@ -29,7 +29,8 @@ typedef enum {
 	ODP_EVENT_PACKET       = 2,
 	ODP_EVENT_TIMEOUT      = 3,
 	ODP_EVENT_CRYPTO_COMPL = 4,
-	ODP_EVENT_IPSEC_STATUS = 5
+	ODP_EVENT_IPSEC_STATUS = 5,
+	ODP_EVENT_PACKET_VECTOR       = 6
 } odp_event_type_t;
 
 typedef enum {

--- a/include/odp/api/abi-default/packet.h
+++ b/include/odp/api/abi-default/packet.h
@@ -19,16 +19,21 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_packet_t;
 /** @internal Dummy  type for strong typing */
 typedef struct { char dummy; /**< *internal Dummy */ } _odp_abi_packet_seg_t;
 
+/** @internal Dummy type for strong typing */
+typedef struct { char dummy; /**< *internal Dummy */ } _odp_abi_packet_vector_t;
+
 /** @ingroup odp_packet
  *  @{
  */
 
 typedef _odp_abi_packet_t *odp_packet_t;
 typedef _odp_abi_packet_seg_t *odp_packet_seg_t;
+typedef _odp_abi_packet_vector_t *odp_packet_vector_t;
 
 #define ODP_PACKET_INVALID        ((odp_packet_t)0)
 #define ODP_PACKET_SEG_INVALID    ((odp_packet_seg_t)0)
 #define ODP_PACKET_OFFSET_INVALID 0xffff
+#define ODP_PACKET_VECTOR_INVALID   ((odp_packet_vector_t)0)
 
 typedef uint8_t odp_proto_l2_type_t;
 

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -281,6 +281,9 @@ typedef struct odp_cls_cos_param {
 
 	/** Back Pressure configuration */
 	odp_bp_param_t bp;
+
+	/** Packet input vector configuration */
+	odp_pktin_vector_config_t vector;
 } odp_cls_cos_param_t;
 
 /**

--- a/include/odp/api/spec/event.h
+++ b/include/odp/api/spec/event.h
@@ -58,6 +58,8 @@ extern "C" {
  *     - Crypto completion event (odp_crypto_compl_t)
  * - ODP_EVENT_IPSEC_STATUS
  *     - IPSEC status update event (odp_ipsec_status_t)
+ * - ODP_EVENT_PACKET_VECTOR
+ *     - Vector of packets(odp_packet_t) as odp_packet_vector_t
  */
 
 /**

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -2028,6 +2028,147 @@ odp_packet_vector_t odp_packet_vector_from_event(odp_event_t ev);
  */
 odp_event_t odp_packet_vector_to_event(odp_packet_vector_t vpkt);
 
+/**
+ * Allocate a packet vector from a packet vector pool
+ *
+ * Allocates a packet vector from the specified packet vector pool.
+ * The pool must have been created with the ODP_POOL_VECTOR type.
+ *
+ * @param pool Packet vector pool handle
+ *
+ * @return Handle of allocated packet vector
+ * @retval ODP_PACKET_VECTOR_INVALID  Packet vector could not be allocated
+ *
+ * @note The newly allocated vector shall not contain any packets, instead, alloc
+ * operation shall reserve the space for odp_pool_param_t::vector::max_vector_size packets.
+ */
+odp_packet_vector_t odp_packet_vector_alloc(odp_pool_t pool);
+
+/**
+ * Free packet vector
+ *
+ * Frees the packet vector into the packet vector pool it was allocated from.
+ *
+ * @param vpkt Packet vector handle
+ *
+ * @note This API just frees the vector, not any packets inside the vector.
+ * Application can use odp_event_free() to free the vector and packets inside
+ * the vector.
+ */
+void odp_packet_vector_free(odp_packet_vector_t vpkt);
+
+/**
+ * Get packet vector table
+ *
+ * Packet vector table is a array of packets(odp_packet_t) stored
+ * in contiguous memory location. Upon completion of this API,
+ * the implementation returns the packet table pointer in pkts_tbl.
+ *
+ * @param vpkt Packet vector handle
+ * @param [out] pkts_tbl Points to packet vector table
+ *
+ * @return Number of packets available in the vector.
+ *
+ * @note When pktin subsystem is producing the packet vectors,
+ * odp_pktin_vector_config_t::vector_pool shall be used to configure
+ * the pool to form the vector table.
+ *
+ * @note The maximum number of packets can hold this vector is defined
+ * by odp_pool_param_t:vector:max_vector_size. The return value of this
+ * function will not be greater than odp_pool_param_t:vector:max_vector_size
+ *
+ * @note The pkts_tbl points to the packet vector table. Application can edit the packet
+ * handles in the table directly(up to odp_pool_param_t::vector::max_vector_size).
+ * Application must update the size of the table using odp_packet_vector_size_set() when
+ * there is a change in the size of the vector.
+ *
+ * @note Invalid packet handle(ODP_PACKET_INVALID) is not allowed to store in the table to
+ * allow consumers of odp_packet_vector_t handle to have optimized implementation.
+ * So consumption of packets in the middle of the vector would call for moving
+ * remaining packets up to form the contiguous array of packets and update
+ * the size of the new vector using odp_packet_vector_size_set().
+ *
+ * @note The table memory is backed by the vector pool buffer. The ownership of the
+ * table memory is linked to ownership of the event. i.e after sending the event to a queue,
+ * the sender loses ownership to the table also.
+ *
+ */
+uint32_t odp_packet_vector_tbl(odp_packet_vector_t vpkt, odp_packet_t **pkts_tbl);
+
+/**
+ * Get number of packets in a vector
+ *
+ * @param vpkt Packet vector handle
+ *
+ * @return The number of packets available in the vector
+ */
+uint32_t odp_packet_vector_size(odp_packet_vector_t vpkt);
+
+/**
+ * Set the number of packets stored in a vector
+ *
+ * Update the number of packets stored in a vector. When the application is
+ * producing the packet vector, this function shall be used by the application
+ * to set the number of packets available in this vector.
+ *
+ * @param vpkt Packet vector handle
+ * @param size Number of packets in this vector
+ *
+ * @note The maximum number of packets can hold this vector is defined
+ * by odp_pool_param_t::vector::max_vector_size. The size value should not be
+ * greater than odp_pool_param_t::vector::max_vector_size
+ *
+ * @note (0 .. size - 1) handles in the vector table needs to be valid packet handles.
+ * @see odp_packet_vector_tbl()
+ *
+ */
+void odp_packet_vector_size_set(odp_packet_vector_t vpkt, uint32_t size);
+
+/**
+ * Perform full packet vector validity check
+ *
+ * The operation may consume considerable number of cpu cycles depending on
+ * the check level.
+ *
+ * @param vpkt Packet vector handle
+ *
+ * @retval 0 Packet vector is not valid
+ * @retval 1 Packet vector is valid
+ */
+int odp_packet_vector_valid(odp_packet_vector_t vpkt);
+
+/**
+ * Get packet vector pool
+ *
+ * Returns handle to the packet vector pool where the packet vector was allocated from.
+ *
+ * @param vpkt Packet vector handle
+ *
+ * @return Packet vector pool handle
+ */
+odp_pool_t odp_packet_vector_pool(odp_packet_vector_t vpkt);
+
+/**
+ * Print packet vector debug information
+ *
+ * Print all packet vector debug information to the ODP log.
+ *
+ * @param vpkt Packet vector handle
+ */
+void odp_packet_vector_print(odp_packet_vector_t vpkt);
+
+/**
+ * Get printable value for an odp_packet_vector_t
+ *
+ * @param hdl  odp_packet_vector_t handle to be printed
+ * @return uint64_t value that can be used to print/display this handle
+ *
+ * @note This routine is intended to be used for diagnostic purposes
+ * to enable applications to generate a printable value that represents
+ * an odp_packet_vector_t handle.
+ */
+uint64_t odp_packet_vector_to_u64(odp_packet_vector_t hdl);
+
 /*
  *
  * Debugging

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -168,6 +168,16 @@ extern "C" {
  */
 
 /**
+ * @typedef odp_packet_vector_t
+ * ODP packet vector
+ */
+
+/**
+ * @def ODP_PACKET_VECTOR_INVALID
+ * Invalid packet vector
+ */
+
+/**
  * Protocol
  */
 typedef enum odp_proto_t {
@@ -1989,6 +1999,34 @@ int8_t odp_packet_shaper_len_adjust(odp_packet_t pkt);
  * @param adj Signed adjustment value
  */
 void odp_packet_shaper_len_adjust_set(odp_packet_t pkt, int8_t adj);
+
+/*
+ *
+ * Packet vector handling routines
+ * ********************************************************
+ *
+ */
+
+/**
+ * Get packet vector handle from event
+ *
+ * Converts an ODP_EVENT_PACKET_VECTOR type event to a packet vector handle
+ *
+ * @param ev Event handle
+ * @return Packet vector handle
+ *
+ * @see odp_event_type()
+ */
+odp_packet_vector_t odp_packet_vector_from_event(odp_event_t ev);
+
+/**
+ * Convert packet vector handle to event
+ *
+ * @param vpkt Packet vector handle
+ *
+ * @return Event handle
+ */
+odp_event_t odp_packet_vector_to_event(odp_packet_vector_t vpkt);
 
 /*
  *

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -160,6 +160,39 @@ typedef struct odp_pktin_queue_param_ovr_t {
 } odp_pktin_queue_param_ovr_t;
 
 /**
+ * Packet input vector configuration
+ */
+typedef struct odp_pktin_vector_config_t {
+	/** A boolean to enable Packet input vector
+	 * When true, Packet input vector is enabled and configured with vector config parameters.
+	 * Otherwise, Packet input vector configuration parameters are ignored.
+	 */
+	odp_bool_t enable;
+	/** Vector pool to allocate the vector to hold the packets.
+	 * The pool must have been created with the ODP_POOL_VECTOR type.
+	 */
+	odp_pool_t vector_pool;
+	/** Maximum timeout in nanoseconds to wait for producer form the vector of
+	 * packet event(odp_packet_vector_t). This value should be in the range of
+	 * odp_pktin_vector_capability_t::min_tmo_ns to
+	 * odp_pktin_vector_capability_t::max_tmo_ns.
+	 */
+	uint64_t max_vector_tmo_ns;
+	/** Maximum allowed number of packets in a vector.
+	 * The packet input subsystem form the packet vector events when either
+	 * it reaches odp_pktin_vector_config_t::max_vector_tmo_ns or producer
+	 * reaches max_vector_size packets. This value should be in the range of
+	 * odp_pktin_vector_capability_t::min_size to
+	 * odp_pktin_vector_capability_t::max_size.
+	 *
+	 * @note The maximum number of packets can hold this vector is defined
+	 * by odp_pool_param_t:vector:max_vector_size with odp_pktin_vector_config_t::vector_pool.
+	 * The max_vector_size should not be greater than odp_pool_param_t:vector:max_vector_size.
+	 */
+	uint32_t max_vector_size;
+} odp_pktin_vector_config_t;
+
+/**
  * Packet input queue parameters
  */
 typedef struct odp_pktin_queue_param_t {
@@ -226,6 +259,9 @@ typedef struct odp_pktin_queue_param_t {
 	  * NULL.
 	  */
 	odp_pktin_queue_param_ovr_t *queue_param_ovr;
+
+	/** Packet input vector configuration */
+	odp_pktin_vector_config_t vector;
 } odp_pktin_queue_param_t;
 
 /**
@@ -548,6 +584,24 @@ typedef union odp_pktio_set_op_t {
 } odp_pktio_set_op_t;
 
 /**
+ * Packet input vector capabilities
+ */
+typedef struct odp_pktin_vector_capability_t {
+	/** Packet input vector availability */
+	odp_support_t supported;
+	/** Maximum number of packets can be accumulated by the packet in vector producer.
+	 * odp_pktin_vector_config_t::max_vector_size should not be greater than this value */
+	uint32_t max_size;
+	/** Minimum value allowed to configure the odp_pktin_vector_config_t::max_vector_size */
+	uint64_t min_size;
+	/** Maximum timeout in nanoseconds to wait for producer form the vector of packets.
+	 * odp_pktin_vector_config_t::max_vector_tmo_ns should not be greater than this value */
+	uint64_t max_tmo_ns;
+	/** Minimum value allowed to configure the odp_pktin_vector_config_t::max_vector_tmo_ns */
+	uint64_t min_tmo_ns;
+} odp_pktin_vector_capability_t;
+
+/**
  * Packet IO capabilities
  */
 typedef struct odp_pktio_capability_t {
@@ -568,6 +622,9 @@ typedef struct odp_pktio_capability_t {
 
 	/** @deprecated Use enable_loop inside odp_pktin_config_t */
 	odp_bool_t ODP_DEPRECATE(loop_supported);
+
+	/** Packet input vector capability */
+	odp_pktin_vector_capability_t vector;
 } odp_pktio_capability_t;
 
 /**

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -407,6 +407,7 @@ typedef struct odp_pool_param_t {
  *
  * The pool to hold a vector of general type such as odp_packet_t.
  * Each vector holds an array of generic types of the same type.
+ * @see ODP_EVENT_PACKET_VECTOR
  */
 #define ODP_POOL_VECTOR	      (ODP_POOL_TIMEOUT + 1)
 

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -181,6 +181,27 @@ typedef struct odp_pool_capability_t {
 		uint32_t max_cache_size;
 	} tmo;
 
+	/** Vector pool capabilities */
+	struct {
+		/** Maximum number of vector pools */
+		unsigned int max_pools;
+
+		/** Maximum number of vector events in a pool
+		 *
+		 * The value of zero means that limited only by the available
+		 * memory size for the pool. */
+		uint32_t max_num;
+
+		/** Maximum number of general type such as odp_packet_t in a vector */
+		uint32_t max_vector_size;
+
+		/** Minimum size of thread local cache */
+		uint32_t min_cache_size;
+
+		/** Maximum size of thread local cache */
+		uint32_t max_cache_size;
+	} vector;
+
 } odp_pool_capability_t;
 
 /**
@@ -359,6 +380,21 @@ typedef struct odp_pool_param_t {
 		uint32_t cache_size;
 	} tmo;
 
+	/** Parameters for vector pools */
+	struct {
+		/** Number of vectors in the pool */
+		uint32_t num;
+
+		/** Maximum number of general type such as odp_packet_t in a vector */
+		uint32_t max_vector_size;
+
+		/** Maximum number of vectors cached locally per thread
+		 *
+		 *  See buf.cache_size documentation for details.
+		 */
+		uint32_t cache_size;
+	} vector;
+
 } odp_pool_param_t;
 
 /** Packet pool*/
@@ -367,6 +403,12 @@ typedef struct odp_pool_param_t {
 #define ODP_POOL_BUFFER       ODP_EVENT_BUFFER
 /** Timeout pool */
 #define ODP_POOL_TIMEOUT      ODP_EVENT_TIMEOUT
+/** Vector pool
+ *
+ * The pool to hold a vector of general type such as odp_packet_t.
+ * Each vector holds an array of generic types of the same type.
+ */
+#define ODP_POOL_VECTOR	      (ODP_POOL_TIMEOUT + 1)
 
 /**
  * Create a pool

--- a/platform/linux-generic/include-abi/odp/api/abi/packet.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet.h
@@ -35,6 +35,10 @@ typedef ODP_HANDLE_T(odp_packet_seg_t);
 
 #define ODP_PACKET_SEG_INVALID _odp_cast_scalar(odp_packet_seg_t, 0)
 
+typedef ODP_HANDLE_T(odp_packet_vector_t);
+
+#define ODP_PACKET_VECTOR_INVALID _odp_cast_scalar(odp_packet_vector_t, 0)
+
 #define ODP_PACKET_OFFSET_INVALID 0xffff
 
 typedef uint8_t odp_proto_l2_type_t;


### PR DESCRIPTION
## api: pool: introduce vector pool

Introduce the vector pool to hold the vector of a generic type such
as packets. Updated odp_pool_capability_t to advertise the new vector
pool capabilities and odp_pool_param_t to configure the vector pool.
The application shall use the max_vector_size parameter to configure
the max number of general types such as odp_packet_t that
can hold in the vector.

When vector pool used as odp_packet_t container,
either pktin subsystem can allocate a buffer to hold/form
the vector in packet input path as pktin producer or
the application can allocate the vector pool using
odp_packet_vector_alloc() from packet API to create a vector
of packets to store an array of packets as a vector.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>

## api: event: introduce packet vector event

Introduce packet vector events which hold an array of odp_packet_t.

This patch also introduce the odp_packet_vector_from_event()
and odp_packet_vector_to_event() event conversion APIs.

In order to build the linux-generic in --disable-abi-compat mode,
A dummy definition of odp_packet_vector_t has been added.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>

## api: pktio: configure pktin vector producer

There are two configuration aspects of the pktin vector producer.

First, When pktin subsystem produces the vector of packets,
it needs to choose the ODP_VECTOR_POOL to hold/form
the vector.

Second, The max timeout interval to accumulate a vector for
packets.

The odp_pktin_vector_config_t depicts the configuration
parameters.

Either it max timeout reaches or max_vector_size configured
in the pool reaches the value, the pktin subsystem forms the
odp_packet_vector_t and inject as an event to the event queue.

The pktin configuration available either through pktio or
classification subsystem based on the final odp queue delivery.

This patch also introduces odp_pktin_vector_capability_t capability
parameter to probe the pktin vector producer availability in the
implementation as well as to know the max and min timeout value
for accumulating the packet by the pktin vector producer and
also the max_vector_size.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>

## api: packet: introduce packet vector handling routines

Introduce odp_packet_vector_t type handling functions such
alloc and free the vector from packet vector pool,
get and set the vector size and get the vector packets array
for creating, manipulating the packet vector abstracted
using the odp_packet_vector_t.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>
