### PR TITLE
[PATCH v5] IPsec validation test application fixes

### DIFF
--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -453,7 +453,8 @@ static void test_out_ipv4_esp_aes_gcm128(void)
 static void test_out_ipv4_ah_aes_gmac_128(void)
 {
 	odp_ipsec_sa_param_t param;
-	odp_ipsec_sa_t sa;
+	odp_ipsec_sa_t out_sa;
+	odp_ipsec_sa_t in_sa;
 
 	ipsec_sa_param_fill(&param,
 			    false, true, 123, NULL,
@@ -461,9 +462,19 @@ static void test_out_ipv4_ah_aes_gmac_128(void)
 			    ODP_AUTH_ALG_AES_GMAC, &key_a5_128,
 			    NULL, &key_mcgrew_gcm_salt_2);
 
-	sa = odp_ipsec_sa_create(&param);
+	out_sa = odp_ipsec_sa_create(&param);
 
-	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
+	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, out_sa);
+
+	ipsec_sa_param_fill(&param,
+			    true, true, 123, NULL,
+			    ODP_CIPHER_ALG_NULL, NULL,
+			    ODP_AUTH_ALG_AES_GMAC, &key_a5_128,
+			    NULL, &key_mcgrew_gcm_salt_2);
+
+	in_sa = odp_ipsec_sa_create(&param);
+
+	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, in_sa);
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0,
@@ -471,19 +482,23 @@ static void test_out_ipv4_ah_aes_gmac_128(void)
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv4_icmp_0_ah_aes_gmac_128_1 },
+			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
+			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
+			  .pkt_out = &pkt_ipv4_icmp_0 },
 		},
 	};
 
-	ipsec_check_out_one(&test, sa);
+	ipsec_check_out_in_one(&test, out_sa, in_sa);
 
-	ipsec_sa_destroy(sa);
+	ipsec_sa_destroy(out_sa);
+	ipsec_sa_destroy(in_sa);
 }
 
 static void test_out_ipv4_esp_null_aes_gmac_128(void)
 {
 	odp_ipsec_sa_param_t param;
-	odp_ipsec_sa_t sa;
+	odp_ipsec_sa_t out_sa;
+	odp_ipsec_sa_t in_sa;
 
 	ipsec_sa_param_fill(&param,
 			    false, false, 123, NULL,
@@ -491,9 +506,19 @@ static void test_out_ipv4_esp_null_aes_gmac_128(void)
 			    ODP_AUTH_ALG_AES_GMAC, &key_a5_128,
 			    NULL, &key_mcgrew_gcm_salt_2);
 
-	sa = odp_ipsec_sa_create(&param);
+	out_sa = odp_ipsec_sa_create(&param);
 
-	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
+	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, out_sa);
+
+	ipsec_sa_param_fill(&param,
+			    true, false, 123, NULL,
+			    ODP_CIPHER_ALG_NULL, NULL,
+			    ODP_AUTH_ALG_AES_GMAC, &key_a5_128,
+			    NULL, &key_mcgrew_gcm_salt_2);
+
+	in_sa = odp_ipsec_sa_create(&param);
+
+	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, in_sa);
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0,
@@ -501,13 +526,16 @@ static void test_out_ipv4_esp_null_aes_gmac_128(void)
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv4_icmp_0_esp_null_aes_gmac_128_1 },
+			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
+			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
+			  .pkt_out = &pkt_ipv4_icmp_0 },
 		},
 	};
 
-	ipsec_check_out_one(&test, sa);
+	ipsec_check_out_in_one(&test, out_sa, in_sa);
 
-	ipsec_sa_destroy(sa);
+	ipsec_sa_destroy(out_sa);
+	ipsec_sa_destroy(in_sa);
 }
 
 static void test_out_ipv4_esp_chacha20_poly1305(void)


### PR DESCRIPTION
This PR consists of following two fixes to IPsec validation test applications:

1.  Fix test_out_ipv4_esp_null_aes_gmac_128() test function:
Perform both outbound and inbound processing similar to test_out_ipv4_esp_aes_gcm128. This is required as AES-GMAC algorithm uses IV for ICV generation and is generated by the ODP IPsec implementation during the IPsec outbound processing. The IV value is not known to the receiver until it receives the packet, but the test function expects a predefined IV value in the resulting packet.

2. Set L3 type for a test packet in ipsec_packet()
Similar to setting the l3 offset, set the L3 type to IPv4/IPv6 in ipsec_packet()
