### PR TITLE
[PATCH v8] api: cls-term

### DIFF
--- a/helper/include/odp/helper/gtpu.h
+++ b/helper/include/odp/helper/gtpu.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2020, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP GTPU header
+ */
+#ifndef _ODPH_GTP_H_
+#define _ODPH_GTP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp_api.h>
+
+/**
+ * Simplified GTP protocol header.
+ * Contains 8-bit gtp_hdr_info, 8-bit msg_type,
+ * 16-bit plen, 32-bit teid.
+ * No optional fields and next extension header.
+ */
+typedef struct ODP_PACKED {
+	uint8_t gtp_hdr_info; /**< GTP header info */
+	uint8_t msg_type;     /**< GTP message type */
+	odp_u16be_t plen;     /**< Total payload length */
+	odp_u32be_t teid;     /**< Tunnel endpoint ID */
+} odph_gtpuhdr_t;
+
+/** GTP header length */
+#define ODP_GTPU_HLEN sizeof(odph_gtpuhdr_t)
+
+/** GTP UDP port number */
+#define ODP_GTPU_UDP_PORT 2152
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ODP_GTP_H_ */

--- a/helper/include/odp/helper/igmp.h
+++ b/helper/include/odp/helper/igmp.h
@@ -1,0 +1,41 @@
+/* Copyright (c) 2020, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP IGMP header
+ */
+#ifndef _ODPH_IGMP_H_
+#define _ODPH_IGMP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp_api.h>
+
+/**
+ * Simplified IGMP protocol header.
+ * Contains 8-bit type, 8-bit code,
+ * 16-bit csum, 32-bit group.
+ * No optional fields and next extension header.
+ */
+typedef struct ODP_PACKED {
+	uint8_t type; /** Message Type */
+	uint8_t code; /** Max response code */
+	odp_u16be_t csum; /** Checksum */
+	odp_u32be_t group; /** Group address */
+} odph_igmphdr_t;
+
+/** IGMP header length */
+#define ODP_IGMP_HLEN sizeof(odph_igmphdr_t)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ODP_IGMP_H_ */

--- a/helper/include/odp/helper/ip.h
+++ b/helper/include/odp/helper/ip.h
@@ -252,6 +252,7 @@ typedef struct ODP_PACKED {
  * @{*/
 #define ODPH_IPPROTO_HOPOPTS 0x00 /**< IPv6 hop-by-hop options */
 #define ODPH_IPPROTO_ICMPV4  0x01 /**< Internet Control Message Protocol (1) */
+#define ODPH_IPPROTO_IGMP    0x02 /**< Internet Group Message Protocol (1) */
 #define ODPH_IPPROTO_TCP     0x06 /**< Transmission Control Protocol (6) */
 #define ODPH_IPPROTO_UDP     0x11 /**< User Datagram Protocol (17) */
 #define ODPH_IPPROTO_ROUTE   0x2B /**< IPv6 Routing header (43) */

--- a/helper/include/odp/helper/odph_api.h
+++ b/helper/include/odp/helper/odph_api.h
@@ -25,6 +25,7 @@ extern "C" {
 #include <odp/helper/gtpu.h>
 #include <odp/helper/odph_hashtable.h>
 #include <odp/helper/icmp.h>
+#include <odp/helper/igmp.h>
 #include <odp/helper/ip.h>
 #include <odp/helper/ipsec.h>
 #include <odp/helper/odph_lineartable.h>

--- a/helper/include/odp/helper/odph_api.h
+++ b/helper/include/odp/helper/odph_api.h
@@ -22,6 +22,7 @@ extern "C" {
 #include <odp/helper/chksum.h>
 #include <odp/helper/odph_cuckootable.h>
 #include <odp/helper/eth.h>
+#include <odp/helper/gtpu.h>
 #include <odp/helper/odph_hashtable.h>
 #include <odp/helper/icmp.h>
 #include <odp/helper/ip.h>

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -115,6 +115,8 @@ typedef union odp_cls_pmr_terms_t {
 		uint64_t	sctp_sport:1;
 		/** Destination SCTP port */
 		uint64_t	sctp_dport:1;
+		/** GTPU Tunnel endpoint identifier, with UDP port 2152 */
+		uint64_t	gtpu_teid:1;
 	} bit;
 	/** All bits of the bit field structure */
 	uint64_t all_bits;
@@ -580,6 +582,9 @@ typedef enum {
 
 	/** Destination SCTP port (val_sz = 2) */
 	ODP_PMR_SCTP_DPORT,
+
+	/** GTPU Tunnel endpoint identifier  (val_sz = 4), with UDP port 2152 */
+	ODP_PMR_GTPU_TEID,
 
 	/** Inner header may repeat above values with this offset */
 	ODP_PMR_INNER_HDR_OFF = 32

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -105,6 +105,12 @@ typedef union odp_cls_pmr_terms_t {
 		uint64_t        custom_l3:1;
 		/** IGMP Group address */
 		uint64_t	igmp_grp_addr:1;
+		/** ICMP identifier */
+		uint64_t	icmp_id:1;
+		/** ICMP type */
+		uint64_t	icmp_type:1;
+		/** ICMP code */
+		uint64_t	icmp_code:1;
 
 	} bit;
 	/** All bits of the bit field structure */
@@ -556,6 +562,15 @@ typedef enum {
 
 	/** IGMP Group address (val_sz = 4) */
 	ODP_PMR_IGMP_GRP_ADDR,
+
+	/** ICMP identifier (val_sz = 2) */
+	ODP_PMR_ICMP_ID,
+
+	/** ICMP type (val_sz = 1) */
+	ODP_PMR_ICMP_TYPE,
+
+	/** ICMP code (val_sz = 1) */
+	ODP_PMR_ICMP_CODE,
 
 	/** Inner header may repeat above values with this offset */
 	ODP_PMR_INNER_HDR_OFF = 32

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -103,6 +103,8 @@ typedef union odp_cls_pmr_terms_t {
 		/** Custom layer 3 match rule. PMR offset is counted from
 		 *  the start of layer 3 in the packet. */
 		uint64_t        custom_l3:1;
+		/** IGMP Group address */
+		uint64_t	igmp_grp_addr:1;
 
 	} bit;
 	/** All bits of the bit field structure */
@@ -551,6 +553,9 @@ typedef enum {
 	 * Custom L3 rules may be combined with other PMRs.
 	 */
 	ODP_PMR_CUSTOM_L3,
+
+	/** IGMP Group address (val_sz = 4) */
+	ODP_PMR_IGMP_GRP_ADDR,
 
 	/** Inner header may repeat above values with this offset */
 	ODP_PMR_INNER_HDR_OFF = 32

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -111,7 +111,10 @@ typedef union odp_cls_pmr_terms_t {
 		uint64_t	icmp_type:1;
 		/** ICMP code */
 		uint64_t	icmp_code:1;
-
+		/** Source SCTP port */
+		uint64_t	sctp_sport:1;
+		/** Destination SCTP port */
+		uint64_t	sctp_dport:1;
 	} bit;
 	/** All bits of the bit field structure */
 	uint64_t all_bits;
@@ -571,6 +574,12 @@ typedef enum {
 
 	/** ICMP code (val_sz = 1) */
 	ODP_PMR_ICMP_CODE,
+
+	/** Source SCTP port (val_sz = 2) */
+	ODP_PMR_SCTP_SPORT,
+
+	/** Destination SCTP port (val_sz = 2) */
+	ODP_PMR_SCTP_DPORT,
 
 	/** Inner header may repeat above values with this offset */
 	ODP_PMR_INNER_HDR_OFF = 32

--- a/test/validation/api/classification/odp_classification_common.c
+++ b/test/validation/api/classification/odp_classification_common.c
@@ -95,6 +95,9 @@ int cls_pkt_set_seq(odp_packet_t pkt)
 	uint32_t offset;
 	odph_ipv4hdr_t *ip;
 	odph_tcphdr_t *tcp;
+	odph_udphdr_t *udp;
+	uint16_t port = 0;
+	uint32_t hlen = 0;
 	int status;
 
 	data.magic = DATA_MAGIC;
@@ -110,10 +113,18 @@ int cls_pkt_set_seq(odp_packet_t pkt)
 	} else if (ip->proto == ODPH_IPPROTO_SCTP) {
 		status = odp_packet_copy_from_mem(pkt, offset + ODPH_SCTPHDR_LEN,
 						  sizeof(data), &data);
-	} else if (ip->proto == ODPH_IPPROTO_UDP)
-		status = odp_packet_copy_from_mem(pkt, offset + ODPH_UDPHDR_LEN,
-						  sizeof(data), &data);
-	else {
+	} else if (ip->proto == ODPH_IPPROTO_UDP) {
+		udp = (odph_udphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+		port = odp_be_to_cpu_16(udp->dst_port);
+		if (port == ODP_GTPU_UDP_PORT) {
+			hlen = offset + ODPH_UDPHDR_LEN + ODP_GTPU_HLEN;
+			status = odp_packet_copy_from_mem(pkt, hlen,
+							  sizeof(data), &data);
+		} else {
+			status = odp_packet_copy_from_mem(pkt, offset + ODPH_UDPHDR_LEN,
+							  sizeof(data), &data);
+		}
+	} else {
 		tcp = (odph_tcphdr_t *)odp_packet_l4_ptr(pkt, NULL);
 		status = odp_packet_copy_from_mem(pkt, offset + tcp->hl * 4,
 						  sizeof(data), &data);
@@ -128,6 +139,9 @@ uint32_t cls_pkt_get_seq(odp_packet_t pkt)
 	cls_test_packet_t data;
 	odph_ipv4hdr_t *ip;
 	odph_tcphdr_t *tcp;
+	odph_udphdr_t *udp;
+	uint32_t hlen = 0;
+	uint16_t port = 0;
 
 	ip = (odph_ipv4hdr_t *)odp_packet_l3_ptr(pkt, NULL);
 	offset = odp_packet_l4_offset(pkt);
@@ -140,10 +154,17 @@ uint32_t cls_pkt_get_seq(odp_packet_t pkt)
 	} else if (ip->proto == ODPH_IPPROTO_SCTP) {
 		odp_packet_copy_to_mem(pkt, offset + ODPH_SCTPHDR_LEN,
 				       sizeof(data), &data);
-	} else if (ip->proto == ODPH_IPPROTO_UDP)
-		odp_packet_copy_to_mem(pkt, offset + ODPH_UDPHDR_LEN,
-				       sizeof(data), &data);
-	else {
+	} else if (ip->proto == ODPH_IPPROTO_UDP) {
+		udp = (odph_udphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+		port = odp_be_to_cpu_16(udp->dst_port);
+		if (port == ODP_GTPU_UDP_PORT) {
+			hlen = offset + ODPH_UDPHDR_LEN + ODP_GTPU_HLEN;
+			odp_packet_copy_to_mem(pkt, hlen, sizeof(data), &data);
+		} else {
+			odp_packet_copy_to_mem(pkt, offset + ODPH_UDPHDR_LEN,
+					       sizeof(data), &data);
+		}
+	} else {
 		tcp = (odph_tcphdr_t *)odp_packet_l4_ptr(pkt, NULL);
 		odp_packet_copy_to_mem(pkt, offset + tcp->hl * 4,
 				       sizeof(data), &data);
@@ -253,6 +274,8 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 	odph_icmphdr_t *icmp;
 	odph_ipv4hdr_t *ip;
 	odph_ipv6hdr_t *ipv6;
+	odph_gtpuhdr_t *gtpu;
+	uint8_t *hlen = 0;
 	uint16_t payload_len;
 	uint32_t addr = 0;
 	uint32_t mask;
@@ -271,6 +294,9 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 	uint8_t dst_mac[] = CLS_DEFAULT_DMAC;
 
 	payload_len = sizeof(cls_test_packet_t) + pkt_info.len;
+	if (pkt_info.gtpu)
+		payload_len += sizeof(odph_gtpuhdr_t);
+
 	seqno = odp_atomic_fetch_inc_u32(pkt_info.seq);
 
 	vlan_hdr_len = pkt_info.vlan ? ODPH_VLANHDR_LEN : 0;
@@ -281,6 +307,8 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 	next_hdr = pkt_info.udp ? ODPH_IPPROTO_UDP : ODPH_IPPROTO_TCP;
 	next_hdr = pkt_info.sctp ? ODPH_IPPROTO_SCTP : next_hdr;
 	next_hdr = pkt_info.icmp ? ODPH_IPPROTO_ICMPV4 : next_hdr;
+	if (pkt_info.gtpu)
+		next_hdr = ODPH_IPPROTO_UDP;
 	l2_hdr_len   = ODPH_ETHHDR_LEN + vlan_hdr_len;
 	l4_len	= l4_hdr_len + payload_len;
 	l3_len	= l3_hdr_len + l4_len;
@@ -385,6 +413,22 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 		udp->length = odp_cpu_to_be_16(payload_len + ODPH_UDPHDR_LEN);
 		udp->chksum = 0;
 		odp_packet_has_udp_set(pkt, 1);
+		if (odph_udp_tcp_chksum(pkt, ODPH_CHKSUM_GENERATE, NULL) != 0) {
+			ODPH_ERR("odph_udp_tcp_chksum failed\n");
+			return ODP_PACKET_INVALID;
+		}
+	} else if (pkt_info.gtpu) {
+		udp->src_port = odp_cpu_to_be_16(ODP_GTPU_UDP_PORT);
+		udp->dst_port = odp_cpu_to_be_16(ODP_GTPU_UDP_PORT);
+		udp->length = odp_cpu_to_be_16(payload_len + ODPH_UDPHDR_LEN);
+		udp->chksum = 0;
+		odp_packet_has_udp_set(pkt, 1);
+		hlen = (uint8_t *)odp_packet_l4_ptr(pkt, NULL);
+		gtpu = (odph_gtpuhdr_t *)(hlen + sizeof(odph_udphdr_t));
+		gtpu->teid = odp_cpu_to_be_32(0xdeadbeef);
+		gtpu->gtp_hdr_info = 0x30;
+		gtpu->msg_type = 1;
+		gtpu->plen = 0;
 		if (odph_udp_tcp_chksum(pkt, ODPH_CHKSUM_GENERATE, NULL) != 0) {
 			ODPH_ERR("odph_udp_tcp_chksum failed\n");
 			return ODP_PACKET_INVALID;

--- a/test/validation/api/classification/odp_classification_common.c
+++ b/test/validation/api/classification/odp_classification_common.c
@@ -104,7 +104,10 @@ int cls_pkt_set_seq(odp_packet_t pkt)
 	offset = odp_packet_l4_offset(pkt);
 	CU_ASSERT_FATAL(offset != ODP_PACKET_OFFSET_INVALID);
 
-	if (ip->proto == ODPH_IPPROTO_UDP)
+	if (ip->proto == ODPH_IPPROTO_SCTP) {
+		status = odp_packet_copy_from_mem(pkt, offset + ODPH_SCTPHDR_LEN,
+						  sizeof(data), &data);
+	} else if (ip->proto == ODPH_IPPROTO_UDP)
 		status = odp_packet_copy_from_mem(pkt, offset + ODPH_UDPHDR_LEN,
 						  sizeof(data), &data);
 	else {
@@ -128,8 +131,10 @@ uint32_t cls_pkt_get_seq(odp_packet_t pkt)
 
 	if (offset == ODP_PACKET_OFFSET_INVALID || ip == NULL)
 		return TEST_SEQ_INVALID;
-
-	if (ip->proto == ODPH_IPPROTO_UDP)
+	if (ip->proto == ODPH_IPPROTO_SCTP) {
+		odp_packet_copy_to_mem(pkt, offset + ODPH_SCTPHDR_LEN,
+				       sizeof(data), &data);
+	} else if (ip->proto == ODPH_IPPROTO_UDP)
 		odp_packet_copy_to_mem(pkt, offset + ODPH_UDPHDR_LEN,
 				       sizeof(data), &data);
 	else {
@@ -238,6 +243,7 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 	odph_ethhdr_t *ethhdr;
 	odph_udphdr_t *udp;
 	odph_tcphdr_t *tcp;
+	odph_sctphdr_t *sctp;
 	odph_ipv4hdr_t *ip;
 	odph_ipv6hdr_t *ipv6;
 	uint16_t payload_len;
@@ -266,6 +272,7 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 	l4_hdr_len = pkt_info.udp ? ODPH_UDPHDR_LEN : ODPH_TCPHDR_LEN;
 	eth_type = pkt_info.ipv6 ? ODPH_ETHTYPE_IPV6 : ODPH_ETHTYPE_IPV4;
 	next_hdr = pkt_info.udp ? ODPH_IPPROTO_UDP : ODPH_IPPROTO_TCP;
+	next_hdr = pkt_info.sctp ? ODPH_IPPROTO_SCTP : next_hdr;
 	l2_hdr_len   = ODPH_ETHHDR_LEN + vlan_hdr_len;
 	l4_len	= l4_hdr_len + payload_len;
 	l3_len	= l3_hdr_len + l4_len;
@@ -344,9 +351,20 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 	odp_packet_l4_offset_set(pkt, l4_offset);
 	tcp = (odph_tcphdr_t *)(buf + l4_offset);
 	udp = (odph_udphdr_t *)(buf + l4_offset);
+	sctp = (odph_sctphdr_t *)(buf + l4_offset);
 
-	/* udp */
-	if (pkt_info.udp) {
+	if (pkt_info.sctp) {
+		sctp->src_port = odp_cpu_to_be_16(CLS_DEFAULT_SPORT);
+		sctp->dst_port = odp_cpu_to_be_16(CLS_DEFAULT_DPORT);
+		sctp->tag = 0;
+		sctp->chksum = 0;
+		odp_packet_has_sctp_set(pkt, 1);
+		if (odph_sctp_chksum_set(pkt) != 0) {
+			ODPH_ERR("odph_sctp_chksum failed\n");
+			return ODP_PACKET_INVALID;
+		}
+	} else if (pkt_info.udp) {
+		/* udp */
 		udp->src_port = odp_cpu_to_be_16(CLS_DEFAULT_SPORT);
 		udp->dst_port = odp_cpu_to_be_16(CLS_DEFAULT_DPORT);
 		udp->length = odp_cpu_to_be_16(payload_len + ODPH_UDPHDR_LEN);

--- a/test/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/validation/api/classification/odp_classification_test_pmr.c
@@ -2650,6 +2650,381 @@ static void classification_test_pmr_term_sctp_dport(void)
 	odp_pktio_close(pktio);
 }
 
+static void classification_test_pmr_term_icmp_type(void)
+{
+	odp_packet_t pkt;
+	odph_icmphdr_t *icmp;
+	uint8_t val;
+	uint8_t mask;
+	uint32_t seqno;
+	int retval;
+	odp_pktio_t pktio;
+	odp_queue_t queue;
+	odp_queue_t retqueue;
+	odp_queue_t default_queue;
+	odp_cos_t default_cos;
+	odp_pool_t default_pool;
+	odp_pool_t pool;
+	odp_pool_t recvpool;
+	odp_pmr_t pmr;
+	odp_cos_t cos;
+	char cosname[ODP_COS_NAME_LEN];
+	odp_cls_cos_param_t cls_param;
+	odp_pmr_param_t pmr_param;
+	odph_ethhdr_t *eth;
+	cls_packet_info_t pkt_info;
+
+	val  = 0x8;
+	mask = 0xff;
+	seqno = 0;
+
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
+	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
+	retval = start_pktio(pktio);
+	CU_ASSERT(retval == 0);
+
+	configure_default_cos(pktio, &default_cos,
+			      &default_queue, &default_pool);
+
+	queue = queue_create("icmp_type", true);
+	CU_ASSERT_FATAL(queue != ODP_QUEUE_INVALID);
+
+	pool = pool_create("icmp_type");
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	sprintf(cosname, "icmp_type");
+	odp_cls_cos_param_init(&cls_param);
+	cls_param.pool = pool;
+	cls_param.queue = queue;
+	cls_param.drop_policy = ODP_COS_DROP_POOL;
+
+	cos = odp_cls_cos_create(cosname, &cls_param);
+	CU_ASSERT_FATAL(cos != ODP_COS_INVALID);
+
+	odp_cls_pmr_param_init(&pmr_param);
+	pmr_param.term = ODP_PMR_ICMP_TYPE;
+	pmr_param.match.value = &val;
+	pmr_param.match.mask = &mask;
+	pmr_param.val_sz = sizeof(val);
+
+	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
+
+	pkt_info = default_pkt_info;
+	pkt_info.icmp = true;
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	icmp = (odph_icmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	icmp->un.echo.id = 0x123;
+	icmp->un.echo.sequence = 0x1;
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == pool);
+	icmp = (odph_icmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	CU_ASSERT(icmp->un.echo.id == 0x123);
+	CU_ASSERT(icmp->un.echo.sequence == 0x1);
+	odp_packet_free(pkt);
+
+	/* Other packets should goto default queue */
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	icmp = (odph_icmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	icmp->type = 0;
+	icmp->un.echo.id = 0x456;
+	icmp->un.echo.sequence = 0x2;
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == default_queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == default_pool);
+	icmp = (odph_icmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	CU_ASSERT(icmp->un.echo.id == 0x456);
+	CU_ASSERT(icmp->un.echo.sequence == 0x2);
+
+	odp_packet_free(pkt);
+	odp_cos_destroy(cos);
+	odp_cos_destroy(default_cos);
+	odp_cls_pmr_destroy(pmr);
+	stop_pktio(pktio);
+	odp_pool_destroy(default_pool);
+	odp_pool_destroy(pool);
+	odp_queue_destroy(queue);
+	odp_queue_destroy(default_queue);
+	odp_pktio_close(pktio);
+}
+
+static void classification_test_pmr_term_icmp_code(void)
+{
+	odp_packet_t pkt;
+	odph_icmphdr_t *icmp;
+	uint8_t val;
+	uint8_t mask;
+	uint32_t seqno;
+	int retval;
+	odp_pktio_t pktio;
+	odp_queue_t queue;
+	odp_queue_t retqueue;
+	odp_queue_t default_queue;
+	odp_cos_t default_cos;
+	odp_pool_t default_pool;
+	odp_pool_t pool;
+	odp_pool_t recvpool;
+	odp_pmr_t pmr;
+	odp_cos_t cos;
+	char cosname[ODP_COS_NAME_LEN];
+	odp_cls_cos_param_t cls_param;
+	odp_pmr_param_t pmr_param;
+	odph_ethhdr_t *eth;
+	cls_packet_info_t pkt_info;
+
+	val  = 0x1;
+	mask = 0xff;
+	seqno = 0;
+
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
+	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
+	retval = start_pktio(pktio);
+	CU_ASSERT(retval == 0);
+
+	configure_default_cos(pktio, &default_cos,
+			      &default_queue, &default_pool);
+
+	queue = queue_create("icmp_code", true);
+	CU_ASSERT_FATAL(queue != ODP_QUEUE_INVALID);
+
+	pool = pool_create("icmp_code");
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	sprintf(cosname, "icmp_code");
+	odp_cls_cos_param_init(&cls_param);
+	cls_param.pool = pool;
+	cls_param.queue = queue;
+	cls_param.drop_policy = ODP_COS_DROP_POOL;
+
+	cos = odp_cls_cos_create(cosname, &cls_param);
+	CU_ASSERT_FATAL(cos != ODP_COS_INVALID);
+
+	odp_cls_pmr_param_init(&pmr_param);
+	pmr_param.term = ODP_PMR_ICMP_CODE;
+	pmr_param.match.value = &val;
+	pmr_param.match.mask = &mask;
+	pmr_param.val_sz = sizeof(val);
+
+	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
+
+	pkt_info = default_pkt_info;
+	pkt_info.icmp = true;
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	icmp = (odph_icmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	icmp->code = 0x1;
+	icmp->un.echo.id = 0x123;
+	icmp->un.echo.sequence = 0x1;
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == pool);
+	icmp = (odph_icmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	CU_ASSERT(icmp->un.echo.id == 0x123);
+	CU_ASSERT(icmp->un.echo.sequence == 0x1);
+	odp_packet_free(pkt);
+
+	/* Other packets should goto default queue */
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	icmp = (odph_icmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	icmp->code = 0;
+	icmp->un.echo.id = 0x456;
+	icmp->un.echo.sequence = 0x2;
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == default_queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == default_pool);
+	icmp = (odph_icmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	CU_ASSERT(icmp->un.echo.id == 0x456);
+	CU_ASSERT(icmp->un.echo.sequence == 0x2);
+
+	odp_packet_free(pkt);
+	odp_cos_destroy(cos);
+	odp_cos_destroy(default_cos);
+	odp_cls_pmr_destroy(pmr);
+	stop_pktio(pktio);
+	odp_pool_destroy(default_pool);
+	odp_pool_destroy(pool);
+	odp_queue_destroy(queue);
+	odp_queue_destroy(default_queue);
+	odp_pktio_close(pktio);
+}
+
+static void classification_test_pmr_term_icmp_id(void)
+{
+	odp_packet_t pkt;
+	odph_icmphdr_t *icmp;
+	uint16_t val;
+	uint16_t mask;
+	uint32_t seqno;
+	int retval;
+	odp_pktio_t pktio;
+	odp_queue_t queue;
+	odp_queue_t retqueue;
+	odp_queue_t default_queue;
+	odp_cos_t default_cos;
+	odp_pool_t default_pool;
+	odp_pool_t pool;
+	odp_pool_t recvpool;
+	odp_pmr_t pmr;
+	odp_cos_t cos;
+	char cosname[ODP_COS_NAME_LEN];
+	odp_cls_cos_param_t cls_param;
+	odp_pmr_param_t pmr_param;
+	odph_ethhdr_t *eth;
+	cls_packet_info_t pkt_info;
+
+	val  = odp_cpu_to_be_16(0x1234);
+	mask = odp_cpu_to_be_16(0xffff);
+	seqno = 0;
+
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
+	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
+	retval = start_pktio(pktio);
+	CU_ASSERT(retval == 0);
+
+	configure_default_cos(pktio, &default_cos,
+			      &default_queue, &default_pool);
+
+	queue = queue_create("icmp_id", true);
+	CU_ASSERT_FATAL(queue != ODP_QUEUE_INVALID);
+
+	pool = pool_create("icmp_id");
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	sprintf(cosname, "icmp_id");
+	odp_cls_cos_param_init(&cls_param);
+	cls_param.pool = pool;
+	cls_param.queue = queue;
+	cls_param.drop_policy = ODP_COS_DROP_POOL;
+
+	cos = odp_cls_cos_create(cosname, &cls_param);
+	CU_ASSERT_FATAL(cos != ODP_COS_INVALID);
+
+	odp_cls_pmr_param_init(&pmr_param);
+	pmr_param.term = ODP_PMR_ICMP_ID;
+	pmr_param.match.value = &val;
+	pmr_param.match.mask = &mask;
+	pmr_param.val_sz = sizeof(val);
+
+	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
+
+	pkt_info = default_pkt_info;
+	pkt_info.icmp = true;
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	icmp = (odph_icmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	icmp->un.echo.id = odp_cpu_to_be_16(0x1234);
+	icmp->un.echo.sequence = 0x1;
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == pool);
+	icmp = (odph_icmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	CU_ASSERT(icmp->un.echo.id == odp_cpu_to_be_16(0x1234));
+	CU_ASSERT(icmp->un.echo.sequence == 0x1);
+	odp_packet_free(pkt);
+
+	/* Other packets should goto default queue */
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	icmp = (odph_icmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	icmp->un.echo.id = 0x4567;
+	icmp->un.echo.sequence = 0x2;
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == default_queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == default_pool);
+	icmp = (odph_icmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	CU_ASSERT(icmp->un.echo.id == 0x4567);
+	CU_ASSERT(icmp->un.echo.sequence == 0x2);
+
+	odp_packet_free(pkt);
+	odp_cos_destroy(cos);
+	odp_cos_destroy(default_cos);
+	odp_cls_pmr_destroy(pmr);
+	stop_pktio(pktio);
+	odp_pool_destroy(default_pool);
+	odp_pool_destroy(pool);
+	odp_queue_destroy(queue);
+	odp_queue_destroy(default_queue);
+	odp_pktio_close(pktio);
+}
+
 static void classification_test_pmr_serial(void)
 {
 	test_pmr_series(1, 0);
@@ -2794,6 +3169,21 @@ static int check_capa_sctp_dport(void)
 	return cls_capa.supported_terms.bit.sctp_dport;
 }
 
+static int check_capa_icmp_type(void)
+{
+	return cls_capa.supported_terms.bit.icmp_type;
+}
+
+static int check_capa_icmp_code(void)
+{
+	return cls_capa.supported_terms.bit.icmp_code;
+}
+
+static int check_capa_icmp_id(void)
+{
+	return cls_capa.supported_terms.bit.icmp_id;
+}
+
 odp_testinfo_t classification_suite_pmr[] = {
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_tcp_dport,
 				  check_capa_tcp_dport),
@@ -2807,6 +3197,12 @@ odp_testinfo_t classification_suite_pmr[] = {
 				  check_capa_sctp_sport),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_sctp_dport,
 				  check_capa_sctp_dport),
+	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_icmp_type,
+				  check_capa_icmp_type),
+	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_icmp_code,
+				  check_capa_icmp_code),
+	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_icmp_id,
+				  check_capa_icmp_id),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_ipproto,
 				  check_capa_ip_proto),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_dmac,

--- a/test/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/validation/api/classification/odp_classification_test_pmr.c
@@ -2406,6 +2406,250 @@ static void test_pmr_series(const int num_udp, int marking)
 	odp_pktio_close(pktio);
 }
 
+static void classification_test_pmr_term_sctp_sport(void)
+{
+	odp_packet_t pkt;
+	odph_sctphdr_t *sctp;
+	uint32_t seqno;
+	uint16_t val;
+	uint16_t mask;
+	int retval;
+	odp_pktio_t pktio;
+	odp_queue_t queue;
+	odp_queue_t retqueue;
+	odp_queue_t default_queue;
+	odp_cos_t default_cos;
+	odp_pool_t default_pool;
+	odp_pool_t pool;
+	odp_pool_t recvpool;
+	odp_pmr_t pmr;
+	odp_cos_t cos;
+	char cosname[ODP_COS_NAME_LEN];
+	odp_cls_cos_param_t cls_param;
+	odp_pmr_param_t pmr_param;
+	odph_ethhdr_t *eth;
+	cls_packet_info_t pkt_info;
+
+	val  = odp_cpu_to_be_16(CLS_DEFAULT_SPORT);
+	mask = odp_cpu_to_be_16(0xffff);
+	seqno = 0;
+
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
+	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
+	retval = start_pktio(pktio);
+	CU_ASSERT(retval == 0);
+
+	configure_default_cos(pktio, &default_cos,
+			      &default_queue, &default_pool);
+
+	queue = queue_create("sctp_sport", true);
+	CU_ASSERT_FATAL(queue != ODP_QUEUE_INVALID);
+
+	pool = pool_create("sctp_sport");
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	sprintf(cosname, "sctp_sport");
+	odp_cls_cos_param_init(&cls_param);
+	cls_param.pool = pool;
+	cls_param.queue = queue;
+	cls_param.drop_policy = ODP_COS_DROP_POOL;
+
+	cos = odp_cls_cos_create(cosname, &cls_param);
+	CU_ASSERT_FATAL(cos != ODP_COS_INVALID);
+
+	odp_cls_pmr_param_init(&pmr_param);
+	pmr_param.term = ODP_PMR_SCTP_SPORT;
+	pmr_param.match.value = &val;
+	pmr_param.match.mask = &mask;
+	pmr_param.val_sz = sizeof(val);
+
+	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
+
+	pkt_info = default_pkt_info;
+	pkt_info.sctp = true;
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	sctp = (odph_sctphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	sctp->src_port = val;
+	sctp->tag = 0x11223344;
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == pool);
+	sctp = (odph_sctphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	CU_ASSERT(sctp->tag == 0x11223344);
+	odp_packet_free(pkt);
+
+	/* Other packets should goto default queue */
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	sctp = (odph_sctphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	sctp->src_port = odp_cpu_to_be_16(CLS_DEFAULT_SPORT + 1);
+	sctp->tag = 0xdeadbeef;
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == default_queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == default_pool);
+	sctp = (odph_sctphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	CU_ASSERT(sctp->tag == 0xdeadbeef);
+
+	odp_packet_free(pkt);
+	odp_cos_destroy(cos);
+	odp_cos_destroy(default_cos);
+	odp_cls_pmr_destroy(pmr);
+	stop_pktio(pktio);
+	odp_pool_destroy(default_pool);
+	odp_pool_destroy(pool);
+	odp_queue_destroy(queue);
+	odp_queue_destroy(default_queue);
+	odp_pktio_close(pktio);
+}
+
+static void classification_test_pmr_term_sctp_dport(void)
+{
+	odp_packet_t pkt;
+	odph_sctphdr_t *sctp;
+	uint16_t val;
+	uint16_t mask;
+	uint32_t seqno;
+	int retval;
+	odp_pktio_t pktio;
+	odp_queue_t queue;
+	odp_queue_t retqueue;
+	odp_queue_t default_queue;
+	odp_cos_t default_cos;
+	odp_pool_t default_pool;
+	odp_pool_t pool;
+	odp_pool_t recvpool;
+	odp_pmr_t pmr;
+	odp_cos_t cos;
+	char cosname[ODP_COS_NAME_LEN];
+	odp_cls_cos_param_t cls_param;
+	odp_pmr_param_t pmr_param;
+	odph_ethhdr_t *eth;
+	cls_packet_info_t pkt_info;
+
+	val  = odp_cpu_to_be_16(CLS_DEFAULT_DPORT);
+	mask = odp_cpu_to_be_16(0xffff);
+	seqno = 0;
+
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
+	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
+	retval = start_pktio(pktio);
+	CU_ASSERT(retval == 0);
+
+	configure_default_cos(pktio, &default_cos,
+			      &default_queue, &default_pool);
+
+	queue = queue_create("sctp_dport", true);
+	CU_ASSERT_FATAL(queue != ODP_QUEUE_INVALID);
+
+	pool = pool_create("sctp_dport");
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	sprintf(cosname, "sctp_dport");
+	odp_cls_cos_param_init(&cls_param);
+	cls_param.pool = pool;
+	cls_param.queue = queue;
+	cls_param.drop_policy = ODP_COS_DROP_POOL;
+
+	cos = odp_cls_cos_create(cosname, &cls_param);
+	CU_ASSERT_FATAL(cos != ODP_COS_INVALID);
+
+	odp_cls_pmr_param_init(&pmr_param);
+	pmr_param.term = ODP_PMR_SCTP_DPORT;
+	pmr_param.match.value = &val;
+	pmr_param.match.mask = &mask;
+	pmr_param.val_sz = sizeof(val);
+
+	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
+
+	pkt_info = default_pkt_info;
+	pkt_info.sctp = true;
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	sctp = (odph_sctphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	sctp->dst_port = val;
+	sctp->tag = 0x10203040;
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == pool);
+	sctp = (odph_sctphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	CU_ASSERT(sctp->tag == 0x10203040);
+	odp_packet_free(pkt);
+
+	/* Other packets should goto default queue */
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	sctp = (odph_sctphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	sctp->dst_port = odp_cpu_to_be_16(CLS_DEFAULT_DPORT + 1);
+	sctp->tag = 0xdeadbeef;
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == default_queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == default_pool);
+	sctp = (odph_sctphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	CU_ASSERT(sctp->tag == 0xdeadbeef);
+
+	odp_packet_free(pkt);
+	odp_cos_destroy(cos);
+	odp_cos_destroy(default_cos);
+	odp_cls_pmr_destroy(pmr);
+	stop_pktio(pktio);
+	odp_pool_destroy(default_pool);
+	odp_pool_destroy(pool);
+	odp_queue_destroy(queue);
+	odp_queue_destroy(default_queue);
+	odp_pktio_close(pktio);
+}
+
 static void classification_test_pmr_serial(void)
 {
 	test_pmr_series(1, 0);
@@ -2540,6 +2784,16 @@ static int check_capa_pmr_marking(void)
 	return 0;
 }
 
+static int check_capa_sctp_sport(void)
+{
+	return cls_capa.supported_terms.bit.sctp_sport;
+}
+
+static int check_capa_sctp_dport(void)
+{
+	return cls_capa.supported_terms.bit.sctp_dport;
+}
+
 odp_testinfo_t classification_suite_pmr[] = {
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_tcp_dport,
 				  check_capa_tcp_dport),
@@ -2549,6 +2803,10 @@ odp_testinfo_t classification_suite_pmr[] = {
 				  check_capa_udp_dport),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_udp_sport,
 				  check_capa_udp_sport),
+	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_sctp_sport,
+				  check_capa_sctp_sport),
+	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_sctp_dport,
+				  check_capa_sctp_dport),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_ipproto,
 				  check_capa_ip_proto),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_dmac,

--- a/test/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/validation/api/classification/odp_classification_test_pmr.c
@@ -3025,6 +3025,122 @@ static void classification_test_pmr_term_icmp_id(void)
 	odp_pktio_close(pktio);
 }
 
+static void classification_test_pmr_term_gtpu_teid(void)
+{
+	odp_packet_t pkt;
+	odph_gtpuhdr_t *gtpu;
+	uint32_t seqno;
+	uint32_t val;
+	uint32_t mask;
+	int retval;
+	odp_pktio_t pktio;
+	odp_queue_t queue;
+	odp_queue_t retqueue;
+	odp_queue_t default_queue;
+	odp_cos_t default_cos;
+	odp_pool_t default_pool;
+	odp_pool_t pool;
+	odp_pool_t recvpool;
+	odp_pmr_t pmr;
+	odp_cos_t cos;
+	char cosname[ODP_COS_NAME_LEN];
+	odp_cls_cos_param_t cls_param;
+	odp_pmr_param_t pmr_param;
+	odph_ethhdr_t *eth;
+	cls_packet_info_t pkt_info;
+	uint8_t *hlen = 0;
+
+	val  = odp_cpu_to_be_32(0xdeadbeef);
+	mask = odp_cpu_to_be_32(0xffffffff);
+	seqno = 0;
+
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
+	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
+	retval = start_pktio(pktio);
+	CU_ASSERT(retval == 0);
+
+	configure_default_cos(pktio, &default_cos,
+			      &default_queue, &default_pool);
+
+	queue = queue_create("gtp_teid", true);
+	CU_ASSERT_FATAL(queue != ODP_QUEUE_INVALID);
+
+	pool = pool_create("gtp_teid");
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	sprintf(cosname, "gtp_teid");
+	odp_cls_cos_param_init(&cls_param);
+	cls_param.pool = pool;
+	cls_param.queue = queue;
+	cls_param.drop_policy = ODP_COS_DROP_POOL;
+
+	cos = odp_cls_cos_create(cosname, &cls_param);
+	CU_ASSERT_FATAL(cos != ODP_COS_INVALID);
+
+	odp_cls_pmr_param_init(&pmr_param);
+	pmr_param.term = ODP_PMR_GTPU_TEID;
+	pmr_param.match.value = &val;
+	pmr_param.match.mask = &mask;
+	pmr_param.val_sz = sizeof(val);
+
+	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
+
+	pkt_info = default_pkt_info;
+	pkt_info.gtpu = true;
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == pool);
+	odp_packet_free(pkt);
+
+	pkt_info = default_pkt_info;
+	pkt_info.gtpu = true;
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	hlen = (uint8_t *)odp_packet_l4_ptr(pkt, NULL);
+	gtpu = (odph_gtpuhdr_t *)(hlen + ODPH_UDPHDR_LEN);
+	gtpu->teid = odp_cpu_to_be_32(0xdeadbeef + 1);
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == default_queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == default_pool);
+
+	odp_packet_free(pkt);
+	odp_cos_destroy(cos);
+	odp_cos_destroy(default_cos);
+	odp_cls_pmr_destroy(pmr);
+	stop_pktio(pktio);
+	odp_pool_destroy(default_pool);
+	odp_pool_destroy(pool);
+	odp_queue_destroy(queue);
+	odp_queue_destroy(default_queue);
+	odp_pktio_close(pktio);
+}
+
 static void classification_test_pmr_serial(void)
 {
 	test_pmr_series(1, 0);
@@ -3184,6 +3300,11 @@ static int check_capa_icmp_id(void)
 	return cls_capa.supported_terms.bit.icmp_id;
 }
 
+static int check_capa_gtpu_teid(void)
+{
+	return cls_capa.supported_terms.bit.gtpu_teid;
+}
+
 odp_testinfo_t classification_suite_pmr[] = {
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_tcp_dport,
 				  check_capa_tcp_dport),
@@ -3193,6 +3314,8 @@ odp_testinfo_t classification_suite_pmr[] = {
 				  check_capa_udp_dport),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_udp_sport,
 				  check_capa_udp_sport),
+	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_gtpu_teid,
+				  check_capa_gtpu_teid),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_sctp_sport,
 				  check_capa_sctp_sport),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_sctp_dport,

--- a/test/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/validation/api/classification/odp_classification_test_pmr.c
@@ -3141,6 +3141,120 @@ static void classification_test_pmr_term_gtpu_teid(void)
 	odp_pktio_close(pktio);
 }
 
+static void classification_test_pmr_term_igmp_grpaddr(void)
+{
+	odp_packet_t pkt;
+	odph_igmphdr_t *igmp;
+	uint32_t seqno;
+	uint32_t val;
+	uint32_t mask;
+	int retval;
+	odp_pktio_t pktio;
+	odp_queue_t queue;
+	odp_queue_t retqueue;
+	odp_queue_t default_queue;
+	odp_cos_t default_cos;
+	odp_pool_t default_pool;
+	odp_pool_t pool;
+	odp_pool_t recvpool;
+	odp_pmr_t pmr;
+	odp_cos_t cos;
+	char cosname[ODP_COS_NAME_LEN];
+	odp_cls_cos_param_t cls_param;
+	odp_pmr_param_t pmr_param;
+	odph_ethhdr_t *eth;
+	cls_packet_info_t pkt_info;
+
+	val  = odp_cpu_to_be_32(0xdeadbeef);
+	mask = odp_cpu_to_be_32(0xffffffff);
+	seqno = 0;
+
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
+	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
+	retval = start_pktio(pktio);
+	CU_ASSERT(retval == 0);
+
+	configure_default_cos(pktio, &default_cos,
+			      &default_queue, &default_pool);
+
+	queue = queue_create("igmp_grpaddr", true);
+	CU_ASSERT_FATAL(queue != ODP_QUEUE_INVALID);
+
+	pool = pool_create("igmp_grpaddr");
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	sprintf(cosname, "igmp_grpaddr");
+	odp_cls_cos_param_init(&cls_param);
+	cls_param.pool = pool;
+	cls_param.queue = queue;
+	cls_param.drop_policy = ODP_COS_DROP_POOL;
+
+	cos = odp_cls_cos_create(cosname, &cls_param);
+	CU_ASSERT_FATAL(cos != ODP_COS_INVALID);
+
+	odp_cls_pmr_param_init(&pmr_param);
+	pmr_param.term = ODP_PMR_IGMP_GRP_ADDR;
+	pmr_param.match.value = &val;
+	pmr_param.match.mask = &mask;
+	pmr_param.val_sz = sizeof(val);
+
+	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
+
+	pkt_info = default_pkt_info;
+	pkt_info.igmp = true;
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == pool);
+	odp_packet_free(pkt);
+
+	pkt_info = default_pkt_info;
+	pkt_info.igmp = true;
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	igmp = (odph_igmphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	igmp->group = odp_cpu_to_be_32(0xdeadbeef + 1);
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+	CU_ASSERT(retqueue == default_queue);
+	recvpool = odp_packet_pool(pkt);
+	CU_ASSERT(recvpool == default_pool);
+
+	odp_packet_free(pkt);
+	odp_cos_destroy(cos);
+	odp_cos_destroy(default_cos);
+	odp_cls_pmr_destroy(pmr);
+	stop_pktio(pktio);
+	odp_pool_destroy(default_pool);
+	odp_pool_destroy(pool);
+	odp_queue_destroy(queue);
+	odp_queue_destroy(default_queue);
+	odp_pktio_close(pktio);
+}
+
 static void classification_test_pmr_serial(void)
 {
 	test_pmr_series(1, 0);
@@ -3305,6 +3419,11 @@ static int check_capa_gtpu_teid(void)
 	return cls_capa.supported_terms.bit.gtpu_teid;
 }
 
+static int check_capa_igmp_grpaddr(void)
+{
+	return cls_capa.supported_terms.bit.igmp_grp_addr;
+}
+
 odp_testinfo_t classification_suite_pmr[] = {
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_tcp_dport,
 				  check_capa_tcp_dport),
@@ -3316,6 +3435,8 @@ odp_testinfo_t classification_suite_pmr[] = {
 				  check_capa_udp_sport),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_gtpu_teid,
 				  check_capa_gtpu_teid),
+	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_igmp_grpaddr,
+				  check_capa_igmp_grpaddr),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_sctp_sport,
 				  check_capa_sctp_sport),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_sctp_dport,

--- a/test/validation/api/classification/odp_classification_testsuites.h
+++ b/test/validation/api/classification/odp_classification_testsuites.h
@@ -19,6 +19,7 @@ typedef struct cls_packet_info {
 	odp_atomic_u32_t *seq;
 	bool	udp;
 	bool	sctp;
+	bool	icmp;
 	bool	ipv6;
 	uint32_t len;
 } cls_packet_info_t;

--- a/test/validation/api/classification/odp_classification_testsuites.h
+++ b/test/validation/api/classification/odp_classification_testsuites.h
@@ -18,6 +18,7 @@ typedef struct cls_packet_info {
 	bool	vlan_qinq;
 	odp_atomic_u32_t *seq;
 	bool	udp;
+	bool	gtpu;
 	bool	sctp;
 	bool	icmp;
 	bool	ipv6;

--- a/test/validation/api/classification/odp_classification_testsuites.h
+++ b/test/validation/api/classification/odp_classification_testsuites.h
@@ -18,6 +18,7 @@ typedef struct cls_packet_info {
 	bool	vlan_qinq;
 	odp_atomic_u32_t *seq;
 	bool	udp;
+	bool	sctp;
 	bool	ipv6;
 	uint32_t len;
 } cls_packet_info_t;

--- a/test/validation/api/classification/odp_classification_testsuites.h
+++ b/test/validation/api/classification/odp_classification_testsuites.h
@@ -19,6 +19,7 @@ typedef struct cls_packet_info {
 	odp_atomic_u32_t *seq;
 	bool	udp;
 	bool	gtpu;
+	bool	igmp;
 	bool	sctp;
 	bool	icmp;
 	bool	ipv6;


### PR DESCRIPTION
## api: cls: introduce IGMP group addr term

Introduce IGMP group address term.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>
Signed-off-by: Kiran Kumar K <kirankumark@marvell.com>
Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>

## api: cls: introduce ICMP terms

Introduce ICMP identifier, code and type terms.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>
Signed-off-by: Kiran Kumar K <kirankumark@marvell.com>
Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>

## api: cls: introduce SCTP terms

Introduce SCTP source and destination port terms.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>
Signed-off-by: Kiran Kumar K <kirankumark@marvell.com>
Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>

## api: cls: introduce GTPU tunnel endpoint id term

Introduce GTPU tunnel endpoint identifier term.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>
Signed-off-by: Kiran Kumar K <kirankumark@marvell.com>
Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>

## helper: add odph_gtpu header description

Adds GTPU header description struct odph_gtpuhdr_t in helper directory.
This structure is used for accessing GTPU header information from the
packet.

Signed-off-by: Kiran Kumar K <kirankumark@marvell.com>
Signed-off-by: Satheesh Paul <psatheesh@marvell.com>
Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>

## helper: add odph_igmp header description

Adds IGMP header description struct odph_igmphdr_t in helper directory.
This structure is used for accessing IGMP header information from the
packet.

Signed-off-by: Kiran Kumar K <kirankumark@marvell.com>
Signed-off-by: Satheesh Paul <psatheesh@marvell.com>
Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>

## validation: cls: add validation test cases for pmr types sctp

Adding validation test cases to test PMR types SCTP SPORT, SCTP DPORT.

Signed-off-by: Kiran Kumar K <kirankumark@marvell.com>
Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>

## validation: cls: add validation test cases for pmr types icmp

Adding validation test cases to test PMR types ICMP TYPE, ICMP CODE
and ICMP ID.

Signed-off-by: Kiran Kumar K <kirankumark@marvell.com>
Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>

## validation: cls: add validation test cases for pmr type gtpu

Adding validation test case to test PMR type GTPU TEID.

Signed-off-by: Satheesh Paul <psatheesh@marvell.com>
Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>

## validation: cls: add validation test case for pmr type IGMP

Adding validation test case to test PMR types IGMP group address.

Signed-off-by: Satheesh Paul <psatheesh@marvell.com>
Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>
