### PR TITLE
[PATCH v2] linux-gen: shm: wait fdserver with PID

### DIFF
--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -51,6 +51,7 @@ typedef struct odp_global_data_ro_t {
 	uint64_t shm_max_size;
 	int shm_single_va;
 	pid_t main_pid;
+	pid_t fdserver_pid;
 	char uid[UID_MAXLEN];
 	odp_log_func_t log_fn;
 	odp_abort_func_t abort_fn;


### PR DESCRIPTION
ODP may have other child processes in addition to fdserver,
especially, when application uses processes as worker threads.
Wait for fdserver process termination (instead of any child
process).

Signed-off-by: Petri Savolainen <petri.savolainen@nokia.com>