### PR TITLE
[PATCH v1] linux-gen: random: null: fix integer overflow in assert check

### DIFF
--- a/platform/linux-generic/odp_random_null.c
+++ b/platform/linux-generic/odp_random_null.c
@@ -17,7 +17,7 @@
 
 /* Assume at least two rand bytes are available and RAND_MAX is power of two - 1 */
 ODP_STATIC_ASSERT(RAND_MAX >= UINT16_MAX, "RAND_MAX too small");
-ODP_STATIC_ASSERT((RAND_MAX & (RAND_MAX + 1))  ==  0, "RAND_MAX not power of two - 1");
+ODP_STATIC_ASSERT((RAND_MAX & (RAND_MAX + 1ULL))  ==  0, "RAND_MAX not power of two - 1");
 
 odp_random_kind_t odp_random_max_kind(void)
 {


### PR DESCRIPTION
Fixes build failure caused by integer overflow.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reviewed-by: Petri Savolainen <petri.savolainen@nokia.com>
Reported-by: Ville Luttinen <ville.luttinen@nokia.com>