### PR TITLE
[PATCH v6] example: script: enhance application run script

### DIFF
--- a/example/generator/Makefile.am
+++ b/example/generator/Makefile.am
@@ -21,7 +21,7 @@ all-local:
 		for f in $(EXTRA_DIST); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/example/ipsec_api/Makefile.am
+++ b/example/ipsec_api/Makefile.am
@@ -48,7 +48,7 @@ all-local:
 		for f in $(dist_check_SCRIPTS); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/example/ipsec_crypto/Makefile.am
+++ b/example/ipsec_crypto/Makefile.am
@@ -46,7 +46,7 @@ all-local:
 		for f in $(dist_check_SCRIPTS); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/example/l2fwd_simple/.gitignore
+++ b/example/l2fwd_simple/.gitignore
@@ -1,3 +1,4 @@
 odp_l2fwd_simple
+pktio_env
 *.log
 *.trs

--- a/example/l2fwd_simple/Makefile.am
+++ b/example/l2fwd_simple/Makefile.am
@@ -20,7 +20,7 @@ all-local:
 		for f in $(EXTRA_DIST); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/example/l2fwd_simple/Makefile.am
+++ b/example/l2fwd_simple/Makefile.am
@@ -24,6 +24,8 @@ all-local:
 			fi \
 		done \
 	fi
+	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/l2fwd_simple/pktio_env \
+		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/l3fwd/.gitignore
+++ b/example/l3fwd/.gitignore
@@ -1,3 +1,4 @@
 odp_l3fwd
+pktio_env
 *.log
 *.trs

--- a/example/l3fwd/Makefile.am
+++ b/example/l3fwd/Makefile.am
@@ -29,6 +29,8 @@ all-local:
 			fi \
 		done \
 	fi
+	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/l3fwd/pktio_env \
+		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/l3fwd/Makefile.am
+++ b/example/l3fwd/Makefile.am
@@ -25,7 +25,7 @@ all-local:
 		for f in $(EXTRA_DIST); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/example/packet/.gitignore
+++ b/example/packet/.gitignore
@@ -1,5 +1,6 @@
 odp_packet_dump
 odp_pktio
+pktio_env
 *.log
 *.trs
 pcapout.pcap

--- a/example/packet/Makefile.am
+++ b/example/packet/Makefile.am
@@ -27,6 +27,8 @@ all-local:
 			fi \
 		done \
 	fi
+	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/packet/pktio_env \
+		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/packet/Makefile.am
+++ b/example/packet/Makefile.am
@@ -23,7 +23,7 @@ all-local:
 		for f in $(EXTRA_DIST); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/example/packet/packet_dump_run.sh
+++ b/example/packet/packet_dump_run.sh
@@ -6,15 +6,23 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
-PCAP_IN=`find . ${TEST_DIR} $(dirname $0) -name udp64.pcap -print -quit`
+if  [ -f ./pktio_env ]; then
+  . ./pktio_env
+else
+  echo "BUG: unable to find pktio_env!"
+  echo "pktio_env has to be in current directory"
+  exit 1
+fi
 
-echo "Packet dump test using PCAP_IN = ${PCAP_IN}"
+setup_interfaces
 
-./odp_packet_dump${EXEEXT} -i pcap:in=${PCAP_IN}:loops=10 -n 10 -o 0 -l 64
+./odp_packet_dump${EXEEXT} -i $IF0 -n 10 -o 0 -l 64
 STATUS=$?
 if [ "$STATUS" -ne 0 ]; then
   echo "Error: status was: $STATUS, expected 0"
   exit 1
 fi
+
+cleanup_interfaces
 
 exit 0

--- a/example/packet/pktio_run.sh
+++ b/example/packet/pktio_run.sh
@@ -6,57 +6,63 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
-PCAP_IN=`find . ${TEST_DIR} $(dirname $0) -name udp64.pcap -print -quit`
-PCAP_OUT="pcapout.pcap"
-PCAP_IN_SIZE=`stat -c %s ${PCAP_IN}`
-echo "using PCAP in=${PCAP_IN}:out=${PCAP_OUT} size %${PCAP_IN_SIZE}"
+if  [ -f ./pktio_env ]; then
+	. ./pktio_env
+else
+        echo "BUG: unable to find pktio_env!"
+        echo "pktio_env has to be in current directory"
+        exit 1
+fi
+
+setup_interfaces
 
 # burst mode
-./odp_pktio${EXEEXT} -ipcap:in=${PCAP_IN}:out=${PCAP_OUT} -t 5 -m 0
+./odp_pktio${EXEEXT} -i $IF1 -t 5 -m 0
 STATUS=$?
-PCAP_OUT_SIZE=`stat -c %s ${PCAP_OUT}`
-rm -f ${PCAP_OUT}
-
-if [ ${STATUS} -ne 0 ] || [ ${PCAP_IN_SIZE} -ne ${PCAP_OUT_SIZE} ]; then
-	echo "Error: status ${STATUS}, in:${PCAP_IN_SIZE} out:${PCAP_OUT_SIZE}"
+if [ ${STATUS} -ne 0 ]; then
+	echo "Error: status ${STATUS}"
 	exit 1
 fi
-echo "Pass -m 0: status ${STATUS}, in:${PCAP_IN_SIZE} out:${PCAP_OUT_SIZE}"
+
+validate_result
+echo "Pass -m 0: status ${STATUS}"
 
 # queue mode
-./odp_pktio${EXEEXT} -ipcap:in=${PCAP_IN}:out=${PCAP_OUT} -t 5 -m 1
+./odp_pktio${EXEEXT} -i $IF1 -t 5 -m 1
 STATUS=$?
-PCAP_OUT_SIZE=`stat -c %s ${PCAP_OUT}`
-rm -f ${PCAP_OUT}
 
-if [ ${STATUS} -ne 0 ] || [ ${PCAP_IN_SIZE} -ne ${PCAP_OUT_SIZE} ]; then
-	echo "Error: status ${STATUS}, in:${PCAP_IN_SIZE} out:${PCAP_OUT_SIZE}"
+if [ ${STATUS} -ne 0 ]; then
+	echo "Error: status ${STATUS}"
 	exit 2
 fi
-echo "Pass -m 1: status ${STATUS}, in:${PCAP_IN_SIZE} out:${PCAP_OUT_SIZE}"
+
+validate_result
+echo "Pass -m 1: status ${STATUS}"
 
 # sched/queue mode
-./odp_pktio${EXEEXT} -ipcap:in=${PCAP_IN}:out=${PCAP_OUT} -t 5 -m 2
+./odp_pktio${EXEEXT} -i $IF1 -t 5 -m 2
 STATUS=$?
-PCAP_OUT_SIZE=`stat -c %s ${PCAP_OUT}`
-rm -f ${PCAP_OUT}
 
-if [ ${STATUS} -ne 0 ] || [ ${PCAP_IN_SIZE} -ne ${PCAP_OUT_SIZE} ]; then
-	echo "Error: status ${STATUS}, in:${PCAP_IN_SIZE} out:${PCAP_OUT_SIZE}"
+if [ ${STATUS} -ne 0 ]; then
+	echo "Error: status ${STATUS}"
 	exit 3
 fi
-echo "Pass -m 2: status ${STATUS}, in:${PCAP_IN_SIZE} out:${PCAP_OUT_SIZE}"
+
+validate_result
+echo "Pass -m 2: status ${STATUS}"
 
 # cpu number option test 1
-./odp_pktio${EXEEXT} -ipcap:in=${PCAP_IN}:out=${PCAP_OUT} -t 5 -m 0 -c 1
+./odp_pktio${EXEEXT} -i $IF1 -t 5 -m 0 -c 1
 STATUS=$?
-PCAP_OUT_SIZE=`stat -c %s ${PCAP_OUT}`
-rm -f ${PCAP_OUT}
 
-if [ ${STATUS} -ne 0 ] || [ ${PCAP_IN_SIZE} -ne ${PCAP_OUT_SIZE} ]; then
-	echo "Error: status ${STATUS}, in:${PCAP_IN_SIZE} out:${PCAP_OUT_SIZE}"
+if [ ${STATUS} -ne 0 ]; then
+	echo "Error: status ${STATUS}"
 	exit 4
 fi
-echo "Pass -m 0 -c 1: status ${STATUS}, in:${PCAP_IN_SIZE} out:${PCAP_OUT_SIZE}"
+
+validate_result
+echo "Pass -m 0 -c 1: status ${STATUS}"
+
+cleanup_interfaces
 
 exit 0

--- a/example/ping/.gitignore
+++ b/example/ping/.gitignore
@@ -1,4 +1,5 @@
 odp_ping
+pktio_env
 *.log
 *.trs
 pcapout.pcap

--- a/example/ping/Makefile.am
+++ b/example/ping/Makefile.am
@@ -20,7 +20,7 @@ all-local:
 		for f in $(EXTRA_DIST); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/example/ping/Makefile.am
+++ b/example/ping/Makefile.am
@@ -24,6 +24,8 @@ all-local:
 			fi \
 		done \
 	fi
+	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/ping/pktio_env \
+		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/simple_pipeline/.gitignore
+++ b/example/simple_pipeline/.gitignore
@@ -1,3 +1,4 @@
 odp_simple_pipeline
+pktio_env
 *.log
 *.trs

--- a/example/simple_pipeline/Makefile.am
+++ b/example/simple_pipeline/Makefile.am
@@ -20,7 +20,7 @@ all-local:
 		for f in $(EXTRA_DIST); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/example/simple_pipeline/Makefile.am
+++ b/example/simple_pipeline/Makefile.am
@@ -24,6 +24,8 @@ all-local:
 			fi \
 		done \
 	fi
+	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/simple_pipeline/pktio_env \
+		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/switch/.gitignore
+++ b/example/switch/.gitignore
@@ -1,3 +1,4 @@
 odp_switch
+pktio_env
 *.log
 *.trs

--- a/example/switch/Makefile.am
+++ b/example/switch/Makefile.am
@@ -24,6 +24,8 @@ all-local:
 			fi \
 		done \
 	fi
+	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/switch/pktio_env \
+		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/switch/Makefile.am
+++ b/example/switch/Makefile.am
@@ -20,7 +20,7 @@ all-local:
 		for f in $(EXTRA_DIST); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/example/switch/switch_run.sh
+++ b/example/switch/switch_run.sh
@@ -6,33 +6,27 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
-NUM_RX_PORT=3
 RETVAL=0
 
-PCAP_IN=`find . ${TEST_DIR} $(dirname $0) -name udp64.pcap -print -quit`
+if  [ -f ./pktio_env ]; then
+  . ./pktio_env
+else
+  echo "BUG: unable to find pktio_env!"
+  echo "pktio_env has to be in current directory"
+  exit 1
+fi
 
-echo "Switch test using PCAP_IN = ${PCAP_IN}"
+setup_interfaces
 
-RX_PORTS=""
-for i in `seq 1 $NUM_RX_PORT`;
-do
-	RX_PORTS="${RX_PORTS},pcap:out=pcapout${i}.pcap"
-done
-
-./odp_switch${EXEEXT} -i pcap:in=${PCAP_IN}${RX_PORTS} -t 1
+./odp_switch${EXEEXT} -i $IF0,$IF1,$IF2,$IF3 -t 1
 STATUS=$?
 if [ "$STATUS" -ne 0 ]; then
   echo "Error: status was: $STATUS, expected 0"
   RETVAL=1
 fi
 
-for i in `seq 1 $NUM_RX_PORT`;
-do
-	if [ `stat -c %s pcapout${i}.pcap` -ne `stat -c %s ${PCAP_IN}` ]; then
-		echo "Error: Output file $i size not matching"
-		RETVAL=1
-	fi
-	rm -f pcapout${i}.pcap
-done
+validate_result
+
+cleanup_interfaces
 
 exit $RETVAL

--- a/helper/test/Makefile.am
+++ b/helper/test/Makefile.am
@@ -50,7 +50,7 @@ all-local:
 		for f in $(dist_check_SCRIPTS); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -43,6 +43,13 @@ AC_CONFIG_FILES([platform/linux-generic/Makefile
 		 platform/linux-generic/libodp-linux.pc
 		 platform/linux-generic/dumpconfig/Makefile
 		 platform/linux-generic/test/Makefile
+		 platform/linux-generic/test/example/Makefile
+		 platform/linux-generic/test/example/l2fwd_simple/Makefile
+		 platform/linux-generic/test/example/l3fwd/Makefile
+		 platform/linux-generic/test/example/packet/Makefile
+		 platform/linux-generic/test/example/ping/Makefile
+		 platform/linux-generic/test/example/simple_pipeline/Makefile
+		 platform/linux-generic/test/example/switch/Makefile
 		 platform/linux-generic/test/validation/api/shmem/Makefile
 		 platform/linux-generic/test/validation/api/pktio/Makefile
 		 platform/linux-generic/test/pktio_ipc/Makefile])

--- a/platform/linux-generic/test/Makefile.am
+++ b/platform/linux-generic/test/Makefile.am
@@ -23,7 +23,8 @@ test_SCRIPTS = $(dist_check_SCRIPTS)
 
 SUBDIRS += validation/api/pktio\
 	  validation/api/shmem\
-	  pktio_ipc
+	  pktio_ipc \
+	  example
 
 if ODP_PKTIO_PCAP
 TESTS += validation/api/pktio/pktio_run_pcap.sh

--- a/platform/linux-generic/test/Makefile.am
+++ b/platform/linux-generic/test/Makefile.am
@@ -73,7 +73,7 @@ all-local:
 		for f in $(dist_check_SCRIPTS); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/platform/linux-generic/test/example/Makefile.am
+++ b/platform/linux-generic/test/example/Makefile.am
@@ -1,0 +1,7 @@
+SUBDIRS = \
+	l2fwd_simple \
+	l3fwd \
+	packet \
+	ping \
+	simple_pipeline \
+	switch

--- a/platform/linux-generic/test/example/l2fwd_simple/Makefile.am
+++ b/platform/linux-generic/test/example/l2fwd_simple/Makefile.am
@@ -1,0 +1,1 @@
+EXTRA_DIST = pktio_env

--- a/platform/linux-generic/test/example/l2fwd_simple/pktio_env
+++ b/platform/linux-generic/test/example/l2fwd_simple/pktio_env
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Copyright (C) 2020, Marvell
+# All rights reserved.
+#
+# SPDX-License-Identifier:	BSD-3-Clause
+#
+# Script to setup interfaces used for running application on linux-generic.
+#
+# For linux-generic the default behavior is to create two pcap interfaces
+# and one interface uses udp64.pcap to inject traffic. An output pcap file
+# is generated via second interface.
+#
+# Network set-up
+# IF0 <---> IF1
+
+PCAP_IN=`find . ${TEST_DIR} $(dirname $0) -name udp64.pcap -print -quit`
+echo "using PCAP_IN = ${PCAP_IN}"
+
+IF0=pcap:in=${PCAP_IN}
+IF1=pcap:out=pcapout.pcap
+
+if [ "$0" = "$BASH_SOURCE" ]; then
+	echo "Error: Platform specific env file has to be sourced."
+fi
+
+validate_result()
+{
+	if [ `stat -c %s pcapout.pcap` -ne `stat -c %s  ${PCAP_IN}` ]; then
+		echo "File sizes disagree"
+		exit 1
+	fi
+
+	rm -f pcapout.pcap
+}
+
+setup_interfaces()
+{
+	echo "pktio: setting up test interfaces $IF0, $IF1."
+	return 0
+}
+
+cleanup_interfaces()
+{
+	echo "pktio: cleaning up test interfaces $IF0, $IF1."
+	return 0
+}

--- a/platform/linux-generic/test/example/l3fwd/Makefile.am
+++ b/platform/linux-generic/test/example/l3fwd/Makefile.am
@@ -1,0 +1,1 @@
+EXTRA_DIST = pktio_env

--- a/platform/linux-generic/test/example/l3fwd/pktio_env
+++ b/platform/linux-generic/test/example/l3fwd/pktio_env
@@ -1,0 +1,51 @@
+#!/bin/sh
+#
+# Copyright (C) 2020, Marvell
+# All rights reserved.
+#
+# SPDX-License-Identifier:	BSD-3-Clause
+#
+# Script to setup interfaces used for running application on linux-generic.
+#
+# For linux-generic the default behavior is to create two pcap interfaces
+# and one interface uses udp64.pcap to inject traffic. An output pcap file
+# is generated via second interface.
+#
+# Network set-up
+# IF0 <---> IF1
+
+PCAP_IN=`find . ${TEST_DIR} $(dirname $0) -name udp64.pcap -print -quit`
+PCAP_OUT="pcapout.pcap"
+PCAP_IN_SIZE=`stat -c %s ${PCAP_IN}`
+echo "using PCAP_IN = ${PCAP_IN}, PCAP_OUT = ${PCAP_OUT}"
+
+IF0=pcap:in=${PCAP_IN}
+IF1=pcap:out=${PCAP_OUT}
+
+if [ "$0" = "$BASH_SOURCE" ]; then
+	echo "Error: Platform specific env file has to be sourced."
+fi
+
+validate_result()
+{
+	PCAP_OUT_SIZE=`stat -c %s ${PCAP_OUT}`
+	if [ ${PCAP_IN_SIZE} -ne ${PCAP_OUT_SIZE} ]; then
+		echo "in:${PCAP_IN_SIZE} out:${PCAP_OUT_SIZE}"
+		exit 1
+	fi
+
+	echo "Pass: in:${PCAP_IN_SIZE} out:${PCAP_OUT_SIZE}"
+	rm -f pcapout.pcap
+}
+
+setup_interfaces()
+{
+	echo "pktio: setting up test interfaces $IF0, $IF1."
+	return 0
+}
+
+cleanup_interfaces()
+{
+	echo "pktio: cleaning up test interfaces $IF0, $IF1."
+	return 0
+}

--- a/platform/linux-generic/test/example/packet/Makefile.am
+++ b/platform/linux-generic/test/example/packet/Makefile.am
@@ -1,0 +1,1 @@
+EXTRA_DIST = pktio_env

--- a/platform/linux-generic/test/example/packet/pktio_env
+++ b/platform/linux-generic/test/example/packet/pktio_env
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Copyright (C) 2020, Marvell
+# All rights reserved.
+#
+# SPDX-License-Identifier:	BSD-3-Clause
+#
+# Script to setup interfaces used for running application on linux-generic.
+#
+# For linux-generic the default behavior is to create two pcap interfaces
+# and one interface uses udp64.pcap to inject traffic. An output pcap file
+# is generated via second interface.
+#
+# Network set-up
+# IF0 <---> IF1
+
+PCAP_IN=`find . ${TEST_DIR} $(dirname $0) -name udp64.pcap -print -quit`
+PCAP_OUT="pcapout.pcap"
+PCAP_IN_SIZE=`stat -c %s ${PCAP_IN}`
+echo "using PCAP in=${PCAP_IN}:out=${PCAP_OUT} size %${PCAP_IN_SIZE}"
+
+IF0=pcap:in=${PCAP_IN}:loops=10
+IF1=pcap:in=${PCAP_IN}:out=${PCAP_OUT}
+
+if [ "$0" = "$BASH_SOURCE" ]; then
+	echo "Error: Platform specific env file has to be sourced."
+fi
+
+validate_result()
+{
+	PCAP_OUT_SIZE=`stat -c %s ${PCAP_OUT}`
+	if [ ${PCAP_IN_SIZE} -ne ${PCAP_OUT_SIZE} ]; then
+		echo "Error: in:${PCAP_IN_SIZE} out:${PCAP_OUT_SIZE}"
+		exit 1
+	fi
+
+	rm -f pcapout.pcap
+}
+
+setup_interfaces()
+{
+	echo "pktio: setting up test interfaces $IF0, $IF1."
+	return 0
+}
+
+cleanup_interfaces()
+{
+	echo "pktio: cleaning up test interfaces $IF0, $IF1."
+	return 0
+}

--- a/platform/linux-generic/test/example/ping/Makefile.am
+++ b/platform/linux-generic/test/example/ping/Makefile.am
@@ -1,0 +1,1 @@
+EXTRA_DIST = pktio_env

--- a/platform/linux-generic/test/example/ping/pktio_env
+++ b/platform/linux-generic/test/example/ping/pktio_env
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Copyright (C) 2020, Marvell
+# All rights reserved.
+#
+# SPDX-License-Identifier:	BSD-3-Clause
+#
+# Script to setup interfaces used for running application on linux-generic.
+#
+# For linux-generic the default behavior is to create two pcap interfaces
+# and one interface uses udp64.pcap to inject traffic. An output pcap file
+# is generated via second interface.
+#
+# Network set-up
+# IF0 <---> IF1
+
+PCAP_IN=`find . ${TEST_DIR} $(dirname $0) -name icmp_echo_req.pcap -print -quit`
+PCAP_OUT="pcapout.pcap"
+PCAP_IN_SIZE=`stat -c %s ${PCAP_IN}`
+echo "using PCAP in=${PCAP_IN}:out=${PCAP_OUT} size %${PCAP_IN_SIZE}"
+
+IF0=pcap:in=${PCAP_IN}:out=${PCAP_OUT}
+
+if [ "$0" = "$BASH_SOURCE" ]; then
+	echo "Error: Platform specific env file has to be sourced."
+fi
+
+validate_result()
+{
+	PCAP_OUT_SIZE=`stat -c %s ${PCAP_OUT}`
+	if [ ${PCAP_IN_SIZE} -ne ${PCAP_OUT_SIZE} ]; then
+		echo "Error: in:${PCAP_IN_SIZE} out:${PCAP_OUT_SIZE}"
+		exit 1
+	fi
+
+	echo "pcap in size:${PCAP_IN_SIZE} pcap out size:${PCAP_OUT_SIZE}"
+	rm -f pcapout.pcap
+}
+
+setup_interfaces()
+{
+	echo "pktio: setting up test interfaces $IF0, $IF1."
+	return 0
+}
+
+cleanup_interfaces()
+{
+	echo "pktio: cleaning up test interfaces $IF0, $IF1."
+	return 0
+}

--- a/platform/linux-generic/test/example/simple_pipeline/Makefile.am
+++ b/platform/linux-generic/test/example/simple_pipeline/Makefile.am
@@ -1,0 +1,1 @@
+EXTRA_DIST = pktio_env

--- a/platform/linux-generic/test/example/simple_pipeline/pktio_env
+++ b/platform/linux-generic/test/example/simple_pipeline/pktio_env
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Copyright (C) 2020, Marvell
+# All rights reserved.
+#
+# SPDX-License-Identifier:	BSD-3-Clause
+#
+# Script to setup interfaces used for running application on linux-generic.
+#
+# For linux-generic the default behavior is to create two pcap interfaces
+# and one interface uses udp64.pcap to inject traffic. An output pcap file
+# is generated via second interface.
+#
+# Network set-up
+# IF0 <---> IF1
+
+PCAP_IN=`find . ${TEST_DIR} $(dirname $0) -name udp64.pcap -print -quit`
+echo "using PCAP_IN = ${PCAP_IN}"
+
+IF0=pcap:in=${PCAP_IN}
+IF1=pcap:out=pcapout.pcap
+
+if [ "$0" = "$BASH_SOURCE" ]; then
+	echo "Error: Platform specific env file has to be sourced."
+fi
+
+validate_result()
+{
+	if [ `stat -c %s pcapout.pcap` -ne `stat -c %s  ${PCAP_IN}` ]; then
+		echo "File sizes disagree"
+		exit 1
+	fi
+
+	rm -f pcapout.pcap
+}
+
+setup_interfaces()
+{
+	echo "pktio: setting up test interfaces $IF0, $IF1."
+	return 0
+}
+
+cleanup_interfaces()
+{
+	echo "pktio: cleaning up test interfaces $IF0, $IF1."
+	return 0
+}

--- a/platform/linux-generic/test/example/switch/Makefile.am
+++ b/platform/linux-generic/test/example/switch/Makefile.am
@@ -1,0 +1,1 @@
+EXTRA_DIST = pktio_env

--- a/platform/linux-generic/test/example/switch/pktio_env
+++ b/platform/linux-generic/test/example/switch/pktio_env
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Copyright (C) 2020, Marvell
+# All rights reserved.
+#
+# SPDX-License-Identifier:	BSD-3-Clause
+#
+# Script to setup interfaces used for running application on linux-generic.
+#
+# For linux-generic the default behavior is to create two pcap interfaces
+# and one interface uses udp64.pcap to inject traffic. An output pcap file
+# is generated via second interface.
+#
+# Network set-up
+# IF0 |---> IF1
+#     |---> IF2
+#     |---> IF3
+
+NUM_RX_PORT=3
+PCAP_IN=`find . ${TEST_DIR} $(dirname $0) -name udp64.pcap -print -quit`
+echo "Switch test using PCAP_IN = ${PCAP_IN}"
+
+IF0=pcap:in=${PCAP_IN}
+IF1=pcap:out=pcapout1.pcap
+IF2=pcap:out=pcapout2.pcap
+IF3=pcap:out=pcapout3.pcap
+
+if [ "$0" = "$BASH_SOURCE" ]; then
+	echo "Error: Platform specific env file has to be sourced."
+fi
+
+validate_result()
+{
+	for i in `seq 1 $NUM_RX_PORT`;
+	do
+		if [ `stat -c %s pcapout${i}.pcap` -ne `stat -c %s ${PCAP_IN}` ]; then
+			echo "Error: Output file $i size not matching"
+		fi
+		rm -f pcapout${i}.pcap
+	done
+}
+
+setup_interfaces()
+{
+	echo "pktio: setting up test interfaces $IF0, $IF1, $IF2, $IF3."
+	return 0
+}
+
+cleanup_interfaces()
+{
+	echo "pktio: cleaning up test interfaces $IF0, $IF1, $IF2, $IF3."
+	return 0
+}

--- a/platform/linux-generic/test/pktio_ipc/Makefile.am
+++ b/platform/linux-generic/test/pktio_ipc/Makefile.am
@@ -19,7 +19,7 @@ all-local:
 		for f in $(dist_check_SCRIPTS); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/platform/linux-generic/test/validation/api/pktio/Makefile.am
+++ b/platform/linux-generic/test/validation/api/pktio/Makefile.am
@@ -23,7 +23,7 @@ all-local:
 		for f in $(dist_check_SCRIPTS); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi

--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -71,7 +71,7 @@ all-local:
 		for f in $(dist_check_SCRIPTS) $(dist_check_DATA); do \
 			if [ -e $(srcdir)/$$f ]; then \
 				mkdir -p $(builddir)/$$(dirname $$f); \
-				cp $(srcdir)/$$f $(builddir)/$$f; \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
 			fi \
 		done \
 	fi


### PR DESCRIPTION
Currently example applications uses pcap based pktio to validate the
functionality on linux-generic platform during make check but other
platforms may not be supporting pcap interfaces as pktio.

So example application's run scripts are enhanced to use generic framework
to define pktio interfaces and corresponding interface environment scripts
are placed under platform implementation.

Signed-off-by: Sunil Kumar Kori <skori@marvell.com>