### PR TITLE
[PATCH v4] validation: cls: get rid of alignment warning

### DIFF
--- a/test/validation/api/classification/odp_classification_common.c
+++ b/test/validation/api/classification/odp_classification_common.c
@@ -253,7 +253,6 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 	uint16_t l3_hdr_len = 0;
 	uint16_t l4_hdr_len = 0;
 	uint16_t eth_type;
-	odp_u16be_t *vlan_type;
 	odph_vlanhdr_t *vlan_hdr;
 	uint8_t src_mac[] = CLS_DEFAULT_SMAC;
 	uint8_t dst_mac[] = CLS_DEFAULT_DMAC;
@@ -282,23 +281,24 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 	ethhdr = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
 	memcpy(ethhdr->src.addr, &src_mac, ODPH_ETHADDR_LEN);
 	memcpy(ethhdr->dst.addr, &dst_mac, ODPH_ETHADDR_LEN);
-	vlan_type = (odp_u16be_t *)(void *)&ethhdr->type;
 	vlan_hdr = (odph_vlanhdr_t *)(ethhdr + 1);
 
-	if (pkt_info.vlan_qinq) {
-		odp_packet_has_vlan_qinq_set(pkt, 1);
-		*vlan_type = odp_cpu_to_be_16(ODPH_ETHTYPE_VLAN_OUTER);
-		vlan_hdr->tci = odp_cpu_to_be_16(0);
-		vlan_type = (uint16_t *)(void *)&vlan_hdr->type;
-		vlan_hdr++;
-	}
 	if (pkt_info.vlan) {
+		if (pkt_info.vlan_qinq) {
+			odp_packet_has_vlan_qinq_set(pkt, 1);
+			ethhdr->type = odp_cpu_to_be_16(ODPH_ETHTYPE_VLAN_OUTER);
+			vlan_hdr->tci = odp_cpu_to_be_16(0);
+			vlan_hdr->type = odp_cpu_to_be_16(ODPH_ETHTYPE_VLAN);
+			vlan_hdr++;
+		} else {
+			ethhdr->type = odp_cpu_to_be_16(ODPH_ETHTYPE_VLAN);
+		}
 		/* Default vlan header */
 		odp_packet_has_vlan_set(pkt, 1);
-		*vlan_type = odp_cpu_to_be_16(ODPH_ETHTYPE_VLAN);
 		vlan_hdr->tci = odp_cpu_to_be_16(0);
 		vlan_hdr->type = odp_cpu_to_be_16(eth_type);
 	} else {
+		CU_ASSERT_FATAL(!pkt_info.vlan_qinq);
 		ethhdr->type = odp_cpu_to_be_16(eth_type);
 	}
 


### PR DESCRIPTION
Rearrange VLAN header building code a little bit to avoid using
address of a packed struct member in a way that loses alignment
information.

v2: fixed checkpatch complaint
v3: added reviewd-by tag
v4: removed an unrelated commit that accidentally slipped in during rebase