### PR TITLE
[PATCH v3] api: unaligned int types

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,8 +3,8 @@ AC_PREREQ([2.5])
 # ODP API version
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
-m4_define([odpapi_major_version], [24])
-m4_define([odpapi_minor_version], [2])
+m4_define([odpapi_major_version], [25])
+m4_define([odpapi_minor_version], [0])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])

--- a/configure.ac
+++ b/configure.ac
@@ -128,11 +128,6 @@ ODP_CHECK_CFLAG([-Wwrite-strings])
 ODP_CHECK_CFLAG([-Wformat-truncation=0])
 ODP_CHECK_CFLAG([-Wformat-overflow=0])
 
-# Suppressed warnings:
-# GCC-9 warns about taking pointers to packed structure fields (e.g. protocol
-# header structures). Generate only warnings on those, not errors.
-ODP_CHECK_CFLAG([-Wno-error=address-of-packed-member])
-
 # GCC 10 sometimes gets confused about object sizes and gives bogus warnings.
 # Make the affected warnings generate only warnings, not errors.
 AS_IF([test "$GCC" == yes],

--- a/helper/chksum.c
+++ b/helper/chksum.c
@@ -105,7 +105,7 @@ static inline int odph_process_l4_hdr(odp_packet_t      odp_pkt,
 	odph_tcphdr_t  *tcp_hdr_ptr;
 	odp_bool_t      split_l4_hdr, is_tcp;
 	uint32_t        l4_offset, l4_len, pkt_chksum_offset;
-	uint16_t       *pkt_chksum_ptr;
+	odp_una_u16_t  *pkt_chksum_ptr;
 	uint8_t        *l4_ptr;
 	uint32_t hdr_len = 0;
 
@@ -130,7 +130,7 @@ static inline int odph_process_l4_hdr(odp_packet_t      odp_pkt,
 		 * should come from the udp header, unlike for TCP where is
 		 * derived. */
 		l4_len            = odp_be_to_cpu_16(udp_hdr_ptr->length);
-		pkt_chksum_ptr    = (uint16_t *)(void *)&udp_hdr_ptr->chksum;
+		pkt_chksum_ptr    = (odp_una_u16_t *)&udp_hdr_ptr->chksum;
 		pkt_chksum_offset = l4_offset + offsetof(odph_udphdr_t, chksum);
 	} else if (odp_packet_has_tcp(odp_pkt)) {
 		tcp_hdr_ptr  = (odph_tcphdr_t *)l4_ptr;
@@ -141,7 +141,7 @@ static inline int odph_process_l4_hdr(odp_packet_t      odp_pkt,
 					       ODPH_TCPHDR_LEN, tcp_hdr_ptr);
 		}
 
-		pkt_chksum_ptr    = (uint16_t *)(void *)&tcp_hdr_ptr->cksm;
+		pkt_chksum_ptr    = (odp_una_u16_t *)&tcp_hdr_ptr->cksm;
 		pkt_chksum_offset = l4_offset + offsetof(odph_tcphdr_t, cksm);
 		is_tcp            = true;
 	} else {
@@ -186,7 +186,7 @@ static inline int odph_process_l3_hdr(odp_packet_t odp_pkt,
 	swap_buf_t      swap_buf;
 	uint32_t        l3_offset, l4_offset, l3_hdrs_len, addrs_len;
 	uint32_t        protocol, l3_len, l4_len, idx, ipv6_payload_len, sum;
-	uint16_t       *addrs_ptr;
+	odp_una_u16_t  *addrs_ptr;
 	uint32_t hdr_len = 0;
 
 	/* The following computation using the l3 and l4 offsets handles both
@@ -206,7 +206,7 @@ static inline int odph_process_l3_hdr(odp_packet_t odp_pkt,
 			ipv4_hdr_ptr = &ipv4_hdr;
 		}
 
-		addrs_ptr = (uint16_t *)(void *)&ipv4_hdr_ptr->src_addr;
+		addrs_ptr = (odp_una_u16_t *)&ipv4_hdr_ptr->src_addr;
 		addrs_len = 2 * ODPH_IPV4ADDR_LEN;
 		protocol  = ipv4_hdr_ptr->proto;
 		l3_len    = odp_be_to_cpu_16(ipv4_hdr_ptr->tot_len);
@@ -219,7 +219,7 @@ static inline int odph_process_l3_hdr(odp_packet_t odp_pkt,
 			ipv6_hdr_ptr = &ipv6_hdr;
 		}
 
-		addrs_ptr        = (uint16_t *)(void *)&ipv6_hdr_ptr->src_addr;
+		addrs_ptr        = (odp_una_u16_t *)&ipv6_hdr_ptr->src_addr;
 		addrs_len        = 2 * ODPH_IPV6ADDR_LEN;
 		protocol         = ipv6_hdr_ptr->next_hdr;
 		ipv6_payload_len = odp_be_to_cpu_16(ipv6_hdr_ptr->payload_len);

--- a/include/odp/api/spec/std_types.h
+++ b/include/odp/api/spec/std_types.h
@@ -16,6 +16,7 @@
 #include <odp/visibility_begin.h>
 /* uint64_t, uint32_t, etc */
 #include <stdint.h>
+#include <odp/api/align.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,6 +40,15 @@ extern "C" {
  * Hence 100% is represented as integer value 10000.
  */
 typedef uint32_t odp_percent_t;
+
+/** Unaligned uint16_t type */
+typedef uint16_t odp_una_u16_t ODP_ALIGNED(1);
+
+/** Unaligned uint32_t type */
+typedef uint32_t odp_una_u32_t ODP_ALIGNED(1);
+
+/** Unaligned uint64_t type */
+typedef uint64_t odp_una_u64_t ODP_ALIGNED(1);
 
 /**
  * @}


### PR DESCRIPTION
This is one option to handle GCC9 warnings of taking a pointer to packed structure. We could introduce unaligned integer types as part of ODP API.

PR https://github.com/OpenDataPlane/odp/pull/1046 is solving the same warnings with re-write of the checksum code.
