### PR TITLE
[PATCH v1] api: pktio: add DMAC and l3_custom based flow hash

### DIFF
--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -121,6 +121,10 @@ typedef union odp_pktin_hash_proto_t {
 		uint32_t ipv6_tcp : 1;
 		/** IPv6 addresses */
 		uint32_t ipv6     : 1;
+		/** Destination MAC address */
+		uint32_t dmac	  : 1;
+		/** Custom L3 fields */
+		uint32_t l3_custom: 1;
 	} proto;
 
 	/** All bits of the bit field structure */


### PR DESCRIPTION
Add DMAC and l3_custom based flow hash configuration.
When DMAC is selected, the implementation uses 6B destination
mac address from the packet to form the hash value.
When l3_custom is selected, implementation can select any of
the fields in the L3 layer to form the hash. This would enable,
custom protocols in the L3 layer from the hash.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>