### PR TITLE
[PATCH v1] api: ipsec: add flag to indicate inline enabled SA

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -692,6 +692,15 @@ typedef struct odp_ipsec_sa_param_t {
 	 */
 	uint32_t context_len;
 
+	/** Specify whether SA is to be used for inline IPsec
+	 *
+	 *  Allow inline IPSEC processing to be performed with the SA. For
+	 *  inbound SA, lookup_mode must not be ODP_IPSEC_LOOKUP_DISABLED
+	 *  as IPSEC processing need to be performed before application
+	 *  receives the packet for performing SA lookup.
+	 */
+	odp_bool_t is_inline;
+
 	/** IPSEC SA direction dependent parameters */
 	union {
 		/** Inbound specific parameters */


### PR DESCRIPTION
Allow application to specify whether the SA created can be used for
inline IPsec operations. With this flag, application can indicate the
SAs that need to be inline processed. ESP packets for which the SA
has 'is_inline' set to 0, the packet will not be processed inline and
application can then submit the same to ODP for lookaside processing
using odp_ipsec_in() & odp_ipsec_in_enq().

The features supported in inline & non-inline(lookaside) path need not
be the same. So indicating the usage model will allow application to
create the SA with required flags and be assured that datapath APIs
won't suffer a failure due to lack of feature support.

For inline IPsec enabled inbound SAs, the lookup_mode must not be
ODP_IPSEC_LOOKUP_DISABLED, as with inline processing, lookup need to be
done before application receives the ESP packet.

Signed-off-by: Anoob Joseph <anoobj@marvell.com>
Signed-off-by: Vidya Sagar <vvelumuri@marvell.com>