### PR TITLE
[PATCH v6] api: pktio: add pktout no packet refs

### DIFF
--- a/doc/users-guide/users-guide-pktio.adoc
+++ b/doc/users-guide/users-guide-pktio.adoc
@@ -392,6 +392,11 @@ transmitted:
  * contain at least as many data bytes after L3/L4 offsets as the headers
  * indicate. Other data bytes of the packet are ignored for the checksum
  * insertion.
+ *
+ * No packet refs is an offload when set indicates that this pktio
+ * can always free the packet buffer after transmission and need not check
+ * for packet references and application will make sure that a packet
+ * transmitted via this pktio will always have only single reference.
  */
 typedef union odp_pktout_config_opt_t {
 	/** Option flags for packet output */
@@ -419,6 +424,20 @@ typedef union odp_pktout_config_opt_t {
 
 		/** Insert SCTP checksum on packet by default */
 		uint64_t sctp_chksum     : 1;
+
+		/** Packet references not used on packet output
+		 *
+		 * When set, application indicates that it will not transmit
+		 * packet references on this packet IO interface.
+		 * Since every ODP implementation supports it, it is always
+		 * ok to set this flag.
+		 *
+		 * 0: Packet references may be transmitted on the
+		 *    interface (the default value).
+		 * 1: Packet references will not be transmitted on the
+		 *    interface.
+		 */
+		uint64_t no_packet_refs  : 1;
 
 	} bit;
 

--- a/example/l3fwd/odp_l3fwd.c
+++ b/example/l3fwd/odp_l3fwd.c
@@ -128,6 +128,10 @@ static int create_pktio(const char *name, odp_pool_t pool,
 	config.parser.layer = global->cmd_args.error_check ?
 			ODP_PROTO_LAYER_ALL :
 			ODP_PROTO_LAYER_L4;
+
+	/* Provide hint to pktio that packet references are not used */
+	config.pktout.bit.no_packet_refs = 1;
+
 	odp_pktio_config(pktio, &config);
 
 	fwd_pktio->nb_rxq = (int)capa.max_input_queues;

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -414,6 +414,20 @@ typedef union odp_pktout_config_opt_t {
 		/** Insert SCTP checksum on packet by default */
 		uint64_t sctp_chksum     : 1;
 
+		/** Packet references not used on packet output
+		 *
+		 * When set, application indicates that it will not transmit
+		 * packet references on this packet IO interface.
+		 * Since every ODP implementation supports it, it is always
+		 * ok to set this flag.
+		 *
+		 * 0: Packet references may be transmitted on the
+		 *    interface (the default value).
+		 * 1: Packet references will not be transmitted on the
+		 *    interface.
+		 */
+		uint64_t no_packet_refs  : 1;
+
 	} bit;
 
 	/** All bits of the bit field structure

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1450,6 +1450,10 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 		capa->config.parser.layer = ODP_PROTO_LAYER_ALL;
 		/* Header skip is not supported */
 		capa->set_op.op.skip_offset = 0;
+		/* Irrespective of whether we optimize the fast path or not,
+		 * we can report that it is supported.
+		 */
+		capa->config.pktout.bit.no_packet_refs = 1;
 	}
 
 	return ret;

--- a/test/performance/odp_l2fwd.c
+++ b/test/performance/odp_l2fwd.c
@@ -790,6 +790,9 @@ static int create_pktio(const char *dev, int idx, int num_rx, int num_tx,
 		config.pktout.bit.tcp_chksum_ena  = 1;
 	}
 
+	/* Provide hint to pktio that packet references are not used */
+	config.pktout.bit.no_packet_refs = 1;
+
 	odp_pktio_config(pktio, &config);
 
 	if (gbl_args->appl.promisc_mode) {

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1441,6 +1441,9 @@ static void pktio_test_pktio_config(void)
 
 	odp_pktio_config_init(&config);
 
+	/* Indicate packet refs might be used */
+	config.pktout.bit.no_packet_refs = 0;
+
 	CU_ASSERT(config.parser.layer == ODP_PROTO_LAYER_ALL);
 
 	CU_ASSERT(odp_pktio_config(pktio, NULL) == 0);


### PR DESCRIPTION
Currently ODP spec provides support for holding references
to packets and thereby those packets are not freed by platform
after transmission if they have more than one reference.

This support is useful when using stack that needs retransmissions
like TCP or some fragmentation implementations.

Most of the other forwarding/pipeline applications will not be using
this support as they don't hold any references and forward traffic
after packet manipulations.

Since there is a performance hit in some platforms for supporting
ref count update and validation in odp_pktout_send(),
this patch adds support to indicate via pktio config if PKTIO
can optimize the fastpath for case where packets sent for
transmission will not have multiple references and platform/HW
can always free them post transmission.

In our CN9K platform, we are seeing a performance hit of ~8 % with
odp_l2fwd even thought it is not using pkt references.

Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>