### PR TITLE
[PATCH v4] Pull request for maxlen_packet_tests

### DIFF
--- a/test/performance/odp_bench_packet.c
+++ b/test/performance/odp_bench_packet.c
@@ -1823,7 +1823,8 @@ int main(int argc, char *argv[])
 		ODPH_ERR("Error: packet pool size not supported.\n");
 		printf("MAX: %" PRIu32 "\n", capa.pkt.max_num);
 		exit(EXIT_FAILURE);
-	} else if (capa.pkt.max_len && capa.pkt.max_len < TEST_MAX_PKT_SIZE) {
+	} else if (capa.pkt.max_len &&
+		   capa.pkt.max_len < 2 * TEST_MAX_PKT_SIZE) {
 		ODPH_ERR("Error: packet length not supported.\n");
 		exit(EXIT_FAILURE);
 	} else if (capa.pkt.max_seg_len &&
@@ -1839,7 +1840,11 @@ int main(int argc, char *argv[])
 	/* Create packet pool */
 	odp_pool_param_init(&params);
 	params.pkt.seg_len = PKT_POOL_SEG_LEN;
-	params.pkt.len     = TEST_MAX_PKT_SIZE;
+	/* Using packet length as twice the TEST_MAX_PKT_SIZE as some
+	 * test cases (bench_packet_ref_pkt) might allocate a bigger
+	 * packet than TEST_MAX_PKT_SIZE.
+	 */
+	params.pkt.len     = 2 * TEST_MAX_PKT_SIZE;
 	params.pkt.num     = pkt_num;
 	params.pkt.uarea_size = PKT_POOL_UAREA_SIZE;
 	params.type        = ODP_POOL_PACKET;

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -187,6 +187,10 @@ static int packet_suite_init(void)
 	params.type           = ODP_POOL_PACKET;
 	params.pkt.seg_len    = pool_capa.pkt.min_seg_len;
 	params.pkt.len        = pool_capa.pkt.min_seg_len;
+	/* Defining max_len to ensure packet of segmented_packet_len
+	 * length can be allocated from this pool.
+	 */
+	params.pkt.max_len    = segmented_packet_len;
 	params.pkt.num        = num;
 	params.pkt.uarea_size = sizeof(struct udata_struct);
 


### PR DESCRIPTION
## test: bench_packet: change packet length pool param

Changing the value of packet length pool parameter as twice of
TEST_MAX_PKT_SIZE (viz 2048), so that packet of length up to
2 * 2048 can be allocated from the pool.
This change is required to honour certain test cases like
"bench_packet_ref_pkt", where for 2048 byte packet test iteration,
header packet of same length is prefixed to the base packet,
leading to the failure as with current pool configuration packets
allocated from the pool can be of maximum 2048 bytes.

Signed-off-by: Harman Kalra <hkalra@marvell.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>

## validation: packet: add maxlen pool param

Defining maximum length pool parameter while create pool
to ensure packet of length max_len will never fail.
As in default pool creation, segmented_packet_len gets the
value from pool capability to allocate maximum packet length.
So same should be used as max_len while creating the pool.

Signed-off-by: Harman Kalra <hkalra@marvell.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>
