### PR TITLE
[PATCH v7] api: system info call

### DIFF
--- a/include/odp/api/spec/system_info.h
+++ b/include/odp/api/spec/system_info.h
@@ -242,6 +242,15 @@ int odp_sys_cache_line_size(void);
 void odp_sys_info_print(void);
 
 /**
+ * Print configuration
+ *
+ * Print out implementation defined information about selected configuration options. This
+ * information is intended for debugging purposes and may contain e.g. content of various
+ * configuration files, environment variables and configuration options of ODP API.
+ */
+void odp_sys_config_print(void);
+
+/**
  * @}
  */
 

--- a/include/odp/api/spec/system_info.h
+++ b/include/odp/api/spec/system_info.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2020, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -22,6 +23,174 @@ extern "C" {
  *  System information.
  *  @{
  */
+
+/**
+ * CPU instruction set architecture (ISA) families
+ */
+typedef enum odp_cpu_arch_t {
+	/** Unknown CPU architecture */
+	ODP_CPU_ARCH_UNKNOWN = 0,
+
+	/** ARM */
+	ODP_CPU_ARCH_ARM,
+
+	/** MIPS */
+	ODP_CPU_ARCH_MIPS,
+
+	/** PowerPC */
+	ODP_CPU_ARCH_PPC,
+
+	/** RISC-V */
+	ODP_CPU_ARCH_RISCV,
+
+	/** x86 */
+	ODP_CPU_ARCH_X86
+
+} odp_cpu_arch_t;
+
+/**
+ * ARM ISA versions
+ *
+ * ISA versions are defined in ascending order.
+ */
+typedef enum odp_cpu_arch_arm_t {
+	/** Unknown ARM ISA version */
+	ODP_CPU_ARCH_ARM_UNKNOWN = 0,
+
+	/** ARMv6 ISA */
+	ODP_CPU_ARCH_ARMV6,
+
+	/** ARMv7-A ISA */
+	ODP_CPU_ARCH_ARMV7,
+
+	/** ARMv8.0-A ISA */
+	ODP_CPU_ARCH_ARMV8_0,
+
+	/** ARMv8.1-A ISA */
+	ODP_CPU_ARCH_ARMV8_1,
+
+	/** ARMv8.2-A ISA */
+	ODP_CPU_ARCH_ARMV8_2,
+
+	/** ARMv8.3-A ISA */
+	ODP_CPU_ARCH_ARMV8_3,
+
+	/** ARMv8.4-A ISA */
+	ODP_CPU_ARCH_ARMV8_4,
+
+	/** ARMv8.5-A ISA */
+	ODP_CPU_ARCH_ARMV8_5,
+
+	/** ARMv8.6-A ISA */
+	ODP_CPU_ARCH_ARMV8_6,
+
+} odp_cpu_arch_arm_t;
+
+/**
+ * MIPS ISA versions
+ */
+typedef enum odp_cpu_arch_mips_t {
+	/** Unknown MIPS ISA version */
+	ODP_CPU_ARCH_MIPS_UNKNOWN = 0
+
+} odp_cpu_arch_mips_t;
+
+/**
+ * PowerPC ISA versions
+ */
+typedef enum odp_cpu_arch_ppc_t {
+	/** Unknown PPC ISA version */
+	ODP_CPU_ARCH_PPC_UNKNOWN = 0
+
+} odp_cpu_arch_ppc_t;
+
+/**
+ * RISC-V ISA versions
+ */
+typedef enum odp_cpu_arch_riscv_t {
+	/** Unknown RISC-V ISA version */
+	ODP_CPU_ARCH_RISCV_UNKNOWN = 0
+
+} odp_cpu_arch_riscv_t;
+
+/**
+ * x86 ISA versions
+ */
+typedef enum odp_cpu_arch_x86_t {
+	/** Unknown x86 ISA version */
+	ODP_CPU_ARCH_X86_UNKNOWN = 0,
+
+	/** x86 32bit ISA */
+	ODP_CPU_ARCH_X86_I686,
+
+	/** x86 64bit ISA */
+	ODP_CPU_ARCH_X86_64
+
+} odp_cpu_arch_x86_t;
+
+/**
+ * CPU ISA versions
+ */
+typedef union odp_cpu_arch_isa_t {
+	/** ARM ISA versions */
+	odp_cpu_arch_arm_t arm;
+
+	/** MIPS ISA versions */
+	odp_cpu_arch_mips_t mips;
+
+	/** PowerPC ISA versions */
+	odp_cpu_arch_ppc_t ppc;
+
+	/** RISC-V ISA versions */
+	odp_cpu_arch_riscv_t riscv;
+
+	/** x86 ISA versions */
+	odp_cpu_arch_x86_t x86;
+
+} odp_cpu_arch_isa_t;
+
+/**
+ * System info
+ */
+typedef struct odp_system_info_t {
+	/**
+	 * CPU architecture
+	 *
+	 * Defines CPU ISA family: ARM, MIPS, PPC, RISC-V, x86 or unknown
+	 */
+	odp_cpu_arch_t cpu_arch;
+
+	/**
+	 * ISA version of ODP software
+	 *
+	 * Defines the ISA version that was used to build the ODP library. Depending on compiler
+	 * target architecture setting, the value may be lower than the ISA version supported by
+	 * the CPU hardware.
+	 */
+	odp_cpu_arch_isa_t cpu_isa_sw;
+
+	/**
+	 * ISA version of CPU hardware
+	 *
+	 * Defines the ISA version supported by the CPU hardware. The value is set to
+	 * ODP_CPU_ARCH_<arch>_UNKNOWN, when the ISA version cannot be determined.
+	 */
+	odp_cpu_arch_isa_t cpu_isa_hw;
+
+} odp_system_info_t;
+
+/**
+ * Retrieve system information
+ *
+ * Fills in system information structure on success. The call is not intended
+ * for fast path use.
+ *
+ * @param[out] info    Pointer to system info struct for output
+ *
+ * @retval  0 on success
+ * @retval <0 on failure
+ */
+int odp_system_info(odp_system_info_t *info);
 
 /**
  * Default system huge page size in bytes

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -265,7 +265,7 @@ endif
 if ARCH_IS_ARM
 __LIB__libodp_linux_la_SOURCES += arch/default/odp_cpu_cycles.c \
 				  arch/default/odp_global_time.c \
-				  arch/default/odp_sysinfo_parse.c
+				  arch/arm/odp_sysinfo_parse.c
 odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/cpu_inlines.h \
 				arch/default/odp/api/abi/cpu_time.h
 if !ODP_ABI_COMPAT

--- a/platform/linux-generic/arch/arm/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/arm/odp_sysinfo_parse.c
@@ -1,0 +1,33 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp_global_data.h>
+#include <odp_sysinfo_internal.h>
+
+int cpuinfo_parser(FILE * file ODP_UNUSED, system_info_t *sysinfo)
+{
+	sysinfo->cpu_arch = ODP_CPU_ARCH_ARM;
+	sysinfo->cpu_isa_sw.arm = ODP_CPU_ARCH_ARM_UNKNOWN;
+	sysinfo->cpu_isa_hw.arm = ODP_CPU_ARCH_ARM_UNKNOWN;
+
+#if defined(__ARM_ARCH)
+	if (__ARM_ARCH == 6)
+		sysinfo->cpu_isa_sw.arm = ODP_CPU_ARCH_ARMV6;
+	else if (__ARM_ARCH == 7)
+		sysinfo->cpu_isa_sw.arm = ODP_CPU_ARCH_ARMV7;
+#endif
+
+	return _odp_dummy_cpuinfo(sysinfo);
+}
+
+void sys_info_print_arch(void)
+{
+}
+
+uint64_t odp_cpu_arch_hz_current(int id ODP_UNUSED)
+{
+	return odp_global_ro.system_info.default_cpu_hz;
+}

--- a/platform/linux-generic/arch/mips64/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/mips64/odp_sysinfo_parse.c
@@ -18,6 +18,10 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 	int count = 2;
 	int id = 0;
 
+	sysinfo->cpu_arch        = ODP_CPU_ARCH_MIPS;
+	sysinfo->cpu_isa_sw.mips = ODP_CPU_ARCH_MIPS_UNKNOWN;
+	sysinfo->cpu_isa_hw.mips = ODP_CPU_ARCH_MIPS_UNKNOWN;
+
 	strcpy(sysinfo->cpu_arch_str, "mips64");
 	while (fgets(str, sizeof(str), file) != NULL && id < CONFIG_NUM_CPU_IDS) {
 		if (!mhz) {

--- a/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
@@ -18,6 +18,10 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 	int count = 2;
 	int id = 0;
 
+	sysinfo->cpu_arch       = ODP_CPU_ARCH_PPC;
+	sysinfo->cpu_isa_sw.ppc = ODP_CPU_ARCH_PPC_UNKNOWN;
+	sysinfo->cpu_isa_hw.ppc = ODP_CPU_ARCH_PPC_UNKNOWN;
+
 	strcpy(sysinfo->cpu_arch_str, "powerpc");
 	while (fgets(str, sizeof(str), file) != NULL && id < CONFIG_NUM_CPU_IDS) {
 		if (!mhz) {

--- a/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
@@ -18,6 +18,16 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 	int id = 0;
 	bool freq_set = false;
 
+	sysinfo->cpu_arch = ODP_CPU_ARCH_X86;
+	sysinfo->cpu_isa_sw.x86 = ODP_CPU_ARCH_X86_UNKNOWN;
+	sysinfo->cpu_isa_hw.x86 = ODP_CPU_ARCH_X86_UNKNOWN;
+
+	#if defined __x86_64 || defined __x86_64__
+	sysinfo->cpu_isa_sw.x86 = ODP_CPU_ARCH_X86_64;
+	#elif defined __i686 || defined __i686__
+	sysinfo->cpu_isa_sw.x86 = ODP_CPU_ARCH_X86_I686;
+	#endif
+
 	strcpy(sysinfo->cpu_arch_str, "x86");
 	while (fgets(str, sizeof(str), file) != NULL && id < CONFIG_NUM_CPU_IDS) {
 		pos = strstr(str, "model name");

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <odp/api/init.h>
 #include <odp/api/cpumask.h>
 #include <odp/api/random.h>
+#include <odp/api/system_info.h>
 #include <sys/types.h>
 #include <pthread.h>
 #include <stdint.h>
@@ -30,6 +31,9 @@ typedef struct {
 	uint64_t page_size;
 	int      cache_line_size;
 	int      cpu_count;
+	odp_cpu_arch_t cpu_arch;
+	odp_cpu_arch_isa_t cpu_isa_sw;
+	odp_cpu_arch_isa_t cpu_isa_hw;
 	char     cpu_arch_str[128];
 	char     model_str[CONFIG_NUM_CPU_IDS][MODEL_STR_SIZE];
 } system_info_t;

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -64,6 +64,7 @@ typedef struct odp_global_data_ro_t {
 	odp_cpumask_t control_cpus;
 	odp_cpumask_t worker_cpus;
 	int num_cpus_installed;
+	uint8_t has_config_rt;
 	config_t libconfig_default;
 	config_t libconfig_runtime;
 	odp_random_kind_t ipsec_rand_kind;

--- a/platform/linux-generic/include/odp_libconfig_internal.h
+++ b/platform/linux-generic/include/odp_libconfig_internal.h
@@ -28,6 +28,8 @@ int _odp_libconfig_lookup_ext_int(const char *base_path,
 				  const char *name,
 				  int *value);
 
+int _odp_libconfig_print(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/include/odp_sysinfo_internal.h
+++ b/platform/linux-generic/include/odp_sysinfo_internal.h
@@ -26,6 +26,8 @@ static inline int _odp_dummy_cpuinfo(system_info_t *sysinfo)
 	uint64_t cpu_hz_max = sysinfo->default_cpu_hz_max;
 	int i;
 
+	sysinfo->cpu_arch = ODP_CPU_ARCH_UNKNOWN;
+
 	ODP_DBG("Warning: use dummy values for freq and model string\n");
 	for (i = 0; i < CONFIG_NUM_CPU_IDS; i++) {
 		ODP_PRINT("WARN: cpu[%i] uses default max frequency of "

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -527,6 +527,18 @@ int odp_cpu_count(void)
 	return odp_global_ro.system_info.cpu_count;
 }
 
+int odp_system_info(odp_system_info_t *info)
+{
+	system_info_t *sys_info = &odp_global_ro.system_info;
+
+	memset(info, 0, sizeof(odp_system_info_t));
+
+	info->cpu_arch   = sys_info->cpu_arch;
+	info->cpu_isa_sw = sys_info->cpu_isa_sw;
+
+	return 0;
+}
+
 void odp_sys_info_print(void)
 {
 	int len, num_cpu;

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -21,6 +21,7 @@
 #include <odp_init_internal.h>
 #include <odp_libconfig_internal.h>
 #include <odp_debug_internal.h>
+#include <odp_config_internal.h>
 #include <odp/api/align.h>
 #include <odp/api/cpu.h>
 #include <errno.h>
@@ -576,4 +577,27 @@ void odp_sys_info_print(void)
 	ODP_PRINT("%s", str);
 
 	sys_info_print_arch();
+}
+
+void odp_sys_config_print(void)
+{
+	/* Print ODP_CONFIG_FILE default and override values */
+	if (_odp_libconfig_print())
+		ODP_ERR("Config file print failed\n");
+
+	ODP_PRINT("\n\nodp_config_internal.h values:\n"
+		  "-----------------------------\n");
+	ODP_PRINT("ODP_CONFIG_POOLS:            %i\n", ODP_CONFIG_POOLS);
+	ODP_PRINT("CONFIG_MAX_PLAIN_QUEUES:     %i\n", CONFIG_MAX_PLAIN_QUEUES);
+	ODP_PRINT("CONFIG_MAX_SCHED_QUEUES:     %i\n", CONFIG_MAX_SCHED_QUEUES);
+	ODP_PRINT("CONFIG_QUEUE_MAX_ORD_LOCKS:  %i\n", CONFIG_QUEUE_MAX_ORD_LOCKS);
+	ODP_PRINT("ODP_CONFIG_PKTIO_ENTRIES:    %i\n", ODP_CONFIG_PKTIO_ENTRIES);
+	ODP_PRINT("CONFIG_PACKET_HEADROOM:      %i\n", CONFIG_PACKET_HEADROOM);
+	ODP_PRINT("CONFIG_PACKET_TAILROOM:      %i\n", CONFIG_PACKET_TAILROOM);
+	ODP_PRINT("CONFIG_PACKET_MAX_LEN:       %i\n", CONFIG_PACKET_MAX_LEN);
+	ODP_PRINT("ODP_CONFIG_SHM_BLOCKS:       %i\n", ODP_CONFIG_SHM_BLOCKS);
+	ODP_PRINT("CONFIG_BURST_SIZE:           %i\n", CONFIG_BURST_SIZE);
+	ODP_PRINT("CONFIG_POOL_MAX_NUM:         %i\n", CONFIG_POOL_MAX_NUM);
+	ODP_PRINT("CONFIG_POOL_CACHE_MAX_SIZE:  %i\n", CONFIG_POOL_CACHE_MAX_SIZE);
+	ODP_PRINT("\n");
 }

--- a/test/validation/api/system/system.c
+++ b/test/validation/api/system/system.c
@@ -464,6 +464,13 @@ static void system_test_info_print(void)
 	printf("...done. ");
 }
 
+static void system_test_config_print(void)
+{
+	printf("\n\nCalling system config print...\n");
+	odp_sys_config_print();
+	printf("...done. ");
+}
+
 static void system_test_info(void)
 {
 	odp_system_info_t info;
@@ -551,6 +558,7 @@ odp_testinfo_t system_suite[] = {
 				  system_check_cycle_counter),
 	ODP_TEST_INFO(system_test_info),
 	ODP_TEST_INFO(system_test_info_print),
+	ODP_TEST_INFO(system_test_config_print),
 	ODP_TEST_INFO_NULL,
 };
 

--- a/test/validation/api/system/system.c
+++ b/test/validation/api/system/system.c
@@ -464,6 +464,62 @@ static void system_test_info_print(void)
 	printf("...done. ");
 }
 
+static void system_test_info(void)
+{
+	odp_system_info_t info;
+	odp_cpu_arch_t cpu_arch;
+
+	memset(&info, 0xff, sizeof(odp_system_info_t));
+	CU_ASSERT(odp_system_info(&info) == 0);
+	cpu_arch = info.cpu_arch;
+
+	memset(&info, 0, sizeof(odp_system_info_t));
+	CU_ASSERT(odp_system_info(&info) == 0);
+
+	CU_ASSERT(info.cpu_arch == cpu_arch);
+	CU_ASSERT(info.cpu_arch >= ODP_CPU_ARCH_UNKNOWN && info.cpu_arch <= ODP_CPU_ARCH_X86);
+
+	if (info.cpu_arch == ODP_CPU_ARCH_X86) {
+		printf("\n        ODP_CPU_ARCH_X86\n");
+		CU_ASSERT(info.cpu_isa_sw.x86 != ODP_CPU_ARCH_X86_UNKNOWN);
+
+		if (info.cpu_isa_sw.x86 == ODP_CPU_ARCH_X86_64)
+			printf("        ODP_CPU_ARCH_X86_64\n");
+		else if (info.cpu_isa_sw.x86 == ODP_CPU_ARCH_X86_I686)
+			printf("        ODP_CPU_ARCH_X86_I686\n");
+
+		if (info.cpu_isa_hw.x86 != ODP_CPU_ARCH_X86_UNKNOWN)
+			CU_ASSERT(info.cpu_isa_sw.x86 <= info.cpu_isa_hw.x86);
+	}
+
+	if (info.cpu_arch == ODP_CPU_ARCH_ARM) {
+		printf("\n        ODP_CPU_ARCH_ARM\n");
+		CU_ASSERT(info.cpu_isa_sw.arm != ODP_CPU_ARCH_ARM_UNKNOWN);
+
+		if (info.cpu_isa_sw.arm == ODP_CPU_ARCH_ARMV6)
+			printf("        ODP_CPU_ARCH_ARMV6\n");
+		else if (info.cpu_isa_sw.arm == ODP_CPU_ARCH_ARMV7)
+			printf("        ODP_CPU_ARCH_ARMV7\n");
+		else if (info.cpu_isa_sw.arm == ODP_CPU_ARCH_ARMV8_0)
+			printf("        ODP_CPU_ARCH_ARMV8_0\n");
+		else if (info.cpu_isa_sw.arm == ODP_CPU_ARCH_ARMV8_1)
+			printf("        ODP_CPU_ARCH_ARMV8_1\n");
+		else if (info.cpu_isa_sw.arm == ODP_CPU_ARCH_ARMV8_2)
+			printf("        ODP_CPU_ARCH_ARMV8_2\n");
+		else if (info.cpu_isa_sw.arm == ODP_CPU_ARCH_ARMV8_3)
+			printf("        ODP_CPU_ARCH_ARMV8_3\n");
+		else if (info.cpu_isa_sw.arm == ODP_CPU_ARCH_ARMV8_4)
+			printf("        ODP_CPU_ARCH_ARMV8_4\n");
+		else if (info.cpu_isa_sw.arm == ODP_CPU_ARCH_ARMV8_5)
+			printf("        ODP_CPU_ARCH_ARMV8_5\n");
+		else if (info.cpu_isa_sw.arm == ODP_CPU_ARCH_ARMV8_6)
+			printf("        ODP_CPU_ARCH_ARMV8_6\n");
+
+		if (info.cpu_isa_hw.arm != ODP_CPU_ARCH_ARM_UNKNOWN)
+			CU_ASSERT(info.cpu_isa_sw.arm <= info.cpu_isa_hw.arm);
+	}
+}
+
 odp_testinfo_t system_suite[] = {
 	ODP_TEST_INFO(test_version_api_str),
 	ODP_TEST_INFO(test_version_str),
@@ -493,6 +549,7 @@ odp_testinfo_t system_suite[] = {
 				  system_check_cycle_counter),
 	ODP_TEST_INFO_CONDITIONAL(system_test_cpu_cycles_long_period,
 				  system_check_cycle_counter),
+	ODP_TEST_INFO(system_test_info),
 	ODP_TEST_INFO(system_test_info_print),
 	ODP_TEST_INFO_NULL,
 };

--- a/test/validation/api/system/system.c
+++ b/test/validation/api/system/system.c
@@ -327,8 +327,7 @@ static void system_test_odp_sys_huge_page_size_all(void)
 static int system_check_cycle_counter(void)
 {
 	if (odp_cpu_cycles_max() == 0) {
-		fprintf(stderr, "Cycle counter is not supported, skipping "
-			"test\n");
+		printf("Cycle counter is not supported, skipping test\n");
 		return ODP_TEST_INACTIVE;
 	}
 
@@ -338,8 +337,7 @@ static int system_check_cycle_counter(void)
 static int system_check_odp_cpu_hz(void)
 {
 	if (odp_cpu_hz() == 0) {
-		fprintf(stderr, "odp_cpu_hz() is not supported, skipping "
-			"test\n");
+		printf("odp_cpu_hz() is not supported, skipping test\n");
 		return ODP_TEST_INACTIVE;
 	}
 
@@ -369,8 +367,7 @@ static int system_check_odp_cpu_hz_id(void)
 	for (i = 0; i < num; i++) {
 		hz = odp_cpu_hz_id(cpu);
 		if (hz == 0) {
-			fprintf(stderr, "odp_cpu_hz_id() is not supported by "
-				"CPU %d, skipping test\n", cpu);
+			printf("odp_cpu_hz_id() is not supported by CPU %d, skipping test\n", cpu);
 			return ODP_TEST_INACTIVE;
 		}
 		cpu = odp_cpumask_next(&mask, cpu);
@@ -401,8 +398,7 @@ static void system_test_odp_cpu_hz_id(void)
 static int system_check_odp_cpu_hz_max(void)
 {
 	if (odp_cpu_hz_max() == 0) {
-		fprintf(stderr, "odp_cpu_hz_max() is not supported, skipping "
-			"test\n");
+		printf("odp_cpu_hz_max() is not supported, skipping test\n");
 		return ODP_TEST_INACTIVE;
 	}
 	return ODP_TEST_ACTIVE;
@@ -429,8 +425,8 @@ static int system_check_odp_cpu_hz_max_id(void)
 	for (i = 0; i < num; i++) {
 		hz = odp_cpu_hz_max_id(cpu);
 		if (hz == 0) {
-			fprintf(stderr, "odp_cpu_hz_max_id() is not supported "
-			"by CPU %d, skipping test\n", cpu);
+			printf("odp_cpu_hz_max_id() is not supported by CPU %d, skipping test\n",
+			       cpu);
 			return ODP_TEST_INACTIVE;
 		}
 		cpu = odp_cpumask_next(&mask, cpu);


### PR DESCRIPTION
System info may be used to retrieve various system information
with a single call. Content of the system info structure may be
extended later, but it contains initially e.g. CPU ISA family
and version.
