### PR TITLE
[PATCH v2] helper: thread: print pthread_create() return value to error log

### DIFF
--- a/helper/linux/thread.c
+++ b/helper/linux/thread.c
@@ -89,7 +89,8 @@ int odph_linux_pthread_create(odph_linux_pthread_t *pthread_tbl,
 				     _odph_run_start_routine,
 				     &pthread_tbl[i].thr_params);
 		if (ret != 0) {
-			ODPH_ERR("Failed to start thread on cpu #%d\n", cpu);
+			ODPH_ERR("Failed to start thread on CPU #%d: %d\n", cpu,
+				 ret);
 			break;
 		}
 

--- a/helper/threads.c
+++ b/helper/threads.c
@@ -182,7 +182,7 @@ static int create_pthread(odph_thread_t *thread, int cpu)
 			     run_thread,
 			     &thread->start_args);
 	if (ret != 0) {
-		ODPH_ERR("Failed to start thread on cpu #%d\n", cpu);
+		ODPH_ERR("Failed to start thread on CPU #%d: %d\n", cpu, ret);
 		thread->cpu = FAILED_CPU;
 		return ret;
 	}

--- a/platform/linux-generic/odp_pcapng.c
+++ b/platform/linux-generic/odp_pcapng.c
@@ -373,7 +373,7 @@ int _odp_pcapng_start(pktio_entry_t *entry)
 	ret = pthread_create(&pcapng_gbl->inotify_thread, &attr, inotify_update,
 			     &pcapng_gbl->inotify_fd);
 	if (ret) {
-		ODP_ERR("can't start inotify thread. pcap disabled\n");
+		ODP_ERR("Can't start inotify thread (ret=%d). pcapng disabled.\n", ret);
 	} else {
 		pcapng_gbl->entry[odp_pktio_index(entry->s.handle)] = entry;
 		pcapng_gbl->num_entries++;

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1188,7 +1188,7 @@ static void itimer_init(timer_pool_t *tp)
 	odp_atomic_init_u32(&tp->thr_ready, 0);
 	ret = pthread_create(&tp->thr_pthread, NULL, timer_thread, tp);
 	if (ret)
-		ODP_ABORT("unable to create timer thread\n");
+		ODP_ABORT("Unable to create timer thread: %d\n", ret);
 
 	/* wait thread set tp->thr_pid */
 	while (tp->thr_pid == 0)

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2745,8 +2745,8 @@ static int tm_thread_create(tm_system_group_t *tm_group)
 	rc = pthread_create(&tm_group->thread, &tm_group->attr,
 			    tm_system_thread, tm_group);
 	if (rc != 0)
-		ODP_DBG("Failed to start thread on cpu num=%u\n", cpu_num);
-
+		ODP_ERR("Failed to start TM thread on CPU #%u: %d\n", cpu_num,
+			rc);
 	return rc;
 }
 static void _odp_tm_group_destroy(_odp_tm_group_t odp_tm_group)


### PR DESCRIPTION
Print pthread_create() return value to error log on failure.