### PR TITLE
[PATCH v2] DEPENDENCIES: update cunit cross compilation instructions

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -65,13 +65,13 @@ Prerequisites for building the OpenDataPlane (ODP) API
 
    # Build and install 32 bit version of openssl
    $ ./Configure linux-generic32 --cross-compile-prefix=arm-linux-gnueabihf- \
-     --prefix=/home/user/src/install-openssl shared
+     --prefix=/home/${USER}/src/install-openssl shared
    $ make
    $ make install
 
    # Build and install 64 bit version of openssl
    $ ./Configure linux-generic64 --cross-compile-prefix=aarch64-linux-gnu- \
-     --prefix=/home/user/src/install-openssl-aarch64 shared
+     --prefix=/home/${USER}/src/install-openssl-aarch64 shared
    $ make
    $ make install
 
@@ -82,12 +82,12 @@ Prerequisites for building the OpenDataPlane (ODP) API
 
    # Build 32 bit version of ODP
    $ ./configure --host=arm-linux-gnueabihf \
-     --with-openssl-path=/home/user/src/install-openssl
+     --with-openssl-path=/home/${USER}/src/install-openssl
    $ make
 
    # Or build 64 bit version of ODP
    $ ./configure --host=aarch64-linux-gnu \
-     --with-openssl-path=/home/user/src/install-openssl-aarch64
+     --with-openssl-path=/home/${USER}/src/install-openssl-aarch64
    $ make
 
 3.3 Netmap packet I/O support (optional)
@@ -278,7 +278,16 @@ Prerequisites for building the OpenDataPlane (ODP) API
    $ git svn clone http://svn.code.sf.net/p/cunit/code/trunk cunit-code
    $ cd cunit-code
    $ ./bootstrap
+
+   # Build and install 32 bit version of cunit
    $ ./configure --host=arm-linux-gnueabihf --prefix=/home/${USER}/src/install-cunit
+   $ make
+   $ make install
+
+   # Build and install 64 bit version of cunit
+   $ ./configure --host=aarch64-linux-gnu --prefix=/home/${USER}/src/install-cunit
+   $ make
+   $ make install
 
 4.4 Using CUnit with ODP
 


### PR DESCRIPTION
The current instructions for cunit cross compilation cater only to
configuring arm32 binaries on x86_64 platform and are incomplete, i.e,
'make' and 'make install' commands are missing. As well as adding those
commands, the instructions are updated to also include cunit cross
compilation for arm64 binaries.

In addition to the above changes, the '/home/user/' path in OpenSSL cross
compilation has been also been updated to '/home/${USER}/' to be consistent
with the cunit cross compilation instructions. It will allow users to
simply copy-paste the commands in a terminal to build OpenSSL.

Signed-off-by: Malvika Gupta <Malvika.Gupta@arm.com>
Reviewed-by: Govindarajan Mohandoss <Govindarajan.Mohandoss@arm.com>