### PR TITLE
[PATCH v13] api: ipsec: add odp_ipsec_sa_info

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -34,6 +34,7 @@ odpapiinclude_HEADERS = \
 	odp/api/packet_flags.h \
 	odp/api/packet_io.h \
 	odp/api/packet_io_stats.h \
+	odp/api/protocols.h \
 	odp/api/pool.h \
 	odp/api/queue.h \
 	odp/api/random.h \
@@ -84,6 +85,7 @@ odpapispecinclude_HEADERS = \
 		  odp/api/spec/packet_flags.h \
 		  odp/api/spec/packet_io.h \
 		  odp/api/spec/packet_io_stats.h \
+		  odp/api/spec/protocols.h \
 		  odp/api/spec/pool.h \
 		  odp/api/spec/queue.h \
 		  odp/api/spec/queue_types.h \

--- a/include/odp/api/protocols.h
+++ b/include/odp/api/protocols.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP protocols
+ */
+
+#ifndef ODP_API_PROTOCOLS_H_
+#define ODP_API_PROTOCOLS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/spec/protocols.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/api/spec/protocols.h
+++ b/include/odp/api/spec/protocols.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2020, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP protocols
+ */
+
+#ifndef ODP_API_SPEC_PROTOCOLS_H_
+#define ODP_API_SPEC_PROTOCOLS_H_
+#include <odp/visibility_begin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup odp_protocols
+ * @details
+ * <b> Protocols </b>
+ *
+ *  @{
+ */
+
+/** IPv4 address size */
+#define ODP_IPV4_ADDR_SIZE 4
+
+/** IPv6 address size */
+#define ODP_IPV6_ADDR_SIZE 16
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <odp/visibility_end.h>
+#endif

--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -207,6 +207,8 @@ struct ipsec_sa_s {
 		 */
 		odp_atomic_u64_t post_lifetime_err_pkts;
 	} stats;
+
+	odp_ipsec_sa_param_t param;
 };
 
 /**


### PR DESCRIPTION
The proposed API, odp_ipsec_sa_info(), allows application to check
parameters associated with an IPsec SA. Retrieved information
covers constant fields that application had provided while
creating session (like details of cipher choices) and variables
associated with IPsec (like sequence number, anti-replay parameters).
Also, this API allows application to check session constants which
implementation is allowed to update based on the support available
(like anti-replay window)

This pull request consists of:
1. The API spec update for odp_ipsec_sa_info()
2. An implementation of odp_ipsec_sa_info() for linux-generic platform
3. An oubound test function to verify the API.