### PR TITLE
[PATCH v2] test: README: document command for running tests under gdb

### DIFF
--- a/test/README
+++ b/test/README
@@ -15,3 +15,8 @@ $ make
 $ cd test/<platform_name>
 $ make check-valgrind
 
+To run these tests with gdb, use the following libtool command:
+$ libtool --mode=execute gdb ./<test_name>
+
+Refer to the prerequisites section of the DEPENDENCIES file for how to
+install the libtool package.


### PR DESCRIPTION
The command to run validation and performance tests under gdb is not
quite intutive and requires the use of libtool package. It distinctly
varies with how ODP examples are run under gdb which make use of the
generic command, i.e., "gdb <example>" and is very straightforward.
Documenting this command in the README file for tests will help
developers who are not familiar with usage of libtool for gdb as
well as improve the source code documentation.

Signed-off-by: Malvika Gupta <Malvika.Gupta@arm.com>
Reviewed-by: Govindarajan Mohandoss <Govindarajan.Mohandoss@arm.com>