### PR TITLE
[PATCH v5] api: add odp_event_is_valid()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.5])
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [25])
-m4_define([odpapi_minor_version], [0])
+m4_define([odpapi_minor_version], [1])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])

--- a/include/odp/api/spec/buffer.h
+++ b/include/odp/api/spec/buffer.h
@@ -74,7 +74,11 @@ void *odp_buffer_addr(odp_buffer_t buf);
 uint32_t odp_buffer_size(odp_buffer_t buf);
 
 /**
- * Tests if buffer is valid
+ * Check that buffer is valid
+ *
+ * This function can be used for debugging purposes to check if a buffer handle represents
+ * a valid buffer. The level of error checks depends on the implementation. The call should not
+ * crash if the buffer handle is corrupted.
  *
  * @param buf      Buffer handle
  *
@@ -95,8 +99,8 @@ odp_pool_t odp_buffer_pool(odp_buffer_t buf);
 /**
  * Buffer alloc
  *
- * The validity of a buffer can be checked at any time with
- * odp_buffer_is_valid().
+ * Allocates a buffer from the pool. Returns ODP_BUFFER_INVALID when a buffer
+ * can not be allocated.
  *
  * @param pool      Pool handle
  *
@@ -107,8 +111,8 @@ odp_buffer_t odp_buffer_alloc(odp_pool_t pool);
 
 /**
  * Allocate multiple buffers
-
- * Otherwise like odp_buffer_alloc(), but allocates multiple buffers from a pool
+ *
+ * Otherwise like odp_buffer_alloc(), but allocates multiple buffers from a pool.
  *
  * @param pool      Pool handle
  * @param[out] buf  Array of buffer handles for output

--- a/include/odp/api/spec/event.h
+++ b/include/odp/api/spec/event.h
@@ -182,6 +182,20 @@ int odp_event_filter_packet(const odp_event_t event[],
 uint64_t odp_event_to_u64(odp_event_t hdl);
 
 /**
+ * Check that event is valid
+ *
+ * This function can be used for debugging purposes to check if an event handle represents
+ * a valid event. The level of error checks depends on the implementation. The call should not
+ * crash if the event handle is corrupted.
+ *
+ * @param event    Event handle
+ *
+ * @retval 1 Event handle represents a valid event.
+ * @retval 0 Event handle does not represent a valid event.
+ */
+int odp_event_is_valid(odp_event_t event);
+
+/**
  * Free event
  *
  * Frees the event based on its type. Results are undefined if event

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -2162,10 +2162,12 @@ uint32_t odp_packet_vector_size(odp_packet_vector_t pktv);
 void odp_packet_vector_size_set(odp_packet_vector_t pktv, uint32_t size);
 
 /**
- * Perform full packet vector validity check
+ * Check that packet vector is valid
  *
- * The operation may consume considerable number of cpu cycles depending on
- * the check level.
+ * This function can be used for debugging purposes to check if a packet vector handle represents
+ * a valid packet vector. The level of error checks depends on the implementation. Considerable
+ * number of cpu cycles may be consumed depending on the level. The call should not crash if
+ * the packet vector handle is corrupted.
  *
  * @param pktv Packet vector handle
  *
@@ -2238,10 +2240,12 @@ void odp_packet_print(odp_packet_t pkt);
 void odp_packet_print_data(odp_packet_t pkt, uint32_t offset, uint32_t len);
 
 /**
- * Perform full packet validity check
+ * Check that packet is valid
  *
- * The operation may consume considerable number of cpu cycles depending on
- * the check level.
+ * This function can be used for debugging purposes to check if a packet handle represents
+ * a valid packet. The level of error checks depends on the implementation. Considerable number of
+ * cpu cycles may be consumed depending on the level. The call should not crash if the packet
+ * handle is corrupted.
  *
  * @param pkt  Packet handle
  *

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -73,6 +73,7 @@ typedef struct pool_t {
 	uint32_t         block_size;
 	uint32_t         block_offset;
 	uint8_t         *base_addr;
+	uint8_t         *max_addr;
 	uint8_t         *uarea_base_addr;
 
 	/* Used by DPDK zero-copy pktio */
@@ -152,6 +153,7 @@ static inline odp_buffer_hdr_t *buf_hdr_from_index_u32(uint32_t u32)
 
 int buffer_alloc_multi(pool_t *pool, odp_buffer_hdr_t *buf_hdr[], int num);
 void buffer_free_multi(odp_buffer_hdr_t *buf_hdr[], int num_free);
+int _odp_buffer_is_valid(odp_buffer_t buf);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -97,3 +97,34 @@ uint64_t odp_event_to_u64(odp_event_t hdl)
 {
 	return _odp_pri(hdl);
 }
+
+int odp_event_is_valid(odp_event_t event)
+{
+	odp_buffer_t buf;
+
+	if (event == ODP_EVENT_INVALID)
+		return 0;
+
+	buf = odp_buffer_from_event(event);
+	if (_odp_buffer_is_valid(buf) == 0)
+		return 0;
+
+	switch (odp_event_type(event)) {
+	case ODP_EVENT_BUFFER:
+		/* Fall through */
+	case ODP_EVENT_PACKET:
+		/* Fall through */
+	case ODP_EVENT_TIMEOUT:
+		/* Fall through */
+	case ODP_EVENT_CRYPTO_COMPL:
+		/* Fall through */
+	case ODP_EVENT_IPSEC_STATUS:
+		/* Fall through */
+	case ODP_EVENT_PACKET_VECTOR:
+		break;
+	default:
+		return 0;
+	}
+
+	return 1;
+}

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1694,11 +1694,32 @@ void odp_packet_print_data(odp_packet_t pkt, uint32_t offset,
 
 int odp_packet_is_valid(odp_packet_t pkt)
 {
-	if (odp_buffer_is_valid(packet_to_buffer(pkt)) == 0)
+	odp_event_t ev;
+
+	if (pkt == ODP_PACKET_INVALID)
 		return 0;
 
-	if (odp_event_type(odp_packet_to_event(pkt)) != ODP_EVENT_PACKET)
+	if (_odp_buffer_is_valid(packet_to_buffer(pkt)) == 0)
 		return 0;
+
+	ev = odp_packet_to_event(pkt);
+
+	if (odp_event_type(ev) != ODP_EVENT_PACKET)
+		return 0;
+
+	switch (odp_event_subtype(ev)) {
+	case ODP_EVENT_PACKET_BASIC:
+		/* Fall through */
+	case ODP_EVENT_PACKET_COMP:
+		/* Fall through */
+	case ODP_EVENT_PACKET_CRYPTO:
+		/* Fall through */
+	case ODP_EVENT_PACKET_IPSEC:
+		/* Fall through */
+		break;
+	default:
+		return 0;
+	}
 
 	return 1;
 }

--- a/platform/linux-generic/odp_packet_vector.c
+++ b/platform/linux-generic/odp_packet_vector.c
@@ -62,12 +62,24 @@ void odp_packet_vector_free(odp_packet_vector_t pktv)
 
 int odp_packet_vector_valid(odp_packet_vector_t pktv)
 {
-	odp_event_vector_hdr_t *pktv_hdr = _odp_packet_vector_hdr(pktv);
-	pool_t *pool = pktv_hdr->buf_hdr.pool_ptr;
+	odp_event_vector_hdr_t *pktv_hdr;
+	odp_event_t ev;
+	pool_t *pool;
 	uint32_t i;
 
 	if (odp_unlikely(pktv == ODP_PACKET_VECTOR_INVALID))
 		return 0;
+
+	if (_odp_buffer_is_valid((odp_buffer_t)pktv) == 0)
+		return 0;
+
+	ev = odp_packet_vector_to_event(pktv);
+
+	if (odp_event_type(ev) != ODP_EVENT_PACKET_VECTOR)
+		return 0;
+
+	pktv_hdr = _odp_packet_vector_hdr(pktv);
+	pool = pktv_hdr->buf_hdr.pool_ptr;
 
 	if (odp_unlikely(pktv_hdr->size > pool->params.vector.max_size))
 		return 0;

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -213,6 +213,7 @@ static int alg_op(odp_packet_t pkt,
 			event = odp_queue_deq(suite_context.queue);
 		} while (event == ODP_EVENT_INVALID);
 
+		CU_ASSERT(odp_event_is_valid(event) == 1);
 		CU_ASSERT(ODP_EVENT_CRYPTO_COMPL == odp_event_type(event));
 		CU_ASSERT(ODP_EVENT_NO_SUBTYPE == odp_event_subtype(event));
 		CU_ASSERT(ODP_EVENT_CRYPTO_COMPL ==

--- a/test/validation/api/event/event.c
+++ b/test/validation/api/event/event.c
@@ -33,6 +33,7 @@ static void event_test_free(void)
 
 	for (i = 0; i < EVENT_BURST; i++) {
 		buf = odp_buffer_alloc(pool);
+		CU_ASSERT(odp_event_is_valid(odp_buffer_to_event(buf)) == 1);
 		CU_ASSERT_FATAL(buf != ODP_BUFFER_INVALID);
 		event[i] = odp_buffer_to_event(buf);
 		CU_ASSERT(odp_event_type(event[i]) == ODP_EVENT_BUFFER);
@@ -58,6 +59,7 @@ static void event_test_free(void)
 
 	for (i = 0; i < EVENT_BURST; i++) {
 		pkt = odp_packet_alloc(pool, EVENT_SIZE);
+		CU_ASSERT(odp_event_is_valid(odp_packet_to_event(pkt)) == 1);
 		CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 		event[i] = odp_packet_to_event(pkt);
 		CU_ASSERT(odp_event_type(event[i]) == ODP_EVENT_PACKET);
@@ -83,6 +85,7 @@ static void event_test_free(void)
 
 	for (i = 0; i < EVENT_BURST; i++) {
 		tmo = odp_timeout_alloc(pool);
+		CU_ASSERT(odp_event_is_valid(odp_timeout_to_event(tmo)) == 1);
 		CU_ASSERT_FATAL(tmo != ODP_TIMEOUT_INVALID);
 		event[i] = odp_timeout_to_event(tmo);
 		CU_ASSERT(odp_event_type(event[i]) == ODP_EVENT_TIMEOUT);
@@ -384,12 +387,21 @@ static void event_test_filter_packet(void)
 	CU_ASSERT(odp_pool_destroy(pkt_pool) == 0);
 }
 
+static void event_test_is_valid(void)
+{
+	CU_ASSERT(odp_event_is_valid(ODP_EVENT_INVALID) == 0);
+	CU_ASSERT(odp_buffer_is_valid(ODP_BUFFER_INVALID) == 0);
+	CU_ASSERT(odp_packet_is_valid(ODP_PACKET_INVALID) == 0);
+	CU_ASSERT(odp_packet_vector_valid(ODP_PACKET_VECTOR_INVALID) == 0);
+}
+
 odp_testinfo_t event_suite[] = {
 	ODP_TEST_INFO(event_test_free),
 	ODP_TEST_INFO(event_test_free_multi),
 	ODP_TEST_INFO(event_test_free_multi_mixed),
 	ODP_TEST_INFO(event_test_type_multi),
 	ODP_TEST_INFO(event_test_filter_packet),
+	ODP_TEST_INFO(event_test_is_valid),
 	ODP_TEST_INFO_NULL,
 };
 

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -463,6 +463,7 @@ void ipsec_sa_destroy(odp_ipsec_sa_t sa)
 			event = odp_queue_deq(suite_context.queue);
 		} while (event == ODP_EVENT_INVALID);
 
+		CU_ASSERT(odp_event_is_valid(event) == 1);
 		CU_ASSERT_EQUAL(ODP_EVENT_IPSEC_STATUS, odp_event_type(event));
 
 		ret = odp_ipsec_status(&status, event);
@@ -635,6 +636,7 @@ static int ipsec_send_in_one(const ipsec_test_part *part,
 				event = odp_queue_deq(suite_context.queue);
 			} while (event == ODP_EVENT_INVALID);
 
+			CU_ASSERT(odp_event_is_valid(event) == 1);
 			CU_ASSERT_EQUAL(ODP_EVENT_PACKET,
 					odp_event_types(event, &subtype));
 			CU_ASSERT_EQUAL(ODP_EVENT_PACKET_IPSEC, subtype);
@@ -663,6 +665,7 @@ static int ipsec_send_in_one(const ipsec_test_part *part,
 
 			ev = odp_queue_deq(queue);
 			if (ODP_EVENT_INVALID != ev) {
+				CU_ASSERT(odp_event_is_valid(ev) == 1);
 				CU_ASSERT_EQUAL(ODP_EVENT_PACKET,
 						odp_event_types(ev, &subtype));
 				CU_ASSERT_EQUAL(ODP_EVENT_PACKET_BASIC,
@@ -675,6 +678,7 @@ static int ipsec_send_in_one(const ipsec_test_part *part,
 
 			ev = odp_queue_deq(suite_context.queue);
 			if (ODP_EVENT_INVALID != ev) {
+				CU_ASSERT(odp_event_is_valid(ev) == 1);
 				CU_ASSERT_EQUAL(ODP_EVENT_PACKET,
 						odp_event_types(ev, &subtype));
 				CU_ASSERT_EQUAL(ODP_EVENT_PACKET_IPSEC,
@@ -732,6 +736,7 @@ static int ipsec_send_out_one(const ipsec_test_part *part,
 				event = odp_queue_deq(suite_context.queue);
 			} while (event == ODP_EVENT_INVALID);
 
+			CU_ASSERT(odp_event_is_valid(event) == 1);
 			CU_ASSERT_EQUAL(ODP_EVENT_PACKET,
 					odp_event_types(event, &subtype));
 			CU_ASSERT_EQUAL(ODP_EVENT_PACKET_IPSEC, subtype);
@@ -777,6 +782,7 @@ static int ipsec_send_out_one(const ipsec_test_part *part,
 
 			ev = odp_queue_deq(queue);
 			if (ODP_EVENT_INVALID != ev) {
+				CU_ASSERT(odp_event_is_valid(ev) == 1);
 				CU_ASSERT_EQUAL(ODP_EVENT_PACKET,
 						odp_event_types(ev, &subtype));
 				CU_ASSERT_EQUAL(ODP_EVENT_PACKET_BASIC,
@@ -789,6 +795,7 @@ static int ipsec_send_out_one(const ipsec_test_part *part,
 
 			ev = odp_queue_deq(suite_context.queue);
 			if (ODP_EVENT_INVALID != ev) {
+				CU_ASSERT(odp_event_is_valid(ev) == 1);
 				CU_ASSERT_EQUAL(ODP_EVENT_PACKET,
 						odp_event_types(ev, &subtype));
 				CU_ASSERT_EQUAL(ODP_EVENT_PACKET_IPSEC,

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -208,6 +208,8 @@ static void alloc_packet_vector(uint32_t cache_size)
 	for (i = 0; i < max_num; i++) {
 		pkt_vec[num] = odp_packet_vector_alloc(pool);
 		CU_ASSERT(pkt_vec[num] != ODP_PACKET_VECTOR_INVALID);
+		CU_ASSERT(odp_packet_vector_valid(pkt_vec[num]) == 1);
+		CU_ASSERT(odp_event_is_valid(odp_packet_vector_to_event(pkt_vec[num])) == 1);
 
 		if (pkt_vec[num] != ODP_PACKET_VECTOR_INVALID)
 			num++;
@@ -512,8 +514,11 @@ static void pool_test_buf_max_num(void)
 	for (i = 0; i < max_num; i++) {
 		buf[num] = odp_buffer_alloc(pool);
 
-		if (buf[num] != ODP_BUFFER_INVALID)
+		if (buf[num] != ODP_BUFFER_INVALID) {
+			CU_ASSERT(odp_buffer_is_valid(buf[num]) == 1);
+			CU_ASSERT(odp_event_is_valid(odp_buffer_to_event(buf[num])) == 1);
 			num++;
+		}
 	}
 
 	CU_ASSERT(num == max_num);
@@ -566,8 +571,11 @@ static void pool_test_pkt_max_num(void)
 	for (i = 0; i < max_num; i++) {
 		pkt[num] = odp_packet_alloc(pool, len);
 
-		if (pkt[num] != ODP_PACKET_INVALID)
+		if (pkt[num] != ODP_PACKET_INVALID) {
+			CU_ASSERT(odp_packet_is_valid(pkt[num]) == 1);
+			CU_ASSERT(odp_event_is_valid(odp_packet_to_event(pkt[num])) == 1);
 			num++;
+		}
 	}
 
 	CU_ASSERT(num == max_num);
@@ -702,8 +710,10 @@ static void pool_test_tmo_max_num(void)
 	for (i = 0; i < max_num; i++) {
 		tmo[num] = odp_timeout_alloc(pool);
 
-		if (tmo[num] != ODP_TIMEOUT_INVALID)
+		if (tmo[num] != ODP_TIMEOUT_INVALID) {
+			CU_ASSERT(odp_event_is_valid(odp_timeout_to_event(tmo[num])) == 1);
 			num++;
+		}
 	}
 
 	CU_ASSERT(num == max_num);

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -1271,13 +1271,16 @@ static int schedule_common_(void *arg)
 				}
 			}
 
-			for (j = 0; j < num; j++)
+			for (j = 0; j < num; j++) {
+				CU_ASSERT(odp_event_is_valid(events[j]) == 1);
 				odp_event_free(events[j]);
+			}
 		} else {
 			ev  = odp_schedule(&from, ODP_SCHED_NO_WAIT);
 			if (ev == ODP_EVENT_INVALID)
 				continue;
 
+			CU_ASSERT(odp_event_is_valid(ev) == 1);
 			buf = odp_buffer_from_event(ev);
 			num = 1;
 			if (sync == ODP_SCHED_SYNC_ORDERED) {


### PR DESCRIPTION
This is needed for debugging e.g. when it is suspected that scheduler returns bad event handles.