### PR TITLE
[PATCH v3] linux-gen: ipsec: discard replayed packets before lifetime update

### DIFF
--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -689,14 +689,14 @@ static ipsec_sa_t *ipsec_in_single(odp_packet_t pkt,
 		goto err;
 	}
 
-	if (_odp_ipsec_sa_stats_update(ipsec_sa,
-				       state.stats_length,
-				       status) < 0)
-		goto err;
-
 	if (_odp_ipsec_sa_replay_update(ipsec_sa,
 					state.in.seq_no,
 					status) < 0)
+		goto err;
+
+	if (_odp_ipsec_sa_stats_update(ipsec_sa,
+				       state.stats_length,
+				       status) < 0)
 		goto err;
 
 	state.ip = odp_packet_l3_ptr(pkt, NULL);


### PR DESCRIPTION
Discard packets that fail the anti-replay check before checking
SA lifetime and updating the packet and byte counters. Previously
such packets could have been used to prematurely age an SA, leading
to a possible denial of service.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>