### PR TITLE
[PATCH v2] test: run validation tests before other tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,12 +16,20 @@ SUBDIRS = \
 	  helper \
 	  doc
 
+# Tests are run in this SUBDIRS order. The intention is to run validation tests first,
+# then example/performance/platform specific tests.
+if WITH_TESTS
+SUBDIRS += test/common
+SUBDIRS += test/miscellaneous
+SUBDIRS += test/validation
+endif
+
 if WITH_EXAMPLES
 SUBDIRS += example
 endif
 
 if WITH_TESTS
-SUBDIRS += test
+SUBDIRS += test/performance
 SUBDIRS += helper/test
 SUBDIRS += $(PLATFORM_TEST_DIR)
 endif

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,1 +1,0 @@
-SUBDIRS = common validation performance miscellaneous

--- a/test/m4/configure.m4
+++ b/test/m4/configure.m4
@@ -13,8 +13,7 @@ m4_include([test/m4/miscellaneous.m4])
 m4_include([test/m4/performance.m4])
 m4_include([test/m4/validation.m4])
 
-AC_CONFIG_FILES([test/Makefile
-		 test/common/Makefile
+AC_CONFIG_FILES([test/common/Makefile
 		 test/miscellaneous/Makefile
 		 test/performance/Makefile
 		 test/validation/Makefile


### PR DESCRIPTION
Change test execution order during 'make check', so that
validation tests are run before other tests. Example tests
are run before performance (and platform specific) tests as
example tests are simpler and run faster (involves less
packet IO).

Makefile.am in test directory became empty and was removed.

Signed-off-by: Petri Savolainen <petri.savolainen@nokia.com>