### PR TITLE
[PATCH v3] shippable: fix cloud node build

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -19,6 +19,7 @@ env:
 
 build:
   ci:
+    - rm -f /etc/apt/sources.list.d/basho_riak.list
     - apt-get update
     - apt-get install --no-install-recommends -yy asciidoctor autoconf automake build-essential ccache clang doxygen gcc graphviz libconfig-dev libcunit1-dev libnuma-dev libpcap-dev libssl-dev libtool mscgen xsltproc
     - mkdir -p $HOME/odp-shmdir


### PR DESCRIPTION
Fix Shippable cloud node build by removing a broken riak apt source.
Solution suggested here:
https://github.com/Shippable/support/issues/5172#issuecomment-726399640

Signed-off-by: Matias Elo <matias.elo@nokia.com>