### PR TITLE
[PATCH v10] api: ipsec: test sa update

### DIFF
--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -136,6 +136,7 @@ int odp_ipsec_capability(odp_ipsec_capability_t *capa)
 	capa->max_queues = queue_capa.max_queues;
 	capa->inline_ipsec_tm = ODP_SUPPORT_NO;
 
+	capa->test.sa_operations.seq_num = 1;
 	return 0;
 }
 
@@ -2038,6 +2039,26 @@ err:
 	}
 
 	return in_pkt;
+}
+
+int odp_ipsec_test_sa_update(odp_ipsec_sa_t sa,
+			     odp_ipsec_test_sa_operation_t sa_op,
+			     const odp_ipsec_test_sa_param_t *sa_param)
+{
+	ipsec_sa_t *ipsec_sa;
+
+	ipsec_sa = _odp_ipsec_sa_entry_from_hdl(sa);
+	ODP_ASSERT(NULL != ipsec_sa);
+
+	switch (sa_op) {
+	case ODP_IPSEC_TEST_SA_UPDATE_SEQ_NUM:
+		odp_atomic_store_u64(&ipsec_sa->hot.out.seq, sa_param->seq_num);
+		break;
+	default:
+		return -1;
+	}
+
+	return 0;
 }
 
 int odp_ipsec_result(odp_ipsec_packet_result_t *result, odp_packet_t packet)

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -59,6 +59,7 @@ typedef struct {
 	odp_bool_t lookup;
 	odp_bool_t ah;
 	odp_bool_t inline_hdr_in_packet;
+	odp_bool_t test_sa_seq_num;
 	enum ipsec_test_stats stats;
 } ipsec_test_flags;
 
@@ -73,6 +74,7 @@ typedef struct {
 		const ipsec_test_packet *pkt_res;
 		odp_proto_l3_type_t l3_type;
 		odp_proto_l4_type_t l4_type;
+		uint32_t seq_num;
 	} out[1];
 	struct {
 		odp_ipsec_op_status_t status;
@@ -101,6 +103,7 @@ void ipsec_check_out_one(const ipsec_test_part *part, odp_ipsec_sa_t sa);
 void ipsec_check_out_in_one(const ipsec_test_part *part,
 			    odp_ipsec_sa_t sa,
 			    odp_ipsec_sa_t sa_in);
+int ipsec_test_sa_update_seq_num(odp_ipsec_sa_t sa, uint32_t seq_num);
 
 int ipsec_check(odp_bool_t ah,
 		odp_cipher_alg_t cipher,
@@ -128,5 +131,6 @@ int ipsec_check_esp_null_aes_gmac_128(void);
 int ipsec_check_esp_null_aes_gmac_192(void);
 int ipsec_check_esp_null_aes_gmac_256(void);
 int ipsec_check_esp_chacha20_poly1305(void);
+int ipsec_check_test_sa_update_seq_num(void);
 
 #endif

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -460,6 +460,21 @@ static void test_out_in_common(ipsec_test_flags *flags,
 		test_ipsec_stats_zero_assert(&stats);
 	}
 
+	if (flags->test_sa_seq_num) {
+		int rc;
+
+		test.out[0].seq_num = 0x1235;
+		rc = ipsec_test_sa_update_seq_num(sa_out, test.out[0].seq_num);
+
+		/* Skip further checks related to this specific test if the
+		 * SA update call was not successful.
+		 */
+		if (rc < 0) {
+			printf("\t >> skipped");
+			test.flags.test_sa_seq_num = false;
+		}
+	}
+
 	ipsec_check_out_in_one(&test, sa_out, sa_in);
 
 	if (flags->stats == IPSEC_TEST_STATS_SUCCESS) {
@@ -1364,6 +1379,19 @@ static void test_sa_info(void)
 	ipsec_sa_destroy(sa_in);
 }
 
+static void test_test_sa_update_seq_num(void)
+{
+	ipsec_test_flags flags;
+
+	memset(&flags, 0, sizeof(flags));
+	flags.display_algo = true;
+	flags.test_sa_seq_num = true;
+
+	test_esp_out_in_all(&flags);
+
+	printf("\n  ");
+}
+
 static void ipsec_test_capability(void)
 {
 	odp_ipsec_capability_t capa;
@@ -1444,6 +1472,8 @@ odp_testinfo_t ipsec_out_suite[] = {
 				  ipsec_check_esp_null_sha256),
 	ODP_TEST_INFO_CONDITIONAL(test_sa_info,
 				  ipsec_check_esp_aes_cbc_128_sha1),
+	ODP_TEST_INFO_CONDITIONAL(test_test_sa_update_seq_num,
+				  ipsec_check_test_sa_update_seq_num),
 	ODP_TEST_INFO(test_esp_out_in_all_basic),
 	ODP_TEST_INFO_CONDITIONAL(test_esp_out_in_all_hdr_in_packet,
 				  is_out_mode_inline),


### PR DESCRIPTION
With IPSEC implementations, the protocol specific fields
like sequence number is not exposed to the application.
But for debugging as well as for validation, finer control
of such fields would be required. The proposed API,
odp_ipsec_test_sa_update(), would allow access to such
fields which are not expected to be exposed in the data
path.