### PR TITLE
[PATCH v14] api: ipsec: add IPsec stats

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -320,6 +320,14 @@ typedef struct odp_ipsec_config_t {
 	/** IPSEC outbound processing configuration */
 	odp_ipsec_outbound_config_t outbound;
 
+	/** Enable stats collection
+	 *
+	 *  Default value is false (stats collection disabled).
+	 *
+	 *  @see odp_ipsec_stats(), odp_ipsec_stats_multi()
+	 */
+	odp_bool_t stats_en;
+
 } odp_ipsec_config_t;
 
 /**
@@ -771,6 +779,35 @@ typedef struct odp_ipsec_sa_param_t {
 	};
 
 } odp_ipsec_sa_param_t;
+
+/**
+ * IPSEC stats content
+ */
+typedef struct odp_ipsec_stats_t {
+	/** Number of packets processed successfully */
+	uint64_t success;
+
+	/** Number of packets with protocol errors */
+	uint64_t proto_err;
+
+	/** Number of packets with authentication errors */
+	uint64_t auth_err;
+
+	/** Number of packets with antireplay check failures */
+	uint64_t antireplay_err;
+
+	/** Number of packets with algorithm errors */
+	uint64_t alg_err;
+
+	/** Number of packes with MTU errors */
+	uint64_t mtu_err;
+
+	/** Number of packets with hard lifetime(bytes) expired */
+	uint64_t hard_exp_bytes_err;
+
+	/** Number of packets with hard lifetime(packets) expired */
+	uint64_t hard_exp_pkts_err;
+} odp_ipsec_stats_t;
 
 /**
  * Query IPSEC capabilities
@@ -1642,6 +1679,29 @@ void odp_ipsec_print(void);
  * Print implementation-defined IPSEC SA debug information to the ODP log.
  */
 void odp_ipsec_sa_print(odp_ipsec_sa_t sa);
+
+/**
+ * Get IPSEC stats for the IPSEC SA handle
+ *
+ * @param          sa       IPSEC SA handle
+ * @param[out]     stats    Stats output
+ *
+ * @retval 0 on success
+ * @retval <0 on failure
+ */
+int odp_ipsec_stats(odp_ipsec_sa_t sa, odp_ipsec_stats_t *stats);
+
+/**
+ * Get IPSEC stats for multiple IPSEC SA handles
+ *
+ * @param          sa       Array of IPSEC SA handles
+ * @param[out]     stats    Stats array for output
+ * @param          num      Number of SA handles
+ *
+ * @retval 0 on success
+ * @retval <0 on failure
+ */
+int odp_ipsec_stats_multi(odp_ipsec_sa_t sa[], odp_ipsec_stats_t stats[], int num);
 
 /**
  * @}

--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -190,6 +190,23 @@ struct ipsec_sa_s {
 			};
 		} out;
 	};
+
+	struct {
+		odp_atomic_u64_t proto_err;
+		odp_atomic_u64_t auth_err;
+		odp_atomic_u64_t antireplay_err;
+		odp_atomic_u64_t alg_err;
+		odp_atomic_u64_t mtu_err;
+		odp_atomic_u64_t hard_exp_bytes_err;
+		odp_atomic_u64_t hard_exp_pkts_err;
+
+		/*
+		 * Track error packets after lifetime check is done.
+		 * Required since, the stats tracking lifetime is being
+		 * used for SA success packets stats.
+		 */
+		odp_atomic_u64_t post_lifetime_err_pkts;
+	} stats;
 };
 
 /**
@@ -250,12 +267,12 @@ int _odp_ipsec_sa_stats_precheck(ipsec_sa_t *ipsec_sa,
 				 odp_ipsec_op_status_t *status);
 
 /**
- * Update SA usage statistics, filling respective status for the packet.
+ * Update SA lifetime counters, filling respective status for the packet.
  *
  * @retval <0 if hard limits were breached
  */
-int _odp_ipsec_sa_stats_update(ipsec_sa_t *ipsec_sa, uint32_t len,
-			       odp_ipsec_op_status_t *status);
+int _odp_ipsec_sa_lifetime_update(ipsec_sa_t *ipsec_sa, uint32_t len,
+				  odp_ipsec_op_status_t *status);
 
 /* Run pre-check on sequence number of the packet.
  *
@@ -283,6 +300,12 @@ uint16_t _odp_ipsec_sa_alloc_ipv4_id(ipsec_sa_t *ipsec_sa);
  *           processing
  */
 int _odp_ipsec_try_inline(odp_packet_t *pkt);
+
+/**
+ * Get number of packets successfully processed by the SA
+ *
+ */
+uint64_t _odp_ipsec_sa_stats_pkts(ipsec_sa_t *sa);
 
 /**
  * @}

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -591,7 +591,7 @@ static int ipsec_send_in_one(const ipsec_test_part *part,
 	pkt = ipsec_packet(part->pkt_in);
 
 	memset(&param, 0, sizeof(param));
-	if (!part->lookup) {
+	if (!part->flags.lookup) {
 		param.num_sa = 1;
 		param.sa = &sa;
 	} else {

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -1,5 +1,6 @@
 /* Copyright (c) 2017-2018, Linaro Limited
  * Copyright (c) 2019-2020, Nokia
+ * Copyright (c) 2020, Marvell
  * All rights reserved.
  *
  * SPDX-License-Identifier:	 BSD-3-Clause
@@ -332,12 +333,6 @@ int ipsec_check_esp_aes_gcm_128(void)
 				ODP_AUTH_ALG_AES_GCM, 0);
 }
 
-int ipsec_check_esp_aes_gcm_192(void)
-{
-	return  ipsec_check_esp(ODP_CIPHER_ALG_AES_GCM, 192,
-				ODP_AUTH_ALG_AES_GCM, 0);
-}
-
 int ipsec_check_esp_aes_gcm_256(void)
 {
 	return  ipsec_check_esp(ODP_CIPHER_ALG_AES_GCM, 256,
@@ -378,24 +373,6 @@ int ipsec_check_esp_null_aes_gmac_256(void)
 {
 	return  ipsec_check_esp(ODP_CIPHER_ALG_NULL, 0,
 				ODP_AUTH_ALG_AES_GMAC, 256);
-}
-
-int ipsec_check_esp_aes_ccm_128(void)
-{
-	return  ipsec_check_esp(ODP_CIPHER_ALG_AES_CCM, 128,
-				ODP_AUTH_ALG_AES_CCM, 0);
-}
-
-int ipsec_check_esp_aes_ccm_192(void)
-{
-	return  ipsec_check_esp(ODP_CIPHER_ALG_AES_CCM, 192,
-				ODP_AUTH_ALG_AES_CCM, 0);
-}
-
-int ipsec_check_esp_aes_ccm_256(void)
-{
-	return  ipsec_check_esp(ODP_CIPHER_ALG_AES_CCM, 256,
-				ODP_AUTH_ALG_AES_CCM, 0);
 }
 
 int ipsec_check_esp_chacha20_poly1305(void)

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2017-2018, Linaro Limited
+ * Copyright (c) 2020, Marvell
  * Copyright (c) 2020, Nokia
  * All rights reserved.
  *
@@ -96,7 +97,6 @@ int ipsec_check_esp_aes_cbc_128_sha1(void);
 int ipsec_check_esp_aes_cbc_128_sha256(void);
 int ipsec_check_esp_aes_ctr_128_null(void);
 int ipsec_check_esp_aes_gcm_128(void);
-int ipsec_check_esp_aes_gcm_192(void);
 int ipsec_check_esp_aes_gcm_256(void);
 int ipsec_check_ah_aes_gmac_128(void);
 int ipsec_check_ah_aes_gmac_192(void);
@@ -104,9 +104,6 @@ int ipsec_check_ah_aes_gmac_256(void);
 int ipsec_check_esp_null_aes_gmac_128(void);
 int ipsec_check_esp_null_aes_gmac_192(void);
 int ipsec_check_esp_null_aes_gmac_256(void);
-int ipsec_check_esp_aes_ccm_128(void);
-int ipsec_check_esp_aes_ccm_192(void);
-int ipsec_check_esp_aes_ccm_256(void);
 int ipsec_check_esp_chacha20_poly1305(void);
 
 #endif

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -52,13 +52,19 @@ typedef struct {
 	odp_bool_t lookup;
 	int num_opt;
 	odp_ipsec_out_opt_t opt;
-	int out_pkt;
+	int num_pkt;
 	struct {
 		odp_ipsec_op_status_t status;
-		const ipsec_test_packet *pkt_out;
+		const ipsec_test_packet *pkt_res;
 		odp_proto_l3_type_t l3_type;
 		odp_proto_l4_type_t l4_type;
 	} out[1];
+	struct {
+		odp_ipsec_op_status_t status;
+		const ipsec_test_packet *pkt_res;
+		odp_proto_l3_type_t l3_type;
+		odp_proto_l4_type_t l4_type;
+	} in[1];
 } ipsec_test_part;
 
 void ipsec_sa_param_fill(odp_ipsec_sa_param_t *param,

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -48,8 +48,13 @@ typedef struct {
 #define _ODP_PROTO_L4_TYPE_UNDEF ((odp_proto_l4_type_t)-1)
 
 typedef struct {
-	const ipsec_test_packet *pkt_in;
 	odp_bool_t lookup;
+	odp_bool_t ah;
+} ipsec_test_flags;
+
+typedef struct {
+	const ipsec_test_packet *pkt_in;
+	ipsec_test_flags flags;
 	int num_opt;
 	odp_ipsec_out_opt_t opt;
 	int num_pkt;

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -47,9 +47,18 @@ typedef struct {
 #define _ODP_PROTO_L3_TYPE_UNDEF ((odp_proto_l3_type_t)-1)
 #define _ODP_PROTO_L4_TYPE_UNDEF ((odp_proto_l4_type_t)-1)
 
+enum ipsec_test_stats {
+	IPSEC_TEST_STATS_NONE = 0,
+	IPSEC_TEST_STATS_SUCCESS,
+	IPSEC_TEST_STATS_PROTO_ERR,
+	IPSEC_TEST_STATS_AUTH_ERR,
+};
+
 typedef struct {
+	odp_bool_t display_algo;
 	odp_bool_t lookup;
 	odp_bool_t ah;
+	enum ipsec_test_stats stats;
 } ipsec_test_flags;
 
 typedef struct {

--- a/test/validation/api/ipsec/ipsec_test_in.c
+++ b/test/validation/api/ipsec/ipsec_test_in.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2017-2018, Linaro Limited
+ * Copyright (c) 2020, Marvell
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -25,13 +26,13 @@ static void test_in_ipv4_ah_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -60,13 +61,13 @@ static void test_in_ipv4_ah_sha256_tun_ipv4(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_tun_ipv4_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -95,13 +96,13 @@ static void test_in_ipv4_ah_sha256_tun_ipv6(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_tun_ipv6_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -127,14 +128,14 @@ static void test_in_ipv4_ah_sha256_tun_ipv4_notun(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_tun_ipv4_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  /* It is L4_TYPE_IPV4 */
 			  .l4_type = _ODP_PROTO_L4_TYPE_UNDEF,
-			  .pkt_out = &pkt_ipv4_icmp_0_ipip },
+			  .pkt_res = &pkt_ipv4_icmp_0_ipip },
 		},
 	};
 
@@ -160,13 +161,13 @@ static void test_in_ipv4_esp_null_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -192,13 +193,13 @@ static void test_in_ipv4_esp_aes_cbc_null(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_aes_cbc_null_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -224,13 +225,13 @@ static void test_in_ipv4_esp_aes_cbc_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_aes_cbc_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -256,13 +257,13 @@ static void test_in_ipv4_esp_aes_ctr_null(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_aes_ctr_null_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -289,13 +290,13 @@ static void test_in_ipv4_ah_sha256_lookup(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1,
 		.lookup = 1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -322,13 +323,13 @@ static void test_in_ipv4_esp_null_sha256_lookup(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1,
 		.lookup = 1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -357,13 +358,13 @@ static void test_in_ipv4_esp_null_sha256_tun_ipv4(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_tun_ipv4_null_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -392,13 +393,13 @@ static void test_in_ipv4_esp_null_sha256_tun_ipv6(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_tun_ipv6_null_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -425,13 +426,13 @@ static void test_in_ipv4_esp_udp_null_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_udp_null_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -459,13 +460,13 @@ static void test_in_ipv4_esp_udp_null_sha256_lookup(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_udp_null_sha256_1,
 		.lookup = 1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -492,25 +493,25 @@ static void test_in_ipv4_ah_sha256_noreplay(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
 	ipsec_test_part test_1235 = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1235,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -543,29 +544,29 @@ static void test_in_ipv4_ah_sha256_replay(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
 	test_repl.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1;
-	test_repl.out_pkt = 1;
-	test_repl.out[0].status.error.antireplay = 1;
+	test_repl.num_pkt = 1;
+	test_repl.in[0].status.error.antireplay = 1;
 
 	ipsec_test_part test_1235 = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1235,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -595,25 +596,25 @@ static void test_in_ipv4_esp_null_sha256_noreplay(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
 	ipsec_test_part test_1235 = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1235,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -646,29 +647,43 @@ static void test_in_ipv4_esp_null_sha256_replay(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
+		},
+		.in = {
+			{ .status.warn.all = 0,
+			  .status.error.all = 0,
+			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
+			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
 	test_repl.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1;
-	test_repl.out_pkt = 1;
-	test_repl.out[0].status.error.antireplay = 1;
+	test_repl.num_pkt = 1;
+	test_repl.in[0].status.error.antireplay = 1;
 
 	ipsec_test_part test_1235 = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1235,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
+		},
+		.in = {
+			{ .status.warn.all = 0,
+			  .status.error.all = 0,
+			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
+			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -704,8 +719,8 @@ static void test_in_ipv4_ah_esp_pkt(void)
 	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
 
 	test.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1;
-	test.out_pkt = 1;
-	test.out[0].status.error.proto = 1;
+	test.num_pkt = 1;
+	test.in[0].status.error.proto = 1;
 
 	ipsec_check_in_one(&test, sa);
 
@@ -736,8 +751,8 @@ static void test_in_ipv4_esp_ah_pkt(void)
 	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
 
 	test.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1;
-	test.out_pkt = 1;
-	test.out[0].status.error.proto = 1;
+	test.num_pkt = 1;
+	test.in[0].status.error.proto = 1;
 
 	ipsec_check_in_one(&test, sa);
 
@@ -764,8 +779,8 @@ static void test_in_ipv4_ah_esp_pkt_lookup(void)
 
 	test.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1;
 	test.lookup = 1;
-	test.out_pkt = 1;
-	test.out[0].status.error.sa_lookup = 1;
+	test.num_pkt = 1;
+	test.in[0].status.error.sa_lookup = 1;
 
 	ipsec_check_in_one(&test, ODP_IPSEC_SA_INVALID);
 
@@ -792,8 +807,8 @@ static void test_in_ipv4_esp_ah_pkt_lookup(void)
 
 	test.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1;
 	test.lookup = 1;
-	test.out_pkt = 1;
-	test.out[0].status.error.sa_lookup = 1;
+	test.num_pkt = 1;
+	test.in[0].status.error.sa_lookup = 1;
 
 	ipsec_check_in_one(&test, ODP_IPSEC_SA_INVALID);
 
@@ -819,8 +834,8 @@ static void test_in_ipv4_ah_sha256_bad1(void)
 	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
 
 	test.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1_bad1;
-	test.out_pkt = 1;
-	test.out[0].status.error.auth = 1;
+	test.num_pkt = 1;
+	test.in[0].status.error.auth = 1;
 
 	ipsec_check_in_one(&test, sa);
 
@@ -846,8 +861,8 @@ static void test_in_ipv4_ah_sha256_bad2(void)
 	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
 
 	test.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1_bad2;
-	test.out_pkt = 1;
-	test.out[0].status.error.auth = 1;
+	test.num_pkt = 1;
+	test.in[0].status.error.auth = 1;
 
 	ipsec_check_in_one(&test, sa);
 
@@ -873,8 +888,8 @@ static void test_in_ipv4_esp_null_sha256_bad1(void)
 	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
 
 	test.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1_bad1;
-	test.out_pkt = 1;
-	test.out[0].status.error.auth = 1;
+	test.num_pkt = 1;
+	test.in[0].status.error.auth = 1;
 
 	ipsec_check_in_one(&test, sa);
 
@@ -898,13 +913,13 @@ static void test_in_ipv4_rfc3602_5_esp(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_rfc3602_5_esp,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_rfc3602_5 },
+			  .pkt_res = &pkt_rfc3602_5 },
 		},
 	};
 
@@ -930,13 +945,13 @@ static void test_in_ipv4_rfc3602_6_esp(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_rfc3602_6_esp,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_rfc3602_6 },
+			  .pkt_res = &pkt_rfc3602_6 },
 		},
 	};
 
@@ -965,13 +980,13 @@ static void test_in_ipv4_rfc3602_7_esp(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_rfc3602_7_esp,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_rfc3602_7 },
+			  .pkt_res = &pkt_rfc3602_7 },
 		},
 	};
 
@@ -1000,13 +1015,13 @@ static void test_in_ipv4_rfc3602_8_esp(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_rfc3602_8_esp,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_rfc3602_8 },
+			  .pkt_res = &pkt_rfc3602_8 },
 		},
 	};
 
@@ -1035,13 +1050,13 @@ static void test_in_ipv4_mcgrew_gcm_2_esp(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_mcgrew_gcm_test_2_esp,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_UDP,
-			  .pkt_out = &pkt_mcgrew_gcm_test_2},
+			  .pkt_res = &pkt_mcgrew_gcm_test_2},
 		},
 	};
 
@@ -1070,13 +1085,13 @@ static void test_in_ipv4_mcgrew_gcm_3_esp(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_mcgrew_gcm_test_3_esp,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = _ODP_PROTO_L4_TYPE_UNDEF,
-			  .pkt_out = &pkt_mcgrew_gcm_test_3},
+			  .pkt_res = &pkt_mcgrew_gcm_test_3},
 		},
 	};
 
@@ -1105,13 +1120,13 @@ static void test_in_ipv4_mcgrew_gcm_4_esp(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_mcgrew_gcm_test_4_esp,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_mcgrew_gcm_test_4},
+			  .pkt_res = &pkt_mcgrew_gcm_test_4},
 		},
 	};
 
@@ -1145,13 +1160,13 @@ static void test_in_ipv4_mcgrew_gcm_12_esp(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_mcgrew_gcm_test_12_esp,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_NONE,
 			  .l4_type = _ODP_PROTO_L4_TYPE_UNDEF,
-			  .pkt_out = &pkt_mcgrew_gcm_test_12},
+			  .pkt_res = &pkt_mcgrew_gcm_test_12},
 		},
 	};
 
@@ -1177,13 +1192,13 @@ static void test_in_ipv4_mcgrew_gcm_12_esp_notun(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_mcgrew_gcm_test_12_esp,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_NO_NEXT,
-			  .pkt_out = &pkt_mcgrew_gcm_test_12_notun },
+			  .pkt_res = &pkt_mcgrew_gcm_test_12_notun },
 		},
 	};
 
@@ -1212,13 +1227,13 @@ static void test_in_ipv4_mcgrew_gcm_15_esp(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_mcgrew_gcm_test_15_esp,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_mcgrew_gcm_test_15},
+			  .pkt_res = &pkt_mcgrew_gcm_test_15},
 		},
 	};
 
@@ -1247,13 +1262,13 @@ static void test_in_ipv4_rfc7634_chacha(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_rfc7634_esp,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_rfc7634},
+			  .pkt_res = &pkt_ipv4_rfc7634},
 		},
 	};
 
@@ -1279,13 +1294,13 @@ static void test_in_ipv4_ah_aes_gmac_128(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_aes_gmac_128_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -1311,13 +1326,13 @@ static void test_in_ipv4_esp_null_aes_gmac_128(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_aes_gmac_128_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -1343,13 +1358,13 @@ static void test_in_ipv6_ah_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_ah_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV6,
-			  .pkt_out = &pkt_ipv6_icmp_0 },
+			  .pkt_res = &pkt_ipv6_icmp_0 },
 		},
 	};
 
@@ -1378,13 +1393,13 @@ static void test_in_ipv6_ah_sha256_tun_ipv4(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_ah_tun_ipv4_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV6,
-			  .pkt_out = &pkt_ipv6_icmp_0 },
+			  .pkt_res = &pkt_ipv6_icmp_0 },
 		},
 	};
 
@@ -1413,13 +1428,13 @@ static void test_in_ipv6_ah_sha256_tun_ipv6(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_ah_tun_ipv6_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV6,
-			  .pkt_out = &pkt_ipv6_icmp_0 },
+			  .pkt_res = &pkt_ipv6_icmp_0 },
 		},
 	};
 
@@ -1445,13 +1460,13 @@ static void test_in_ipv6_esp_null_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_esp_null_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV6,
-			  .pkt_out = &pkt_ipv6_icmp_0 },
+			  .pkt_res = &pkt_ipv6_icmp_0 },
 		},
 	};
 
@@ -1480,13 +1495,13 @@ static void test_in_ipv6_esp_null_sha256_tun_ipv4(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_esp_tun_ipv4_null_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV6,
-			  .pkt_out = &pkt_ipv6_icmp_0 },
+			  .pkt_res = &pkt_ipv6_icmp_0 },
 		},
 	};
 
@@ -1515,13 +1530,13 @@ static void test_in_ipv6_esp_null_sha256_tun_ipv6(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_esp_tun_ipv6_null_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV6,
-			  .pkt_out = &pkt_ipv6_icmp_0 },
+			  .pkt_res = &pkt_ipv6_icmp_0 },
 		},
 	};
 
@@ -1548,13 +1563,13 @@ static void test_in_ipv6_esp_udp_null_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_esp_udp_null_sha256_1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV6,
-			  .pkt_out = &pkt_ipv6_icmp_0 },
+			  .pkt_res = &pkt_ipv6_icmp_0 },
 		},
 	};
 
@@ -1582,13 +1597,13 @@ static void test_in_ipv6_esp_udp_null_sha256_lookup(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_esp_udp_null_sha256_1,
 		.lookup = 1,
-		.out_pkt = 1,
-		.out = {
+		.num_pkt = 1,
+		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV6,
-			  .pkt_out = &pkt_ipv6_icmp_0 },
+			  .pkt_res = &pkt_ipv6_icmp_0 },
 		},
 	};
 

--- a/test/validation/api/ipsec/ipsec_test_in.c
+++ b/test/validation/api/ipsec/ipsec_test_in.c
@@ -289,7 +289,9 @@ static void test_in_ipv4_ah_sha256_lookup(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1,
-		.lookup = 1,
+		.flags = {
+			.lookup = 1,
+		},
 		.num_pkt = 1,
 		.in = {
 			{ .status.warn.all = 0,
@@ -322,7 +324,9 @@ static void test_in_ipv4_esp_null_sha256_lookup(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1,
-		.lookup = 1,
+		.flags = {
+			.lookup = 1,
+		},
 		.num_pkt = 1,
 		.in = {
 			{ .status.warn.all = 0,
@@ -459,7 +463,9 @@ static void test_in_ipv4_esp_udp_null_sha256_lookup(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_udp_null_sha256_1,
-		.lookup = 1,
+		.flags = {
+			.lookup = 1,
+		},
 		.num_pkt = 1,
 		.in = {
 			{ .status.warn.all = 0,
@@ -778,7 +784,7 @@ static void test_in_ipv4_ah_esp_pkt_lookup(void)
 	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
 
 	test.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1;
-	test.lookup = 1;
+	test.flags.lookup = 1;
 	test.num_pkt = 1;
 	test.in[0].status.error.sa_lookup = 1;
 
@@ -806,7 +812,7 @@ static void test_in_ipv4_esp_ah_pkt_lookup(void)
 	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
 
 	test.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1;
-	test.lookup = 1;
+	test.flags.lookup = 1;
 	test.num_pkt = 1;
 	test.in[0].status.error.sa_lookup = 1;
 
@@ -1596,7 +1602,9 @@ static void test_in_ipv6_esp_udp_null_sha256_lookup(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_esp_udp_null_sha256_1,
-		.lookup = 1,
+		.flags = {
+			.lookup = 1,
+		},
 		.num_pkt = 1,
 		.in = {
 			{ .status.warn.all = 0,

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -123,11 +123,11 @@ static void test_out_ipv4_ah_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv4_icmp_0_ah_sha256_1 },
+			  .pkt_res = &pkt_ipv4_icmp_0_ah_sha256_1 },
 		},
 	};
 
@@ -167,11 +167,11 @@ static void test_out_ipv4_ah_sha256_tun_ipv4(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv4_icmp_0_ah_tun_ipv4_sha256_1 },
+			  .pkt_res = &pkt_ipv4_icmp_0_ah_tun_ipv4_sha256_1 },
 		},
 	};
 
@@ -212,11 +212,11 @@ static void test_out_ipv4_ah_sha256_tun_ipv6(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv4_icmp_0_ah_tun_ipv6_sha256_1 },
+			  .pkt_res = &pkt_ipv4_icmp_0_ah_tun_ipv6_sha256_1 },
 		},
 	};
 
@@ -242,11 +242,11 @@ static void test_out_ipv4_esp_null_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv4_icmp_0_esp_null_sha256_1 },
+			  .pkt_res = &pkt_ipv4_icmp_0_esp_null_sha256_1 },
 		},
 	};
 
@@ -281,11 +281,11 @@ static void test_out_ipv4_esp_null_sha256_tun_ipv4(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out =
+			  .pkt_res =
 				  &pkt_ipv4_icmp_0_esp_tun_ipv4_null_sha256_1 },
 		},
 	};
@@ -327,11 +327,11 @@ static void test_out_ipv4_esp_null_sha256_tun_ipv6(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out =
+			  .pkt_res =
 				  &pkt_ipv4_icmp_0_esp_tun_ipv6_null_sha256_1 },
 		},
 	};
@@ -375,13 +375,20 @@ static void test_out_in_common(odp_bool_t ah,
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_out = &pkt_ipv4_icmp_0 },
+			  .pkt_res = &pkt_ipv4_icmp_0 },
+		},
+		.in = {
+			{ .status.warn.all = 0,
+			  .status.error.all = 0,
+			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
+			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
+			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
 	};
 
@@ -471,11 +478,11 @@ static void test_out_ipv4_esp_udp_null_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv4_icmp_0_esp_udp_null_sha256_1 },
+			  .pkt_res = &pkt_ipv4_icmp_0_esp_udp_null_sha256_1 },
 		},
 	};
 
@@ -531,15 +538,15 @@ static void test_out_ipv4_ah_sha256_frag_check(void)
 	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
 
 	test.pkt_in = &pkt_ipv4_icmp_0;
-	test.out_pkt = 1;
+	test.num_pkt = 1;
 	test.out[0].status.error.mtu = 1;
 
 	test2.pkt_in = &pkt_ipv4_icmp_0;
 	test2.num_opt = 1;
 	test2.opt.flag.frag_mode = 1;
 	test2.opt.frag_mode = ODP_IPSEC_FRAG_DISABLED;
-	test2.out_pkt = 1;
-	test2.out[0].pkt_out = &pkt_ipv4_icmp_0_ah_sha256_1;
+	test2.num_pkt = 1;
+	test2.out[0].pkt_res = &pkt_ipv4_icmp_0_ah_sha256_1;
 
 	ipsec_check_out_one(&test, sa);
 
@@ -569,16 +576,16 @@ static void test_out_ipv4_ah_sha256_frag_check_2(void)
 	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
 
 	test.pkt_in = &pkt_ipv4_icmp_0;
-	test.out_pkt = 1;
+	test.num_pkt = 1;
 	test.out[0].status.error.mtu = 1;
 
 	ipsec_test_part test2 = {
 		.pkt_in = &pkt_ipv4_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv4_icmp_0_ah_sha256_1 },
+			  .pkt_res = &pkt_ipv4_icmp_0_ah_sha256_1 },
 		},
 	};
 
@@ -615,15 +622,15 @@ static void test_out_ipv4_esp_null_sha256_frag_check(void)
 	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
 
 	test.pkt_in = &pkt_ipv4_icmp_0;
-	test.out_pkt = 1;
+	test.num_pkt = 1;
 	test.out[0].status.error.mtu = 1;
 
 	test2.pkt_in = &pkt_ipv4_icmp_0;
 	test2.num_opt = 1;
 	test2.opt.flag.frag_mode = 1;
 	test2.opt.frag_mode = ODP_IPSEC_FRAG_DISABLED;
-	test2.out_pkt = 1;
-	test2.out[0].pkt_out = &pkt_ipv4_icmp_0_esp_null_sha256_1;
+	test2.num_pkt = 1;
+	test2.out[0].pkt_res = &pkt_ipv4_icmp_0_esp_null_sha256_1;
 
 	ipsec_check_out_one(&test, sa);
 
@@ -654,16 +661,16 @@ static void test_out_ipv4_esp_null_sha256_frag_check_2(void)
 	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
 
 	test.pkt_in = &pkt_ipv4_icmp_0;
-	test.out_pkt = 1;
+	test.num_pkt = 1;
 	test.out[0].status.error.mtu = 1;
 
 	ipsec_test_part test2 = {
 		.pkt_in = &pkt_ipv4_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv4_icmp_0_esp_null_sha256_1 },
+			  .pkt_res = &pkt_ipv4_icmp_0_esp_null_sha256_1 },
 		},
 	};
 
@@ -693,11 +700,11 @@ static void test_out_ipv6_ah_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv6_icmp_0_ah_sha256_1 },
+			  .pkt_res = &pkt_ipv6_icmp_0_ah_sha256_1 },
 		},
 	};
 
@@ -732,11 +739,11 @@ static void test_out_ipv6_ah_sha256_tun_ipv4(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv6_icmp_0_ah_tun_ipv4_sha256_1 },
+			  .pkt_res = &pkt_ipv6_icmp_0_ah_tun_ipv4_sha256_1 },
 		},
 	};
 
@@ -777,11 +784,11 @@ static void test_out_ipv6_ah_sha256_tun_ipv6(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv6_icmp_0_ah_tun_ipv6_sha256_1 },
+			  .pkt_res = &pkt_ipv6_icmp_0_ah_tun_ipv6_sha256_1 },
 		},
 	};
 
@@ -807,11 +814,11 @@ static void test_out_ipv6_esp_null_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv6_icmp_0_esp_null_sha256_1 },
+			  .pkt_res = &pkt_ipv6_icmp_0_esp_null_sha256_1 },
 		},
 	};
 
@@ -846,11 +853,11 @@ static void test_out_ipv6_esp_null_sha256_tun_ipv4(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out =
+			  .pkt_res =
 				  &pkt_ipv6_icmp_0_esp_tun_ipv4_null_sha256_1 },
 		},
 	};
@@ -892,11 +899,11 @@ static void test_out_ipv6_esp_null_sha256_tun_ipv6(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out =
+			  .pkt_res =
 				  &pkt_ipv6_icmp_0_esp_tun_ipv6_null_sha256_1 },
 		},
 	};
@@ -924,11 +931,11 @@ static void test_out_ipv6_esp_udp_null_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv6_icmp_0_esp_udp_null_sha256_1 },
+			  .pkt_res = &pkt_ipv6_icmp_0_esp_udp_null_sha256_1 },
 		},
 	};
 
@@ -986,7 +993,7 @@ static void test_out_dummy_esp_null_sha256_tun_ipv4(void)
 	test.num_opt = 1;
 	test.opt .flag.tfc_dummy = 1;
 	test.opt.tfc_pad_len = 16;
-	test.out_pkt = 1;
+	test.num_pkt = 1;
 	test.out[0].l3_type = ODP_PROTO_L3_TYPE_IPV4;
 	test.out[0].l4_type = ODP_PROTO_L4_TYPE_NO_NEXT;
 
@@ -994,7 +1001,7 @@ static void test_out_dummy_esp_null_sha256_tun_ipv4(void)
 	test_empty.num_opt = 1;
 	test_empty.opt.flag.tfc_dummy = 1;
 	test_empty.opt.tfc_pad_len = 16;
-	test_empty.out_pkt = 1;
+	test_empty.num_pkt = 1;
 	test_empty.out[0].l3_type = ODP_PROTO_L3_TYPE_IPV4;
 	test_empty.out[0].l4_type = ODP_PROTO_L4_TYPE_NO_NEXT;
 
@@ -1060,7 +1067,7 @@ static void test_out_dummy_esp_null_sha256_tun_ipv6(void)
 	test.num_opt = 1;
 	test.opt .flag.tfc_dummy = 1;
 	test.opt.tfc_pad_len = 16;
-	test.out_pkt = 1;
+	test.num_pkt = 1;
 	test.out[0].l3_type = ODP_PROTO_L3_TYPE_IPV4;
 	test.out[0].l4_type = ODP_PROTO_L4_TYPE_NO_NEXT;
 
@@ -1068,7 +1075,7 @@ static void test_out_dummy_esp_null_sha256_tun_ipv6(void)
 	test_empty.num_opt = 1;
 	test_empty.opt.flag.tfc_dummy = 1;
 	test_empty.opt.tfc_pad_len = 16;
-	test_empty.out_pkt = 1;
+	test_empty.num_pkt = 1;
 	test_empty.out[0].l3_type = ODP_PROTO_L3_TYPE_IPV4;
 	test_empty.out[0].l4_type = ODP_PROTO_L4_TYPE_NO_NEXT;
 
@@ -1096,11 +1103,11 @@ static void test_out_ipv4_udp_esp_null_sha256(void)
 
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_udp,
-		.out_pkt = 1,
+		.num_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
-			  .pkt_out = &pkt_ipv4_udp_esp_null_sha256 },
+			  .pkt_res = &pkt_ipv4_udp_esp_null_sha256 },
 		},
 	};
 

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -341,7 +341,7 @@ static void test_out_ipv4_esp_null_sha256_tun_ipv6(void)
 	ipsec_sa_destroy(sa);
 }
 
-static void test_out_in_common(odp_bool_t ah,
+static void test_out_in_common(ipsec_test_flags *flags,
 			       odp_cipher_alg_t cipher,
 			       const odp_crypto_key_t *cipher_key,
 			       odp_auth_alg_t auth,
@@ -354,7 +354,7 @@ static void test_out_in_common(odp_bool_t ah,
 	odp_ipsec_sa_t sa_in;
 
 	ipsec_sa_param_fill(&param,
-			    false, ah, 123, NULL,
+			    false, flags->ah, 123, NULL,
 			    cipher, cipher_key,
 			    auth, auth_key,
 			    cipher_key_extra, auth_key_extra);
@@ -364,7 +364,7 @@ static void test_out_in_common(odp_bool_t ah,
 	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa_out);
 
 	ipsec_sa_param_fill(&param,
-			    true, ah, 123, NULL,
+			    true, flags->ah, 123, NULL,
 			    cipher, cipher_key,
 			    auth, auth_key,
 			    cipher_key_extra, auth_key_extra);
@@ -403,6 +403,7 @@ static void test_esp_out_in(struct cipher_param *cipher,
 {
 	int cipher_keylen = cipher->key ? 8 * cipher->key->length : 0;
 	int auth_keylen = auth->key ? 8 * auth->key->length : 0;
+	ipsec_test_flags flags;
 
 	if (ipsec_check_esp(cipher->algo, cipher_keylen,
 			    auth->algo, auth_keylen) != ODP_TEST_ACTIVE)
@@ -411,8 +412,10 @@ static void test_esp_out_in(struct cipher_param *cipher,
 	printf("\n    %s (keylen %d) %s (keylen %d) ",
 	       cipher->name, cipher_keylen, auth->name, auth_keylen);
 
-	test_out_in_common(false /* ESP */,
-			   cipher->algo, cipher->key,
+	memset(&flags, 0, sizeof(flags));
+	flags.ah = false;
+
+	test_out_in_common(&flags, cipher->algo, cipher->key,
 			   auth->algo, auth->key,
 			   cipher->key_extra, auth->key_extra);
 }
@@ -439,14 +442,17 @@ static void test_esp_out_in_all(void)
 static void test_ah_out_in(struct auth_param *auth)
 {
 	int auth_keylen = auth->key ? 8 * auth->key->length : 0;
+	ipsec_test_flags flags;
 
 	if (ipsec_check_ah(auth->algo, auth_keylen) != ODP_TEST_ACTIVE)
 		return;
 
 	printf("\n    %s (keylen %d) ", auth->name, auth_keylen);
 
-	test_out_in_common(true /* AH */,
-			   ODP_CIPHER_ALG_NULL, NULL,
+	memset(&flags, 0, sizeof(flags));
+	flags.ah = true;
+
+	test_out_in_common(&flags, ODP_CIPHER_ALG_NULL, NULL,
 			   auth->algo, auth->key,
 			   NULL, auth->key_extra);
 }
@@ -493,24 +499,36 @@ static void test_out_ipv4_esp_udp_null_sha256(void)
 
 static void test_out_ipv4_ah_aes_gmac_128(void)
 {
-	test_out_in_common(true,
-			   ODP_CIPHER_ALG_NULL, NULL,
+	ipsec_test_flags flags;
+
+	memset(&flags, 0, sizeof(flags));
+	flags.ah = true;
+
+	test_out_in_common(&flags, ODP_CIPHER_ALG_NULL, NULL,
 			   ODP_AUTH_ALG_AES_GMAC, &key_a5_128,
 			   NULL, &key_mcgrew_gcm_salt_2);
 }
 
 static void test_out_ipv4_ah_aes_gmac_192(void)
 {
-	test_out_in_common(true,
-			   ODP_CIPHER_ALG_NULL, NULL,
+	ipsec_test_flags flags;
+
+	memset(&flags, 0, sizeof(flags));
+	flags.ah = true;
+
+	test_out_in_common(&flags, ODP_CIPHER_ALG_NULL, NULL,
 			   ODP_AUTH_ALG_AES_GMAC, &key_a5_192,
 			   NULL, &key_mcgrew_gcm_salt_2);
 }
 
 static void test_out_ipv4_ah_aes_gmac_256(void)
 {
-	test_out_in_common(true,
-			   ODP_CIPHER_ALG_NULL, NULL,
+	ipsec_test_flags flags;
+
+	memset(&flags, 0, sizeof(flags));
+	flags.ah = true;
+
+	test_out_in_common(&flags, ODP_CIPHER_ALG_NULL, NULL,
 			   ODP_AUTH_ALG_AES_GMAC, &key_a5_256,
 			   NULL, &key_mcgrew_gcm_salt_2);
 }


### PR DESCRIPTION
Add support for IPsec stats collection and reporting. This would allow
applications to use ODP APIs for stats collection and retrieval. Also
implementations can optimize stats reporting, which would otherwise
involve inspecting every packet and updating stats atomically.

Stats collection can be disabled using the 'stats_en' option added in
odp_ipsec_config_t.

Signed-off-by: Anoob Joseph <anoobj@marvell.com>
Signed-off-by: Vidya Velumuri <vvelumuri@marvell.com>