### PR TITLE
[PATCH v2] shippable: disable email notifications

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -4,6 +4,15 @@ compiler:
   - gcc
   - clang
 
+integrations:
+  notifications:
+    - integrationName: email
+      type: email
+      on_success: never
+      on_failure: never
+      on_cancel: never
+      on_pull_request: never
+
 env:
     - CONF="--disable-test-perf"
     - CONF="--disable-abi-compat --disable-test-perf"


### PR DESCRIPTION
Disable all Shippable email notifications. The test results are shown
directly in the GitHub page, so there is no need for extra notifications.

Signed-off-by: Matias Elo <matias.elo@nokia.com>