### PR TITLE
[PATCH v2] api: make odp_likely() work also with non-boolean values

### DIFF
--- a/include/odp/api/spec/hints.h
+++ b/include/odp/api/spec/hints.h
@@ -58,7 +58,7 @@ extern "C" {
 /**
  * Branch likely taken
  */
-#define odp_likely(x)   __builtin_expect((x), 1)
+#define odp_likely(x)   __builtin_expect(!!(x), 1)
 
 /**
  * Branch unlikely taken

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -460,7 +460,7 @@ static inline void buffer_ref_inc(odp_buffer_hdr_t *buf_hdr)
 	uint32_t ref_cnt = odp_atomic_load_u32(&buf_hdr->ref_cnt);
 
 	/* First count increment after alloc */
-	if (odp_likely(ref_cnt) == 0)
+	if (odp_likely(ref_cnt == 0))
 		odp_atomic_store_u32(&buf_hdr->ref_cnt, 2);
 	else
 		odp_atomic_inc_u32(&buf_hdr->ref_cnt);

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -191,7 +191,7 @@ static inline uint32_t _rx_pkt_to_iovec(odp_packet_t pkt, struct iovec *iovecs)
 	uint32_t seg_count = odp_packet_num_segs(pkt);
 	uint32_t i;
 
-	if (odp_likely(seg_count) == 1) {
+	if (odp_likely(seg_count == 1)) {
 		iovecs[0].iov_base = odp_packet_data(pkt);
 		iovecs[0].iov_len = odp_packet_len(pkt);
 		return 1;


### PR DESCRIPTION
A change to the behavior of odp_likely(), and a couple of fixes to odp_likely() calls.
