### PR TITLE
[PATCH v2] test: packet_gen: add random packet length option

### DIFF
--- a/test/performance/odp_packet_gen.c
+++ b/test/performance/odp_packet_gen.c
@@ -1514,13 +1514,13 @@ int main(int argc, char **argv)
 	/* Init ODP before calling anything else */
 	if (odp_init_global(&instance, &init, NULL)) {
 		printf("Error: Global init failed.\n");
-		return -1;
+		return 1;
 	}
 
 	/* Init this thread */
 	if (odp_init_local(instance, ODP_THREAD_CONTROL)) {
 		printf("Error: Local init failed.\n");
-		return -1;
+		return 1;
 	}
 
 	shm = odp_shm_reserve("packet_gen_global", sizeof(test_global_t),
@@ -1528,7 +1528,7 @@ int main(int argc, char **argv)
 
 	if (shm == ODP_SHM_INVALID) {
 		printf("Error: SHM reserve failed.\n");
-		return -1;
+		return 1;
 	}
 
 	global = odp_shm_addr(shm);
@@ -1541,7 +1541,7 @@ int main(int argc, char **argv)
 		global->thread_arg[i].global = global;
 
 	if (parse_options(argc, argv, global)) {
-		ret = -1;
+		ret = 1;
 		goto term;
 	}
 
@@ -1550,17 +1550,17 @@ int main(int argc, char **argv)
 	odp_schedule_config(NULL);
 
 	if (set_num_cpu(global)) {
-		ret = -1;
+		ret = 1;
 		goto term;
 	}
 
 	if (open_pktios(global)) {
-		ret = -1;
+		ret = 1;
 		goto term;
 	}
 
 	if (start_pktios(global)) {
-		ret = -1;
+		ret = 1;
 		goto term;
 	}
 
@@ -1579,30 +1579,30 @@ int main(int argc, char **argv)
 			 global->test_options.num_cpu);
 
 	if (stop_pktios(global))
-		ret = -1;
+		ret = 1;
 
 	drain_queues(global);
 
 	if (close_pktios(global))
-		ret = -1;
+		ret = 1;
 
 	if (print_final_stat(global))
-		ret = -2;
+		ret = 2;
 
 term:
 	if (odp_shm_free(shm)) {
 		printf("Error: SHM free failed.\n");
-		return -1;
+		return 1;
 	}
 
 	if (odp_term_local()) {
 		printf("Error: term local failed.\n");
-		return -1;
+		return 1;
 	}
 
 	if (odp_term_global(instance)) {
 		printf("Error: term global failed.\n");
-		return -1;
+		return 1;
 	}
 
 	return ret;

--- a/test/performance/odp_packet_gen_run.sh
+++ b/test/performance/odp_packet_gen_run.sh
@@ -52,10 +52,10 @@ run_packet_gen()
 
 	ret=$?
 
-	if [ $ret -eq -1 ]; then
-		echo "FAIL: test failed"
-	elif [ $ret -eq -2 ]; then
+	if [ $ret -eq 2 ]; then
 		echo "FAIL: too few packets received"
+	elif [ $ret -ne 0 ]; then
+		echo "FAIL: test failed: $ret"
 	fi
 
 	cleanup_pktio_env

--- a/test/performance/odp_packet_gen_run.sh
+++ b/test/performance/odp_packet_gen_run.sh
@@ -48,13 +48,28 @@ run_packet_gen()
 
 	# Runs 500 * 10ms = 5 sec
 	# Sends 500 packets through both interfaces => total 1000 packets
-	odp_packet_gen${EXEEXT} -i $IF0,$IF1 -b 1 -g 10000000 -q 500 -w 10
 
+	# Static packet length
+	odp_packet_gen${EXEEXT} -i $IF0,$IF1 -b 1 -g 10000000 -q 500 -w 10
 	ret=$?
 
 	if [ $ret -eq 2 ]; then
 		echo "FAIL: too few packets received"
-	elif [ $ret -ne 0 ]; then
+	fi
+	if [ $ret -ne 0 ]; then
+		echo "FAIL: test failed: $ret"
+		cleanup_pktio_env
+		exit $ret
+	fi
+
+	# Random packet length
+	odp_packet_gen${EXEEXT} -i $IF0,$IF1 -b 1 -g 10000000 -q 500 -L 60,1514,10 -w 10
+	ret=$?
+
+	if [ $ret -eq 2 ]; then
+		echo "FAIL: too few packets received"
+	fi
+	if [ $ret -ne 0 ]; then
 		echo "FAIL: test failed: $ret"
 	fi
 


### PR DESCRIPTION
Add new packet length range option (-L, --len_range <min,max,bins>) to
enable testing with random packet lengths. To reduce pool size requirement
the length range can be split into even sized bins. Min and max size
packets are always used and one size is selected from each other bin. Bin
value of 0 means that each packet length is used. This option overrides the
standard packet length command line option.