### PR TITLE
[PATCH v1] validation: ipsec: fix result check for outbound

### DIFF
--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -919,8 +919,7 @@ void ipsec_check_out_in_one(const ipsec_test_part *part,
 		} else {
 			/* IPsec packet */
 			CU_ASSERT_EQUAL(0, odp_ipsec_result(&result, pkto[i]));
-			CU_ASSERT_EQUAL(part->out[i].status.error.all,
-					result.status.error.all);
+			CU_ASSERT_EQUAL(0, result.status.error.all);
 			CU_ASSERT_EQUAL(sa, result.sa);
 			CU_ASSERT_EQUAL(IPSEC_SA_CTX,
 					odp_ipsec_sa_context(sa));


### PR DESCRIPTION
Fix result check for outbound packet in the
ipsec_check_out_in_one() function so that it checks only
whether the IPSEC processing has any error and not look for
specific bits in result.status.error meant for the inbound
test case.

Signed-off-by: Aakash Sasidharan <asasidharan@marvell.com>