### PR TITLE
[PATCH v2] travis: enable docker hub authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@
 # 	https://github.com/OpenDataPlane/odp-docker-images
 # CI scripts are maintained under ./scripts/ci/ directory
 # which is passed to the containers during a test run.
+#
+# Prebuilt Docker images are stored in Docker Hub under 'opendataplane'
+# namespace. Set DOCKER_NAMESPACE Travis environment variable to use a custom
+# namespace. To increase Docker Hub pull quota set DOCKER_USERNAME and
+# DOCKER_TOKEN environment variables accordingly.
 
 language: c
 os: linux
@@ -80,6 +85,13 @@ env:
         - CONF="--without-openssl --without-pcap"
         - OS=ubuntu_16.04
         - OS=ubuntu_20.04
+
+before_install:
+        - if [ -n "${DOCKER_USERNAME}" -a -n "${DOCKER_TOKEN}" ] ; then
+               echo ${DOCKER_TOKEN} | docker login --username ${DOCKER_USERNAME} --password-stdin ;
+          else
+               echo "Using Docker Hub anonymously. May run out of pull quota." ;
+          fi
 
 install:
         - if [ ${NETMAP} -eq 1 ] ; then


### PR DESCRIPTION
Docker Hub will soon start limiting anonymous users to max 100 pulls per 6
hours. Enabling user authentication increases this limit to 200 pulls per 6
hours.

To enable authentication in Travis user has to first create a Docker Hub
account and within the account settings generate a new access token for
Travis usage. Then in Travis repository settings DOCKER_USERNAME and
DOCKER_TOKEN environment variables have to be set accordingly.

Signed-off-by: Matias Elo <matias.elo@nokia.com>