### PR TITLE
[PATCH v5] api: tm: tm spec changes 

### DIFF
--- a/example/traffic_mgmt/odp_traffic_mgmt.c
+++ b/example/traffic_mgmt/odp_traffic_mgmt.c
@@ -62,8 +62,8 @@ static const odp_init_t ODP_INIT_PARAMS = {
 
 static profile_params_set_t COMPANY_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 50  * MBPS,  .commit_burst      = 1000000,
-		.peak_bps   = 0,           .peak_burst        = 0,
+		.commit_rate = 50  * MBPS, .commit_burst      = 1000000,
+		.peak_rate   = 0,          .peak_burst        = 0,
 		.dual_rate  = FALSE,       .shaper_len_adjust = 20
 	},
 
@@ -95,8 +95,8 @@ static profile_params_set_t COMPANY_PROFILE_PARAMS = {
 
 static profile_params_set_t COS0_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 1 * MBPS,  .commit_burst      = 100000,
-		.peak_bps   = 4 * MBPS,  .peak_burst        = 200000,
+		.commit_rate = 1 * MBPS, .commit_burst      = 100000,
+		.peak_rate   = 4 * MBPS, .peak_burst        = 200000,
 		.dual_rate  = FALSE,     .shaper_len_adjust = 20
 	},
 
@@ -128,8 +128,8 @@ static profile_params_set_t COS0_PROFILE_PARAMS = {
 
 static profile_params_set_t COS1_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 500  * KBPS,  .commit_burst      = 50000,
-		.peak_bps   = 1500 * KBPS,  .peak_burst        = 150000,
+		.commit_rate = 500  * KBPS, .commit_burst      = 50000,
+		.peak_rate   = 1500 * KBPS, .peak_burst        = 150000,
 		.dual_rate  = FALSE,        .shaper_len_adjust = 20
 	},
 
@@ -161,8 +161,8 @@ static profile_params_set_t COS1_PROFILE_PARAMS = {
 
 static profile_params_set_t COS2_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 200 * KBPS,  .commit_burst      = 20000,
-		.peak_bps   = 400 * KBPS,  .peak_burst        = 40000,
+		.commit_rate = 200 * KBPS, .commit_burst      = 20000,
+		.peak_rate   = 400 * KBPS, .peak_burst        = 40000,
 		.dual_rate  = FALSE,       .shaper_len_adjust = 20
 	},
 
@@ -194,8 +194,8 @@ static profile_params_set_t COS2_PROFILE_PARAMS = {
 
 static profile_params_set_t COS3_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 100 * KBPS,  .commit_burst      = 5000,
-		.peak_bps   = 0,           .peak_burst        = 0,
+		.commit_rate = 100 * KBPS, .commit_burst      = 5000,
+		.peak_rate   = 0,          .peak_burst        = 0,
 		.dual_rate  = FALSE,       .shaper_len_adjust = 20
 	},
 
@@ -272,8 +272,8 @@ static uint32_t create_profile_set(profile_params_set_t *profile_params_set,
 
 	odp_tm_shaper_params_init(&shaper_params);
 	shaper                          = &profile_params_set->shaper_params;
-	shaper_params.commit_bps        = shaper->commit_bps   * shaper_scale;
-	shaper_params.peak_bps          = shaper->peak_bps     * shaper_scale;
+	shaper_params.commit_rate       = shaper->commit_rate  * shaper_scale;
+	shaper_params.peak_rate         = shaper->peak_rate    * shaper_scale;
 	shaper_params.commit_burst      = shaper->commit_burst * shaper_scale;
 	shaper_params.peak_burst        = shaper->peak_burst   * shaper_scale;
 	shaper_params.dual_rate         = shaper->dual_rate;

--- a/example/traffic_mgmt/odp_traffic_mgmt.c
+++ b/example/traffic_mgmt/odp_traffic_mgmt.c
@@ -540,6 +540,8 @@ static int create_and_config_tm(void)
 		       __func__, err_cnt);
 
 	config_company_node("TestCompany");
+
+	odp_tm_start(odp_tm_test);
 	return err_cnt;
 }
 
@@ -752,6 +754,8 @@ static int destroy_tm_queues(void)
 	int i;
 	int class;
 	int ret;
+
+	odp_tm_stop(odp_tm_test);
 
 	for (i = 0; i < NUM_SVC_CLASSES; i++)
 		for (class = 0; class < TM_QUEUES_PER_CLASS; class++) {

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -106,6 +106,10 @@ typedef enum odp_pktout_mode_t {
 	ODP_PKTOUT_MODE_QUEUE,
 	/** Packet output through traffic manager API */
 	ODP_PKTOUT_MODE_TM,
+	/** Packet output through traffic manager API where
+	 * TM queues act as event queues.
+	 */
+	ODP_PKTOUT_MODE_TM_QUEUE,
 	/** Application will never send to this interface */
 	ODP_PKTOUT_MODE_DISABLED
 } odp_pktout_mode_t;
@@ -595,7 +599,8 @@ typedef struct odp_pktio_config_t {
 	 *  through the IPSEC API.
 	 *
 	 *  Support of outbound IPSEC inline operation with traffic manager
-	 *  (ODP_PKTOUT_MODE_TM) can be queried with odp_ipsec_capability().
+	 *  (ODP_PKTOUT_MODE_TM or ODP_PKTOUT_MODE_TM_QUEUE) can be queried
+	 *  with odp_ipsec_capability().
 	 *
 	 * * 0: Disable outbound IPSEC inline operation (default)
 	 * * 1: Enable outbound IPSEC inline operation
@@ -865,8 +870,9 @@ typedef struct odp_pktio_capability_t {
  *
  * Packet output queue configuration must be setup with
  * odp_pktout_queue_config() before odp_pktio_start() is called. When packet
- * output mode is ODP_PKTOUT_MODE_DISABLED or ODP_PKTOUT_MODE_TM,
- * odp_pktout_queue_config() call is optional and will ignore all parameters.
+ * output mode is ODP_PKTOUT_MODE_DISABLED, ODP_PKTOUT_MODE_TM or
+ * ODP_PKTOUT_MODE_TM_QUEUE, odp_pktout_queue_config() call is optional
+ * and will ignore all parameters.
  *
  * Packet receive and transmit on the interface is enabled with a call to
  * odp_pktio_start(). If not specified otherwise, any interface level

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -1655,6 +1655,20 @@ int odp_tm_queue_disconnect(odp_tm_queue_t tm_queue);
  */
 int odp_tm_enq(odp_tm_queue_t tm_queue, odp_packet_t pkt);
 
+/** The odp_tm_enq_multi() function is used to add packets to a given TM system.
+ * This API takes multiple packets to enqueue unlike odp_tm_enq() but
+ * rest of the behaviour is identical to that of odp_tm_enq().
+ *
+ * @param tm_queue  Specifies the tm_queue (and indirectly the TM system).
+ * @param packets   Array of packets to enqueue.
+ * @param num       Number of packets to send.
+ * @return          Returns >0 upon success indicating number of packets
+ *                  enqueued, <= 0 upon failure. One of the more common
+ *                  failure reasons is WRED drop.
+ */
+int odp_tm_enq_multi(odp_tm_queue_t tm_queue, const odp_packet_t packets[],
+		     int num);
+
 /** The odp_tm_enq_with_cnt() function behaves identically to odp_tm_enq(),
  * except that it also returns (an approximation to?) the current tm_queue
  * packet queue count.
@@ -1665,6 +1679,19 @@ int odp_tm_enq(odp_tm_queue_t tm_queue, odp_packet_t pkt);
  *                  this tm_queue upon success, < 0 upon failure.
  */
 int odp_tm_enq_with_cnt(odp_tm_queue_t tm_queue, odp_packet_t pkt);
+
+/** The odp_tm_queue_enq() function is used to add packets to a given TM system.
+ * This API needs to be used to enqueue events of type ODP_EVENT_PACKET_VECTOR
+ * or ODP_EVENT_PACKET to tm queue only when PKTOUT mode is
+ * ODP_PKTOUT_MODE_TM_QUEUE. Apart from this, rest of the behaviour is
+ * identical to that of odp_tm_enq().
+ *
+ * @param tm_queue  Specifies the tm_queue (and indirectly the TM system).
+ * @param ev        Event handle representing a packet or packet vector.
+ * @return          Returns 0 upon success, < 0 upon failure. One of the
+ *                  more common failure reasons is WRED drop.
+ */
+int odp_tm_queue_enq(odp_tm_queue_t tm_queue, odp_event_t ev);
 
 /* Dynamic state query functions */
 

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -331,6 +331,26 @@ typedef struct {
 	/** The per_level array specifies the TM system capabilities that
 	 * can vary based upon the tm_node level. */
 	odp_tm_level_capabilities_t per_level[ODP_TM_MAX_LEVELS];
+
+	/** node_priority indicates that this TM system supports
+	 * only having single priority associated to fan-in nodes at any
+	 * level. When TRUE, Priority is fixed for a fanin node i.e all packets
+	 * fed by a particular fanin node to a tm node will have a fixed priority.
+	 * This is equivalent to the packet priority being overloaded by
+	 * fan-in node priority. When FALSE, every fan-in node can feed packets
+	 * to parent tm node with priorities ranging from
+	 * 0..ODP_TM_MAX_PRIORITIES - 1.
+	 */
+	odp_bool_t node_priority_override;
+
+	/** max_wfq_groups_per_node indicates maximum number of wfq groups supported
+	 * by a tm node at any level. This capability is valid only when
+	 * node_priority_override is TRUE. In a given topology only these many
+	 * groups of children can be formed of same node priority under a parent.
+	 * This value can range from 1..ODP_TM_MAX_PRIORITIES as there can be
+	 * only as many number of WFQ groups as MAX priority.
+	 */
+	uint8_t max_wfq_groups_per_node;
 } odp_tm_capabilities_t;
 
 /** Per Level Requirements
@@ -1233,6 +1253,12 @@ typedef struct {
 	 * greater levels may be connected to the fan-in of tm_node's with
 	 * numerically smaller levels. */
 	uint8_t level;
+
+	/** The strict priority level assigned to packets going through this
+	 * node. In other words all packets going through node
+	 * will be assigned this priority overriding previous priority.
+	 * in the range 0..max_priority. */
+	uint8_t priority;
 } odp_tm_node_params_t;
 
 /** odp_tm_node_params_init() must be called to initialize any

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -794,20 +794,32 @@ typedef enum {
  */
 typedef struct {
 	/** The committed information rate for this shaper profile.  The units
-	 * for this integer are always in bits per second. */
-	uint64_t commit_bps;
+	 * for this integer is in bits per second when packet_mode is
+	 * not TRUE while packets per second when packet mode is TRUE.
+	 */
+	union {
+		uint64_t commit_bps; /**< Commit information rate in bps */
+		uint64_t commit_rate; /**< Commit information rate */
+	};
 
 	/** The peak information rate for this shaper profile.  The units for
-	 * this integer are always in bits per second. */
-	uint64_t peak_bps;
+	 * this integer is in bits per second when packet_mode is
+	 * not TRUE while in packets per second when packet mode is TRUE.
+	 */
+	union {
+		uint64_t peak_bps; /**< Peak information rate in bps */
+		uint64_t peak_rate; /**< Peak information rate */
+	};
 
 	/** The commit burst tolerance for this shaper profile.  The units for
-	 * this field are always bits.  This value sets an upper limit for the
+	 * this field is bits when packet_mode is not TRUE and packets when
+	 * packet_mode is TRUE.  This value sets an upper limit for the
 	 * size of the commitCnt. */
 	uint32_t commit_burst;
 
 	/** The peak burst tolerance for this shaper profile.  The units for
-	 * this field are always bits.  This value sets an upper limit for the
+	 * this field in bits when packet_mode is not TRUE and packets
+	 * when packet_mode is TRUE. This value sets an upper limit for the
 	 * size of the peakCnt. */
 	uint32_t peak_burst;
 
@@ -819,7 +831,9 @@ typedef struct {
 	 * to a value approximating the "time" (in units of bytes) taken by
 	 * the Ethernet preamble and Inter Frame Gap.  Traditionally this
 	 * would be the value 20 (8 + 12), but in same cases can be as low as
-	 * 9 (4 + 5). */
+	 * 9 (4 + 5).
+	 * This field is ignored when packet_mode is TRUE.
+	 */
 	int8_t shaper_len_adjust;
 
 	/** If dual_rate is TRUE it indicates the desire for the
@@ -828,6 +842,12 @@ typedef struct {
 	 * implementation specific, but in any case require a non-zero set of
 	 * both commit and peak parameters. */
 	odp_bool_t dual_rate;
+
+	/** If packet_mode is TRUE it indicates that shaper should work
+	 * in packet mode ignoring lengths of packet and hence shaping
+	 * traffic in packet's per second as opposed to bytes per second.
+	 */
+	odp_bool_t packet_mode;
 } odp_tm_shaper_params_t;
 
 /** odp_tm_shaper_params_init() must be called to initialize any

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -189,6 +189,30 @@ extern "C" {
  * tree/hierarchy of nodes.
  */
 
+/** The tm_node_stats_type enumeration lists possible packet or octet
+ * statistics at a tm node.
+ */
+typedef enum odp_tm_node_stats_type_t {
+	/** Packets dropped by this node after scheduling/shaping at this node */
+	ODP_TM_NODE_STATS_PKTS_DROPPED,
+	/** Octets dropped after scheduling/shaping at this node */
+	ODP_TM_NODE_STATS_OCTETS_DROPPED,
+	/** Green packets that are sent through this tm node */
+	ODP_TM_NODE_STATS_GREEN_PKTS,
+	/** Green octets that are sent through this tm node */
+	ODP_TM_NODE_STATS_GREEN_OCTETS,
+	/** Yellow packets that are sent through this tm node */
+	ODP_TM_NODE_STATS_YELLOW_PKTS,
+	/** Yellow octets that are sent through this tm node */
+	ODP_TM_NODE_STATS_YELLOW_OCTETS,
+	/** Red packets that are sent through this tm node */
+	ODP_TM_NODE_STATS_RED_PKTS,
+	/** Red octets that are sent through this tm node */
+	ODP_TM_NODE_STATS_RED_OCTETS,
+	/** Node stats max */
+	ODP_TM_NODE_STATS_MAX,
+} odp_tm_node_stats_type_t;
+
 /** Per Level Capabilities
  *
  * The odp_tm_level_capabilities_t record is used to describe the capabilities
@@ -248,6 +272,15 @@ typedef struct {
 	/** tm_node_threshold_supported indicates that the tm_nodes at this
 	 * level support threshold profile set. */
 	odp_bool_t tm_node_threshold_supported;
+
+	/** tm_node_stats_supported indicates the statistics supported by
+	 * nodes at this level. When True, that stat counter is supported,
+	 * while False indicates it is not supported.
+	 *
+	 * @see odp_tm_node_stats_type_t
+	 * @see odp_tm_node_stats()
+	 */
+	odp_bool_t tm_node_stats_supported[ODP_TM_NODE_STATS_MAX];
 } odp_tm_level_capabilities_t;
 
 /** TM Capabilities Record.
@@ -1930,6 +1963,29 @@ typedef struct {
  */
 int odp_tm_node_fanin_info(odp_tm_node_t             tm_node,
 			   odp_tm_node_fanin_info_t *info);
+
+/** The odp_tm_node_stats_t record type  is used to return various stats
+ * supported by a given tm_node via the odp_tm_node_stats() function.
+ */
+typedef struct odp_tm_node_stats_t {
+	/** Node statistics. @see odp_tm_node_stats_type_t */
+	uint64_t stats[ODP_TM_NODE_STATS_MAX];
+} odp_tm_node_stats_t;
+
+/** Get tm_node stats
+ *
+ * The odp_tm_node_stats() function is used to extract runtime statistics
+ * associated with a given tm_node. The stats structure is written
+ * only on success.
+ *
+ * @param      tm_node    Specifies the tm_node to be queried.
+ * @param      clear      1: Clear stats before return.
+ *                        0: Don't clear stats.
+ * @param[out] node_stats A pointer to an odp_tm_node_stats_t record that is to
+ *                        be filled in by this call.
+ * @return                Returns < 0 upon failure, 0 upon success.
+ */
+int odp_tm_node_stats(odp_tm_node_t tm_node, int clear, odp_tm_node_stats_t *node_stats);
 
 /** The odp_tm_queue_info_t record type  is used to return various bits of
  * information about a given tm_queue via the odp_tm_queue_info() function.

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -903,7 +903,8 @@ typedef struct {
 	 * not TRUE while packets per second when packet mode is TRUE.
 	 */
 	union {
-		uint64_t commit_bps; /**< Commit information rate in bps */
+		/**< @deprecated Use commit_rate instead */
+		uint64_t ODP_DEPRECATE(commit_bps);
 		uint64_t commit_rate; /**< Commit information rate */
 	};
 
@@ -912,7 +913,8 @@ typedef struct {
 	 * not TRUE while in packets per second when packet mode is TRUE.
 	 */
 	union {
-		uint64_t peak_bps; /**< Peak information rate in bps */
+		/**< @deprecated Use peak_rate instead */
+		uint64_t ODP_DEPRECATE(peak_bps);
 		uint64_t peak_rate; /**< Peak information rate */
 	};
 

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -375,6 +375,52 @@ typedef struct {
 	 * ODP_TM_QUERY_THRESHOLDS.
 	 */
 	uint8_t tm_queue_query_mask;
+
+	/** dynamic_topology_update_supported indicates support for TM system
+	 * dynamic topology update. A topology update is defined as
+	 * update to a TM system topology while TM system is not in stopped
+	 * state. When TRUE, application can  update topology dynamically
+	 * without bringing the TM system to stopped state. When FALSE,
+	 * application has to call odp_tm_stop() before updating the
+	 * topology and odp_tm_start() after completing the update.
+	 */
+	odp_bool_t dynamic_topology_update_supported;
+
+	/** dynamic_shaper_update_supported indicates support for TM
+	 * system's dynamic shaper profile changes. When TRUE, application
+	 * can update shaper profile of a TM queue or TM node dynamically.
+	 * When FALSE, it implies that TM system should be brought to
+	 * stopped state before doing any TM node or TM queue shaper profile
+	 * change.
+	 */
+	odp_bool_t dynamic_shaper_update_supported;
+
+	/** dynamic_sched_update_supported indicates support for TM
+	 * system's dynamic sched profile changes. When TRUE, application
+	 * can update sched profile of a TM queue or TM node dynamically.
+	 * When FALSE, it implies that TM system should be brought to
+	 * stopped state before doing any TM node or TM queue sched profile
+	 * change.
+	 */
+	odp_bool_t dynamic_sched_update_supported;
+
+	/** dynamic_wred_update_supported indicates support for TM
+	 * system's dynamic wred profile changes. When TRUE, application
+	 * can update wred profile of a TM queue or TM node dynamically.
+	 * When FALSE, it implies that TM system should be brought to
+	 * stopped state before doing any TM node or TM queue wred profile
+	 * change.
+	 */
+	odp_bool_t dynamic_wred_update_supported;
+
+	/** dynamic_threshold_update_supported indicates support for TM
+	 * system's dynamic threshold profile changes. When TRUE, application
+	 * can update threshold profile of a TM queue or TM node dynamically.
+	 * When FALSE, it implies that TM system should be brought to
+	 * stopped state before doing any TM node or TM queue threshold profile
+	 * change.
+	 */
+	odp_bool_t dynamic_threshold_update_supported;
 } odp_tm_capabilities_t;
 
 /** Per Level Requirements

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -625,6 +625,34 @@ odp_tm_t odp_tm_find(const char            *name,
  */
 int odp_tm_capability(odp_tm_t odp_tm, odp_tm_capabilities_t *capabilities);
 
+/** Start a TM system.
+ *
+ * odp_tm_start() needs to be used to start an already created / found TM system
+ * and in stopped state. By default platforms can choose to be already in
+ * started state with immediately after created. Calling this function
+ * on an already started TM system will be ignored.
+ *
+ * @param odp_tm  The odp_tm_t value of the TM system to be started.
+ * @return        0 upon success, < 0 upon failure.
+ */
+int odp_tm_start(odp_tm_t odp_tm);
+
+/** Stop a TM system.
+ *
+ * odp_tm_stop() can to be used to stop a TM system that is already started.
+ * Stopping a TM system will cause a TM system to stop / pause processing
+ * packets. This can be used to idle a TM system. Applications cannot call
+ * tm enqueue on a TM system which is in stopped state.
+ *
+ * Stopping a TM system is necessary in scenarios where a platform does not
+ * support dynamic topology, shaper or sched profile update while TM system is
+ * active. In such cases updates can be done after stopping TM system.
+ *
+ * @param odp_tm  The odp_tm_t value of the TM system to be stopped.
+ * @return        0 upon success, < 0 upon failure.
+ */
+int odp_tm_stop(odp_tm_t odp_tm);
+
 /** Destroy a TM system.
  *
  * odp_tm_destroy() may be used to destroy TM systems created via

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -244,6 +244,10 @@ typedef struct {
 	 * When true the min_weight and max_weight fields above specify
 	 * the legal range of such weights. */
 	odp_bool_t weights_supported;
+
+	/** tm_node_threshold_supported indicates that the tm_nodes at this
+	 * level support threshold profile set. */
+	odp_bool_t tm_node_threshold_supported;
 } odp_tm_level_capabilities_t;
 
 /** TM Capabilities Record.
@@ -351,6 +355,26 @@ typedef struct {
 	 * only as many number of WFQ groups as MAX priority.
 	 */
 	uint8_t max_wfq_groups_per_node;
+
+	/** tm_queue_threshold_supported indicates support for threshold
+	 * profile on a TM queue. When TRUE, users can set/clear/update
+	 * threshold profile on a TM queue. When false clear none of it is
+	 * supported.
+	 */
+	odp_bool_t tm_queue_threshold_supported;
+
+	/** tm_queue_query_mask indicates supported types of TM queue query.
+	 * Types of TM queue query are same as query_flags that are passed to
+	 * odp_tm_queue_query(), odp_tm_priority_query() and
+	 * odp_tm_total_query(). When zero, none of the queue query API's are
+	 * supported. When non-zero, only the supported fields are filled
+	 * irrespective of the query_flags passed and rest of the fields are
+	 * untouched.
+	 *
+	 * @see ODP_TM_QUERY_PKT_CNT, ODP_TM_QUERY_BYTE_CNT,
+	 * ODP_TM_QUERY_THRESHOLDS.
+	 */
+	uint8_t tm_queue_query_mask;
 } odp_tm_capabilities_t;
 
 /** Per Level Requirements
@@ -548,6 +572,41 @@ void odp_tm_egress_init(odp_tm_egress_t *egress);
  */
 int odp_tm_capabilities(odp_tm_capabilities_t capabilities[],
 			uint32_t              capabilities_size);
+
+/** Query All TM Capabilities specific to an egress
+ *
+ * The odp_tm_egress_capabilities() function can be used to obtain the complete
+ * set of TM limits supported by this implementation for a given egress.
+ * The reason that this  returns a SET of capabilities and not just one, is
+ * because it is expected  that many HW based implementations may have one set
+ * of limits for the HW and also support a SW TM implementation with a
+ * (presumably larger) different set of limits.  There are also cases where
+ * there could be more than SW implementation (one supporting say tens of
+ * thousands of tm_queues and a variant supporting tens of millions of
+ * tm_queues). This is needed as platforms might have different constraints
+ * for different egress type and there is no way to know them using
+ * odp_tm_capabilities() provided capabilities. The caller passes in an array
+ * of odp_tm_capabilities_t records  and the number of such records.  Then the
+ * first N of these records will be  filled in by the implementation and the
+ * number N will be returned.  In the event that N is larger than the
+ * capabilities_size, N will still be returned, but only capabilities_size
+ * records will be filled in.
+ *
+ * @param[out] capabilities      An array of odp_tm_capabilities_t records to
+ *                               be filled in.
+ * @param      capabilities_size The number of odp_tm_capabilities_t records
+ *                               in the capabilities array.
+ * @param      egress            Only capabilities compatible with this egress
+ *                               are returned.
+ * @return                       Returns < 0 upon failure.  Returns N > 0,
+ *                               where N is the maximum number of different
+ *                               odp_tm_capabilities_t records that the
+ *                               implementations supports. *NOTE* that this
+ *                               number can be > capabilities_size!
+ */
+int odp_tm_egress_capabilities(odp_tm_capabilities_t capabilities[],
+			       uint32_t              capabilities_size,
+			       odp_tm_egress_t       *egress);
 
 /** Create/instantiate a TM Packet Scheduling system.
  *

--- a/platform/linux-generic/odp_name_table.c
+++ b/platform/linux-generic/odp_name_table.c
@@ -376,6 +376,7 @@ static void name_tbl_entry_free(name_tbl_entry_t *name_tbl_entry)
 	memset(name_tbl_entry, 0, sizeof(name_tbl_entry_t));
 	name_tbl_entry->next_entry = name_tbl->free_list_head;
 	name_tbl->free_list_head   = name_tbl_entry;
+	name_tbl_entry->name_tbl_id = name_tbl_id;
 }
 
 static hash_tbl_entry_t make_hash_tbl_entry(name_tbl_entry_t *name_tbl_entry,

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -2090,17 +2090,21 @@ int odp_pktout_queue_config(odp_pktio_t pktio,
 
 	mode = entry->s.param.out_mode;
 
-	/* Ignore the call when packet output is disabled, or routed through
-	 * traffic manager. */
-	if (mode == ODP_PKTOUT_MODE_DISABLED || mode == ODP_PKTOUT_MODE_TM)
+	/* Ignore the call when packet output is disabled. */
+	if (mode == ODP_PKTOUT_MODE_DISABLED)
 		return 0;
 
-	if (mode != ODP_PKTOUT_MODE_DIRECT && mode != ODP_PKTOUT_MODE_QUEUE) {
+	if (mode != ODP_PKTOUT_MODE_DIRECT &&
+	    mode != ODP_PKTOUT_MODE_QUEUE &&
+	    mode != ODP_PKTOUT_MODE_TM) {
 		ODP_DBG("pktio %s: bad packet output mode\n", entry->s.name);
 		return -1;
 	}
 
-	num_queues = param->num_queues;
+	if (mode == ODP_PKTOUT_MODE_TM)
+		num_queues = 1;
+	else
+		num_queues = param->num_queues;
 
 	if (num_queues == 0) {
 		ODP_DBG("pktio %s: zero output queues\n", entry->s.name);
@@ -2304,7 +2308,7 @@ int odp_pktout_queue(odp_pktio_t pktio, odp_pktout_queue_t queues[], int num)
 	if (mode == ODP_PKTOUT_MODE_DISABLED)
 		return 0;
 
-	if (mode != ODP_PKTOUT_MODE_DIRECT)
+	if (mode != ODP_PKTOUT_MODE_DIRECT && mode != ODP_PKTOUT_MODE_TM)
 		return -1;
 
 	num_queues = entry->s.num_out_queue;

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -610,8 +610,8 @@ static void tm_shaper_params_cvt_to(const odp_tm_shaper_params_t *shaper_params,
 	uint32_t min_time_delta;
 	int64_t  commit_burst, peak_burst;
 
-	commit_rate = tm_bps_to_rate(shaper_params->commit_bps);
-	if ((shaper_params->commit_bps == 0) || (commit_rate == 0)) {
+	commit_rate = tm_bps_to_rate(shaper_params->commit_rate);
+	if ((shaper_params->commit_rate == 0) || (commit_rate == 0)) {
 		tm_shaper_params->max_commit_time_delta = 0;
 		tm_shaper_params->max_peak_time_delta   = 0;
 		tm_shaper_params->commit_rate           = 0;
@@ -628,8 +628,8 @@ static void tm_shaper_params_cvt_to(const odp_tm_shaper_params_t *shaper_params,
 	max_commit_time_delta = tm_max_time_delta(commit_rate);
 	commit_burst = (int64_t)shaper_params->commit_burst;
 
-	peak_rate = tm_bps_to_rate(shaper_params->peak_bps);
-	if ((shaper_params->peak_bps == 0) || (peak_rate == 0)) {
+	peak_rate = tm_bps_to_rate(shaper_params->peak_rate);
+	if ((shaper_params->peak_rate == 0) || (peak_rate == 0)) {
 		peak_rate = 0;
 		max_peak_time_delta = 0;
 		peak_burst = 0;
@@ -669,8 +669,8 @@ static void tm_shaper_params_cvt_from(tm_shaper_params_t     *tm_shaper_params,
 	commit_burst = tm_shaper_params->max_commit >> (26 - 3);
 	peak_burst = tm_shaper_params->max_peak >> (26 - 3);
 
-	odp_shaper_params->commit_bps = commit_bps;
-	odp_shaper_params->peak_bps = peak_bps;
+	odp_shaper_params->commit_rate = commit_bps;
+	odp_shaper_params->peak_rate = peak_bps;
 	odp_shaper_params->commit_burst = (uint32_t)commit_burst;
 	odp_shaper_params->peak_burst = (uint32_t)peak_burst;
 	odp_shaper_params->shaper_len_adjust = tm_shaper_params->len_adjust;

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2560,6 +2560,15 @@ int odp_tm_capabilities(odp_tm_capabilities_t capabilities[] ODP_UNUSED,
 	cap_ptr->vlan_marking_supported        = true;
 	cap_ptr->ecn_marking_supported         = true;
 	cap_ptr->drop_prec_marking_supported   = true;
+	cap_ptr->tm_queue_threshold_supported  = true;
+	cap_ptr->tm_queue_query_mask           = (ODP_TM_QUERY_PKT_CNT |
+						  ODP_TM_QUERY_BYTE_CNT |
+						  ODP_TM_QUERY_THRESHOLDS);
+
+	cap_ptr->dynamic_topology_update_supported  = true;
+	cap_ptr->dynamic_shaper_update_supported    = true;
+	cap_ptr->dynamic_sched_update_supported     = true;
+	cap_ptr->dynamic_threshold_update_supported = true;
 
 	for (color = 0; color < ODP_NUM_PACKET_COLORS; color++)
 		cap_ptr->marking_colors_supported[color] = true;
@@ -2578,9 +2587,19 @@ int odp_tm_capabilities(odp_tm_capabilities_t capabilities[] ODP_UNUSED,
 		per_level_cap->tm_node_dual_slope_supported = true;
 		per_level_cap->fair_queuing_supported       = true;
 		per_level_cap->weights_supported            = true;
+		per_level_cap->tm_node_threshold_supported  = true;
 	}
 
 	return 1;
+}
+
+int odp_tm_egress_capabilities(odp_tm_capabilities_t capabilities[],
+			       uint32_t capabilities_size,
+			       odp_tm_egress_t *egress)
+{
+	(void)egress;
+
+	return odp_tm_capabilities(capabilities, capabilities_size);
 }
 
 static void tm_system_capabilities_set(odp_tm_capabilities_t *cap_ptr,
@@ -2613,6 +2632,15 @@ static void tm_system_capabilities_set(odp_tm_capabilities_t *cap_ptr,
 	cap_ptr->ecn_marking_supported         = req_ptr->ecn_marking_needed;
 	cap_ptr->drop_prec_marking_supported   =
 					req_ptr->drop_prec_marking_needed;
+	cap_ptr->tm_queue_threshold_supported  = true;
+	cap_ptr->tm_queue_query_mask           = (ODP_TM_QUERY_PKT_CNT |
+						  ODP_TM_QUERY_BYTE_CNT |
+						  ODP_TM_QUERY_THRESHOLDS);
+
+	cap_ptr->dynamic_topology_update_supported  = true;
+	cap_ptr->dynamic_shaper_update_supported    = true;
+	cap_ptr->dynamic_sched_update_supported     = true;
+	cap_ptr->dynamic_threshold_update_supported = true;
 
 	for (color = 0; color < ODP_NUM_PACKET_COLORS; color++)
 		cap_ptr->marking_colors_supported[color] =
@@ -2647,6 +2675,7 @@ static void tm_system_capabilities_set(odp_tm_capabilities_t *cap_ptr,
 		per_level_cap->tm_node_dual_slope_supported = dual_slope;
 		per_level_cap->fair_queuing_supported       = true;
 		per_level_cap->weights_supported            = true;
+		per_level_cap->tm_node_threshold_supported  = true;
 	}
 }
 

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -3106,6 +3106,7 @@ int odp_tm_destroy(odp_tm_t odp_tm)
 	_odp_queue_pool_destroy(tm_system->_odp_int_queue_pool);
 	_odp_timer_wheel_destroy(tm_system->_odp_int_timer_wheel);
 
+	_odp_int_name_tbl_delete(tm_system->name_tbl_id);
 	tm_system_free(tm_system);
 	return 0;
 }
@@ -3614,7 +3615,7 @@ int odp_tm_wred_destroy(odp_tm_wred_t wred_profile)
 		return -1;
 
 	return tm_common_profile_destroy(wred_profile,
-					 ODP_INVALID_NAME);
+					 wred_params->name_tbl_id);
 }
 
 int odp_tm_wred_params_read(odp_tm_wred_t wred_profile,

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -3038,6 +3038,22 @@ int odp_tm_capability(odp_tm_t odp_tm, odp_tm_capabilities_t *capabilities)
 	return 0;
 }
 
+int odp_tm_start(odp_tm_t odp_tm)
+{
+	(void)odp_tm;
+
+	/* Nothing more to do after TM create */
+	return 0;
+}
+
+int odp_tm_stop(odp_tm_t odp_tm)
+{
+	(void)odp_tm;
+
+	/* Nothing more to do for topology changes */
+	return 0;
+}
+
 int odp_tm_destroy(odp_tm_t odp_tm)
 {
 	tm_system_t *tm_system;

--- a/test/common/odp_cunit_common.c
+++ b/test/common/odp_cunit_common.c
@@ -259,11 +259,40 @@ int odp_cunit_print_inactive(void)
 			continue;
 
 		if (first) {
-			printf("\n\n  Inactive tests:\n");
+			printf("\n\nSuite: %s\n", sinfo->name);
+			printf("  Inactive tests:\n");
 			first = 0;
 		}
 
 		printf("    %s\n", tinfo->name);
+	}
+
+	return 0;
+}
+
+int odp_cunit_set_inactive(void)
+{
+	CU_pSuite cur_suite;
+	CU_pTest ptest;
+	odp_suiteinfo_t *sinfo;
+	odp_testinfo_t *tinfo;
+
+	cur_suite = CU_get_current_suite();
+	if (cur_suite == NULL)
+		return -1;
+
+	sinfo = cunit_get_suite_info(cur_suite->pName);
+	if (sinfo == NULL)
+		return -1;
+
+	for (tinfo = sinfo->testinfo_tbl; tinfo->name; tinfo++) {
+		ptest = CU_get_test_by_name(tinfo->name, cur_suite);
+		if (ptest == NULL) {
+			fprintf(stderr, "%s: test not found: %s\n",
+				__func__, tinfo->name);
+			return -1;
+		}
+		CU_set_test_active(ptest, false);
 	}
 
 	return 0;

--- a/test/common/odp_cunit_common.h
+++ b/test/common/odp_cunit_common.h
@@ -105,6 +105,7 @@ void odp_cunit_register_global_term(int (*func_term_ptr)(odp_instance_t inst));
 
 int odp_cunit_ret(int val);
 int odp_cunit_print_inactive(void);
+int odp_cunit_set_inactive(void);
 
 /*
  * Wrapper for CU_ASSERT_FATAL implementation to show the compiler that

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -2138,9 +2138,9 @@ static void check_shaper_profile(char *shaper_name, uint32_t shaper_idx)
 	memset(&shaper_params, 0, sizeof(shaper_params));
 	rc = odp_tm_shaper_params_read(profile, &shaper_params);
 	CU_ASSERT(rc == 0);
-	CU_ASSERT(approx_eq64(shaper_params.commit_bps,
+	CU_ASSERT(approx_eq64(shaper_params.commit_rate,
 			      shaper_idx * MIN_COMMIT_BW));
-	CU_ASSERT(approx_eq64(shaper_params.peak_bps,
+	CU_ASSERT(approx_eq64(shaper_params.peak_rate,
 			      shaper_idx * MIN_PEAK_BW));
 	CU_ASSERT(approx_eq32(shaper_params.commit_burst,
 			      shaper_idx * MIN_COMMIT_BURST));
@@ -2165,8 +2165,8 @@ static void traffic_mngr_test_shaper_profile(void)
 	for (idx = 1; idx <= NUM_SHAPER_TEST_PROFILES; idx++) {
 		snprintf(shaper_name, sizeof(shaper_name),
 			 "shaper_profile_%" PRIu32, idx);
-		shaper_params.commit_bps   = idx * MIN_COMMIT_BW;
-		shaper_params.peak_bps     = idx * MIN_PEAK_BW;
+		shaper_params.commit_rate  = idx * MIN_COMMIT_BW;
+		shaper_params.peak_rate    = idx * MIN_PEAK_BW;
 		shaper_params.commit_burst = idx * MIN_COMMIT_BURST;
 		shaper_params.peak_burst   = idx * MIN_PEAK_BURST;
 
@@ -2424,8 +2424,8 @@ static int set_shaper(const char    *node_name,
 	}
 
 	odp_tm_shaper_params_init(&shaper_params);
-	shaper_params.commit_bps        = commit_bps;
-	shaper_params.peak_bps          = 0;
+	shaper_params.commit_rate       = commit_bps;
+	shaper_params.peak_rate         = 0;
 	shaper_params.commit_burst      = commit_burst_in_bits;
 	shaper_params.peak_burst        = 0;
 	shaper_params.shaper_len_adjust = 0;

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -1664,6 +1664,14 @@ static int create_tm_system(void)
 		return -1;
 	}
 
+	/* Start TM system */
+	CU_ASSERT((rc = odp_tm_start(odp_tm)) == 0);
+	if (rc != 0) {
+		ODPH_ERR("odp_tm_start() failed for tm: %" PRIx64 "\n",
+			 odp_tm_to_u64(odp_tm));
+		return -1;
+	}
+
 	return 0;
 }
 
@@ -2042,11 +2050,16 @@ static int destroy_tm_systems(void)
 
 	/* Close/free the TM systems. */
 	for (idx = 0; idx < num_odp_tm_systems; idx++) {
+		if (odp_tm_stop(odp_tm_systems[idx]) != 0)
+			return -1;
+
 		if (destroy_tm_subtree(root_node_descs[idx]) != 0)
 			return -1;
 
 		if (odp_tm_destroy(odp_tm_systems[idx]) != 0)
 			return -1;
+
+		odp_tm_systems[idx] = ODP_TM_INVALID;
 	}
 
 	/* Close/free the TM profiles. */


### PR DESCRIPTION
commit 1513b06d6d5dbee86b3f9b26d13d5b633daf5980
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 22:49:11 2020 +0530

    validation: tm: add five level test case suite
    
    Current validation suite only validates 3 level TM systems.
    Refactor the test cases to use suite inited parameters instead
    of compile time and add suite init for 5 level TM system.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 6fc41eee7fea267b522ac2821b38f0fe7205255b
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 22:41:56 2020 +0530

    test: cunit: add API to deactivate all test cases
    
    In test suite init, it is possible to detect that a given test suite
    is not applicable. Hence provide an API to deactivate all the
    test cases of a given test suite.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 7a7a767bc297873fc901c93e87c0541ceffddb41
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 19:36:31 2020 +0530

    validation: tm: use tm start and stop API
    
    Add tm start API after creating a TM system and TM stop API before
    destroying it.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 7a7dc2878acfc5fe8fbc1f13a98c610fb43609b5
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 19:23:55 2020 +0530

    example: tm: use TM start and stop
    
    Use TM start to start the TM system after creation and
    TM stop to stop it before destroying TM queues.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit ee2422bcbe8b80c90d7d3e2c704584fef92719b4
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Thu Nov 5 06:22:55 2020 +0530

    linux-gen: tm: fix issues related to name table cleanup
    
    Name table entry was not cleaned up properly in desroy path
    of tm profile/node/system. This patch fixes the same.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 8999e29d58434eb1d73ad67765a3a901f3fc7c26
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Thu Nov 5 06:19:57 2020 +0530

    linux-gen: tm: express supported features in capa
    
    Update newly added capabilities fields based on available support.
    Also implement egress specific capability API which is in our case
    same as TM support is independent of egress kind.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 24a7f9318f2a5897f3d1adec43af697af358d088
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 19:22:14 2020 +0530

    linux-gen: traffic_mngr: add implementation of TM start/stop
    
    Add implementation of TM start or stop API. Since linux generic platform
    does not have any setup and cleanup constraints, the TM start/stop
    are a no-op.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit abe234464ef3a00215c1cb0850ea7fc63c23ef24
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 20:11:25 2020 +0530

    api: tm: add capability to express support for dynamic update
    
    Not all platforms can support all dynamic TM system update like
    topology update, shaper update, sched update after TM is in start
    state.
    
    Dynamic TM system topology update API for TM node correspond to
    node create/connect/disconnect/destroy. Similarly for TM queue,
    queue create/connect/disconnect/destroy.
    
    Dynamic TM system sched/shaper update API for TM node's correspond
    to odp_tm_node_shaper_config() and odp_tm_node_sched_config()
    Similarly for TM queue, odp_tm_queue_shaper_config() and
    odp_tm_queue_sched_config(). Updating shaper params or sched
    params is also considered dynamic when nodes are already associated
    to that shaper or sched profile.
    
    This patch adds capability expressing the same. These updates
    can be done on any TM system when it is in stopped state.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 6e89babe70dee0f6cb43fb2ba285a82c1f0703f2
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 20:06:49 2020 +0530

    api: tm: add missing capabilities and egress specific capability API
    
    Not all platforms support TM node query, node threshold, queue query,
    and queue threshold features. Since they are missing from existing
    global and level capabilities, adding the same to express no support.
    
    Also, in some platforms capabilities are specific to a egress kind
    like a PKTIO. Since capabilities provide a way to application to know
    things like how many levels can be supported etc, prior to TM creation,
    add a capability get API to retrieve egress function specific capabilities
    records.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit b4a4e2b745a2e39f4dc67ea09c54c9725b778026
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Fri Nov 6 20:48:35 2020 +0530

    api: tm: add option to enable packet mode in shaper
    
    Similar to using packet/frame count in scheduling
    algorithm and weight in units of number of packets,
    add option to enable packet mode in shaper
    by introducing a boolean flag in shaper profile params.
    When packet mode is set to TRUE, commit/peak rate is
    in PPS (packets per second) and commit/peak burst is in
    Packets.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit ddcbd3e5c5e0c7137d6a4c63a8effd300dc5436d
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Sat Nov 7 16:32:37 2020 +0530

    api: tm: add pktout tm queue mode and related API
    
    For Tx, Packet IO, with TM disabled has Direct mode for enqueueing packets
    and Queue mode for enqueueing packet or packet vector events with ordering
    maintained. For Packet IO with TM enabled, there is single mode
    which is equivalent to Direct mode for enqueuing packets. This patch
    adds queue mode with TM enabled as a mode to be able to enqueue packet or
    packet vector events to TM queues and maintain ordering.
    
    This patch also adds TM enqueue multi API equivalent to odp_tm_enq()
    but allowing multiple packets to be enqueued in single API call
    inline with pktout enqueue or send API's in non-TM mode.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 16db32e3a618413299e7b4f50f93c48bfb863a00
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 19:21:28 2020 +0530

    api: tm: add interface to start and stop a TM system
    
    Not all TM systems are started after TM creation or topology
    setup. Platform needs to know when a TM system needs to
    start or stop in order to safely setup or cleanup TM system
    and drain pkts in it. This patch adds support for TM start/stop
    API. Platforms that don't have any constraint on setup or cleanup,
    can have start/stop as a no-op. But applications should call
    TM start after topology create.
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 6fcbaedfd36ff29f3b8944c3ad46abeaa852237f
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 21:57:28 2020 +0530

    api: tm: support node priority override
    
    Current TM spec associates a priority to a packet
    at TM queue and expects all the levels to honour that priority.
    In some platforms, this is not supportable and a packet's priority
    gets overridden by the node priority(with respect to parent),
    it is passing through. In other words, like assigning packet a
    priority based on the TM queue it is enqueued on, every node it
    is passing through overrides the packet priority with a fixed value.
    
    So add a capability expressing the limitation/feature of node
    priority override and also add node priority field in node
    params that corresponds to its priority among his direct
    siblings.
    
    This patch also adds "max_wfq_groups_per_node" capability that is
    expressed by a platform when node priority override is true. This
    field expresses maximum number of WFQ groups can be formed by
    a node under a given parent. WFQ group is a group of children
    having same priority and hence WFQ/WRR is performed among them
    in order to pick a packet for transmit.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>
