### PR TITLE
[PATCH v4] validation: ipsec: improve initialization of unit tests

### DIFF
--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -979,7 +979,7 @@ int ipsec_out_term(void)
 	return ipsec_suite_term();
 }
 
-int ipsec_init(odp_instance_t *inst)
+int ipsec_init(odp_instance_t *inst, odp_ipsec_op_mode_t mode)
 {
 	odp_pool_param_t params;
 	odp_pool_t pool;
@@ -988,6 +988,10 @@ int ipsec_init(odp_instance_t *inst)
 	odp_pktio_t pktio;
 	odp_init_t init_param;
 	odph_helper_options_t helper_options;
+
+	suite_context.pool = ODP_POOL_INVALID;
+	suite_context.queue = ODP_QUEUE_INVALID;
+	suite_context.pktio = ODP_PKTIO_INVALID;
 
 	if (odph_options(&helper_options)) {
 		fprintf(stderr, "error: odph_options() failed.\n");
@@ -1036,16 +1040,21 @@ int ipsec_init(odp_instance_t *inst)
 		fprintf(stderr, "Packet pool creation failed.\n");
 		return -1;
 	}
-	out_queue = odp_queue_create("ipsec-out", NULL);
-	if (ODP_QUEUE_INVALID == out_queue) {
-		fprintf(stderr, "IPsec outq creation failed.\n");
-		return -1;
+	if (mode == ODP_IPSEC_OP_MODE_ASYNC ||
+	    mode == ODP_IPSEC_OP_MODE_INLINE) {
+		out_queue = odp_queue_create("ipsec-out", NULL);
+		if (ODP_QUEUE_INVALID == out_queue) {
+			fprintf(stderr, "IPsec outq creation failed.\n");
+			return -1;
+		}
 	}
 
-	pktio = pktio_create(pool);
-	if (ODP_PKTIO_INVALID == pktio) {
-		fprintf(stderr, "IPsec pktio creation failed.\n");
-		return -1;
+	if (mode == ODP_IPSEC_OP_MODE_INLINE) {
+		pktio = pktio_create(pool);
+		if (ODP_PKTIO_INVALID == pktio) {
+			fprintf(stderr, "IPsec pktio creation failed.\n");
+			return -1;
+		}
 	}
 
 	return 0;
@@ -1092,32 +1101,23 @@ int ipsec_config(odp_instance_t ODP_UNUSED inst)
 
 int ipsec_term(odp_instance_t inst)
 {
-	odp_pool_t pool;
-	odp_queue_t out_queue;
-	odp_pktio_t pktio;
+	odp_pool_t pool = suite_context.pool;
+	odp_queue_t out_queue = suite_context.queue;
+	odp_pktio_t pktio = suite_context.pktio;
 
-	pktio = odp_pktio_lookup("loop");
 	if (ODP_PKTIO_INVALID != pktio) {
 		if (odp_pktio_close(pktio))
 			fprintf(stderr, "IPsec pktio close failed.\n");
-	} else {
-		fprintf(stderr, "IPsec pktio not found.\n");
 	}
 
-	out_queue = odp_queue_lookup("ipsec-out");
 	if (ODP_QUEUE_INVALID != out_queue) {
 		if (odp_queue_destroy(out_queue))
 			fprintf(stderr, "IPsec outq destroy failed.\n");
-	} else {
-		fprintf(stderr, "IPsec outq not found.\n");
 	}
 
-	pool = odp_pool_lookup("packet_pool");
 	if (ODP_POOL_INVALID != pool) {
 		if (odp_pool_destroy(pool))
 			fprintf(stderr, "Packet pool destroy failed.\n");
-	} else {
-		fprintf(stderr, "Packet pool not found.\n");
 	}
 
 	if (0 != odp_term_local()) {

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -14,7 +14,7 @@
 extern odp_testinfo_t ipsec_in_suite[];
 extern odp_testinfo_t ipsec_out_suite[];
 
-int ipsec_init(odp_instance_t *inst);
+int ipsec_init(odp_instance_t *inst, odp_ipsec_op_mode_t mode);
 int ipsec_term(odp_instance_t inst);
 int ipsec_config(odp_instance_t inst);
 

--- a/test/validation/api/ipsec/ipsec_async.c
+++ b/test/validation/api/ipsec/ipsec_async.c
@@ -10,7 +10,7 @@ static int ipsec_async_init(odp_instance_t *inst)
 {
 	int rc;
 
-	rc = ipsec_init(inst);
+	rc = ipsec_init(inst, ODP_IPSEC_OP_MODE_ASYNC);
 	if (rc != 0)
 		return rc;
 
@@ -21,7 +21,6 @@ static int ipsec_async_init(odp_instance_t *inst)
 	if (suite_context.queue == ODP_QUEUE_INVALID)
 		return -1;
 
-	suite_context.pktio = ODP_PKTIO_INVALID;
 	suite_context.inbound_op_mode = ODP_IPSEC_OP_MODE_ASYNC;
 	suite_context.outbound_op_mode = ODP_IPSEC_OP_MODE_ASYNC;
 

--- a/test/validation/api/ipsec/ipsec_inline_in.c
+++ b/test/validation/api/ipsec/ipsec_inline_in.c
@@ -10,7 +10,7 @@ static int ipsec_sync_init(odp_instance_t *inst)
 {
 	int rc;
 
-	rc = ipsec_init(inst);
+	rc = ipsec_init(inst, ODP_IPSEC_OP_MODE_INLINE);
 	if (rc != 0)
 		return rc;
 

--- a/test/validation/api/ipsec/ipsec_inline_out.c
+++ b/test/validation/api/ipsec/ipsec_inline_out.c
@@ -10,7 +10,7 @@ static int ipsec_sync_init(odp_instance_t *inst)
 {
 	int rc;
 
-	rc = ipsec_init(inst);
+	rc = ipsec_init(inst, ODP_IPSEC_OP_MODE_INLINE);
 	if (rc != 0)
 		return rc;
 

--- a/test/validation/api/ipsec/ipsec_sync.c
+++ b/test/validation/api/ipsec/ipsec_sync.c
@@ -10,7 +10,7 @@ static int ipsec_sync_init(odp_instance_t *inst)
 {
 	int rc;
 
-	rc = ipsec_init(inst);
+	rc = ipsec_init(inst, ODP_IPSEC_OP_MODE_SYNC);
 	if (rc != 0)
 		return rc;
 
@@ -18,8 +18,6 @@ static int ipsec_sync_init(odp_instance_t *inst)
 	if (suite_context.pool == ODP_POOL_INVALID)
 		return -1;
 
-	suite_context.queue = ODP_QUEUE_INVALID;
-	suite_context.pktio = ODP_PKTIO_INVALID;
 	suite_context.inbound_op_mode = ODP_IPSEC_OP_MODE_SYNC;
 	suite_context.outbound_op_mode = ODP_IPSEC_OP_MODE_SYNC;
 


### PR DESCRIPTION
Preiously when IPsec unit tests were initialized ODP queue
and ODP pktio were created by default however ODP queue is used
by async unit tests and pktio is used by inline unit tests. Sync
unit tests use neither ODP queue or ODP pktio. This patch updates
IPsec units test initialization so that only required elements are
created for a given mode of tests.

Signed-off-by: Lukasz Bartosik <lbartosik@marvell.com>
Signed-off-by: Anoob Joseph <anoobj@marvell.com>
Signed-off-by: Aakash Sasidharan <asasidharan@marvell.com>