### PR TITLE
[PATCH v4] linux-gen: modify structs for consistency with gcc docs and odp code

### DIFF
--- a/include/odp/api/abi-default/atomic.h
+++ b/include/odp/api/abi-default/atomic.h
@@ -24,9 +24,9 @@ extern "C" {
  * @internal
  * Atomic 32-bit unsigned integer
  */
-struct odp_atomic_u32_s {
+typedef struct ODP_ALIGNED(sizeof(uint32_t)) odp_atomic_u32_s {
 	uint32_t v; /**< Actual storage for the atomic variable */
-} ODP_ALIGNED(sizeof(uint32_t)); /* Enforce alignment! */
+} odp_atomic_u32_t;
 
 #if __GCC_ATOMIC_LLONG_LOCK_FREE >= 2
 
@@ -34,9 +34,9 @@ struct odp_atomic_u32_s {
  * @internal
  * Atomic 64-bit unsigned integer
  */
-struct odp_atomic_u64_s {
+typedef struct ODP_ALIGNED(sizeof(uint64_t)) odp_atomic_u64_s {
 	uint64_t v; /**< Actual storage for the atomic variable */
-} ODP_ALIGNED(sizeof(uint64_t)); /* Enforce alignment! */
+} odp_atomic_u64_t;
 
 #else
 
@@ -50,18 +50,14 @@ struct odp_atomic_u64_s {
  * @internal
  * Atomic 64-bit unsigned integer
  */
-struct odp_atomic_u64_s {
+typedef struct ODP_ALIGNED(sizeof(uint64_t)) odp_atomic_u64_s {
 	uint64_t v; /**< Actual storage for the atomic variable */
 	/* Some architectures do not support lock-free operations on 64-bit
 	 * data types. We use a spin lock to ensure atomicity. */
 	char lock; /**< Spin lock (if needed) used to ensure atomic access */
-} ODP_ALIGNED(sizeof(uint64_t)); /* Enforce alignment! */
+} odp_atomic_u64_t;
 
 #endif
-
-typedef struct odp_atomic_u64_s odp_atomic_u64_t;
-
-typedef struct odp_atomic_u32_s odp_atomic_u32_t;
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include-abi/odp/api/abi/atomic.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/atomic.h
@@ -24,9 +24,9 @@ extern "C" {
  * @internal
  * Atomic 32-bit unsigned integer
  */
-struct odp_atomic_u32_s {
+typedef struct ODP_ALIGNED(sizeof(uint32_t)) odp_atomic_u32_s {
 	uint32_t v; /**< Actual storage for the atomic variable */
-} ODP_ALIGNED(sizeof(uint32_t)); /* Enforce alignment! */
+} odp_atomic_u32_t;
 
 #if __GCC_ATOMIC_LLONG_LOCK_FREE >= 2
 
@@ -34,9 +34,9 @@ struct odp_atomic_u32_s {
  * @internal
  * Atomic 64-bit unsigned integer
  */
-struct odp_atomic_u64_s {
+typedef struct ODP_ALIGNED(sizeof(uint64_t)) odp_atomic_u64_s {
 	uint64_t v; /**< Actual storage for the atomic variable */
-} ODP_ALIGNED(sizeof(uint64_t)); /* Enforce alignment! */
+} odp_atomic_u64_t;
 
 #else
 
@@ -46,18 +46,14 @@ struct odp_atomic_u64_s {
  * @internal
  * Atomic 64-bit unsigned integer
  */
-struct odp_atomic_u64_s {
+typedef struct ODP_ALIGNED(sizeof(uint64_t)) odp_atomic_u64_s {
 	uint64_t v; /**< Actual storage for the atomic variable */
 	/* Some architectures do not support lock-free operations on 64-bit
 	 * data types. We use a spin lock to ensure atomicity. */
 	char lock; /**< Spin lock (if needed) used to ensure atomic access */
-} ODP_ALIGNED(sizeof(uint64_t)); /* Enforce alignment! */
+} odp_atomic_u64_t;
 
 #endif
-
-typedef struct odp_atomic_u64_s odp_atomic_u64_t;
-
-typedef struct odp_atomic_u32_s odp_atomic_u32_t;
 
 /** @ingroup odp_atomic
  *  @{

--- a/platform/linux-generic/odp_queue_lf.c
+++ b/platform/linux-generic/odp_queue_lf.c
@@ -84,9 +84,9 @@ static inline int atomic_is_lockfree_u128(void)
 /* These definitions enable build in non 128 bit compatible systems.
  * Implementation is active only when 128 bit lockfree atomics are available.
  * So, these are never actually used. */
-typedef struct {
+typedef struct ODP_ALIGNED(16) {
 	uint64_t u64[2];
-} u128_t ODP_ALIGNED(16);
+} u128_t;
 
 static inline u128_t atomic_load_u128(u128_t *atomic)
 {
@@ -135,19 +135,19 @@ typedef union {
 } ring_lf_node_t;
 
 /* Lock-free ring */
-typedef struct {
+typedef struct ODP_ALIGNED_CACHE {
 	ring_lf_node_t   node[RING_LF_SIZE];
 	int              used;
 	odp_atomic_u64_t enq_counter;
 
-} queue_lf_t ODP_ALIGNED_CACHE;
+} queue_lf_t;
 
 /* Lock-free queue globals */
-typedef struct {
+typedef struct ODP_ALIGNED_CACHE {
 	queue_lf_t queue_lf[QUEUE_LF_NUM];
 	odp_shm_t  shm;
 
-} queue_lf_global_t ODP_ALIGNED_CACHE;
+} queue_lf_global_t;
 
 static queue_lf_global_t *queue_lf_glb;
 


### PR DESCRIPTION
As per the GCC documentation, the 'aligned' attribute should be added
after the 'struct' keyword. Consequently, the ODP_ALIGNED attribute has
been moved in various structs of the following files:
- include/odp/api/abi-default/atomic.h
- platform/linux-generic/include-abi/odp/api/abi/atomic.h
- platform/linux-generic/odp_queue_lf.c

From the first two files, the 'Enforce alignment' comment has also been
removed since the effect of the ODP_ALIGNED macro is easy to understand.
Also, for these files, the typedef declaration has been combined
with the struct definition which is consistent with most typedef structs
in ODP source code.

Suggested-by: Petri Savolainen <petri.savolainen@nokia.com>
Signed-off-by: Malvika Gupta <Malvika.Gupta@arm.com>
Reviewed-by: Govindarajan Mohandoss <Govindarajan.Mohandoss@arm.com>