### PR TITLE
[PATCH v1] api: new cls terms

### DIFF
--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -109,6 +109,10 @@ typedef union odp_cls_pmr_terms_t {
 		uint64_t	icmp_id:1;
 		/** ICMP type */
 		uint64_t	icmp_type:1;
+		/** Source SCTP port */
+		uint64_t	sctp_sport:1;
+		/** Destination SCTP port */
+		uint64_t	sctp_dport:1;
 
 	} bit;
 	/** All bits of the bit field structure */
@@ -562,6 +566,12 @@ typedef enum {
 
 	/** ICMP type (val_sz = 2) */
 	ODP_PMR_ICMP_TYPE,
+
+	/** Source SCTP port (val_sz = 2) */
+	ODP_PMR_SCTP_SPORT,
+
+	/** Destination SCTP port (val_sz = 2) */
+	ODP_PMR_SCTP_DPORT,
 
 	/** Inner header may repeat above values with this offset */
 	ODP_PMR_INNER_HDR_OFF = 32

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -113,6 +113,8 @@ typedef union odp_cls_pmr_terms_t {
 		uint64_t	sctp_sport:1;
 		/** Destination SCTP port */
 		uint64_t	sctp_dport:1;
+		/** GTPU Tunnel endpoint identifier */
+		uint64_t	gtpu_teid:1;
 
 	} bit;
 	/** All bits of the bit field structure */
@@ -572,6 +574,9 @@ typedef enum {
 
 	/** Destination SCTP port (val_sz = 2) */
 	ODP_PMR_SCTP_DPORT,
+
+	/** GTPU Tunnel endpoint identifier  (val_sz = 4)*/
+	ODP_PMR_GTPU_TEID,
 
 	/** Inner header may repeat above values with this offset */
 	ODP_PMR_INNER_HDR_OFF = 32

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -103,6 +103,8 @@ typedef union odp_cls_pmr_terms_t {
 		/** Custom layer 3 match rule. PMR offset is counted from
 		 *  the start of layer 3 in the packet. */
 		uint64_t        custom_l3:1;
+		/** IGMP Group address */
+		uint64_t	igmp_grp_addr:1;
 
 	} bit;
 	/** All bits of the bit field structure */
@@ -547,6 +549,9 @@ typedef enum {
 	 * Custom L3 rules may be combined with other PMRs.
 	 */
 	ODP_PMR_CUSTOM_L3,
+
+	/** IGMP Group address (val_sz = 4) */
+	ODP_PMR_IGMP_GRP_ADDR,
 
 	/** Inner header may repeat above values with this offset */
 	ODP_PMR_INNER_HDR_OFF = 32

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -105,6 +105,10 @@ typedef union odp_cls_pmr_terms_t {
 		uint64_t        custom_l3:1;
 		/** IGMP Group address */
 		uint64_t	igmp_grp_addr:1;
+		/** ICMP identifier */
+		uint64_t	icmp_id:1;
+		/** ICMP type */
+		uint64_t	icmp_type:1;
 
 	} bit;
 	/** All bits of the bit field structure */
@@ -552,6 +556,12 @@ typedef enum {
 
 	/** IGMP Group address (val_sz = 4) */
 	ODP_PMR_IGMP_GRP_ADDR,
+
+	/** ICMP identifier (val_sz = 2) */
+	ODP_PMR_ICMP_ID,
+
+	/** ICMP type (val_sz = 2) */
+	ODP_PMR_ICMP_TYPE,
 
 	/** Inner header may repeat above values with this offset */
 	ODP_PMR_INNER_HDR_OFF = 32


### PR DESCRIPTION
Pull request to add a few more terms to leverge HW classfication support.

## ap: cls: introduce IGMP group addr term

Introduce IGMP group address term.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>

## api: cls: introduce ICMP terms

Introduce ICMP identifier and type terms.
Signed-off-by: Jerin Jacob <jerinj@marvell.com>

## api: cls: introduce SCTP terms

Introduce SCTP source and destination port terms.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>

## api: cls: introduce GTPU tunnel endpoint id term

Introduce GTPU tunnel endpoint identifier term.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>