### PR TITLE
[PATCH v16] api: timer: add timer pool queue capability

### DIFF
--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -216,6 +216,27 @@ typedef struct {
 	 */
 	odp_timer_res_capability_t max_tmo;
 
+	/**
+	 * Scheduled queue destination support
+	 *
+	 * This defines whether schedule queues are supported as timeout
+	 * destination queues.
+	 * 0: Scheduled queues are not supported as timeout destination queues
+	 * 1: Scheduled queues are supported as timeout destination queues
+	 * @see odp_timer_alloc()
+	 */
+	odp_bool_t queue_type_sched;
+
+	/**
+	 * Plain queue destination support
+	 *
+	 * This defines whether plain queues are supported as timeout
+	 * destination queues.
+	 * 0: Plain queues are not supported as timeout destination queues
+	 * 1: Plain queues are supported as timeout destination queues
+	 * @see odp_timer_alloc()
+	 */
+	odp_bool_t queue_type_plain;
 } odp_timer_capability_t;
 
 /**

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1254,6 +1254,8 @@ int odp_timer_capability(odp_timer_clk_src_t clk_src,
 	capa->max_tmo.res_hz  = timer_global->highest_res_hz;
 	capa->max_tmo.min_tmo = 0;
 	capa->max_tmo.max_tmo = MAX_TMO_NSEC;
+	capa->queue_type_sched = true;
+	capa->queue_type_plain = true;
 
 	return 0;
 }


### PR DESCRIPTION
## api: timer: add timer pool queue capability

In some ODP implementations, plain queues might be using software
primitives such as a simple ring and the ODP timer hardware pools
can enqueue timeouts only into schedule queues.
Introducing capability `queue_type_sched` and `queue_type_plain`
which define the queue types that can be the destination of the
timeout events.

Signed-off-by: Pavan Nikhilesh <pbhagavatula@marvell.com>

## linux-gen: timer: destination queue type capability

Add support for the new timer pool destination queue type
capability.

Signed-off-by: Pavan Nikhilesh <pbhagavatula@marvell.com>

## test: validation: timer: check timer capability

Check timer pool capability and set tests as inactive if destination
queue type is not supported.

Signed-off-by: Pavan Nikhilesh <pbhagavatula@marvell.com>
