### PR TITLE
[PATCH v3] test: performance: add odp_sys_info_print() to all performance tests

### DIFF
--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -1064,6 +1064,8 @@ int main(int argc, char *argv[])
 	/* Init this thread */
 	odp_init_local(instance, ODP_THREAD_WORKER);
 
+	odp_sys_info_print();
+
 	if (odp_crypto_capability(&crypto_capa)) {
 		app_err("Crypto capability request failed.\n");
 		exit(EXIT_FAILURE);

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -1051,6 +1051,8 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	}
 
+	odp_sys_info_print();
+
 	if (odp_pool_capability(&capa)) {
 		app_err("Pool capability request failed.\n");
 		exit(EXIT_FAILURE);

--- a/test/performance/odp_packet_gen.c
+++ b/test/performance/odp_packet_gen.c
@@ -1545,6 +1545,8 @@ int main(int argc, char **argv)
 		goto term;
 	}
 
+	odp_sys_info_print();
+
 	odp_schedule_config(NULL);
 
 	if (set_num_cpu(global)) {

--- a/test/performance/odp_pktio_perf.c
+++ b/test/performance/odp_pktio_perf.c
@@ -1058,6 +1058,8 @@ int main(int argc, char **argv)
 	if (odp_init_local(instance, ODP_THREAD_CONTROL) != 0)
 		ODPH_ABORT("Failed local init.\n");
 
+	odp_sys_info_print();
+
 	shm = odp_shm_reserve("test_globals",
 			      sizeof(test_globals_t), ODP_CACHE_LINE_SIZE, 0);
 	if (shm == ODP_SHM_INVALID)

--- a/test/performance/odp_pool_perf.c
+++ b/test/performance/odp_pool_perf.c
@@ -547,6 +547,8 @@ int main(int argc, char **argv)
 		return -1;
 	}
 
+	odp_sys_info_print();
+
 	if (set_num_cpu(global))
 		return -1;
 

--- a/test/performance/odp_queue_perf.c
+++ b/test/performance/odp_queue_perf.c
@@ -513,7 +513,7 @@ static void print_stat(test_global_t *global)
 	printf("------------------------------------------\n");
 	printf("  duration:                 %.3f msec\n", nsec_ave / 1000000);
 	printf("  num cycles:               %.3f M\n", cycles_ave / 1000000);
-	printf("  evenst per dequeue:       %.3f\n",
+	printf("  events per dequeue:       %.3f\n",
 	       events_ave / rounds_ave);
 	printf("  cycles per event:         %.3f\n",
 	       cycles_ave / events_ave);

--- a/test/performance/odp_queue_perf.c
+++ b/test/performance/odp_queue_perf.c
@@ -560,6 +560,8 @@ int main(int argc, char **argv)
 	if (parse_options(argc, argv, &global->options))
 		return -1;
 
+	odp_sys_info_print();
+
 	global->instance = instance;
 
 	if (create_queues(global)) {

--- a/test/performance/odp_sched_perf.c
+++ b/test/performance/odp_sched_perf.c
@@ -1114,6 +1114,8 @@ int main(int argc, char **argv)
 		return -1;
 	}
 
+	odp_sys_info_print();
+
 	if (global->test_options.ctx_size) {
 		uint64_t size = global->test_options.ctx_size *
 				global->test_options.tot_queue;

--- a/test/performance/odp_timer_perf.c
+++ b/test/performance/odp_timer_perf.c
@@ -704,6 +704,8 @@ int main(int argc, char **argv)
 		return -1;
 	}
 
+	odp_sys_info_print();
+
 	odp_schedule_config(NULL);
 
 	if (set_num_cpu(global))


### PR DESCRIPTION
The first patch adds the odp_sys_info_print() to all the performance tests which currently do not display this info. The ODP system info contains important information such as CPU model, frequency, cache etc. which is needed to correctly analyze and interpret the results, especially those which are given in terms of CPU cycles. As of now, this information is shown for only half of the performance tests.
The second patch fixes a spelling error found in the results of the queue performance test.