### PR TITLE
[PATCH v3] api: pktio: add pktio capability for skip offset support

### DIFF
--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -540,6 +540,8 @@ typedef union odp_pktio_set_op_t {
 		uint32_t promisc_mode : 1;
 		/** MAC address  */
 		uint32_t mac_addr : 1;
+		/** Per port header offset(skip)set */
+		uint32_t skip_offset : 1;
 	} op;
 	/** All bits of the bit field structure.
 	  * This field can be used to set/clear all flags, or bitwise
@@ -1118,6 +1120,11 @@ int odp_pktio_error_cos_set(odp_pktio_t pktio, odp_cos_t error_cos);
  *
  * @param pktio      Ingress port pktio handle.
  * @param offset     Number of bytes the classifier must skip.
+ *
+ * This option is input to packet input parser/classifier indicating
+ * how many bytes of data should be skipped from start of packet,
+ * before parsing starts. So this option effects all packet input
+ * protocol identification and other offloads.
  *
  * @retval  0 on success
  * @retval <0 on failure

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -497,15 +497,11 @@ int odp_pktio_error_cos_set(odp_pktio_t pktio_in, odp_cos_t error_cos)
 
 int odp_pktio_skip_set(odp_pktio_t pktio_in, uint32_t offset)
 {
-	pktio_entry_t *entry = get_pktio_entry(pktio_in);
+	(void)pktio_in;
+	(void)offset;
 
-	if (entry == NULL) {
-		ODP_ERR("Invalid odp_pktio_t handle\n");
-		return -1;
-	}
-
-	entry->s.cls.skip = offset;
-	return 0;
+	/* Skipping bytes before parsing is not supported */
+	return -ENOTSUP;
 }
 
 int odp_pktio_headroom_set(odp_pktio_t pktio_in, uint32_t headroom)

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1445,9 +1445,12 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 	else
 		ret = single_capability(capa);
 
-	/* The same parser is used for all pktios */
-	if (ret == 0)
+	if (ret == 0) {
+		/* The same parser is used for all pktios */
 		capa->config.parser.layer = ODP_PROTO_LAYER_ALL;
+		/* Header skip is not supported */
+		capa->set_op.op.skip_offset = 0;
+	}
 
 	return ret;
 }

--- a/test/validation/api/classification/odp_classification_tests.c
+++ b/test/validation/api/classification/odp_classification_tests.c
@@ -15,6 +15,7 @@ static odp_pool_t pool_list[CLS_ENTRIES];
 
 static odp_pool_t pool_default;
 static odp_pktio_t pktio_loop;
+static odp_pktio_capability_t pktio_capa;
 static odp_cls_testcase_u tc;
 static int global_num_l2_qos;
 
@@ -52,6 +53,12 @@ int classification_suite_init(void)
 		ret = odp_pool_destroy(pool_default);
 		if (ret)
 			fprintf(stderr, "unable to destroy pool.\n");
+		return -1;
+	}
+
+	ret = odp_pktio_capability(pktio_loop, &pktio_capa);
+	if (ret) {
+		fprintf(stderr, "unable to get pktio capability.\n");
 		return -1;
 	}
 
@@ -769,8 +776,14 @@ static void classification_test_pktio_test(void)
 		test_pktio_pmr_composite_cos();
 }
 
+static int check_capa_skip_offset(void)
+{
+	return pktio_capa.set_op.op.skip_offset;
+}
+
 odp_testinfo_t classification_suite[] = {
-	ODP_TEST_INFO(classification_test_pktio_set_skip),
+	ODP_TEST_INFO_CONDITIONAL(classification_test_pktio_set_skip,
+				  check_capa_skip_offset),
 	ODP_TEST_INFO(classification_test_pktio_set_headroom),
 	ODP_TEST_INFO(classification_test_pktio_configure),
 	ODP_TEST_INFO(classification_test_pktio_test),


### PR DESCRIPTION
api: pktio: add pktio capability for skip offset support

Current odp_pktio_skip_set() is supposed to work on all
platforms. Since this API is HW dependent as it asks ingress
parser to skip X bytes before starting to parse packet for standard
L2/L3 protocols, it may not be supported by every platforms.

Hence adding a set_op capability in packet_io for reporting
if a given platform supports it or not.

Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

