### PR TITLE
[PATCH v3] linux-gen: random: always build both implementations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -303,8 +303,11 @@ AC_ARG_WITH([openssl],
 	    [],
 	    [with_openssl=yes])
 AS_IF([test "$with_openssl" != "no"],
-      [ODP_OPENSSL])
+      [ODP_OPENSSL
+       have_openssl=1], [have_openssl=0])
 AM_CONDITIONAL([WITH_OPENSSL], [test x$with_openssl != xno])
+AC_DEFINE_UNQUOTED([_ODP_OPENSSL], [$have_openssl],
+	  [Define to 1 to enable OpenSSL support])
 
 ##########################################################################
 # Include m4 files

--- a/include/odp/autoheader_internal.h.in
+++ b/include/odp/autoheader_internal.h.in
@@ -26,4 +26,7 @@
 /* Define to 1 to enable pcapng support */
 #undef _ODP_PCAPNG
 
+/* Define to 1 to enable OpenSSL support */
+#undef _ODP_OPENSSL
+
 #endif

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -127,6 +127,8 @@ noinst_HEADERS = \
 		  include/odp_queue_basic_internal.h \
 		  include/odp_queue_lf.h \
 		  include/odp_queue_scalable_internal.h \
+		  include/odp_random_std_internal.h \
+		  include/odp_random_openssl_internal.h \
 		  include/odp_ring_common.h \
 		  include/odp_ring_internal.h \
 		  include/odp_ring_mpmc_internal.h \
@@ -193,6 +195,9 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_queue_lf.c \
 			   odp_queue_scalable.c \
 			   odp_queue_spsc.c \
+			   odp_random.c \
+			   odp_random_std.c \
+			   odp_random_openssl.c \
 			   odp_rwlock.c \
 			   odp_rwlock_recursive.c \
 			   odp_schedule_basic.c \
@@ -234,12 +239,10 @@ __LIB__libodp_linux_la_SOURCES = \
 
 if WITH_OPENSSL
 __LIB__libodp_linux_la_SOURCES += \
-			   odp_crypto_openssl.c \
-			   odp_random_openssl.c
+			   odp_crypto_openssl.c
 else
 __LIB__libodp_linux_la_SOURCES += \
-			   odp_crypto_null.c \
-			   odp_random_null.c
+			   odp_crypto_null.c
 endif
 if ODP_ABI_COMPAT
 __LIB__libodp_linux_la_SOURCES += \

--- a/platform/linux-generic/include/odp_random_openssl_internal.h
+++ b/platform/linux-generic/include/odp_random_openssl_internal.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_RANDOM_OPENSSL_INTERNAL_H_
+#define ODP_RANDOM_OPENSSL_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#include <odp/api/random.h>
+
+odp_random_kind_t _odp_random_openssl_max_kind(void);
+int32_t _odp_random_openssl_test_data(uint8_t *buf, uint32_t len, uint64_t *seed);
+int32_t _odp_random_openssl_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind);
+int _odp_random_openssl_init_local(void);
+int _odp_random_openssl_term_local(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* ODP_RANDOM_OPENSSL_INTERNAL_H_ */

--- a/platform/linux-generic/include/odp_random_std_internal.h
+++ b/platform/linux-generic/include/odp_random_std_internal.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_RANDOM_STD_INTERNAL_H_
+#define ODP_RANDOM_STD_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#include <odp/api/random.h>
+
+odp_random_kind_t _odp_random_std_max_kind(void);
+int32_t _odp_random_std_test_data(uint8_t *buf, uint32_t len, uint64_t *seed);
+int32_t _odp_random_std_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind);
+int _odp_random_std_init_local(void);
+int _odp_random_std_term_local(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* ODP_RANDOM_STD_INTERNAL_H_ */

--- a/platform/linux-generic/odp_random.c
+++ b/platform/linux-generic/odp_random.c
@@ -1,0 +1,49 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <stdint.h>
+
+#include <odp/api/random.h>
+
+#include <odp/autoheader_internal.h>
+#include <odp_init_internal.h>
+#include <odp_random_std_internal.h>
+#include <odp_random_openssl_internal.h>
+
+odp_random_kind_t odp_random_max_kind(void)
+{
+	if (_ODP_OPENSSL)
+		return _odp_random_openssl_max_kind();
+	return _odp_random_std_max_kind();
+}
+
+int32_t odp_random_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
+{
+	if (_ODP_OPENSSL)
+		return _odp_random_openssl_data(buf, len, kind);
+	return _odp_random_std_data(buf, len, kind);
+}
+
+int32_t odp_random_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
+{
+	if (_ODP_OPENSSL)
+		return _odp_random_openssl_test_data(buf, len, seed);
+	return _odp_random_std_test_data(buf, len, seed);
+}
+
+int _odp_random_init_local(void)
+{
+	if (_ODP_OPENSSL)
+		return _odp_random_openssl_init_local();
+	return _odp_random_std_init_local();
+}
+
+int _odp_random_term_local(void)
+{
+	if (_ODP_OPENSSL)
+		return _odp_random_openssl_term_local();
+	return _odp_random_std_term_local();
+}

--- a/platform/linux-generic/odp_random_openssl.c
+++ b/platform/linux-generic/odp_random_openssl.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
+ * Copyright (c) 2020, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -7,16 +8,20 @@
 #include <odp_posix_extensions.h>
 #include <stdint.h>
 #include <odp/api/random.h>
+#include <odp/autoheader_internal.h>
 #include <odp_init_internal.h>
+#include <odp_random_openssl_internal.h>
 
+#if _ODP_OPENSSL
 #include <openssl/rand.h>
 
-odp_random_kind_t odp_random_max_kind(void)
+odp_random_kind_t _odp_random_openssl_max_kind(void)
 {
 	return ODP_RANDOM_CRYPTO;
 }
 
-int32_t odp_random_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
+int32_t _odp_random_openssl_data(uint8_t *buf, uint32_t len,
+				 odp_random_kind_t kind)
 {
 	int rc;
 
@@ -32,7 +37,8 @@ int32_t odp_random_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
 	}
 }
 
-int32_t odp_random_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
+int32_t _odp_random_openssl_test_data(uint8_t *buf, uint32_t len,
+				      uint64_t *seed)
 {
 	union {
 		uint32_t rand_word;
@@ -51,13 +57,34 @@ int32_t odp_random_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
 	*seed = seed32;
 	return len;
 }
+#else
+/* Dummy functions for building without OpenSSL support */
+odp_random_kind_t _odp_random_openssl_max_kind(void)
+{
+	return ODP_RANDOM_BASIC;
+}
 
-int _odp_random_init_local(void)
+int32_t _odp_random_openssl_data(uint8_t *buf ODP_UNUSED,
+				 uint32_t len ODP_UNUSED,
+				 odp_random_kind_t kind ODP_UNUSED)
+{
+	return -1;
+}
+
+int32_t _odp_random_openssl_test_data(uint8_t *buf ODP_UNUSED,
+				      uint32_t len ODP_UNUSED,
+				      uint64_t *seed ODP_UNUSED)
+{
+	return -1;
+}
+#endif /* _ODP_OPENSSL */
+
+int _odp_random_openssl_init_local(void)
 {
 	return 0;
 }
 
-int _odp_random_term_local(void)
+int _odp_random_openssl_term_local(void)
 {
 	return 0;
 }

--- a/platform/linux-generic/odp_random_std.c
+++ b/platform/linux-generic/odp_random_std.c
@@ -12,6 +12,7 @@
 #include <odp/api/cpu.h>
 #include <odp/api/debug.h>
 #include <odp_init_internal.h>
+#include <odp_random_std_internal.h>
 
 #include <time.h>
 
@@ -19,7 +20,7 @@
 ODP_STATIC_ASSERT(RAND_MAX >= UINT16_MAX, "RAND_MAX too small");
 ODP_STATIC_ASSERT((RAND_MAX & (RAND_MAX + 1ULL))  ==  0, "RAND_MAX not power of two - 1");
 
-odp_random_kind_t odp_random_max_kind(void)
+odp_random_kind_t _odp_random_std_max_kind(void)
 {
 	return ODP_RANDOM_BASIC;
 }
@@ -44,7 +45,7 @@ static int32_t _random_data(uint8_t *buf, uint32_t len, uint32_t *seed)
 	return len;
 }
 
-int32_t odp_random_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
+int32_t _odp_random_std_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
 {
 	uint32_t seed32 = (*seed) & 0xffffffff;
 
@@ -56,7 +57,7 @@ int32_t odp_random_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
 
 static __thread uint32_t this_seed;
 
-int32_t odp_random_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
+int32_t _odp_random_std_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
 {
 	if (kind != ODP_RANDOM_BASIC)
 		return -1;
@@ -64,7 +65,7 @@ int32_t odp_random_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
 	return _random_data(buf, len, &this_seed);
 }
 
-int _odp_random_init_local(void)
+int _odp_random_std_init_local(void)
 {
 	this_seed = time(NULL);
 	this_seed ^= odp_cpu_id() << 16;
@@ -72,7 +73,7 @@ int _odp_random_init_local(void)
 	return 0;
 }
 
-int _odp_random_term_local(void)
+int _odp_random_std_term_local(void)
 {
 	return 0;
 }


### PR DESCRIPTION
Always build both random module implementations to detect possible build
issues. Renamed random_null implementation to random_std.

Signed-off-by: Matias Elo <matias.elo@nokia.com>