### PR TITLE
[PATCH v6] api: packet: specify errors returned in case of IPsec

### DIFF
--- a/include/odp/api/spec/packet_flags.h
+++ b/include/odp/api/spec/packet_flags.h
@@ -27,13 +27,17 @@ extern "C" {
  */
 
 /**
- * Check for all errors in packet
+ * Check for all parse errors in packet
  *
  * Check if packet parsing has found any errors in the packet. The level of
  * error checking depends on the parse configuration (e.g. included layers and
  * checksums). Protocol layer functions (e.g. odp_packet_has_l3()) indicate
  * which layers have been checked, and layer error functions
  * (e.g. odp_packet_has_l3_error()) which layers have errors.
+ *
+ * If packet subtype is ODP_EVENT_PACKET_IPSEC, odp_packet_has_error() would
+ * indicate parsing errors after IPSEC processing. IPSEC errors/warnings need
+ * to be checked using odp_ipsec_result().
  *
  * @param pkt          Packet handle
  *

--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -115,7 +115,7 @@ typedef union {
 	uint32_t all_flags;
 
 	struct {
-		uint32_t reserved1:     9;
+		uint32_t reserved1:     10;
 
 	/*
 	 * Init flags
@@ -142,15 +142,14 @@ typedef union {
 		uint32_t udp_err:        1; /* UDP error */
 		uint32_t sctp_err:       1; /* SCTP error */
 		uint32_t l4_chksum_err:  1; /* L4 checksum error */
-		uint32_t ipsec_err:      1; /* IPsec error */
 		uint32_t crypto_err:     1; /* Crypto packet operation error */
 	};
 
 	/* Flag groups */
 	struct {
-		uint32_t reserved2:     9;
+		uint32_t reserved2:     10;
 		uint32_t other:         14; /* All other flags */
-		uint32_t error:          9; /* All error flags */
+		uint32_t error:          8; /* All error flags */
 	} all;
 
 } _odp_packet_flags_t;

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -606,7 +606,6 @@ static ipsec_sa_t *ipsec_in_single(odp_packet_t pkt,
 	odp_crypto_packet_op_param_t param;
 	int rc;
 	odp_crypto_packet_result_t crypto; /**< Crypto operation result */
-	odp_packet_hdr_t *pkt_hdr;
 
 	state.ip_offset = odp_packet_l3_offset(pkt);
 	ODP_ASSERT(ODP_PACKET_OFFSET_INVALID != state.ip_offset);
@@ -799,14 +798,7 @@ static ipsec_sa_t *ipsec_in_single(odp_packet_t pkt,
 		odp_packet_parse(pkt, state.ip_offset, &parse_param);
 	}
 
-	*pkt_out = pkt;
-
-	return ipsec_sa;
-
 err:
-	pkt_hdr = packet_hdr(pkt);
-	pkt_hdr->p.flags.ipsec_err = 1;
-
 	*pkt_out = pkt;
 
 	return ipsec_sa;
@@ -1392,7 +1384,6 @@ static ipsec_sa_t *ipsec_out_single(odp_packet_t pkt,
 	odp_crypto_packet_op_param_t param;
 	int rc;
 	odp_crypto_packet_result_t crypto; /**< Crypto operation result */
-	odp_packet_hdr_t *pkt_hdr;
 	odp_ipsec_frag_mode_t frag_mode;
 	uint32_t mtu;
 
@@ -1555,14 +1546,7 @@ static ipsec_sa_t *ipsec_out_single(odp_packet_t pkt,
 	else if (ODP_IPSEC_AH == ipsec_sa->proto)
 		ipsec_out_ah_post(&state, pkt);
 
-	*pkt_out = pkt;
-	return ipsec_sa;
-
 err:
-	pkt_hdr = packet_hdr(pkt);
-
-	pkt_hdr->p.flags.ipsec_err = 1;
-
 	*pkt_out = pkt;
 	return ipsec_sa;
 }

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -831,8 +831,9 @@ void ipsec_check_in_one(const ipsec_test_part *part, odp_ipsec_sa_t sa)
 			CU_ASSERT_EQUAL(0, odp_ipsec_result(&result, pkto[i]));
 			CU_ASSERT_EQUAL(part->out[i].status.error.all,
 					result.status.error.all);
-			CU_ASSERT(!result.status.error.all ==
-				  !odp_packet_has_error(pkto[i]));
+			if (0 == result.status.error.all)
+				CU_ASSERT_EQUAL(0,
+						odp_packet_has_error(pkto[i]));
 			CU_ASSERT_EQUAL(suite_context.inbound_op_mode ==
 					ODP_IPSEC_OP_MODE_INLINE,
 					result.flag.inline_mode);
@@ -881,8 +882,9 @@ void ipsec_check_out_one(const ipsec_test_part *part, odp_ipsec_sa_t sa)
 			CU_ASSERT_EQUAL(0, odp_ipsec_result(&result, pkto[i]));
 			CU_ASSERT_EQUAL(part->out[i].status.error.all,
 					result.status.error.all);
-			CU_ASSERT(!result.status.error.all ==
-				  !odp_packet_has_error(pkto[i]));
+			if (0 == result.status.error.all)
+				CU_ASSERT_EQUAL(0,
+						odp_packet_has_error(pkto[i]));
 			CU_ASSERT_EQUAL(sa, result.sa);
 			CU_ASSERT_EQUAL(IPSEC_SA_CTX,
 					odp_ipsec_sa_context(sa));


### PR DESCRIPTION
In case of IPsec packets, odp_packet_has_error() can be used to check parse
errors after IPsec processing. All IPsec errors/warnings need to be
checked using odp_ipsec_result().