### PR TITLE
[PATCH v1] api: add packet inner layer identification API and inner layer parsing, checksum generation and validation

### DIFF
--- a/doc/users-guide/users-guide-packet.adoc
+++ b/doc/users-guide/users-guide-packet.adoc
@@ -131,7 +131,10 @@ application changes the Layer 3 offset by using the `odp_packet_l3_offset_set()`
 API, the subsequent calls to `odp_packet_l3_ptr()` will return an address
 starting from that changed offset, changing an attribute like
 `odp_packet_has_udp_set()` will not, by itself, turn a non-UDP packet into
-a valid UDP packet. Applications are expected to exercise appropriate care
+a valid UDP packet. The same applies to inner layers and its offsets which
+can be modified using equivalent inner layer API such as
+`odp_packet_inner_l3_offset_set()`, `odp_packet_has_inner_udp_set()`.
+Applications are expected to exercise appropriate care
 when changing packet metadata to ensure that the resulting metadata changes
 reflect the actual changed packet structure that the application has made.
 
@@ -516,21 +519,23 @@ depth of the desired parse, as well as whether checksum validation should be
 performed as part of the parse, and if so which checksums require this
 processing.
 
-Packets containing Layer 3 (IPv4) and Layer 4 (TCP, UDP, SCTP) checksums
-can have these validated (on RX) and generated (on TX) automatically.
-This is normally controlled by the settings on the PktIOs that
-receive/transmit them, however they can also be controlled on an
-individual packet basis.
+Packets containing Layer 3 (IPv4), Layer 4 (TCP, UDP, SCTP) checksums, Inner
+Layer 3 (IPv4) and Inner Layer 4 (TCP, UDP, SCTP) can have these
+validated (on RX) and generated (on TX) automatically. This is normally
+controlled by the settings on the PktIOs that receive/transmit them,
+however they can also be controlled on an individual packet basis.
 
 Packets have associated `odp_packet_chksum_status_t` metadata that indicates
 the state any checksums contained in that packet. These can be queried via
-the APIs `odp_packet_l3_chksum_status()` and `odp_packet_l4_chksum_status()`,
+the APIs `odp_packet_l3_chksum_status()`, `odp_packet_l4_chksum_status()`,
+`odp_packet_inner_l3_chksum_status()`, `odp_packet_inner_l4_chksum_status()`
 respectively. Checksums can either be known good, known bad, or unknown, where
 unknown means that checksum validation processing has not occurred or the
 attempt to validate the checksum failed.
 
-Similarly, the `odp_packet_l3_chksum_insert()` and
-`odp_packet_l4_chksum_insert()` APIs may be used to override default checksum
-processing for individual packets prior to transmission. If no explicit
-checksum processing is specified for a packet, then any checksum generation
-is controlled by the PktIO configuration of the interface used to transmit it.
+Similarly, the `odp_packet_l3_chksum_insert()`, `odp_packet_l4_chksum_insert()`
+`odp_packet_inner_l3_chksum_insert()` and `odp_packet_inner_l4_chksum_insert()`
+APIs may be used to override default checksum processing for individual packets
+prior to transmission. If no explicit checksum processing is specified for a
+packet, then any checksum generation is controlled by the PktIO configuration
+of the interface used to transmit it.

--- a/doc/users-guide/users-guide-pktio.adoc
+++ b/doc/users-guide/users-guide-pktio.adoc
@@ -264,10 +264,15 @@ controls RX processing to be performed on these packets as they are received:
  * IPv4 checksum checking may be enabled only when parsing level is
  * ODP_PROTO_LAYER_L3 or higher. Similarly, L4 level checksum checking
  * may be enabled only with parsing level ODP_PROTO_LAYER_L4 or higher.
+ * Similarly inner IPv4 checksum checking is enabled only whenever parsing level
+ * is ODP_PROTO_LAYER_INNER_L3 or higher and inner L4 level checksum checking
+ * if parsing level is ODP_PROTO_LAYER_INNER_L4 or higher.
  *
  * Whether checksum checking was done and whether a checksum was correct
- * can be queried for each received packet with odp_packet_l3_chksum_status()
- * and odp_packet_l4_chksum_status().
+ * can be queried for each received packet with odp_packet_l3_chksum_status(),
+ * odp_packet_l4_chksum_status() for outer layer checksum status and
+ * odp_packet_inner_l3_chksum_status(), odp_packet_inner_l4_chksum_status()
+ * for inner layer checksum status.
  */
 typedef union odp_pktin_config_opt_t {
 	/** Option flags */
@@ -377,8 +382,8 @@ transmitted:
  * (e.g. a switch) does not modify L3/L4 data and thus checksum does not need
  * to be updated, checksum insertion should be disabled for optimal performance.
  *
- * Packet flags (odp_packet_has_*()) are ignored for the purpose of checksum
- * insertion in packet output.
+ * Packet flags (odp_packet_has_*()) will be used for purpose of identification
+ * of l3 and l4 layer protocols.
  *
  * UDP, TCP and SCTP checksum insertion must not be requested for IP fragments.
  * Use checksum override function (odp_packet_l4_chksum_insert()) to disable
@@ -417,6 +422,30 @@ typedef union odp_pktout_config_opt_t {
 
 		/** Insert SCTP checksum on packet by default */
 		uint64_t sctp_chksum     : 1;
+
+		/** Enable inner IPv4 header checksum insertion. */
+		uint64_t inner_ipv4_chksum_ena : 1;
+
+		/** Enable inner UDP checksum insertion */
+		uint64_t inner_udp_chksum_ena  : 1;
+
+		/** Enable inner TCP checksum insertion */
+		uint64_t inner_tcp_chksum_ena  : 1;
+
+		/** Enable inner SCTP checksum insertion */
+		uint64_t inner_sctp_chksum_ena : 1;
+
+		/** Insert inner IPv4 header checksum by default */
+		uint64_t inner_ipv4_chksum     : 1;
+
+		/** Insert inner UDP checksum on packet by default */
+		uint64_t inner_udp_chksum      : 1;
+
+		/** Insert inner TCP checksum on packet by default */
+		uint64_t inner_tcp_chksum      : 1;
+
+		/** Insert inner SCTP checksum on packet by default */
+		uint64_t inner_sctp_chksum     : 1;
 
 	} bit;
 

--- a/include/odp/api/abi-default/packet.h
+++ b/include/odp/api/abi-default/packet.h
@@ -87,12 +87,24 @@ typedef struct odp_packet_parse_result_flag_t {
 			uint64_t has_l3_error : 1;
 			/** @see odp_packet_has_l4_error() */
 			uint64_t has_l4_error : 1;
+			/** @see odp_packet_has_inner_l2_error() */
+			uint64_t has_inner_l2_error : 1;
+			/** @see odp_packet_has_inner_l3_error() */
+			uint64_t has_inner_l3_error : 1;
+			/** @see odp_packet_has_inner_l4_error() */
+			uint64_t has_inner_l4_error : 1;
 			/** @see odp_packet_has_l2() */
 			uint64_t has_l2 : 1;
 			/** @see odp_packet_has_l3() */
 			uint64_t has_l3 : 1;
 			/** @see odp_packet_has_l4() */
 			uint64_t has_l4 : 1;
+			/** @see odp_packet_has_inner_l2() */
+			uint64_t has_inner_l2 : 1;
+			/** @see odp_packet_has_inner_l3() */
+			uint64_t has_inner_l3 : 1;
+			/** @see odp_packet_has_inner_l4() */
+			uint64_t has_inner_l4 : 1;
 			/** @see odp_packet_has_eth() */
 			uint64_t has_eth : 1;
 			/** @see odp_packet_has_eth_bcast() */
@@ -111,6 +123,10 @@ typedef struct odp_packet_parse_result_flag_t {
 			uint64_t has_ipv4 : 1;
 			/** @see odp_packet_has_ipv6() */
 			uint64_t has_ipv6 : 1;
+			/** @see odp_packet_has_inner_ipv4() */
+			uint64_t has_inner_ipv4 : 1;
+			/** @see odp_packet_has_inner_ipv6() */
+			uint64_t has_inner_ipv6 : 1;
 			/** @see odp_packet_has_ip_bcast() */
 			uint64_t has_ip_bcast : 1;
 			/** @see odp_packet_has_ip_mcast() */
@@ -119,6 +135,10 @@ typedef struct odp_packet_parse_result_flag_t {
 			uint64_t has_ipfrag : 1;
 			/** @see odp_packet_has_ipopt() */
 			uint64_t has_ipopt : 1;
+			/** @see odp_packet_has_inner_ipfrag() */
+			uint64_t has_inner_ipfrag : 1;
+			/** @see odp_packet_has_inner_ipopt() */
+			uint64_t has_inner_ipopt : 1;
 			/** @see odp_packet_has_ipsec() */
 			uint64_t has_ipsec : 1;
 			/** @see odp_packet_has_udp() */
@@ -127,6 +147,12 @@ typedef struct odp_packet_parse_result_flag_t {
 			uint64_t has_tcp : 1;
 			/** @see odp_packet_has_sctp() */
 			uint64_t has_sctp : 1;
+			/** @see odp_packet_has_inner_udp() */
+			uint64_t has_inner_udp : 1;
+			/** @see odp_packet_has_inner_tcp() */
+			uint64_t has_inner_tcp : 1;
+			/** @see odp_packet_has_inner_sctp() */
+			uint64_t has_inner_sctp : 1;
 			/** @see odp_packet_has_icmp() */
 			uint64_t has_icmp : 1;
 		};

--- a/include/odp/api/spec/packet_flags.h
+++ b/include/odp/api/spec/packet_flags.h
@@ -82,6 +82,44 @@ int odp_packet_has_l3_error(odp_packet_t pkt);
 int odp_packet_has_l4_error(odp_packet_t pkt);
 
 /**
+ * Check for errors in inner layer 2
+ *
+ * When inner layer 2 is included in the parse configuration, check if any errors were
+ * found in inner layer 2 of the packet.
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet has errors in inner layer 2
+ * @retval 0           No errors were found in inner layer 2
+ */
+int odp_packet_has_inner_l2_error(odp_packet_t pkt);
+
+/**
+ * Check for errors in inner layer 3
+ *
+ * When inner layer 3 is included in the parse configuration, check if any errors were
+ * found in inner layer 3 of the packet.
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet has errors in inner layer 3
+ * @retval 0           No errors found in inner layer 3
+ */
+int odp_packet_has_inner_l3_error(odp_packet_t pkt);
+
+/**
+ * Check for errors in inner layer 4
+ *
+ * When inner layer 4 is included in the parse configuration, check if any errors were
+ * found in inner layer 4 of the packet.
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet has errors in inner layer 4
+ * @retval 0           No errors were found in inner layer 4
+ */
+int odp_packet_has_inner_l4_error(odp_packet_t pkt);
+/**
  * Check for layer 2 protocols
  *
  * When layer 2 is included in the parse configuration, check if packet parsing
@@ -119,6 +157,45 @@ int odp_packet_has_l3(odp_packet_t pkt);
  * @retval 0           No layer 4 protocol was found
  */
 int odp_packet_has_l4(odp_packet_t pkt);
+
+/**
+ * Check for inner layer 2 protocols
+ *
+ * When inner layer 2 is included in the parse configuration, check if packet parsing
+ * has found and checked a inner layer 2 protocol (e.g. Ethernet) in the packet.
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    A inner layer 2 protocol header was found and checked
+ * @retval 0           No inner layer 2 protocol was found
+ */
+int odp_packet_has_inner_l2(odp_packet_t pkt);
+
+/**
+ * Check for inner layer 3 protocols
+ *
+ * When inner layer 3 is included in the parse configuration, check if packet parsing
+ * has found and checked a inner layer 3 protocol (e.g. IPv4, IPv6) in the packet.
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    A inner layer 3 protocol header was found and checked
+ * @retval 0           No inner layer 3 protocol was found
+ */
+int odp_packet_has_inner_l3(odp_packet_t pkt);
+
+/**
+ * Check for inner layer 4 protocols
+ *
+ * When inner layer 4 is included in the parse configuration, check if packet parsing
+ * has found and checked a layer 4 protocol (e.g. UDP, TCP, SCTP) in the packet.
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    A inner layer 4 protocol header was found and checked
+ * @retval 0           No inner layer 4 protocol was found
+ */
+int odp_packet_has_inner_l4(odp_packet_t pkt);
 
 /**
  * Check for Ethernet header
@@ -305,6 +382,76 @@ int odp_packet_has_tcp(odp_packet_t pkt);
  * @retval 0           Packet does not contain a SCTP header
  */
 int odp_packet_has_sctp(odp_packet_t pkt);
+
+/**
+ * Check for inner IPv4
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains an inner IPv4 header
+ * @retval 0           Packet does not contain an inner IPv4 header
+ */
+int odp_packet_has_inner_ipv4(odp_packet_t pkt);
+
+/**
+ * Check for inner IPv6
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains an inner IPv6 header
+ * @retval 0           Packet does not contain an inner IPv6 header
+ */
+int odp_packet_has_inner_ipv6(odp_packet_t pkt);
+
+/**
+ * Check for inner IP fragment
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Inner packet is an IP fragment
+ * @retval 0           Inner packet is not an IP fragment
+ */
+int odp_packet_has_inner_ipfrag(odp_packet_t pkt);
+
+/**
+ * Check for inner IP options
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains inner IP options
+ * @retval 0           Packet does not contain inner IP options
+ */
+int odp_packet_has_inner_ipopt(odp_packet_t pkt);
+
+/**
+ * Check for inner UDP
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains a inner UDP header
+ * @retval 0           Packet does not contain a inner UDP header
+ */
+int odp_packet_has_inner_udp(odp_packet_t pkt);
+
+/**
+ * Check for inner TCP
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains a inner TCP header
+ * @retval 0           Packet does not contain a inner TCP header
+ */
+int odp_packet_has_inner_tcp(odp_packet_t pkt);
+
+/**
+ * Check for inner SCTP
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains a inner SCTP header
+ * @retval 0           Packet does not contain a inner SCTP header
+ */
+int odp_packet_has_inner_sctp(odp_packet_t pkt);
 
 /**
  * Check for ICMP
@@ -497,6 +644,62 @@ void odp_packet_has_tcp_set(odp_packet_t pkt, int val);
  * @param val Value
  */
 void odp_packet_has_sctp_set(odp_packet_t pkt, int val);
+
+/**
+ * Set flag for inner IPv4
+ *
+ * @param pkt Packet handle
+ * @param val Value
+ */
+void odp_packet_has_inner_ipv4_set(odp_packet_t pkt, int val);
+
+/**
+ * Set flag for inner IPv6
+ *
+ * @param pkt Packet handle
+ * @param val Value
+ */
+void odp_packet_has_inner_ipv6_set(odp_packet_t pkt, int val);
+
+/**
+ * Set flag for inner IP fragment
+ *
+ * @param pkt Packet handle
+ * @param val Value
+ */
+void odp_packet_has_inner_ipfrag_set(odp_packet_t pkt, int val);
+
+/**
+ * Set flag for inner IP options
+ *
+ * @param pkt Packet handle
+ * @param val Value
+ */
+void odp_packet_has_inner_ipopt_set(odp_packet_t pkt, int val);
+
+/**
+ * Set flag for inner UDP
+ *
+ * @param pkt Packet handle
+ * @param val Value
+ */
+void odp_packet_has_inner_udp_set(odp_packet_t pkt, int val);
+
+/**
+ * Set flag for inner TCP
+ *
+ * @param pkt Packet handle
+ * @param val Value
+ */
+void odp_packet_has_inner_tcp_set(odp_packet_t pkt, int val);
+
+/**
+ * Set flag for inner SCTP
+ *
+ * @param pkt Packet handle
+ * @param val Value
+ */
+void odp_packet_has_inner_sctp_set(odp_packet_t pkt, int val);
 
 /**
  * Set flag for ICMP

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -412,6 +412,30 @@ typedef union odp_pktout_config_opt_t {
 		/** Insert SCTP checksum on packet by default */
 		uint64_t sctp_chksum     : 1;
 
+		/** Enable inner IPv4 header checksum insertion. */
+		uint64_t inner_ipv4_chksum_ena : 1;
+
+		/** Enable inner UDP checksum insertion */
+		uint64_t inner_udp_chksum_ena  : 1;
+
+		/** Enable inner TCP checksum insertion */
+		uint64_t inner_tcp_chksum_ena  : 1;
+
+		/** Enable inner SCTP checksum insertion */
+		uint64_t inner_sctp_chksum_ena : 1;
+
+		/** Insert inner IPv4 header checksum by default */
+		uint64_t inner_ipv4_chksum     : 1;
+
+		/** Insert inner UDP checksum on packet by default */
+		uint64_t inner_udp_chksum      : 1;
+
+		/** Insert inner TCP checksum on packet by default */
+		uint64_t inner_tcp_chksum      : 1;
+
+		/** Insert inner SCTP checksum on packet by default */
+		uint64_t inner_sctp_chksum     : 1;
+
 	} bit;
 
 	/** All bits of the bit field structure


### PR DESCRIPTION
This patchset expands pktio and packet spec to allow inner layer parsing, packet identification, checksum generation, validation.
Inner layer API are needed for inner protocol identification, parsing, checksum validation and generation for tunneled packets.
For example, VXLAN tunnel packets will have outer IPv4, IPv6, UDP and then Inner IPv4/IPv6, Inner TCP/UDP. Parsing and checksum generation for both the layers is a must for many usecases.

Also this patchset changes existing behavior of Tx checksum generation dependent on only L3 and L4 offsets in metadata to include L3 and L4 proto's of meta data. For platforms that doesn't support HW parsing of L3 and L4 proto in Tx, platform SW needs to parse them and it effects performance.
Since L3 and L4 offsets are already allowed to be taken from pkt metadata and they are initially filled by Ingress pkt HW parsing,
taking L3 and L4 proto types as well from pkt metadata is beneficial for performance as they are also filled by Ingress pkt HW parsing.
