### PR TITLE
[PATCH v5] validation: cls: fix error packet generation

### DIFF
--- a/test/validation/api/classification/odp_classification_common.c
+++ b/test/validation/api/classification/odp_classification_common.c
@@ -316,11 +316,13 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 		ip->src_addr = odp_cpu_to_be_32(addr);
 		ip->ver_ihl = ODPH_IPV4 << 4 | ODPH_IPV4HDR_IHL_MIN;
 		ip->id = odp_cpu_to_be_16(seqno);
-		odph_ipv4_csum_update(pkt);
 		ip->proto = next_hdr;
 		ip->tot_len = odp_cpu_to_be_16(l3_len);
 		ip->ttl = DEFAULT_TTL;
+		ip->frag_offset = 0;
+		ip->tos = 0;
 		odp_packet_has_ipv4_set(pkt, 1);
+		odph_ipv4_csum_update(pkt);
 	} else {
 		/* ipv6 */
 		odp_packet_has_ipv6_set(pkt, 1);
@@ -357,7 +359,13 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 	} else {
 		tcp->src_port = odp_cpu_to_be_16(CLS_DEFAULT_SPORT);
 		tcp->dst_port = odp_cpu_to_be_16(CLS_DEFAULT_DPORT);
+		tcp->doffset_flags = 0;
+		tcp->seq_no = 0;
+		tcp->ack_no = 0;
+		tcp->window = 0;
+		tcp->urgptr = 0;
 		tcp->hl = ODPH_TCPHDR_LEN / 4;
+		tcp->ack = 1;
 		tcp->cksm = 0;
 		odp_packet_has_tcp_set(pkt, 1);
 		if (odph_udp_tcp_chksum(pkt, ODPH_CHKSUM_GENERATE, NULL) != 0) {

--- a/test/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/validation/api/classification/odp_classification_test_pmr.c
@@ -2283,6 +2283,7 @@ static void test_pmr_series(const int num_udp)
 	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
 	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
 	ip->dst_addr  = dst_addr_be;
+	odph_ipv4_csum_update(pkt);
 
 	seqno = cls_pkt_get_seq(pkt);
 	CU_ASSERT(seqno != TEST_SEQ_INVALID);
@@ -2310,6 +2311,7 @@ static void test_pmr_series(const int num_udp)
 		odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
 		odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
 		ip->dst_addr  = dst_addr_be;
+		odph_ipv4_csum_update(pkt);
 		udp->dst_port = odp_cpu_to_be_16(dst_port + i);
 
 		seqno = cls_pkt_get_seq(pkt);


### PR DESCRIPTION
TCP sample packet header used by classification has TCP
flags set to zero and IP checksum is not being calculated
properly in some cases. Flags set to zero can be generally
considered illegal and treated as a bad packet by some HW.
RFC 793 also does not have any use case as such with all the
flags clear. Hence this patch sets ACK flag in the sample pkt.

Signed-off-by: Kiran Kumar K <kirankumark@marvell.com>