### PR TITLE
[PATCH v6] api: packet vector producer support

### DIFF
--- a/include/odp/api/abi-default/event.h
+++ b/include/odp/api/abi-default/event.h
@@ -25,15 +25,16 @@ typedef _odp_abi_event_t *odp_event_t;
 #define ODP_EVENT_INVALID  ((odp_event_t)0)
 
 typedef enum {
-	ODP_EVENT_BUFFER       = 1,
-	ODP_EVENT_PACKET       = 2,
-	ODP_EVENT_TIMEOUT      = 3,
+	ODP_EVENT_BUFFER = 1,
+	ODP_EVENT_PACKET = 2,
+	ODP_EVENT_TIMEOUT = 3,
 	ODP_EVENT_CRYPTO_COMPL = 4,
-	ODP_EVENT_IPSEC_STATUS = 5
+	ODP_EVENT_IPSEC_STATUS = 5,
+	ODP_EVENT_PACKET_VECTOR = 6
 } odp_event_type_t;
 
 typedef enum {
-	ODP_EVENT_NO_SUBTYPE   = 0,
+	ODP_EVENT_NO_SUBTYPE = 0,
 	ODP_EVENT_PACKET_BASIC = 1,
 	ODP_EVENT_PACKET_CRYPTO = 2,
 	ODP_EVENT_PACKET_IPSEC = 3,

--- a/include/odp/api/abi-default/packet.h
+++ b/include/odp/api/abi-default/packet.h
@@ -19,16 +19,21 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_packet_t;
 /** @internal Dummy  type for strong typing */
 typedef struct { char dummy; /**< *internal Dummy */ } _odp_abi_packet_seg_t;
 
+/** @internal Dummy type for strong typing */
+typedef struct { char dummy; /**< *internal Dummy */ } _odp_abi_packet_vector_t;
+
 /** @ingroup odp_packet
  *  @{
  */
 
 typedef _odp_abi_packet_t *odp_packet_t;
 typedef _odp_abi_packet_seg_t *odp_packet_seg_t;
+typedef _odp_abi_packet_vector_t *odp_packet_vector_t;
 
 #define ODP_PACKET_INVALID        ((odp_packet_t)0)
 #define ODP_PACKET_SEG_INVALID    ((odp_packet_seg_t)0)
 #define ODP_PACKET_OFFSET_INVALID 0xffff
+#define ODP_PACKET_VECTOR_INVALID   ((odp_packet_vector_t)0)
 
 typedef uint8_t odp_proto_l2_type_t;
 

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -285,6 +285,9 @@ typedef struct odp_cls_cos_param {
 
 	/** Back Pressure configuration */
 	odp_bp_param_t bp;
+
+	/** Packet input vector configuration */
+	odp_pktin_vector_config_t vector;
 } odp_cls_cos_param_t;
 
 /**

--- a/include/odp/api/spec/event.h
+++ b/include/odp/api/spec/event.h
@@ -58,6 +58,8 @@ extern "C" {
  *     - Crypto completion event (odp_crypto_compl_t)
  * - ODP_EVENT_IPSEC_STATUS
  *     - IPSEC status update event (odp_ipsec_status_t)
+ * - ODP_EVENT_PACKET_VECTOR
+ *     - Vector of packet events (odp_packet_t) as odp_packet_vector_t
  */
 
 /**

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -177,6 +177,16 @@ extern "C" {
  */
 
 /**
+ * @typedef odp_packet_vector_t
+ * ODP packet vector
+ */
+
+/**
+ * @def ODP_PACKET_VECTOR_INVALID
+ * Invalid packet vector
+ */
+
+/**
  * Protocol
  */
 typedef enum odp_proto_t {
@@ -2024,6 +2034,34 @@ void odp_packet_shaper_len_adjust_set(odp_packet_t pkt, int8_t adj);
  * @see odp_cls_capability_t::max_mark, odp_pmr_create_opt_t::mark, odp_cls_pmr_create_opt()
  */
 uint64_t odp_packet_cls_mark(odp_packet_t pkt);
+
+/*
+ *
+ * Packet vector handling routines
+ * ********************************************************
+ *
+ */
+
+/**
+ * Get packet vector handle from event
+ *
+ * Converts an ODP_EVENT_PACKET_VECTOR type event to a packet vector handle
+ *
+ * @param ev Event handle
+ * @return Packet vector handle
+ *
+ * @see odp_event_type()
+ */
+odp_packet_vector_t odp_packet_vector_from_event(odp_event_t ev);
+
+/**
+ * Convert packet vector handle to event
+ *
+ * @param pktv Packet vector handle
+ *
+ * @return Event handle
+ */
+odp_event_t odp_packet_vector_to_event(odp_packet_vector_t pktv);
 
 /*
  *

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -2063,6 +2063,151 @@ odp_packet_vector_t odp_packet_vector_from_event(odp_event_t ev);
  */
 odp_event_t odp_packet_vector_to_event(odp_packet_vector_t pktv);
 
+/**
+ * Allocate a packet vector from a packet vector pool
+ *
+ * Allocates a packet vector from the specified packet vector pool.
+ * The pool must have been created with the ODP_POOL_VECTOR type.
+ *
+ * @param pool Packet vector pool handle
+ *
+ * @return Handle of allocated packet vector
+ * @retval ODP_PACKET_VECTOR_INVALID  Packet vector could not be allocated
+ *
+ * @note A newly allocated vector shall not contain any packets, instead, alloc
+ * operation shall reserve the space for odp_pool_param_t::vector::max_size packets.
+ */
+odp_packet_vector_t odp_packet_vector_alloc(odp_pool_t pool);
+
+/**
+ * Free packet vector
+ *
+ * Frees the packet vector into the packet vector pool it was allocated from.
+ *
+ * @param pktv Packet vector handle
+ *
+ * @note This API just frees the vector, not any packets inside the vector.
+ * Application can use odp_event_free() to free the vector and packets inside
+ * the vector.
+ */
+void odp_packet_vector_free(odp_packet_vector_t pktv);
+
+/**
+ * Get packet vector table
+ *
+ * Packet vector table is an array of packets (odp_packet_t) stored in
+ * contiguous memory location. Upon completion of this API, the implementation
+ * returns the packet table pointer in pkt_tbl.
+ *
+ * @param      pktv    Packet vector handle
+ * @param[out] pkt_tbl Points to packet vector table
+ *
+ * @return Number of packets available in the vector.
+ *
+ * @note When pktin subsystem is producing the packet vectors,
+ * odp_pktin_vector_config_t::pool shall be used to configure the pool to form
+ * the vector table.
+ *
+ * @note The maximum number of packets this vector can hold is defined by
+ * odp_pool_param_t:vector:max_size. The return value of this function will not
+ * be greater than odp_pool_param_t:vector:max_size
+ *
+ * @note The pkt_tbl points to the packet vector table. Application can edit the
+ * packet handles in the table directly (up to odp_pool_param_t::vector::max_size).
+ * Application must update the size of the table using odp_packet_vector_size_set()
+ * when there is a change in the size of the vector.
+ *
+ * @note Invalid packet handles (ODP_PACKET_INVALID) are not allowed to be
+ * stored in the table to allow consumers of odp_packet_vector_t handle to have
+ * optimized implementation. So consumption of packets in the middle of the
+ * vector would call for moving the remaining packets up to form a contiguous
+ * array of packets and update the size of the new vector using
+ * odp_packet_vector_size_set().
+ *
+ * @note The table memory is backed by a vector pool buffer. The ownership of
+ * the table memory is linked to the ownership of the event. I.e. after sending
+ * the event to a queue, the sender loses ownership to the table also.
+ */
+uint32_t odp_packet_vector_tbl(odp_packet_vector_t pktv, odp_packet_t **pkt_tbl);
+
+/**
+ * Number of packets in a vector
+ *
+ * @param pktv Packet vector handle
+ *
+ * @return The number of packets available in the vector
+ */
+uint32_t odp_packet_vector_size(odp_packet_vector_t pktv);
+
+/**
+ * Set the number of packets stored in a vector
+ *
+ * Update the number of packets stored in a vector. When the application is
+ * producing a packet vector, this function shall be used by the application
+ * to set the number of packets available in this vector.
+ *
+ * @param pktv Packet vector handle
+ * @param size Number of packets in this vector
+ *
+ * @note The maximum number of packets this vector can hold is defined by
+ * odp_pool_param_t::vector::max_size. The size value must not be greater than
+ * odp_pool_param_t::vector::max_size
+ *
+ * @note All handles in the vector table (0 .. size - 1) need to be valid packet
+ * handles.
+ *
+ * @see odp_packet_vector_tbl()
+ *
+ */
+void odp_packet_vector_size_set(odp_packet_vector_t pktv, uint32_t size);
+
+/**
+ * Perform full packet vector validity check
+ *
+ * The operation may consume considerable number of cpu cycles depending on
+ * the check level.
+ *
+ * @param pktv Packet vector handle
+ *
+ * @retval 0 Packet vector is not valid
+ * @retval 1 Packet vector is valid
+ */
+int odp_packet_vector_valid(odp_packet_vector_t pktv);
+
+/**
+ * Packet vector pool
+ *
+ * Returns handle to the packet vector pool where the packet vector was
+ * allocated from.
+ *
+ * @param pktv Packet vector handle
+ *
+ * @return Packet vector pool handle
+ */
+odp_pool_t odp_packet_vector_pool(odp_packet_vector_t pktv);
+
+/**
+ * Print packet vector debug information
+ *
+ * Print all packet vector debug information to ODP log.
+ *
+ * @param pktv Packet vector handle
+ */
+void odp_packet_vector_print(odp_packet_vector_t pktv);
+
+/**
+ * Get printable value for an odp_packet_vector_t
+ *
+ * @param hdl  odp_packet_vector_t handle to be printed
+ *
+ * @return uint64_t value that can be used to print/display this handle
+ *
+ * @note This routine is intended to be used for diagnostic purposes to enable
+ * applications to generate a printable value that represents an
+ * odp_packet_vector_t handle.
+ */
+uint64_t odp_packet_vector_to_u64(odp_packet_vector_t hdl);
+
 /*
  *
  * Debugging

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -160,6 +160,50 @@ typedef struct odp_pktin_queue_param_ovr_t {
 } odp_pktin_queue_param_ovr_t;
 
 /**
+ * Packet input vector configuration
+ */
+typedef struct odp_pktin_vector_config_t {
+	/** Enable packet input vector
+	 *
+	 * When true, packet input vector is enabled and configured with vector
+	 * config parameters. Otherwise, packet input vector configuration
+	 * parameters are ignored.
+	 */
+	odp_bool_t enable;
+
+	/** Vector pool
+	 *
+	 * Vector pool to allocate the vectors to hold packets.
+	 * The pool must have been created with the ODP_POOL_VECTOR type.
+	 */
+	odp_pool_t pool;
+
+	/** Maximum time to wait for packets
+	 *
+	 * Maximum timeout in nanoseconds to wait for the producer to form the
+	 * vector of packet events (odp_packet_vector_t). This value should be
+	 * in the range of odp_pktin_vector_capability_t::min_tmo_ns to
+	 * odp_pktin_vector_capability_t::max_tmo_ns.
+	 */
+	uint64_t max_tmo_ns;
+
+	/** Maximum number of packets in a vector
+	 *
+	 * The packet input subsystem forms packet vector events when either
+	 * it reaches odp_pktin_vector_config_t::max_tmo_ns or producer reaches
+	 * max_size packets. This value should be in the range of
+	 * odp_pktin_vector_capability_t::min_size to
+	 * odp_pktin_vector_capability_t::max_size.
+	 *
+	 * @note The maximum number of packets this vector can hold is defined
+	 * by odp_pool_param_t::vector::max_size with odp_pktin_vector_config_t::pool.
+	 * The max_size should not be greater than odp_pool_param_t::vector::max_size.
+	 */
+	uint32_t max_size;
+
+} odp_pktin_vector_config_t;
+
+/**
  * Packet input queue parameters
  */
 typedef struct odp_pktin_queue_param_t {
@@ -226,6 +270,10 @@ typedef struct odp_pktin_queue_param_t {
 	  * NULL.
 	  */
 	odp_pktin_queue_param_ovr_t *queue_param_ovr;
+
+	/** Packet input vector configuration */
+	odp_pktin_vector_config_t vector;
+
 } odp_pktin_queue_param_t;
 
 /**
@@ -570,6 +618,37 @@ typedef union odp_pktio_set_op_t {
 } odp_pktio_set_op_t;
 
 /**
+ * Packet input vector capabilities
+ */
+typedef struct odp_pktin_vector_capability_t {
+	/** Packet input vector availability */
+	odp_support_t supported;
+
+	/** Maximum number of packets that can be accumulated into a packet
+	 *  vector by a producer
+	 *
+	 * odp_pktin_vector_config_t::max_size should not be greater than this
+	 * value. */
+	uint32_t max_size;
+
+	/** Minimum value allowed to be configured to
+	 * odp_pktin_vector_config_t::max_size */
+	uint32_t min_size;
+
+	/** Maximum timeout in nanoseconds for the producer to wait for the
+	 *  vector of packets
+	 *
+	 * odp_pktin_vector_config_t::max_tmo_ns should not be greater than this
+	 * value. */
+	uint64_t max_tmo_ns;
+
+	/** Minimum value allowed to be configured to
+	 * odp_pktin_vector_config_t::max_tmo_ns */
+	uint64_t min_tmo_ns;
+
+} odp_pktin_vector_capability_t;
+
+/**
  * Packet IO capabilities
  */
 typedef struct odp_pktio_capability_t {
@@ -590,6 +669,10 @@ typedef struct odp_pktio_capability_t {
 
 	/** @deprecated Use enable_loop inside odp_pktin_config_t */
 	odp_bool_t ODP_DEPRECATE(loop_supported);
+
+	/** Packet input vector capability */
+	odp_pktin_vector_capability_t vector;
+
 } odp_pktio_capability_t;
 
 /**

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -181,6 +181,27 @@ typedef struct odp_pool_capability_t {
 		uint32_t max_cache_size;
 	} tmo;
 
+	/** Vector pool capabilities */
+	struct {
+		/** Maximum number of vector pools */
+		unsigned int max_pools;
+
+		/** Maximum number of vector events in a pool
+		 *
+		 * The value of zero means that limited only by the available
+		 * memory size for the pool. */
+		uint32_t max_num;
+
+		/** Maximum number of general types, such as odp_packet_t, in a vector. */
+		uint32_t max_size;
+
+		/** Minimum size of thread local cache */
+		uint32_t min_cache_size;
+
+		/** Maximum size of thread local cache */
+		uint32_t max_cache_size;
+	} vector;
+
 } odp_pool_capability_t;
 
 /**
@@ -359,6 +380,21 @@ typedef struct odp_pool_param_t {
 		uint32_t cache_size;
 	} tmo;
 
+	/** Parameters for vector pools */
+	struct {
+		/** Number of vectors in the pool */
+		uint32_t num;
+
+		/** Maximum number of general types, such as odp_packet_t, in a vector. */
+		uint32_t max_size;
+
+		/** Maximum number of vectors cached locally per thread
+		 *
+		 *  See buf.cache_size documentation for details.
+		 */
+		uint32_t cache_size;
+	} vector;
+
 } odp_pool_param_t;
 
 /** Packet pool*/
@@ -367,6 +403,12 @@ typedef struct odp_pool_param_t {
 #define ODP_POOL_BUFFER       ODP_EVENT_BUFFER
 /** Timeout pool */
 #define ODP_POOL_TIMEOUT      ODP_EVENT_TIMEOUT
+/** Vector pool
+ *
+ * The pool to hold a vector of general type such as odp_packet_t.
+ * Each vector holds an array of generic types of the same type.
+ */
+#define ODP_POOL_VECTOR	      (ODP_POOL_TIMEOUT + 1)
 
 /**
  * Create a pool

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -407,6 +407,7 @@ typedef struct odp_pool_param_t {
  *
  * The pool to hold a vector of general type such as odp_packet_t.
  * Each vector holds an array of generic types of the same type.
+ * @see ODP_EVENT_PACKET_VECTOR
  */
 #define ODP_POOL_VECTOR	      (ODP_POOL_TIMEOUT + 1)
 

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -146,6 +146,7 @@ noinst_HEADERS = \
 		  include/odp_timer_internal.h \
 		  include/odp_timer_wheel_internal.h \
 		  include/odp_traffic_mngr_internal.h \
+		  include/odp_event_vector_internal.h \
 		  include/protocols/eth.h \
 		  include/protocols/ip.h \
 		  include/protocols/ipsec.h \

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -36,6 +36,7 @@ odpapiplatinclude_HEADERS = \
 		  include/odp/api/plat/packet_flag_inlines.h \
 		  include/odp/api/plat/packet_inline_types.h \
 		  include/odp/api/plat/packet_inlines.h \
+		  include/odp/api/plat/packet_vector_inlines.h \
 		  include/odp/api/plat/pktio_inlines.h \
 		  include/odp/api/plat/pool_inline_types.h \
 		  include/odp/api/plat/queue_inlines.h \

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -33,6 +33,7 @@ odpapiplatinclude_HEADERS = \
 		  include/odp/api/plat/byteorder_inlines.h \
 		  include/odp/api/plat/cpu_inlines.h \
 		  include/odp/api/plat/event_inlines.h \
+		  include/odp/api/plat/event_vector_inline_types.h \
 		  include/odp/api/plat/packet_flag_inlines.h \
 		  include/odp/api/plat/packet_inline_types.h \
 		  include/odp/api/plat/packet_inlines.h \

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -188,6 +188,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_libconfig.c \
 			   odp_name_table.c \
 			   odp_packet.c \
+			   odp_packet_vector.c \
 			   odp_packet_flags.c \
 			   odp_packet_io.c \
 			   odp_pkt_queue.c \

--- a/platform/linux-generic/include-abi/odp/api/abi/event.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/event.h
@@ -29,11 +29,12 @@ typedef ODP_HANDLE_T(odp_event_t);
 #define ODP_EVENT_INVALID _odp_cast_scalar(odp_event_t, 0)
 
 typedef enum odp_event_type_t {
-	ODP_EVENT_BUFFER       = 1,
-	ODP_EVENT_PACKET       = 2,
-	ODP_EVENT_TIMEOUT      = 3,
+	ODP_EVENT_BUFFER = 1,
+	ODP_EVENT_PACKET = 2,
+	ODP_EVENT_TIMEOUT = 3,
 	ODP_EVENT_CRYPTO_COMPL = 4,
-	ODP_EVENT_IPSEC_STATUS = 5
+	ODP_EVENT_IPSEC_STATUS = 5,
+	ODP_EVENT_PACKET_VECTOR = 6
 } odp_event_type_t;
 
 typedef enum odp_event_subtype_t {

--- a/platform/linux-generic/include-abi/odp/api/abi/packet.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet.h
@@ -35,6 +35,10 @@ typedef ODP_HANDLE_T(odp_packet_seg_t);
 
 #define ODP_PACKET_SEG_INVALID _odp_cast_scalar(odp_packet_seg_t, 0)
 
+typedef ODP_HANDLE_T(odp_packet_vector_t);
+
+#define ODP_PACKET_VECTOR_INVALID _odp_cast_scalar(odp_packet_vector_t, 0)
+
 #define ODP_PACKET_OFFSET_INVALID 0xffff
 
 typedef uint8_t odp_proto_l2_type_t;

--- a/platform/linux-generic/include-abi/odp/api/abi/packet.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet.h
@@ -123,6 +123,7 @@ typedef struct odp_packet_parse_result_flag_t {
 } odp_packet_parse_result_flag_t;
 
 #include <odp/api/plat/packet_inlines.h>
+#include <odp/api/plat/packet_vector_inlines.h>
 
 /**
  * @}

--- a/platform/linux-generic/include/odp/api/plat/event_vector_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/event_vector_inline_types.h
@@ -1,0 +1,37 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_PLAT_EVENT_VECTOR_INLINE_TYPES_H_
+#define ODP_PLAT_EVENT_VECTOR_INLINE_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+/* Event vector field accessors */
+#define _odp_event_vect_get(vect, cast, field) \
+	(*(cast *)(uintptr_t)((uint8_t *)vect + _odp_event_vector_inline.field))
+#define _odp_event_vect_get_ptr(vect, cast, field) \
+	((cast *)(uintptr_t)((uint8_t *)vect + _odp_event_vector_inline.field))
+
+/* Event vector header field offsets for inline functions */
+typedef struct _odp_event_vector_inline_offset_t {
+	uint16_t packet;
+	uint16_t pool;
+	uint16_t size;
+} _odp_event_vector_inline_offset_t;
+
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ODP_PLAT_EVENT_VECTOR_INLINE_TYPES_H_ */

--- a/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2020, Nokia
+ *
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * Packet vector inline functions
+ */
+
+#ifndef _ODP_PLAT_PACKET_VECTOR_INLINES_H_
+#define _ODP_PLAT_PACKET_VECTOR_INLINES_H_
+
+#include <odp/api/abi/event.h>
+#include <odp/api/abi/packet.h>
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _ODP_NO_INLINE
+	/* Inline functions by default */
+	#define _ODP_INLINE static inline
+	#define odp_packet_vector_from_event __odp_packet_vector_from_event
+	#define odp_packet_vector_to_event __odp_packet_vector_to_event
+#else
+	#undef _ODP_INLINE
+	#define _ODP_INLINE
+#endif
+
+_ODP_INLINE odp_packet_vector_t odp_packet_vector_from_event(odp_event_t ev)
+{
+	return (odp_packet_vector_t)ev;
+}
+
+_ODP_INLINE odp_event_t odp_packet_vector_to_event(odp_packet_vector_t pktv)
+{
+	return (odp_event_t)pktv;
+}
+
+/** @endcond */
+
+#endif

--- a/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
@@ -16,6 +16,12 @@
 
 #include <odp/api/abi/event.h>
 #include <odp/api/abi/packet.h>
+#include <odp/api/abi/pool.h>
+
+#include <odp/api/plat/event_vector_inline_types.h>
+#include <odp/api/plat/pool_inline_types.h>
+
+#include <stdint.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
@@ -24,10 +30,17 @@
 	#define _ODP_INLINE static inline
 	#define odp_packet_vector_from_event __odp_packet_vector_from_event
 	#define odp_packet_vector_to_event __odp_packet_vector_to_event
+	#define odp_packet_vector_tbl __odp_packet_vector_tbl
+	#define odp_packet_vector_pool __odp_packet_vector_pool
+	#define odp_packet_vector_size __odp_packet_vector_size
+	#define odp_packet_vector_size_set __odp_packet_vector_size_set
 #else
 	#undef _ODP_INLINE
 	#define _ODP_INLINE
 #endif
+
+extern const _odp_event_vector_inline_offset_t _odp_event_vector_inline;
+extern const _odp_pool_inline_offset_t _odp_pool_inline;
 
 _ODP_INLINE odp_packet_vector_t odp_packet_vector_from_event(odp_event_t ev)
 {
@@ -37,6 +50,32 @@ _ODP_INLINE odp_packet_vector_t odp_packet_vector_from_event(odp_event_t ev)
 _ODP_INLINE odp_event_t odp_packet_vector_to_event(odp_packet_vector_t pktv)
 {
 	return (odp_event_t)pktv;
+}
+
+_ODP_INLINE uint32_t odp_packet_vector_tbl(odp_packet_vector_t pktv, odp_packet_t **pkt_tbl)
+{
+	*pkt_tbl = _odp_event_vect_get_ptr(pktv, odp_packet_t, packet);
+
+	return _odp_event_vect_get(pktv, uint32_t, size);
+}
+
+_ODP_INLINE odp_pool_t odp_packet_vector_pool(odp_packet_vector_t pktv)
+{
+	void *pool = _odp_event_vect_get(pktv, void *, pool);
+
+	return _odp_pool_get(pool, odp_pool_t, pool_hdl);
+}
+
+_ODP_INLINE uint32_t odp_packet_vector_size(odp_packet_vector_t pktv)
+{
+	return _odp_event_vect_get(pktv, uint32_t, size);
+}
+
+_ODP_INLINE void odp_packet_vector_size_set(odp_packet_vector_t pktv, uint32_t size)
+{
+	uint32_t *vector_size = _odp_event_vect_get_ptr(pktv, uint32_t, size);
+
+	*vector_size = size;
 }
 
 /** @endcond */

--- a/platform/linux-generic/include/odp_classification_datamodel.h
+++ b/platform/linux-generic/include/odp_classification_datamodel.h
@@ -20,6 +20,7 @@ extern "C" {
 
 #include <odp/api/spinlock.h>
 #include <odp/api/classification.h>
+#include <odp/api/debug.h>
 #include <odp_pool_internal.h>
 #include <odp_packet_internal.h>
 #include <odp_packet_io_internal.h>
@@ -28,6 +29,8 @@ extern "C" {
 
 /* Maximum Class Of Service Entry */
 #define CLS_COS_MAX_ENTRY		64
+/* Invalid CoS index */
+#define CLS_COS_IDX_NONE		CLS_COS_MAX_ENTRY
 /* Maximum PMR Entry */
 #define CLS_PMR_MAX_ENTRY		256
 /* Maximum PMR Terms in a PMR Set */
@@ -48,6 +51,9 @@ extern "C" {
 #define CLS_COS_QUEUE_MAX		32
 /* Max number of implementation created queues */
 #define CLS_QUEUE_GROUP_MAX		(CLS_COS_MAX_ENTRY * CLS_COS_QUEUE_MAX)
+
+/* CoS index is stored in odp_packet_hdr_t */
+ODP_STATIC_ASSERT(CLS_COS_MAX_ENTRY <= UINT16_MAX, "CoS_does_not_fit_16_bits");
 
 typedef union {
 	/* All proto fileds */

--- a/platform/linux-generic/include/odp_classification_datamodel.h
+++ b/platform/linux-generic/include/odp_classification_datamodel.h
@@ -129,8 +129,9 @@ typedef struct pmr_term_value {
 Class Of Service
 */
 struct cos_s {
-	odp_queue_t queue;			/* Associated Queue */
+	odp_queue_t queue;		/* Associated Queue */
 	odp_pool_t pool;		/* Associated Buffer pool */
+	odp_pktin_vector_config_t vector;	/* Packet vector config */
 	union pmr_u *pmr[CLS_PMR_PER_COS_MAX];	/* Chained PMR */
 	union cos_u *linked_cos[CLS_PMR_PER_COS_MAX]; /* Chained CoS with PMR*/
 	uint32_t valid;			/* validity Flag */

--- a/platform/linux-generic/include/odp_classification_internal.h
+++ b/platform/linux-generic/include/odp_classification_internal.h
@@ -25,6 +25,8 @@ extern "C" {
 #include <odp_packet_io_internal.h>
 #include <odp_classification_datamodel.h>
 
+cos_t *_odp_cos_entry_from_idx(uint32_t ndx);
+
 /** Classification Internal function **/
 
 /**

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -146,6 +146,9 @@ extern "C" {
  */
 #define CONFIG_POOL_CACHE_MAX_SIZE 256
 
+/* Maximum packet vector size */
+#define CONFIG_PACKET_VECTOR_MAX_SIZE 256
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/include/odp_event_vector_internal.h
+++ b/platform/linux-generic/include/odp_event_vector_internal.h
@@ -40,4 +40,17 @@ static inline odp_event_vector_hdr_t *_odp_packet_vector_hdr(odp_packet_vector_t
 	return (odp_event_vector_hdr_t *)(uintptr_t)pktv;
 }
 
+/**
+ * Free packet vector and contained packets
+ */
+static inline void _odp_packet_vector_free_full(odp_packet_vector_t pktv)
+{
+	odp_event_vector_hdr_t *pktv_hdr = _odp_packet_vector_hdr(pktv);
+
+	if (pktv_hdr->size)
+		odp_packet_free_multi(pktv_hdr->packet, pktv_hdr->size);
+
+	odp_packet_vector_free(pktv);
+}
+
 #endif /* ODP_EVENT_VECTOR_INTERNAL_H_ */

--- a/platform/linux-generic/include/odp_event_vector_internal.h
+++ b/platform/linux-generic/include/odp_event_vector_internal.h
@@ -32,4 +32,12 @@ typedef struct {
 
 } odp_event_vector_hdr_t;
 
+/**
+ * Return the vector header
+ */
+static inline odp_event_vector_hdr_t *_odp_packet_vector_hdr(odp_packet_vector_t pktv)
+{
+	return (odp_event_vector_hdr_t *)(uintptr_t)pktv;
+}
+
 #endif /* ODP_EVENT_VECTOR_INTERNAL_H_ */

--- a/platform/linux-generic/include/odp_event_vector_internal.h
+++ b/platform/linux-generic/include/odp_event_vector_internal.h
@@ -1,0 +1,35 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP event vector descriptor - implementation internal
+ */
+
+#ifndef ODP_EVENT_VECTOR_INTERNAL_H_
+#define ODP_EVENT_VECTOR_INTERNAL_H_
+
+#include <stdint.h>
+#include <odp/api/packet.h>
+#include <odp_buffer_internal.h>
+
+/**
+ * Internal event vector header
+ */
+typedef struct {
+	/* Common buffer header */
+	odp_buffer_hdr_t buf_hdr;
+
+	/* Event vector size */
+	uint32_t size;
+
+	/* Vector of packet handles */
+	odp_packet_t packet[0];
+
+} odp_event_vector_hdr_t;
+
+#endif /* ODP_EVENT_VECTOR_INTERNAL_H_ */

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -126,6 +126,9 @@ typedef struct odp_packet_hdr_t {
 	/* Classifier mark */
 	uint16_t cls_mark;
 
+	/* Classifier handle index */
+	uint16_t cos;
+
 	union {
 		struct {
 			/* Result for crypto packet op */
@@ -235,6 +238,7 @@ static inline void copy_packet_cls_metadata(odp_packet_hdr_t *src_hdr,
 {
 	dst_hdr->p = src_hdr->p;
 	dst_hdr->dst_queue = src_hdr->dst_queue;
+	dst_hdr->cos = src_hdr->cos;
 	dst_hdr->flow_hash = src_hdr->flow_hash;
 	dst_hdr->timestamp = src_hdr->timestamp;
 	dst_hdr->cls_mark  = src_hdr->cls_mark;

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -126,6 +126,7 @@ struct pktio_entry {
 	struct {
 		odp_queue_t        queue;
 		odp_pktin_queue_t  pktin;
+		odp_pktin_vector_config_t vector;
 	} in_queue[PKTIO_MAX_QUEUES];
 
 	struct {

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2019, Nokia
+ * Copyright (c) 2019-2020, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -9,6 +9,7 @@
 #include <odp/api/align.h>
 #include <odp/api/queue.h>
 #include <odp/api/debug.h>
+#include <odp/api/pool.h>
 #include <odp_init_internal.h>
 #include <odp_debug_internal.h>
 #include <odp_packet_internal.h>
@@ -60,6 +61,11 @@ static const rss_key default_rss = {
 	0x6a, 0x42, 0xb7, 0x3b, 0xbe, 0xac, 0x01, 0xfa,
 	}
 };
+
+cos_t *_odp_cos_entry_from_idx(uint32_t ndx)
+{
+	return &cos_tbl->cos_entry[ndx];
+}
 
 static inline uint32_t _odp_cos_to_ndx(odp_cos_t cos)
 {
@@ -138,10 +144,13 @@ int _odp_classification_term_global(void)
 
 void odp_cls_cos_param_init(odp_cls_cos_param_t *param)
 {
+	memset(param, 0, sizeof(odp_cls_cos_param_t));
+
 	param->queue = ODP_QUEUE_INVALID;
 	param->pool = ODP_POOL_INVALID;
 	param->drop_policy = ODP_COS_DROP_NEVER;
 	param->num_queue = 1;
+	param->vector.enable = false;
 	odp_queue_param_init(&param->queue_param);
 }
 
@@ -229,6 +238,29 @@ odp_cos_t odp_cls_cos_create(const char *name, const odp_cls_cos_param_t *param)
 	if (param->num_queue > CLS_COS_QUEUE_MAX || param->num_queue < 1)
 		return ODP_COS_INVALID;
 
+	/* Validate packet vector parameters */
+	if (param->vector.enable) {
+		odp_pool_t pool = param->vector.pool;
+		odp_pool_info_t pool_info;
+
+		if (pool == ODP_POOL_INVALID || odp_pool_info(pool, &pool_info)) {
+			ODP_ERR("invalid packet vector pool\n");
+			return ODP_COS_INVALID;
+		}
+		if (pool_info.params.type != ODP_POOL_VECTOR) {
+			ODP_ERR("wrong pool type\n");
+			return ODP_COS_INVALID;
+		}
+		if (param->vector.max_size == 0) {
+			ODP_ERR("vector.max_size is zero\n");
+			return ODP_COS_INVALID;
+		}
+		if (param->vector.max_size > pool_info.params.vector.max_size) {
+			ODP_ERR("vector.max_size larger than pool max vector size\n");
+			return ODP_COS_INVALID;
+		}
+	}
+
 	drop_policy = param->drop_policy;
 
 	for (i = 0; i < CLS_COS_MAX_ENTRY; i++) {
@@ -280,6 +312,7 @@ odp_cos_t odp_cls_cos_create(const char *name, const odp_cls_cos_param_t *param)
 			cos->s.drop_policy = drop_policy;
 			odp_atomic_init_u32(&cos->s.num_rule, 0);
 			cos->s.index = i;
+			cos->s.vector = param->vector;
 			UNLOCK(&cos->s.lock);
 			return _odp_cos_from_ndx(i);
 		}

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -1579,6 +1579,7 @@ int cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 
 	*pool = cos->s.pool;
 	pkt_hdr->p.input_flags.dst_queue = 1;
+	pkt_hdr->cos = cos->s.index;
 
 	if (!cos->s.queue_group) {
 		pkt_hdr->dst_queue = cos->s.queue;

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2020, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -14,10 +15,12 @@
 #include <odp_ipsec_internal.h>
 #include <odp_debug_internal.h>
 #include <odp_packet_internal.h>
+#include <odp_event_vector_internal.h>
 
 /* Inlined API functions */
 #include <odp/api/plat/event_inlines.h>
 #include <odp/api/plat/packet_inlines.h>
+#include <odp/api/plat/packet_vector_inlines.h>
 
 odp_event_subtype_t odp_event_subtype(odp_event_t event)
 {
@@ -59,6 +62,9 @@ void odp_event_free(odp_event_t event)
 		break;
 	case ODP_EVENT_PACKET:
 		odp_packet_free(odp_packet_from_event(event));
+		break;
+	case ODP_EVENT_PACKET_VECTOR:
+		_odp_packet_vector_free_full(odp_packet_vector_from_event(event));
 		break;
 	case ODP_EVENT_TIMEOUT:
 		odp_timeout_free(odp_timeout_from_event(event));

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -17,6 +17,7 @@
 #include <odp_packet_internal.h>
 #include <odp_ipsec_internal.h>
 #include <odp/api/plat/queue_inlines.h>
+#include <odp_classification_internal.h>
 
 #include <protocols/eth.h>
 #include <protocols/ip.h>
@@ -1808,6 +1809,8 @@ int _odp_ipsec_try_inline(odp_packet_t *pkt)
 	pkt_hdr = packet_hdr(*pkt);
 	pkt_hdr->p.input_flags.dst_queue = 1;
 	pkt_hdr->dst_queue = ipsec_sa->queue;
+	/* Distinguish inline IPsec packets from classifier packets */
+	pkt_hdr->cos = CLS_COS_IDX_NONE;
 
 	/* Last thing */
 	_odp_ipsec_sa_unuse(ipsec_sa);

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -169,8 +169,9 @@ static inline void packet_seg_copy_md(odp_packet_hdr_t *dst,
 	 *   .tailroom
 	 */
 
-	dst->input     = src->input;
+	dst->input = src->input;
 	dst->dst_queue = src->dst_queue;
+	dst->cos = src->cos;
 	dst->flow_hash = src->flow_hash;
 	dst->timestamp = src->timestamp;
 
@@ -1720,6 +1721,7 @@ int _odp_packet_copy_md_to_packet(odp_packet_t srcpkt, odp_packet_t dstpkt)
 
 	dsthdr->input = srchdr->input;
 	dsthdr->dst_queue = srchdr->dst_queue;
+	dsthdr->cos = srchdr->cos;
 	dsthdr->cls_mark = srchdr->cls_mark;
 	dsthdr->buf_hdr.user_ptr = srchdr->buf_hdr.user_ptr;
 	if (dsthdr->buf_hdr.uarea_addr != NULL &&

--- a/platform/linux-generic/odp_packet_api.c
+++ b/platform/linux-generic/odp_packet_api.c
@@ -26,3 +26,4 @@
 /* Include non-inlined versions of API functions */
 #define _ODP_NO_INLINE
 #include <odp/api/plat/packet_inlines.h>
+#include <odp/api/plat/packet_vector_inlines.h>

--- a/platform/linux-generic/odp_packet_vector.c
+++ b/platform/linux-generic/odp_packet_vector.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
+#include <odp/api/align.h>
 #include <odp/api/buffer.h>
 #include <odp/api/hints.h>
 #include <odp/api/packet.h>
@@ -13,6 +14,17 @@
 #include <odp_debug_internal.h>
 #include <odp_event_vector_internal.h>
 #include <odp_pool_internal.h>
+
+#include <odp/visibility_begin.h>
+
+/* Packet vector header field offsets for inline functions */
+const _odp_event_vector_inline_offset_t _odp_event_vector_inline ODP_ALIGNED_CACHE = {
+	.packet    = offsetof(odp_event_vector_hdr_t, packet),
+	.pool      = offsetof(odp_event_vector_hdr_t, buf_hdr.pool_ptr),
+	.size      = offsetof(odp_event_vector_hdr_t, size)
+};
+
+#include <odp/visibility_end.h>
 
 static inline odp_event_vector_hdr_t *event_vector_hdr_from_buffer(odp_buffer_t buf)
 {

--- a/platform/linux-generic/odp_packet_vector.c
+++ b/platform/linux-generic/odp_packet_vector.c
@@ -1,0 +1,45 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/buffer.h>
+#include <odp/api/hints.h>
+#include <odp/api/packet.h>
+#include <odp/api/pool.h>
+#include <odp/api/plat/packet_vector_inlines.h>
+
+#include <odp_debug_internal.h>
+#include <odp_event_vector_internal.h>
+#include <odp_pool_internal.h>
+
+static inline odp_event_vector_hdr_t *event_vector_hdr_from_buffer(odp_buffer_t buf)
+{
+	return (odp_event_vector_hdr_t *)(uintptr_t)buf;
+}
+
+odp_packet_vector_t odp_packet_vector_alloc(odp_pool_t pool)
+{
+	odp_buffer_t buf;
+
+	ODP_ASSERT(pool_entry_from_hdl(pool)->params.type == ODP_POOL_VECTOR);
+
+	buf = odp_buffer_alloc(pool);
+	if (odp_unlikely(buf == ODP_BUFFER_INVALID))
+		return ODP_PACKET_VECTOR_INVALID;
+
+	ODP_ASSERT(event_vector_hdr_from_buffer(buf)->size == 0);
+
+	return odp_packet_vector_from_event(odp_buffer_to_event(buf));
+}
+
+void odp_packet_vector_free(odp_packet_vector_t pktv)
+{
+	odp_event_vector_hdr_t *pktv_hdr = _odp_packet_vector_hdr(pktv);
+	odp_event_t ev = odp_packet_vector_to_event(pktv);
+
+	pktv_hdr->size = 0;
+
+	odp_buffer_free(odp_buffer_from_event(ev));
+}

--- a/platform/linux-generic/odp_packet_vector.c
+++ b/platform/linux-generic/odp_packet_vector.c
@@ -10,10 +10,14 @@
 #include <odp/api/packet.h>
 #include <odp/api/pool.h>
 #include <odp/api/plat/packet_vector_inlines.h>
+#include <odp/api/plat/strong_types.h>
 
 #include <odp_debug_internal.h>
 #include <odp_event_vector_internal.h>
 #include <odp_pool_internal.h>
+
+#include <inttypes.h>
+#include <stdint.h>
 
 #include <odp/visibility_begin.h>
 
@@ -54,4 +58,64 @@ void odp_packet_vector_free(odp_packet_vector_t pktv)
 	pktv_hdr->size = 0;
 
 	odp_buffer_free(odp_buffer_from_event(ev));
+}
+
+int odp_packet_vector_valid(odp_packet_vector_t pktv)
+{
+	odp_event_vector_hdr_t *pktv_hdr = _odp_packet_vector_hdr(pktv);
+	pool_t *pool = pktv_hdr->buf_hdr.pool_ptr;
+	uint32_t i;
+
+	if (odp_unlikely(pktv == ODP_PACKET_VECTOR_INVALID))
+		return 0;
+
+	if (odp_unlikely(pktv_hdr->size > pool->params.vector.max_size))
+		return 0;
+
+	for (i = 0; i < pktv_hdr->size; i++) {
+		if (pktv_hdr->packet[i] == ODP_PACKET_INVALID)
+			return 0;
+	}
+
+	return 1;
+}
+
+void odp_packet_vector_print(odp_packet_vector_t pktv)
+{
+	int max_len = 4096;
+	char str[max_len];
+	int len = 0;
+	int n = max_len - 1;
+	uint32_t i;
+	odp_event_vector_hdr_t *pktv_hdr = _odp_packet_vector_hdr(pktv);
+
+	len += snprintf(&str[len], n - len, "Packet Vector\n");
+	len += snprintf(&str[len], n - len,
+			"  handle %p\n", pktv);
+	len += snprintf(&str[len], n - len,
+			"  size   %" PRIu32 "\n", pktv_hdr->size);
+
+	for (i = 0; i < pktv_hdr->size; i++) {
+		odp_packet_t pkt = pktv_hdr->packet[i];
+		char seg_str[max_len];
+		int str_len;
+
+		str_len = snprintf(seg_str, max_len,
+				   "    packet     %p  len %" PRIu32 "\n",
+				   pkt, odp_packet_len(pkt));
+
+		/* Prevent print buffer overflow */
+		if (n - len - str_len < 10) {
+			len += snprintf(&str[len], n - len, "    ...\n");
+			break;
+		}
+		len += snprintf(&str[len], n - len, "%s", seg_str);
+	}
+
+	ODP_PRINT("%s\n", str);
+}
+
+uint64_t odp_packet_vector_to_u64(odp_packet_vector_t pktv)
+{
+	return _odp_pri(pktv);
 }

--- a/test/validation/api/classification/classification.c
+++ b/test/validation/api/classification/classification.c
@@ -23,6 +23,11 @@ odp_suiteinfo_t classification_suites[] = {
 	  .init_func    = classification_suite_init,
 	  .term_func    = classification_suite_term,
 	},
+	{ .name         = "classification packet vector tests",
+	  .testinfo_tbl = classification_suite_pktv,
+	  .init_func    = classification_suite_pktv_init,
+	  .term_func    = classification_suite_pktv_term,
+	},
 	ODP_SUITE_INFO_NULL,
 };
 

--- a/test/validation/api/classification/odp_classification_common.c
+++ b/test/validation/api/classification/odp_classification_common.c
@@ -46,7 +46,7 @@ odp_pktio_t create_pktio(odp_queue_type_t q_type, odp_pool_t pool,
 	if (pktio == ODP_PKTIO_INVALID) {
 		ret = odp_pool_destroy(pool);
 		if (ret)
-			fprintf(stderr, "unable to destroy pool.\n");
+			ODPH_ERR("Unable to destroy pool\n");
 		return ODP_PKTIO_INVALID;
 	}
 
@@ -56,12 +56,12 @@ odp_pktio_t create_pktio(odp_queue_type_t q_type, odp_pool_t pool,
 	pktin_param.hash_enable = false;
 
 	if (odp_pktin_queue_config(pktio, &pktin_param)) {
-		fprintf(stderr, "pktin queue config failed.\n");
+		ODPH_ERR("Pktin queue config failed\n");
 		return ODP_PKTIO_INVALID;
 	}
 
 	if (odp_pktout_queue_config(pktio, NULL)) {
-		fprintf(stderr, "pktout queue config failed.\n");
+		ODPH_ERR("Pktout queue config failed\n");
 		return ODP_PKTIO_INVALID;
 	}
 
@@ -73,7 +73,7 @@ int stop_pktio(odp_pktio_t pktio)
 	odp_event_t ev;
 
 	if (odp_pktio_stop(pktio)) {
-		fprintf(stderr, "pktio stop failed.\n");
+		ODPH_ERR("Pktio stop failed\n");
 		return -1;
 	}
 

--- a/test/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/validation/api/classification/odp_classification_test_pmr.c
@@ -8,6 +8,7 @@
 #include "odp_classification_testsuites.h"
 #include "classification.h"
 #include <odp_cunit_common.h>
+#include <odp/helper/odph_api.h>
 
 #define MAX_NUM_UDP 4
 #define MARK_IP     1
@@ -25,13 +26,13 @@ int classification_suite_pmr_init(void)
 	memset(&cls_capa, 0, sizeof(odp_cls_capability_t));
 
 	if (odp_cls_capability(&cls_capa)) {
-		fprintf(stderr, "Classifier capability call failed.\n");
+		ODPH_ERR("Classifier capability call failed\n");
 		return -1;
 	}
 
 	pkt_pool = pool_create("classification_pmr_pool");
 	if (ODP_POOL_INVALID == pkt_pool) {
-		fprintf(stderr, "Packet pool creation failed.\n");
+		ODPH_ERR("Packet pool creation failed\n");
 		return -1;
 	}
 
@@ -47,7 +48,7 @@ int classification_suite_pmr_init(void)
 static int start_pktio(odp_pktio_t pktio)
 {
 	if (odp_pktio_start(pktio)) {
-		fprintf(stderr, "unable to start loop\n");
+		ODPH_ERR("Unable to start loop\n");
 		return -1;
 	}
 
@@ -92,7 +93,7 @@ int classification_suite_pmr_term(void)
 	int ret = 0;
 
 	if (0 != odp_pool_destroy(pkt_pool)) {
-		fprintf(stderr, "pkt_pool destroy failed.\n");
+		ODPH_ERR("Packet pool destroy failed\n");
 		ret += -1;
 	}
 

--- a/test/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/validation/api/classification/odp_classification_test_pmr.c
@@ -177,7 +177,7 @@ static void classification_test_pktin_classifier_flag(void)
 
 	/* since classifier flag is disabled in pktin queue configuration
 	packet will not be delivered in classifier queues */
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	pool_recv = odp_packet_pool(pkt);
 	/* since classifier is disabled packet should not be received in
@@ -272,7 +272,7 @@ static void _classification_test_pmr_term_tcp_dport(int num_pkt)
 	}
 
 	for (i = 0; i < num_pkt; i++) {
-		pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+		pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 		CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 		pool_recv = odp_packet_pool(pkt);
 		CU_ASSERT(pool == pool_recv);
@@ -299,7 +299,7 @@ static void _classification_test_pmr_term_tcp_dport(int num_pkt)
 	}
 
 	for (i = 0; i < num_pkt; i++) {
-		pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+		pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 		CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 		CU_ASSERT(seqno[i] == cls_pkt_get_seq(pkt));
 		CU_ASSERT(retqueue == default_queue);
@@ -337,7 +337,7 @@ static void _classification_test_pmr_term_tcp_dport(int num_pkt)
 	recv_default = 0;
 
 	for (i = 0; i < 2 * num_pkt; i++) {
-		pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+		pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 		CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 		CU_ASSERT(retqueue == queue || retqueue == default_queue);
 
@@ -440,7 +440,7 @@ static void classification_test_pmr_term_tcp_sport(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == queue);
@@ -461,7 +461,7 @@ static void classification_test_pmr_term_tcp_sport(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == default_queue);
@@ -555,7 +555,7 @@ static void classification_test_pmr_term_udp_dport(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == queue);
@@ -577,7 +577,7 @@ static void classification_test_pmr_term_udp_dport(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == default_queue);
@@ -671,7 +671,7 @@ static void classification_test_pmr_term_udp_sport(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == queue);
@@ -692,7 +692,7 @@ static void classification_test_pmr_term_udp_sport(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == default_queue);
@@ -782,7 +782,7 @@ static void classification_test_pmr_term_ipproto(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -801,7 +801,7 @@ static void classification_test_pmr_term_ipproto(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -887,7 +887,7 @@ static void classification_test_pmr_term_dmac(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -903,7 +903,7 @@ static void classification_test_pmr_term_dmac(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -996,7 +996,7 @@ static void classification_test_pmr_term_packet_len(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -1015,7 +1015,7 @@ static void classification_test_pmr_term_packet_len(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -1107,7 +1107,7 @@ static void classification_test_pmr_term_vlan_id_0(void)
 	vlan_0->tci = val;
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -1126,7 +1126,7 @@ static void classification_test_pmr_term_vlan_id_0(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -1220,7 +1220,7 @@ static void classification_test_pmr_term_vlan_id_x(void)
 	vlan_x->tci = val;
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -1239,7 +1239,7 @@ static void classification_test_pmr_term_vlan_id_x(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -1328,7 +1328,7 @@ static void classification_test_pmr_term_eth_type_0(void)
 	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -1347,7 +1347,7 @@ static void classification_test_pmr_term_eth_type_0(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -1443,7 +1443,7 @@ static void classification_test_pmr_term_eth_type_x(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -1462,7 +1462,7 @@ static void classification_test_pmr_term_eth_type_x(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -1560,7 +1560,7 @@ static void classification_test_pmr_pool_set(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -1658,7 +1658,7 @@ static void classification_test_pmr_queue_set(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	recvpool = odp_packet_pool(pkt);
@@ -1765,7 +1765,7 @@ static void test_pmr_term_ipv4_addr(int dst)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == queue);
@@ -1782,7 +1782,7 @@ static void test_pmr_term_ipv4_addr(int dst)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == default_queue);
@@ -1886,7 +1886,7 @@ static void classification_test_pmr_term_ipv6daddr(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == queue);
@@ -1903,7 +1903,7 @@ static void classification_test_pmr_term_ipv6daddr(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == default_queue);
@@ -1997,7 +1997,7 @@ static void classification_test_pmr_term_ipv6saddr(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == queue);
@@ -2014,7 +2014,7 @@ static void classification_test_pmr_term_ipv6saddr(void)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == default_queue);
@@ -2138,7 +2138,7 @@ static void test_pmr_term_custom(int custom_l3)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == queue);
@@ -2155,7 +2155,7 @@ static void test_pmr_term_custom(int custom_l3)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == default_queue);
@@ -2314,7 +2314,7 @@ static void test_pmr_series(const int num_udp, int marking)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == queue_ip);
@@ -2353,7 +2353,7 @@ static void test_pmr_series(const int num_udp, int marking)
 
 		enqueue_pktio_interface(pkt, pktio);
 
-		pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+		pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 		CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 		CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 		CU_ASSERT(retqueue == queue_udp[i]);
@@ -2379,7 +2379,7 @@ static void test_pmr_series(const int num_udp, int marking)
 
 	enqueue_pktio_interface(pkt, pktio);
 
-	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS, false);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == default_queue);

--- a/test/validation/api/classification/odp_classification_tests.c
+++ b/test/validation/api/classification/odp_classification_tests.c
@@ -49,7 +49,7 @@ static int classification_suite_common_init(odp_bool_t enable_pktv)
 
 	pool_default = pool_create("classification_pool");
 	if (ODP_POOL_INVALID == pool_default) {
-		fprintf(stderr, "Packet pool creation failed.\n");
+		ODPH_ERR("Packet pool creation failed\n");
 		return -1;
 	}
 
@@ -60,7 +60,7 @@ static int classification_suite_common_init(odp_bool_t enable_pktv)
 	if (pktio_loop == ODP_PKTIO_INVALID) {
 		ret = odp_pool_destroy(pool_default);
 		if (ret)
-			fprintf(stderr, "unable to destroy pool.\n");
+			ODPH_ERR("Unable to destroy pool\n");
 		return -1;
 	}
 
@@ -111,12 +111,12 @@ static int classification_suite_common_init(odp_bool_t enable_pktv)
 	}
 
 	if (odp_pktin_queue_config(pktio_loop, &pktin_param)) {
-		fprintf(stderr, "pktin queue config failed.\n");
+		ODPH_ERR("Pktin queue config failed\n");
 		return -1;
 	}
 
 	if (odp_pktout_queue_config(pktio_loop, NULL)) {
-		fprintf(stderr, "pktout queue config failed.\n");
+		ODPH_ERR("Pktout queue config failed\n");
 		return -1;
 	}
 
@@ -136,7 +136,7 @@ static int classification_suite_common_init(odp_bool_t enable_pktv)
 
 	ret = odp_pktio_start(pktio_loop);
 	if (ret) {
-		fprintf(stderr, "unable to start loop\n");
+		ODPH_ERR("Unable to start loop\n");
 		return -1;
 	}
 
@@ -149,17 +149,17 @@ static int classification_suite_common_term(odp_bool_t enable_pktv)
 	int retcode = 0;
 
 	if (0 >	stop_pktio(pktio_loop)) {
-		fprintf(stderr, "stop pktio failed.\n");
+		ODPH_ERR("Stop pktio failed\n");
 		retcode = -1;
 	}
 
 	if (0 > odp_pktio_close(pktio_loop)) {
-		fprintf(stderr, "pktio close failed.\n");
+		ODPH_ERR("Pktio close failed\n");
 		retcode = -1;
 	}
 
 	if (0 != odp_pool_destroy(pool_default)) {
-		fprintf(stderr, "pool_default destroy failed.\n");
+		ODPH_ERR("Pool_default destroy failed\n");
 		retcode = -1;
 	}
 

--- a/test/validation/api/classification/odp_classification_testsuites.h
+++ b/test/validation/api/classification/odp_classification_testsuites.h
@@ -37,12 +37,16 @@ typedef union odp_cls_testcase {
 extern odp_testinfo_t classification_suite[];
 extern odp_testinfo_t classification_suite_basic[];
 extern odp_testinfo_t classification_suite_pmr[];
+extern odp_testinfo_t classification_suite_pktv[];
 
 int classification_suite_init(void);
 int classification_suite_term(void);
 
 int classification_suite_pmr_term(void);
 int classification_suite_pmr_init(void);
+
+int classification_suite_pktv_init(void);
+int classification_suite_pktv_term(void);
 
 odp_packet_t create_packet(cls_packet_info_t pkt_info);
 int cls_pkt_set_seq(odp_packet_t pkt);
@@ -53,21 +57,22 @@ void configure_default_cos(odp_pktio_t pktio, odp_cos_t *cos,
 			   odp_queue_t *queue, odp_pool_t *pool);
 int parse_ipv4_string(const char *ipaddress, uint32_t *addr, uint32_t *mask);
 void enqueue_pktio_interface(odp_packet_t pkt, odp_pktio_t pktio);
-odp_packet_t receive_packet(odp_queue_t *queue, uint64_t ns);
+odp_packet_t receive_packet(odp_queue_t *queue, uint64_t ns, odp_bool_t enable_pktv);
 odp_pool_t pool_create(const char *poolname);
+odp_pool_t pktv_pool_create(const char *poolname);
 odp_queue_t queue_create(const char *queuename, bool sched);
-void configure_pktio_default_cos(void);
-void test_pktio_default_cos(void);
-void configure_pktio_error_cos(void);
-void test_pktio_error_cos(void);
-void configure_cls_pmr_chain(void);
-void test_cls_pmr_chain(void);
-void configure_cos_with_l2_priority(void);
-void test_cos_with_l2_priority(void);
-void configure_pmr_cos(void);
-void test_pmr_cos(void);
-void configure_pktio_pmr_composite(void);
-void test_pktio_pmr_composite_cos(void);
+void configure_pktio_default_cos(odp_bool_t enable_pktv);
+void test_pktio_default_cos(odp_bool_t enable_pktv);
+void configure_pktio_error_cos(odp_bool_t enable_pktv);
+void test_pktio_error_cos(odp_bool_t enable_pktv);
+void configure_cls_pmr_chain(odp_bool_t enable_pktv);
+void test_cls_pmr_chain(odp_bool_t enable_pktv);
+void configure_cos_with_l2_priority(odp_bool_t enable_pktv);
+void test_cos_with_l2_priority(odp_bool_t enable_pktv);
+void configure_pmr_cos(odp_bool_t enable_pktv);
+void test_pmr_cos(odp_bool_t enable_pktv);
+void configure_pktio_pmr_composite(odp_bool_t enable_pktv);
+void test_pktio_pmr_composite_cos(odp_bool_t enable_pktv);
 int stop_pktio(odp_pktio_t pktio);
 odp_cls_pmr_term_t find_first_supported_l3_pmr(void);
 int set_first_supported_pmr_port(odp_packet_t pkt, uint16_t port);

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -209,25 +209,24 @@ static uint32_t pktio_pkt_seq_hdr(odp_packet_t pkt, size_t l4_hdr_len)
 	pkt_tail_t tail;
 
 	if (pkt == ODP_PACKET_INVALID) {
-		fprintf(stderr, "error: pkt invalid\n");
+		ODPH_ERR("pkt invalid\n");
 		return TEST_SEQ_INVALID;
 	}
 
 	off = odp_packet_l4_offset(pkt);
 	if (off ==  ODP_PACKET_OFFSET_INVALID) {
-		fprintf(stderr, "error: offset invalid\n");
+		ODPH_ERR("offset invalid\n");
 		return TEST_SEQ_INVALID;
 	}
 
 	off += l4_hdr_len;
 	if (odp_packet_copy_to_mem(pkt, off, sizeof(head), &head) != 0) {
-		fprintf(stderr, "error: header copy failed\n");
+		ODPH_ERR("header copy failed\n");
 		return TEST_SEQ_INVALID;
 	}
 
 	if (head.magic != TEST_SEQ_MAGIC) {
-		fprintf(stderr, "error: header magic invalid 0x%" PRIx32 "\n",
-			head.magic);
+		ODPH_ERR("header magic invalid 0x%" PRIx32 "\n", head.magic);
 		odp_packet_print(pkt);
 		return TEST_SEQ_INVALID;
 	}
@@ -236,7 +235,7 @@ static uint32_t pktio_pkt_seq_hdr(odp_packet_t pkt, size_t l4_hdr_len)
 		off = packet_len - sizeof(tail);
 		if (odp_packet_copy_to_mem(pkt, off, sizeof(tail),
 					   &tail) != 0) {
-			fprintf(stderr, "error: header copy failed\n");
+			ODPH_ERR("header copy failed\n");
 			return TEST_SEQ_INVALID;
 		}
 
@@ -244,15 +243,11 @@ static uint32_t pktio_pkt_seq_hdr(odp_packet_t pkt, size_t l4_hdr_len)
 			seq = head.seq;
 			CU_ASSERT(seq != TEST_SEQ_INVALID);
 		} else {
-			fprintf(stderr,
-				"error: tail magic invalid 0x%" PRIx32 "\n",
-				tail.magic);
+			ODPH_ERR("tail magic invalid 0x%" PRIx32 "\n", tail.magic);
 		}
 	} else {
-		fprintf(stderr,
-			"error: packet length invalid: "
-			"%" PRIu32 "(%" PRIu32 ")\n",
-			odp_packet_len(pkt), packet_len);
+		ODPH_ERR("packet length invalid: %" PRIu32 "(%" PRIu32 ")\n",
+			 odp_packet_len(pkt), packet_len);
 	}
 
 	return seq;
@@ -965,10 +960,8 @@ static void pktio_txrx_multi(pktio_info_t *pktio_info_a,
 	num_rx = wait_for_packets(pktio_info_b, rx_pkt, tx_seq, num_pkts, mode,
 				  ODP_TIME_SEC_IN_NS, vector_mode);
 	CU_ASSERT(num_rx == num_pkts);
-	if (num_rx != num_pkts) {
-		fprintf(stderr, "error: received %i, out of %i packets\n",
-			num_rx, num_pkts);
-	}
+	if (num_rx != num_pkts)
+		ODPH_ERR("received %i, out of %i packets\n", num_rx, num_pkts);
 
 	for (i = 0; i < num_rx; ++i) {
 		odp_packet_data_range_t range;
@@ -1831,26 +1824,26 @@ static void pktio_test_pktout_queue_config(void)
 #ifdef DEBUG_STATS
 static void _print_pktio_stats(odp_pktio_stats_t *s, const char *name)
 {
-	fprintf(stderr, "\n%s:\n"
-		"  in_octets %" PRIu64 "\n"
-		"  in_ucast_pkts %" PRIu64 "\n"
-		"  in_discards %" PRIu64 "\n"
-		"  in_errors %" PRIu64 "\n"
-		"  in_unknown_protos %" PRIu64 "\n"
-		"  out_octets %" PRIu64 "\n"
-		"  out_ucast_pkts %" PRIu64 "\n"
-		"  out_discards %" PRIu64 "\n"
-		"  out_errors %" PRIu64 "\n",
-		name,
-		s->in_octets,
-		s->in_ucast_pkts,
-		s->in_discards,
-		s->in_errors,
-		s->in_unknown_protos,
-		s->out_octets,
-		s->out_ucast_pkts,
-		s->out_discards,
-		s->out_errors);
+	ODPH_ERR("\n%s:\n"
+		 "  in_octets %" PRIu64 "\n"
+		 "  in_ucast_pkts %" PRIu64 "\n"
+		 "  in_discards %" PRIu64 "\n"
+		 "  in_errors %" PRIu64 "\n"
+		 "  in_unknown_protos %" PRIu64 "\n"
+		 "  out_octets %" PRIu64 "\n"
+		 "  out_ucast_pkts %" PRIu64 "\n"
+		 "  out_discards %" PRIu64 "\n"
+		 "  out_errors %" PRIu64 "\n",
+		 name,
+		 s->in_octets,
+		 s->in_ucast_pkts,
+		 s->in_discards,
+		 s->in_errors,
+		 s->in_unknown_protos,
+		 s->out_octets,
+		 s->out_ucast_pkts,
+		 s->out_discards,
+		 s->out_errors);
 }
 #endif
 
@@ -3095,8 +3088,7 @@ static int create_pool(const char *iface, int num)
 
 	pool[num] = odp_pool_create(pool_name, &params);
 	if (ODP_POOL_INVALID == pool[num]) {
-		fprintf(stderr, "%s: failed to create pool: %d",
-			__func__, odp_errno());
+		ODPH_ERR("failed to create pool: %d", odp_errno());
 		return -1;
 	}
 
@@ -3307,7 +3299,7 @@ static int pktio_suite_init(void)
 	}
 
 	if (default_pool_create() != 0) {
-		fprintf(stderr, "error: failed to create default pool\n");
+		ODPH_ERR("failed to create default pool\n");
 		return -1;
 	}
 
@@ -3352,8 +3344,7 @@ static int pktio_suite_term(void)
 			continue;
 
 		if (odp_pool_destroy(pool) != 0) {
-			fprintf(stderr, "error: failed to destroy pool %s\n",
-				pool_name);
+			ODPH_ERR("failed to destroy pool %s\n", pool_name);
 			ret = -1;
 		}
 	}
@@ -3372,7 +3363,7 @@ static int pktio_suite_term(void)
 	}
 
 	if (odp_pool_destroy(default_pkt_pool) != 0) {
-		fprintf(stderr, "error: failed to destroy default pool\n");
+		ODPH_ERR("failed to destroy default pool\n");
 		ret = -1;
 	}
 	default_pkt_pool = ODP_POOL_INVALID;


### PR DESCRIPTION
Initial implementation for packet vectors. The validation tests are still incomplete and hence classifier integration is untested.

V3:

- Added classification validation tests
- Added event conversion test to the packet validation suite

V4 & V5:
- Rebase

V6:
- Fixed Petri's comments