### PR TITLE
[PATCH v3] test: l2fwd: avoid tight loop in enqueue to pktout queue

### DIFF
--- a/test/performance/odp_l2fwd.c
+++ b/test/performance/odp_l2fwd.c
@@ -264,9 +264,9 @@ static inline int event_queue_send(odp_queue_t queue, odp_packet_t *pkt_tbl,
 	while (sent < pkts) {
 		ret = odp_queue_enq_multi(queue, &ev_tbl[sent], pkts - sent);
 
-		if (ret < 0) {
-			ODPH_ERR("Failed to send packet as events\n");
-			break;
+		if (odp_unlikely(ret <= 0)) {
+			if (ret < 0 || odp_atomic_load_u32(&gbl_args->exit_threads))
+				break;
 		}
 
 		sent += ret;


### PR DESCRIPTION
Currently in pktout queue mode, only negative return value
causes break from pkt enqueue loop unlike in other modes where
both negative and zero return will cause the packet to be dropped.

Some platforms always return zero which can either indicate no space
in Tx or when Tx is paused due to odp_pktio_stop()(for example in
exit sequence). In such cases, current code can become an infinite loop.

So this patch fixes the same by checking for <=0 return and
break from loop if < 0 or exit is already in progress.

Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>