### PR TITLE
[PATCH v5] api: packet: move odp_packet_chksum_status_t enum

### DIFF
--- a/include/odp/api/abi-default/packet.h
+++ b/include/odp/api/abi-default/packet.h
@@ -70,6 +70,12 @@ typedef enum {
 	ODP_PACKET_ALL_COLORS = 3,
 } odp_packet_color_t;
 
+typedef enum {
+	ODP_PACKET_CHKSUM_UNKNOWN = 0,
+	ODP_PACKET_CHKSUM_BAD,
+	ODP_PACKET_CHKSUM_OK
+} odp_packet_chksum_status_t;
+
 /** Parse result flags */
 typedef struct odp_packet_parse_result_flag_t {
 	/** Flags union */

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -50,25 +50,19 @@ extern "C" {
  * Invalid packet segment
  */
 
- /**
-  * @typedef odp_packet_color_t
-  * Color of packet for shaper/drop processing
-  */
-
- /**
-  * @def ODP_PACKET_GREEN
-  * Packet is green
-  */
-
- /**
-  * @def ODP_PACKET_YELLOW
-  * Packet is yellow
-  */
-
- /**
-  * @def ODP_PACKET_RED
-  * Packet is red
-  */
+/**
+ * @enum odp_packet_color_t
+ * Color of packet for shaper/drop processing
+ *
+ * @var ODP_PACKET_GREEN
+ * Packet is green
+ *
+ * @var ODP_PACKET_YELLOW
+ * Packet is yellow
+ *
+ * @var ODP_PACKET_RED
+ * Packet is red
+ */
 
 /**
  * Maximum number of packet colors which accommodates ODP_PACKET_GREEN, ODP_PACKET_YELLOW and

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -168,6 +168,21 @@ extern "C" {
  */
 
 /**
+ * @enum odp_packet_chksum_status_t
+ * Checksum check status in packet
+ *
+ * @var ODP_PACKET_CHKSUM_UNKNOWN
+ * Checksum was not checked. Checksum check was not
+ * attempted or the attempt failed.
+ *
+ * @var ODP_PACKET_CHKSUM_BAD
+ * Checksum was checked and it was not correct.
+ *
+ * @var ODP_PACKET_CHKSUM_OK
+ * Checksum was checked and it was correct.
+ */
+
+/**
  * Protocol
  */
 typedef enum odp_proto_t {
@@ -217,22 +232,6 @@ typedef struct odp_packet_data_range {
 	uint32_t length;
 
 } odp_packet_data_range_t;
-
-/**
- * Checksum check status in packet
- */
-typedef enum odp_packet_chksum_status_t {
-	/** Checksum was not checked. Checksum check was not attempted or
-	  * the attempt failed. */
-	ODP_PACKET_CHKSUM_UNKNOWN = 0,
-
-	/** Checksum was checked and it was not correct */
-	ODP_PACKET_CHKSUM_BAD,
-
-	/** Checksum was checked and it was correct */
-	ODP_PACKET_CHKSUM_OK
-
-} odp_packet_chksum_status_t;
 
 /**
  * Event subtype of a packet

--- a/platform/linux-generic/include-abi/odp/api/abi/packet.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet.h
@@ -77,6 +77,12 @@ typedef enum {
 	ODP_PACKET_ALL_COLORS = 3,
 } odp_packet_color_t;
 
+typedef enum {
+	ODP_PACKET_CHKSUM_UNKNOWN = 0,
+	ODP_PACKET_CHKSUM_BAD,
+	ODP_PACKET_CHKSUM_OK
+} odp_packet_chksum_status_t;
+
 typedef struct odp_packet_parse_result_flag_t {
 	union {
 		uint64_t all;


### PR DESCRIPTION
## api: packet: move odp_packet_chksum_status_t enum

Move odp_packet_chksum_status_t enum from spec/packet.h
to abi/packet.h to allow platform specific header files
to make use of this enumeration. Currently this is not
possible as spec/packet.h is included after the platform
specific header files.

Signed-off-by: Ashwin Sekhar T K <asekhar@marvell.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>

## api: packet: fix doxygen for odp_packet_color_t

Fix doxygen syntax for odp_packet_color_t enum.

Signed-off-by: Ashwin Sekhar T K <asekhar@marvell.com>
Reviewed-by: Petri Savolainen <petri.savolainen@nokia.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>
