### PR TITLE
[PATCH v4] api: Pull request for pool enhancement APIs for VPP

### DIFF
--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -288,6 +288,9 @@ typedef struct odp_cls_cos_param {
 
 	/** Packet input vector configuration */
 	odp_pktin_vector_config_t vector;
+
+	/** Packet input buffer sort configuration */
+	odp_pktin_buffer_sort_config_t sort;
 } odp_cls_cos_param_t;
 
 /**

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -2052,6 +2052,23 @@ uint64_t odp_packet_cls_mark(odp_packet_t pkt);
  */
 odp_packet_t odp_packet_from_head(odp_pool_t pool, void *headroom_addr);
 
+/**
+ * Get packet handle from the user area address pointer
+ *
+ * Get packet handle from the user area address pointer for the given pool.
+ * The pool must have been created with the ODP_POOL_PACKET type and non zero user area value.
+ * user area addr must point to that address provided by odp_packet_user_area() just after
+ * the odp_packet_alloc().
+ *
+ * @param pool Pool handle
+ * @param uarea_addr user area start address
+ *
+ * @return packet handle
+ * @return ODP_PACKET_INVALID on failure
+ *
+ */
+odp_packet_t odp_packet_from_user_area(odp_pool_t pool, void *uarea_addr);
+
 /*
  *
  * Packet vector handling routines

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -2035,6 +2035,23 @@ void odp_packet_shaper_len_adjust_set(odp_packet_t pkt, int8_t adj);
  */
 uint64_t odp_packet_cls_mark(odp_packet_t pkt);
 
+/**
+ * Get packet handle from the headroom address pointer
+ *
+ * Get packet handle from the headroom address pointer for the given pool.
+ * The pool must have been created with the ODP_POOL_PACKET type and non zero headroom value.
+ * headroom_addr must point to that address provided by odp_packet_head() just after
+ * the odp_packet_alloc().
+ *
+ * @param pool Pool handle
+ * @param headroom_addr head room start address
+ *
+ * @return packet handle
+ * @return ODP_PACKET_INVALID on failure
+ *
+ */
+odp_packet_t odp_packet_from_head(odp_pool_t pool, void *headroom_addr);
+
 /*
  *
  * Packet vector handling routines

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -274,6 +274,42 @@ typedef uintptr_t (*odp_pool_ext_mem_allocate_t)(void *arg, uint32_t total_sz, u
 typedef void (*odp_pool_ext_mem_deallocate_t)(void *arg, uintptr_t ptr);
 
 /**
+ * ODP pool buffer type iterator callback.
+ *
+ * This callback shall be invoked by the implementation when each odp_buffer_t type is freed
+ * to the pool in odp_pool_create().
+ *
+ * @param arg    Opaque pointer registered by the user with odp_pool_param_t::buf::arg
+ * @param data_addr Pointer to the buffer start address.
+ *
+ * On successful pool creation, the application can access the same buffer
+ * address using odp_buffer_addr().
+ *
+ */
+typedef void (*odp_pool_buffer_iterator_t)(void *arg, void *data_addr);
+
+/**
+ * ODP pool packet type iterator callback.
+ *
+ * This callback shall be invoked by the implementation when each odp_packet_seg_t
+ * type is freed to the pool on odp_pool_create().
+ *
+ * @param headroom_addr Pointer to the start address packet headroom.
+ * On successful pool creation, the application can access the same headroom address
+ * using odp_packet_head().
+ * Value NULL will be passed to the callback when packet headroom of size zero.
+ *
+ * @param arg    Opaque pointer registered by the user with odp_pool_param_t::pkt::arg
+ * @param uarea_addr Pointer to the start address packet user area.
+ *
+ * On successful pool creation, the application can access the same user area address
+ * using odp_packet_user_area().
+ * Value NULL will be passed to the callback when the packet user area of size zero.
+ *
+ */
+typedef void (*odp_pool_packet_iterator_t)(void *arg, void *headroom_addr, void *uarea_addr);
+
+/**
  * Pool parameters
  */
 typedef struct odp_pool_param_t {
@@ -311,6 +347,12 @@ typedef struct odp_pool_param_t {
 		 *  implementation specific and set by odp_pool_param_init().
 		 */
 		uint32_t cache_size;
+
+		/** Opaque pointer to be passed in buf_iter invocation */
+		void *arg;
+
+		/** Buffer type iterator callback */
+		odp_pool_buffer_iterator_t buf_iter;
 	} buf;
 
 	/** Parameters for packet pools */
@@ -411,6 +453,12 @@ typedef struct odp_pool_param_t {
 		 *  See buf.cache_size documentation for details.
 		 */
 		uint32_t cache_size;
+
+		/** Opaque pointer to be passed in pkt_iter invocation */
+		void *arg;
+
+		/** Packet segment type iterator callback */
+		odp_pool_packet_iterator_t pkt_iter;
 	} pkt;
 
 	/** Parameters for timeout pools */


### PR DESCRIPTION
v4:
- Rebase to master
- Fix build issue with clang by avoid forward declaration with typedef ie. introding
callback arguments as "void *" and allows any opaque type.

v3:
- Rebase to master
- Update sorting entry table configuration definition. Reason for the change as default pool should
be able to handle all packet lengths in the sort table.

v2:
- Split debug API to different PR ( https://github.com/OpenDataPlane/odp/pull/1100 )

## api: pool: introduce external memory allocator

Some of the ODP application manages the packet io memory
for better control of memory management.
Introduce an external memory allocator in the ODP specification
to use that memory for the pool memory.

Introducing an external memory callback for allocator and
deallocator to allocate and deallocate the pool memory.

This callback will be called once in the pool create and destroy
to allow ODP application to allocate and destroy the pool memory.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>

## api: pool: introduce pool type iterators

Some of the ODP application needs to store the
application-specific data in the pool creation time.

Introducing pool type iterators to allow getting
a callback to update/store in the application-specific
metadata in the pool creation phase on different types.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>

## api: pktio: introduce buffer sort capability

Some of the HW has support for allocating the packet buffer
based on the size.

This is often useful for saving the memory where the application
can create a different pool to steer the specific size of
the packet, thus enabling effective use of memory.

A similar use case can be achieved through the sub pool scheme,
however, if the application needs finer control on the number of
pools and to give the very same pool to different packet
in sort entries then this capability will be handy.

Packet input buffer sorting entries define the sorting requirements.
When sorting is enabled and packet received in given a packet io,
the implementation shall scan the configured entries, if the packet size
is less than or equal odp_pktin_sort_desc_t::len, it allocates
the packets from odp_pktin_sort_desc_t::pool.

odp_pktin_sort_desc_t::len value in each entry must be unique and must
be sorted in ascending order. Otherwise, the behavior is undefined.

Example sorting entry table configuration:

- (0B <= packet_size <= 1500B), steer to pool a
- (1500B < packet_size <= 4000B), steer to pool b
- (4000B < packet_size <= 7000B), steer to pool c
- (7000B < packet_size <= default_pool::param::max_len), steer to
default pool configured for the pktio.

tbl[0].len = 1500;
tbl[0].pool = pool_a;
tbl[1].len = 4000;
tbl[1].pool = pool_b;
tbl[2].len = 7000;
tbl[2].pool = pool_c;

Signed-off-by: Jerin Jacob <jerinj@marvell.com>
Signed-off-by: Ashwin Sekhar T K <asekhar@marvell.com>

## api: packet: introduce packet handle get from headroom

The use case where odp_packet_t converted as the application-specific
object on the Rx path and application-specific object to odp_packet_t on
Tx path would need a get function for getting odp_packet_t
from the predefined location from the packet.

odp_packet_from_head() enables such use case in Tx path
where, if application objects stores in place in headroom location
and the application wants to convert the application-specific
object to odp_packet_t before transmitting the packet.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>

## api: packet: introduce packet handle get from user area

The use case where odp_packet_t converted as the application-specific
object on the Rx path and application-specific object to odp_packet_t
on Tx path would need a get function for getting
odp_packet_t from the predefined location from the packet.

odp_packet_from_user_area() enables such use case in Tx path
where, if application objects stores in place in user area location
and the application wants to convert the application-specific
object to odp_packet_t before transmitting the packet.

Signed-off-by: Jerin Jacob <jerinj@marvell.com>
