### PR TITLE
[PATCH v7] linux-gen: rename some global symbols in the static library

### DIFF
--- a/platform/linux-generic/arch/aarch64/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/aarch64/odp_sysinfo_parse.c
@@ -204,7 +204,7 @@ static odp_cpu_arch_arm_t arm_isa_version(void)
 	return ODP_CPU_ARCH_ARM_UNKNOWN;
 }
 
-int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
+int _odp_cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 {
 	char str[1024];
 	char impl_str[TMP_STR_LEN];
@@ -301,7 +301,7 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 	return 0;
 }
 
-void sys_info_print_arch(void)
+void _odp_sys_info_print_arch(void)
 {
 	const char *ndef = "n/a";
 

--- a/platform/linux-generic/arch/arm/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/arm/odp_sysinfo_parse.c
@@ -7,7 +7,7 @@
 #include <odp_global_data.h>
 #include <odp_sysinfo_internal.h>
 
-int cpuinfo_parser(FILE * file ODP_UNUSED, system_info_t *sysinfo)
+int _odp_cpuinfo_parser(FILE *file ODP_UNUSED, system_info_t *sysinfo)
 {
 	sysinfo->cpu_arch = ODP_CPU_ARCH_ARM;
 	sysinfo->cpu_isa_sw.arm = ODP_CPU_ARCH_ARM_UNKNOWN;
@@ -23,7 +23,7 @@ int cpuinfo_parser(FILE * file ODP_UNUSED, system_info_t *sysinfo)
 	return _odp_dummy_cpuinfo(sysinfo);
 }
 
-void sys_info_print_arch(void)
+void _odp_sys_info_print_arch(void)
 {
 }
 

--- a/platform/linux-generic/arch/default/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/default/odp_sysinfo_parse.c
@@ -7,12 +7,12 @@
 #include <odp_global_data.h>
 #include <odp_sysinfo_internal.h>
 
-int cpuinfo_parser(FILE *file ODP_UNUSED, system_info_t *sysinfo)
+int _odp_cpuinfo_parser(FILE *file ODP_UNUSED, system_info_t *sysinfo)
 {
 	return _odp_dummy_cpuinfo(sysinfo);
 }
 
-void sys_info_print_arch(void)
+void _odp_sys_info_print_arch(void)
 {
 }
 

--- a/platform/linux-generic/arch/mips64/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/mips64/odp_sysinfo_parse.c
@@ -8,7 +8,7 @@
 #include <odp_sysinfo_internal.h>
 #include <string.h>
 
-int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
+int _odp_cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 {
 	char str[1024];
 	char *pos;
@@ -63,7 +63,7 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 	return 0;
 }
 
-void sys_info_print_arch(void)
+void _odp_sys_info_print_arch(void)
 {
 }
 

--- a/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
@@ -8,7 +8,7 @@
 #include <odp_sysinfo_internal.h>
 #include <string.h>
 
-int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
+int _odp_cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 {
 	char str[1024];
 	char *pos;
@@ -62,7 +62,7 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 	return 0;
 }
 
-void sys_info_print_arch(void)
+void _odp_sys_info_print_arch(void)
 {
 }
 

--- a/platform/linux-generic/arch/x86/cpu_flags.c
+++ b/platform/linux-generic/arch/x86/cpu_flags.c
@@ -329,7 +329,7 @@ static const char *cpu_get_flag_name(enum rte_cpu_flag_t feature)
 	return cpu_feature_table[feature].name;
 }
 
-void cpu_flags_print_all(void)
+void _odp_cpu_flags_print_all(void)
 {
 	int len, i;
 	int max_str = 1024;
@@ -367,7 +367,7 @@ int _odp_cpu_has_global_time(void)
 	return 0;
 }
 
-int cpu_flags_has_rdtsc(void)
+int _odp_cpu_flags_has_rdtsc(void)
 {
 	if (cpu_get_flag_enabled(RTE_CPUFLAG_TSC) > 0)
 		return 1;

--- a/platform/linux-generic/arch/x86/cpu_flags.h
+++ b/platform/linux-generic/arch/x86/cpu_flags.h
@@ -11,8 +11,8 @@
 extern "C" {
 #endif
 
-void cpu_flags_print_all(void);
-int cpu_flags_has_rdtsc(void);
+void _odp_cpu_flags_print_all(void);
+int _odp_cpu_flags_has_rdtsc(void);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/arch/x86/odp_cpu_cycles.c
+++ b/platform/linux-generic/arch/x86/odp_cpu_cycles.c
@@ -12,7 +12,7 @@
 
 int _odp_cpu_cycles_init_global(void)
 {
-	if (cpu_flags_has_rdtsc() == 0) {
+	if (_odp_cpu_flags_has_rdtsc() == 0) {
 		ODP_ERR("RDTSC instruction not supported\n");
 		return -1;
 	}

--- a/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
@@ -8,7 +8,7 @@
 #include "cpu_flags.h"
 #include <string.h>
 
-int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
+int _odp_cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 {
 	char str[1024];
 	char *pos, *pos_end;
@@ -77,9 +77,9 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 	return 0;
 }
 
-void sys_info_print_arch(void)
+void _odp_sys_info_print_arch(void)
 {
-	cpu_flags_print_all();
+	_odp_cpu_flags_print_all();
 }
 
 uint64_t odp_cpu_arch_hz_current(int id)

--- a/platform/linux-generic/include/odp_classification_internal.h
+++ b/platform/linux-generic/include/odp_classification_internal.h
@@ -38,9 +38,9 @@ Start function for Packet Classifier
 This function calls Classifier module internal functions for a given packet and
 selects destination queue and packet pool based on selected PMR and CoS.
 **/
-int cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
-			uint16_t pkt_len, uint32_t seg_len, odp_pool_t *pool,
-			odp_packet_hdr_t *pkt_hdr, odp_bool_t parse);
+int _odp_cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
+			     uint16_t pkt_len, uint32_t seg_len, odp_pool_t *pool,
+			     odp_packet_hdr_t *pkt_hdr, odp_bool_t parse);
 
 /**
 Packet IO classifier init
@@ -48,7 +48,7 @@ Packet IO classifier init
 This function does initialization of classifier object associated with pktio.
 This function should be called during pktio initialization.
 **/
-int pktio_classifier_init(pktio_entry_t *pktio);
+int _odp_pktio_classifier_init(pktio_entry_t *pktio);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_ethtool_rss.h
+++ b/platform/linux-generic/include/odp_ethtool_rss.h
@@ -22,8 +22,8 @@ extern "C" {
  *
  * @returns Number enabled hash protocols
  */
-int rss_conf_get_fd(int fd, const char *name,
-		    odp_pktin_hash_proto_t *hash_proto);
+int _odp_rss_conf_get_fd(int fd, const char *name,
+			 odp_pktin_hash_proto_t *hash_proto);
 
 /**
  * Get supported RSS hash protocols of a packet socket
@@ -36,8 +36,8 @@ int rss_conf_get_fd(int fd, const char *name,
  *
  * @returns Number of supported hash protocols
  */
-int rss_conf_get_supported_fd(int fd, const char *name,
-			      odp_pktin_hash_proto_t *hash_proto);
+int _odp_rss_conf_get_supported_fd(int fd, const char *name,
+				   odp_pktin_hash_proto_t *hash_proto);
 
 /**
  * Set RSS hash protocols of a packet socket
@@ -49,15 +49,15 @@ int rss_conf_get_supported_fd(int fd, const char *name,
  * @retval 0 on success
  * @retval <0 on failure
  */
-int rss_conf_set_fd(int fd, const char *name,
-		    const odp_pktin_hash_proto_t *proto);
+int _odp_rss_conf_set_fd(int fd, const char *name,
+			 const odp_pktin_hash_proto_t *proto);
 
 /**
  * Print enabled RSS hash protocols
  *
  * @param hash_proto      Hash protocols
  */
-void rss_conf_print(const odp_pktin_hash_proto_t *hash_proto);
+void _odp_rss_conf_print(const odp_pktin_hash_proto_t *hash_proto);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_ethtool_stats.h
+++ b/platform/linux-generic/include/odp_ethtool_stats.h
@@ -17,7 +17,7 @@ extern "C" {
 /**
  * Get ethtool statistics of a packet socket
  */
-int ethtool_stats_get_fd(int fd, const char *name, odp_pktio_stats_t *stats);
+int _odp_ethtool_stats_get_fd(int fd, const char *name, odp_pktio_stats_t *stats);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -33,7 +33,7 @@ extern "C" {
 
 #include <stdint.h>
 
-/** Minimum segment length expected by packet_parse_common() */
+/** Minimum segment length expected by _odp_packet_parse_common() */
 #define PACKET_PARSE_SEG_LEN 96
 
 ODP_STATIC_ASSERT(sizeof(_odp_packet_input_flags_t) == sizeof(uint64_t),
@@ -292,9 +292,9 @@ int packet_alloc_multi(odp_pool_t pool_hdl, uint32_t len,
 		       odp_packet_t pkt[], int max_num);
 
 /* Perform packet parse up to a given protocol layer */
-int packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
-		       odp_proto_layer_t layer,
-		       odp_proto_chksums_t chksums);
+int _odp_packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
+			    odp_proto_layer_t layer,
+			    odp_proto_chksums_t chksums);
 
 /* Reset parser metadata for a new parse */
 static inline void packet_parse_reset(odp_packet_hdr_t *pkt_hdr, int all)
@@ -345,9 +345,9 @@ static inline void packet_set_ts(odp_packet_hdr_t *pkt_hdr, odp_time_t *ts)
 	}
 }
 
-int packet_parse_common(packet_parser_t *pkt_hdr, const uint8_t *ptr,
-			uint32_t pkt_len, uint32_t seg_len, int layer,
-			odp_proto_chksums_t chksums);
+int _odp_packet_parse_common(packet_parser_t *pkt_hdr, const uint8_t *ptr,
+			     uint32_t pkt_len, uint32_t seg_len, int layer,
+			     odp_proto_chksums_t chksums);
 
 int _odp_cls_parse(odp_packet_hdr_t *pkt_hdr, const uint8_t *parseptr);
 

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -207,7 +207,7 @@ typedef struct pktio_if_ops {
 				    const odp_pktout_queue_param_t *p);
 } pktio_if_ops_t;
 
-extern void *pktio_entry_ptr[];
+extern void *_odp_pktio_entry_ptr[];
 
 static inline pktio_entry_t *get_pktio_entry(odp_pktio_t pktio)
 {
@@ -224,7 +224,7 @@ static inline pktio_entry_t *get_pktio_entry(odp_pktio_t pktio)
 
 	idx = odp_pktio_index(pktio);
 
-	return pktio_entry_ptr[idx];
+	return _odp_pktio_entry_ptr[idx];
 }
 
 static inline int pktio_cls_enabled(pktio_entry_t *entry)
@@ -251,15 +251,15 @@ static inline void _odp_pktio_tx_ts_set(pktio_entry_t *entry)
 
 extern const pktio_if_ops_t netmap_pktio_ops;
 extern const pktio_if_ops_t dpdk_pktio_ops;
-extern const pktio_if_ops_t sock_mmsg_pktio_ops;
-extern const pktio_if_ops_t sock_mmap_pktio_ops;
-extern const pktio_if_ops_t loopback_pktio_ops;
+extern const pktio_if_ops_t _odp_sock_mmsg_pktio_ops;
+extern const pktio_if_ops_t _odp_sock_mmap_pktio_ops;
+extern const pktio_if_ops_t _odp_loopback_pktio_ops;
 #ifdef _ODP_PKTIO_PCAP
-extern const pktio_if_ops_t pcap_pktio_ops;
+extern const pktio_if_ops_t _odp_pcap_pktio_ops;
 #endif
-extern const pktio_if_ops_t tap_pktio_ops;
-extern const pktio_if_ops_t null_pktio_ops;
-extern const pktio_if_ops_t ipc_pktio_ops;
+extern const pktio_if_ops_t _odp_tap_pktio_ops;
+extern const pktio_if_ops_t _odp_null_pktio_ops;
+extern const pktio_if_ops_t _odp_ipc_pktio_ops;
 extern const pktio_if_ops_t * const pktio_if_ops[];
 
 /**
@@ -276,11 +276,11 @@ extern const pktio_if_ops_t * const pktio_if_ops[];
  * @return >=0 on success, number of packets received
  * @return <0 on failure
  */
-int sock_recv_mq_tmo_try_int_driven(const struct odp_pktin_queue_t queues[],
-				    unsigned num_q, unsigned *from,
-				    odp_packet_t packets[], int num,
-				    uint64_t usecs,
-				    int *trial_successful);
+int _odp_sock_recv_mq_tmo_try_int_driven(const struct odp_pktin_queue_t queues[],
+					 unsigned int num_q, unsigned int *from,
+					 odp_packet_t packets[], int num,
+					 uint64_t usecs,
+					 int *trial_successful);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_packet_io_stats.h
+++ b/platform/linux-generic/include/odp_packet_io_stats.h
@@ -17,12 +17,12 @@ extern "C" {
 #include <odp_packet_io_internal.h>
 #include <odp_packet_io_stats_common.h>
 
-int sock_stats_fd(pktio_entry_t *pktio_entry,
-		  odp_pktio_stats_t *stats,
-		  int fd);
-int sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd);
+int _odp_sock_stats_fd(pktio_entry_t *pktio_entry,
+		       odp_pktio_stats_t *stats,
+		       int fd);
+int _odp_sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd);
 
-pktio_stats_type_t sock_stats_type_fd(pktio_entry_t *pktio_entry, int fd);
+pktio_stats_type_t _odp_sock_stats_type_fd(pktio_entry_t *pktio_entry, int fd);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_queue_basic_internal.h
+++ b/platform/linux-generic/include/odp_queue_basic_internal.h
@@ -87,7 +87,7 @@ typedef struct queue_global_t {
 
 } queue_global_t;
 
-extern queue_global_t *queue_glb;
+extern queue_global_t *_odp_queue_glb;
 
 static inline uint32_t queue_to_index(odp_queue_t handle)
 {
@@ -98,7 +98,7 @@ static inline uint32_t queue_to_index(odp_queue_t handle)
 
 static inline queue_entry_t *qentry_from_index(uint32_t queue_id)
 {
-	return &queue_glb->queue[queue_id];
+	return &_odp_queue_glb->queue[queue_id];
 }
 
 static inline odp_queue_t queue_from_index(uint32_t queue_id)
@@ -111,13 +111,13 @@ static inline queue_entry_t *qentry_from_handle(odp_queue_t handle)
 	return (queue_entry_t *)(uintptr_t)handle;
 }
 
-void queue_spsc_init(queue_entry_t *queue, uint32_t queue_size);
+void _odp_queue_spsc_init(queue_entry_t *queue, uint32_t queue_size);
 
 /* Functions for schedulers */
-void sched_queue_set_status(uint32_t queue_index, int status);
-int sched_queue_deq(uint32_t queue_index, odp_event_t ev[], int num,
-		    int update_status);
-int sched_queue_empty(uint32_t queue_index);
+void _odp_sched_queue_set_status(uint32_t queue_index, int status);
+int _odp_sched_queue_deq(uint32_t queue_index, odp_event_t ev[], int num,
+			 int update_status);
+int _odp_sched_queue_empty(uint32_t queue_index);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_queue_if.h
+++ b/platform/linux-generic/include/odp_queue_if.h
@@ -61,7 +61,7 @@ typedef struct {
 	queue_deq_multi_fn_t orig_deq_multi;
 } queue_fn_t;
 
-extern const queue_fn_t *queue_fn;
+extern const queue_fn_t *_odp_queue_fn;
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_queue_lf.h
+++ b/platform/linux-generic/include/odp_queue_lf.h
@@ -22,13 +22,13 @@ typedef struct {
 
 } queue_lf_func_t;
 
-uint32_t queue_lf_init_global(uint32_t *queue_lf_size,
-			      queue_lf_func_t *lf_func);
-void queue_lf_term_global(void);
-void *queue_lf_create(queue_entry_t *queue);
-void queue_lf_destroy(void *queue_lf);
-uint32_t queue_lf_length(void *queue_lf);
-uint32_t queue_lf_max_length(void);
+uint32_t _odp_queue_lf_init_global(uint32_t *queue_lf_size,
+				   queue_lf_func_t *lf_func);
+void _odp_queue_lf_term_global(void);
+void *_odp_queue_lf_create(queue_entry_t *queue);
+void _odp_queue_lf_destroy(void *queue_lf);
+uint32_t _odp_queue_lf_length(void *queue_lf);
+uint32_t _odp_queue_lf_max_length(void);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_queue_scalable_internal.h
+++ b/platform/linux-generic/include/odp_queue_scalable_internal.h
@@ -62,7 +62,7 @@ int _odp_queue_deq(sched_elem_t *q, odp_buffer_hdr_t *buf_hdr[], int num);
 int _odp_queue_deq_sc(sched_elem_t *q, odp_event_t *evp, int num);
 int _odp_queue_deq_mc(sched_elem_t *q, odp_event_t *evp, int num);
 int _odp_queue_enq_sp(sched_elem_t *q, odp_buffer_hdr_t *buf_hdr[], int num);
-queue_entry_t *qentry_from_ext(odp_queue_t handle);
+queue_entry_t *_odp_qentry_from_ext(odp_queue_t handle);
 
 /* Round up memory size to next cache line size to
  * align all memory addresses on cache line boundary.
@@ -79,7 +79,7 @@ static inline void *shm_pool_alloc_align(_odp_ishm_pool_t *pool, uint32_t size)
 
 static inline uint32_t queue_to_id(odp_queue_t handle)
 {
-	return qentry_from_ext(handle)->s.index;
+	return _odp_qentry_from_ext(handle)->s.index;
 }
 
 static inline queue_entry_t *qentry_from_int(odp_queue_t handle)

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -78,13 +78,13 @@ typedef struct schedule_fn_t {
 } schedule_fn_t;
 
 /* Interface towards the scheduler */
-extern const schedule_fn_t *sched_fn;
+extern const schedule_fn_t *_odp_sched_fn;
 
 /* Interface for the scheduler */
-int sched_cb_pktin_poll(int pktio_index, int pktin_index,
-			odp_buffer_hdr_t *hdr_tbl[], int num);
-int sched_cb_pktin_poll_one(int pktio_index, int rx_queue, odp_event_t evts[]);
-void sched_cb_pktio_stop_finalize(int pktio_index);
+int _odp_sched_cb_pktin_poll(int pktio_index, int pktin_index,
+			     odp_buffer_hdr_t *hdr_tbl[], int num);
+int _odp_sched_cb_pktin_poll_one(int pktio_index, int rx_queue, odp_event_t evts[]);
+void _odp_sched_cb_pktio_stop_finalize(int pktio_index);
 
 /* For debugging */
 extern int _odp_schedule_configured;

--- a/platform/linux-generic/include/odp_schedule_scalable.h
+++ b/platform/linux-generic/include/odp_schedule_scalable.h
@@ -142,9 +142,9 @@ typedef struct ODP_ALIGNED_CACHE {
 	uint32_t loop_cnt; /*Counter to check pktio ingress queue dead loop */
 } sched_scalable_thread_state_t;
 
-void sched_update_enq(sched_elem_t *q, uint32_t actual);
-void sched_update_enq_sp(sched_elem_t *q, uint32_t actual);
-sched_queue_t *sched_queue_add(odp_schedule_group_t grp, uint32_t prio);
-void sched_queue_rem(odp_schedule_group_t grp, uint32_t prio);
+void _odp_sched_update_enq(sched_elem_t *q, uint32_t actual);
+void _odp_sched_update_enq_sp(sched_elem_t *q, uint32_t actual);
+sched_queue_t *_odp_sched_queue_add(odp_schedule_group_t grp, uint32_t prio);
+void _odp_sched_queue_rem(odp_schedule_group_t grp, uint32_t prio);
 
 #endif  /* ODP_SCHEDULE_SCALABLE_H */

--- a/platform/linux-generic/include/odp_schedule_scalable_ordered.h
+++ b/platform/linux-generic/include/odp_schedule_scalable_ordered.h
@@ -110,15 +110,15 @@ struct ODP_ALIGNED_CACHE reorder_context {
 	queue_entry_t *destq[RC_EVT_SIZE];
 };
 
-reorder_window_t *rwin_alloc(_odp_ishm_pool_t *pool,
-			     unsigned lock_count);
-int rwin_free(_odp_ishm_pool_t *pool, reorder_window_t *rwin);
-bool rwin_reserve(reorder_window_t *rwin, uint32_t *sn);
-bool rwin_reserve_sc(reorder_window_t *rwin, uint32_t *sn);
-void rwin_unreserve_sc(reorder_window_t *rwin, uint32_t sn);
-void rctx_init(reorder_context_t *rctx, uint16_t idx,
-	       reorder_window_t *rwin, uint32_t sn);
-void rctx_release(reorder_context_t *rctx);
-int rctx_save(queue_entry_t *queue, odp_buffer_hdr_t *buf_hdr[], int num);
+reorder_window_t *_odp_rwin_alloc(_odp_ishm_pool_t *pool,
+				  unsigned int lock_count);
+int _odp_rwin_free(_odp_ishm_pool_t *pool, reorder_window_t *rwin);
+bool _odp_rwin_reserve(reorder_window_t *rwin, uint32_t *sn);
+bool _odp_rwin_reserve_sc(reorder_window_t *rwin, uint32_t *sn);
+void _odp_rwin_unreserve_sc(reorder_window_t *rwin, uint32_t sn);
+void _odp_rctx_init(reorder_context_t *rctx, uint16_t idx,
+		    reorder_window_t *rwin, uint32_t sn);
+void _odp_rctx_release(reorder_context_t *rctx);
+int _odp_rctx_save(queue_entry_t *queue, odp_buffer_hdr_t *buf_hdr[], int num);
 
 #endif  /* ODP_SCHEDULE_SCALABLE_ORDERED_H */

--- a/platform/linux-generic/include/odp_socket_common.h
+++ b/platform/linux-generic/include/odp_socket_common.h
@@ -32,37 +32,37 @@ ethaddrs_equal(unsigned char mac_a[], unsigned char mac_b[])
 /**
  * Read the MAC address from a packet socket
  */
-int mac_addr_get_fd(int fd, const char *name, unsigned char mac_dst[]);
+int _odp_mac_addr_get_fd(int fd, const char *name, unsigned char mac_dst[]);
 
 /**
  * Read the MTU from a packet socket
  */
-uint32_t mtu_get_fd(int fd, const char *name);
+uint32_t _odp_mtu_get_fd(int fd, const char *name);
 
 /**
  * Set a packet socket MTU
  */
-int mtu_set_fd(int fd, const char *name, int mtu);
+int _odp_mtu_set_fd(int fd, const char *name, int mtu);
 
 /**
  * Enable/Disable promisc mode for a packet socket
  */
-int promisc_mode_set_fd(int fd, const char *name, int enable);
+int _odp_promisc_mode_set_fd(int fd, const char *name, int enable);
 
 /**
  * Return promisc mode of a packet socket
  */
-int promisc_mode_get_fd(int fd, const char *name);
+int _odp_promisc_mode_get_fd(int fd, const char *name);
 
 /**
  * Return link status of a packet socket (up/down)
  */
-int link_status_fd(int fd, const char *name);
+int _odp_link_status_fd(int fd, const char *name);
 
 /**
  * Read link information from a packet socket
  */
-int link_info_fd(int fd, const char *name, odp_pktio_link_info_t *info);
+int _odp_link_info_fd(int fd, const char *name, odp_pktio_link_info_t *info);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_sysfs_stats.h
+++ b/platform/linux-generic/include/odp_sysfs_stats.h
@@ -14,8 +14,8 @@ extern "C" {
 #include <odp/api/packet_io_stats.h>
 #include <odp_packet_io_internal.h>
 
-int sysfs_stats(pktio_entry_t *pktio_entry,
-		odp_pktio_stats_t *stats);
+int _odp_sysfs_stats(pktio_entry_t *pktio_entry,
+		     odp_pktio_stats_t *stats);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_sysinfo_internal.h
+++ b/platform/linux-generic/include/odp_sysinfo_internal.h
@@ -16,10 +16,10 @@ extern "C" {
 #include <inttypes.h>
 #include <string.h>
 
-int cpuinfo_parser(FILE *file, system_info_t *sysinfo);
+int _odp_cpuinfo_parser(FILE *file, system_info_t *sysinfo);
 uint64_t odp_cpu_hz_current(int id);
 uint64_t odp_cpu_arch_hz_current(int id);
-void sys_info_print_arch(void);
+void _odp_sys_info_print_arch(void);
 
 static inline int _odp_dummy_cpuinfo(system_info_t *sysinfo)
 {

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -1495,7 +1495,7 @@ static cos_t *match_pmr_cos(cos_t *cos, const uint8_t *pkt_addr, pmr_t *pmr,
 	return NULL;
 }
 
-int pktio_classifier_init(pktio_entry_t *entry)
+int _odp_pktio_classifier_init(pktio_entry_t *entry)
 {
 	classifier_t *cls;
 
@@ -1581,9 +1581,9 @@ static uint32_t packet_rss_hash(odp_packet_hdr_t *pkt_hdr,
  *
  * @note *base is not released
  */
-int cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
-			uint16_t pkt_len, uint32_t seg_len, odp_pool_t *pool,
-			odp_packet_hdr_t *pkt_hdr, odp_bool_t parse)
+int _odp_cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
+			     uint16_t pkt_len, uint32_t seg_len, odp_pool_t *pool,
+			     odp_packet_hdr_t *pkt_hdr, odp_bool_t parse)
 {
 	cos_t *cos;
 	uint32_t tbl_index;
@@ -1595,9 +1595,9 @@ int cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 		packet_parse_reset(pkt_hdr, 1);
 		packet_set_len(pkt_hdr, pkt_len);
 
-		packet_parse_common(&pkt_hdr->p, base, pkt_len, seg_len,
-				    ODP_PROTO_LAYER_ALL,
-				    entry->s.in_chksums);
+		_odp_packet_parse_common(&pkt_hdr->p, base, pkt_len, seg_len,
+					 ODP_PROTO_LAYER_ALL,
+					 entry->s.in_chksums);
 	}
 	cos = cls_select_cos(entry, base, pkt_hdr);
 

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -489,14 +489,14 @@ static int term_local(enum init_stage stage)
 	case ALL_INIT:
 
 	case SCHED_INIT:
-		if (sched_fn->term_local()) {
+		if (_odp_sched_fn->term_local()) {
 			ODP_ERR("ODP schedule local term failed.\n");
 			rc = -1;
 		}
 		/* Fall through */
 
 	case QUEUE_INIT:
-		if (queue_fn->term_local()) {
+		if (_odp_queue_fn->term_local()) {
 			ODP_ERR("ODP queue local term failed.\n");
 			rc = -1;
 		}
@@ -606,13 +606,13 @@ int odp_init_local(odp_instance_t instance, odp_thread_type_t thr_type)
 	}
 	stage = POOL_INIT;
 
-	if (queue_fn->init_local()) {
+	if (_odp_queue_fn->init_local()) {
 		ODP_ERR("ODP queue local init failed.\n");
 		goto init_fail;
 	}
 	stage = QUEUE_INIT;
 
-	if (sched_fn->init_local()) {
+	if (_odp_sched_fn->init_local()) {
 		ODP_ERR("ODP schedule local init failed.\n");
 		goto init_fail;
 	}

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2310,9 +2310,9 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
  * The function expects at least PACKET_PARSE_SEG_LEN bytes of data to be
  * available from the ptr. Also parse metadata must be already initialized.
  */
-int packet_parse_common(packet_parser_t *prs, const uint8_t *ptr,
-			uint32_t frame_len, uint32_t seg_len,
-			int layer, odp_proto_chksums_t chksums)
+int _odp_packet_parse_common(packet_parser_t *prs, const uint8_t *ptr,
+			     uint32_t frame_len, uint32_t seg_len,
+			     int layer, odp_proto_chksums_t chksums)
 {
 	uint32_t offset;
 	uint16_t ethtype;
@@ -2581,9 +2581,9 @@ static int packet_l4_chksum(odp_packet_hdr_t *pkt_hdr,
 /**
  * Simple packet parser
  */
-int packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
-		       odp_proto_layer_t layer,
-		       odp_proto_chksums_t chksums)
+int _odp_packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
+			    odp_proto_layer_t layer,
+			    odp_proto_chksums_t chksums)
 {
 	uint32_t seg_len = packet_first_seg_len(pkt_hdr);
 	const uint8_t *base = packet_data(pkt_hdr);

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -42,7 +42,7 @@
 static int queue_init(queue_entry_t *queue, const char *name,
 		      const odp_queue_param_t *param);
 
-queue_global_t *queue_glb;
+queue_global_t *_odp_queue_glb;
 extern _odp_queue_inline_offset_t _odp_queue_inline_offset;
 
 static int queue_capa(odp_queue_capability_t *capa, int sched ODP_UNUSED)
@@ -52,16 +52,16 @@ static int queue_capa(odp_queue_capability_t *capa, int sched ODP_UNUSED)
 	/* Reserve some queues for internal use */
 	capa->max_queues        = CONFIG_MAX_QUEUES - CONFIG_INTERNAL_QUEUES;
 	capa->plain.max_num     = CONFIG_MAX_PLAIN_QUEUES;
-	capa->plain.max_size    = queue_glb->config.max_queue_size;
-	capa->plain.lockfree.max_num  = queue_glb->queue_lf_num;
-	capa->plain.lockfree.max_size = queue_glb->queue_lf_size;
+	capa->plain.max_size    = _odp_queue_glb->config.max_queue_size;
+	capa->plain.lockfree.max_num  = _odp_queue_glb->queue_lf_num;
+	capa->plain.lockfree.max_size = _odp_queue_glb->queue_lf_size;
 #if ODP_DEPRECATED_API
 	capa->sched.max_num     = CONFIG_MAX_SCHED_QUEUES;
-	capa->sched.max_size    = queue_glb->config.max_queue_size;
+	capa->sched.max_size    = _odp_queue_glb->config.max_queue_size;
 
 	if (sched) {
-		capa->max_ordered_locks = sched_fn->max_ordered_locks();
-		capa->max_sched_groups  = sched_fn->num_grps();
+		capa->max_ordered_locks = _odp_sched_fn->max_ordered_locks();
+		capa->max_sched_groups  = _odp_sched_fn->num_grps();
 		capa->sched_prios       = odp_schedule_num_prio();
 	}
 #endif
@@ -69,7 +69,7 @@ static int queue_capa(odp_queue_capability_t *capa, int sched ODP_UNUSED)
 	return 0;
 }
 
-static int read_config_file(queue_global_t *queue_glb)
+static int read_config_file(queue_global_t *_odp_queue_glb)
 {
 	const char *str;
 	uint32_t val_u32;
@@ -91,7 +91,7 @@ static int read_config_file(queue_global_t *queue_glb)
 		return -1;
 	}
 
-	queue_glb->config.max_queue_size = val_u32;
+	_odp_queue_glb->config.max_queue_size = val_u32;
 	ODP_PRINT("  %s: %u\n", str, val_u32);
 
 	str = "queue_basic.default_queue_size";
@@ -102,14 +102,14 @@ static int read_config_file(queue_global_t *queue_glb)
 
 	val_u32 = val;
 
-	if (val_u32 > queue_glb->config.max_queue_size ||
+	if (val_u32 > _odp_queue_glb->config.max_queue_size ||
 	    val_u32 < MIN_QUEUE_SIZE ||
 	    !CHECK_IS_POWER2(val_u32)) {
 		ODP_ERR("Bad value %s = %u\n", str, val_u32);
 		return -1;
 	}
 
-	queue_glb->config.default_queue_size = val_u32;
+	_odp_queue_glb->config.default_queue_size = val_u32;
 	ODP_PRINT("  %s: %u\n\n", str, val_u32);
 
 	return 0;
@@ -139,9 +139,9 @@ static int queue_init_global(void)
 	if (shm == ODP_SHM_INVALID)
 		return -1;
 
-	queue_glb = odp_shm_addr(shm);
+	_odp_queue_glb = odp_shm_addr(shm);
 
-	memset(queue_glb, 0, sizeof(queue_global_t));
+	memset(_odp_queue_glb, 0, sizeof(queue_global_t));
 
 	for (i = 0; i < CONFIG_MAX_QUEUES; i++) {
 		/* init locks */
@@ -151,30 +151,30 @@ static int queue_init_global(void)
 		queue->s.handle = (odp_queue_t)queue;
 	}
 
-	if (read_config_file(queue_glb)) {
+	if (read_config_file(_odp_queue_glb)) {
 		odp_shm_free(shm);
 		return -1;
 	}
 
-	queue_glb->queue_gbl_shm = shm;
+	_odp_queue_glb->queue_gbl_shm = shm;
 	mem_size = sizeof(uint32_t) * CONFIG_MAX_QUEUES *
-		   (uint64_t)queue_glb->config.max_queue_size;
+		   (uint64_t)_odp_queue_glb->config.max_queue_size;
 
 	shm = odp_shm_reserve("_odp_queue_rings", mem_size,
 			      ODP_CACHE_LINE_SIZE,
 			      0);
 
 	if (shm == ODP_SHM_INVALID) {
-		odp_shm_free(queue_glb->queue_gbl_shm);
+		odp_shm_free(_odp_queue_glb->queue_gbl_shm);
 		return -1;
 	}
 
-	queue_glb->queue_ring_shm = shm;
-	queue_glb->ring_data      = odp_shm_addr(shm);
+	_odp_queue_glb->queue_ring_shm = shm;
+	_odp_queue_glb->ring_data      = odp_shm_addr(shm);
 
-	lf_func = &queue_glb->queue_lf_func;
-	queue_glb->queue_lf_num  = queue_lf_init_global(&lf_size, lf_func);
-	queue_glb->queue_lf_size = lf_size;
+	lf_func = &_odp_queue_glb->queue_lf_func;
+	_odp_queue_glb->queue_lf_num  = _odp_queue_lf_init_global(&lf_size, lf_func);
+	_odp_queue_glb->queue_lf_size = lf_size;
 
 	queue_capa(&capa, 0);
 
@@ -214,14 +214,14 @@ static int queue_term_global(void)
 		UNLOCK(queue);
 	}
 
-	queue_lf_term_global();
+	_odp_queue_lf_term_global();
 
-	if (odp_shm_free(queue_glb->queue_ring_shm)) {
+	if (odp_shm_free(_odp_queue_glb->queue_ring_shm)) {
 		ODP_ERR("shm free failed");
 		ret = -1;
 	}
 
-	if (odp_shm_free(queue_glb->queue_gbl_shm)) {
+	if (odp_shm_free(_odp_queue_glb->queue_gbl_shm)) {
 		ODP_ERR("shm free failed");
 		ret = -1;
 	}
@@ -289,13 +289,13 @@ static odp_queue_t queue_create(const char *name,
 	}
 
 	if (param->nonblocking == ODP_BLOCKING) {
-		if (param->size > queue_glb->config.max_queue_size)
+		if (param->size > _odp_queue_glb->config.max_queue_size)
 			return ODP_QUEUE_INVALID;
 	} else if (param->nonblocking == ODP_NONBLOCKING_LF) {
 		/* Only plain type lock-free queues supported */
 		if (type != ODP_QUEUE_TYPE_PLAIN)
 			return ODP_QUEUE_INVALID;
-		if (param->size > queue_glb->queue_lf_size)
+		if (param->size > _odp_queue_glb->queue_lf_size)
 			return ODP_QUEUE_INVALID;
 	} else {
 		/* Wait-free queues not supported */
@@ -330,9 +330,9 @@ static odp_queue_t queue_create(const char *name,
 			    param->nonblocking == ODP_NONBLOCKING_LF) {
 				queue_lf_func_t *lf_fn;
 
-				lf_fn = &queue_glb->queue_lf_func;
+				lf_fn = &_odp_queue_glb->queue_lf_func;
 
-				queue_lf = queue_lf_create(queue);
+				queue_lf = _odp_queue_lf_create(queue);
 
 				if (queue_lf == NULL) {
 					UNLOCK(queue);
@@ -363,8 +363,8 @@ static odp_queue_t queue_create(const char *name,
 		return ODP_QUEUE_INVALID;
 
 	if (type == ODP_QUEUE_TYPE_SCHED) {
-		if (sched_fn->create_queue(queue->s.index,
-					   &queue->s.param.sched)) {
+		if (_odp_sched_fn->create_queue(queue->s.index,
+						&queue->s.param.sched)) {
 			queue->s.status = QUEUE_STATUS_FREE;
 			ODP_ERR("schedule queue init failed\n");
 			return ODP_QUEUE_INVALID;
@@ -374,7 +374,7 @@ static odp_queue_t queue_create(const char *name,
 	return handle;
 }
 
-void sched_queue_set_status(uint32_t queue_index, int status)
+void _odp_sched_queue_set_status(uint32_t queue_index, int status)
 {
 	queue_entry_t *queue = qentry_from_index(queue_index);
 
@@ -425,7 +425,7 @@ static int queue_destroy(odp_queue_t handle)
 		break;
 	case QUEUE_STATUS_NOTSCHED:
 		queue->s.status = QUEUE_STATUS_FREE;
-		sched_fn->destroy_queue(queue->s.index);
+		_odp_sched_fn->destroy_queue(queue->s.index);
 		break;
 	case QUEUE_STATUS_SCHED:
 		/* Queue is still in scheduling */
@@ -436,7 +436,7 @@ static int queue_destroy(odp_queue_t handle)
 	}
 
 	if (queue->s.queue_lf)
-		queue_lf_destroy(queue->s.queue_lf);
+		_odp_queue_lf_destroy(queue->s.queue_lf);
 
 	UNLOCK(queue);
 
@@ -506,7 +506,7 @@ static inline int _plain_queue_enq_multi(odp_queue_t handle,
 	queue = qentry_from_handle(handle);
 	ring_mpmc = &queue->s.ring_mpmc;
 
-	if (sched_fn->ord_enq_multi(handle, (void **)buf_hdr, num, &ret))
+	if (_odp_sched_fn->ord_enq_multi(handle, (void **)buf_hdr, num, &ret))
 		return ret;
 
 	buffer_index_from_buf(buf_idx, buf_hdr, num);
@@ -748,7 +748,7 @@ static void queue_print(odp_queue_t handle)
 	if (queue->s.queue_lf) {
 		ODP_PRINT("  implementation  queue_lf\n");
 		ODP_PRINT("  length          %" PRIu32 "/%" PRIu32 "\n",
-			  queue_lf_length(queue->s.queue_lf), queue_lf_max_length());
+			  _odp_queue_lf_length(queue->s.queue_lf), _odp_queue_lf_max_length());
 	} else if (queue->s.spsc) {
 		ODP_PRINT("  implementation  ring_spsc\n");
 		ODP_PRINT("  length          %" PRIu32 "/%" PRIu32 "\n",
@@ -780,7 +780,7 @@ static inline int _sched_queue_enq_multi(odp_queue_t handle,
 	queue = qentry_from_handle(handle);
 	ring_st = &queue->s.ring_st;
 
-	if (sched_fn->ord_enq_multi(handle, (void **)buf_hdr, num, &ret))
+	if (_odp_sched_fn->ord_enq_multi(handle, (void **)buf_hdr, num, &ret))
 		return ret;
 
 	buffer_index_from_buf(buf_idx, buf_hdr, num);
@@ -803,14 +803,14 @@ static inline int _sched_queue_enq_multi(odp_queue_t handle,
 	UNLOCK(queue);
 
 	/* Add queue to scheduling */
-	if (sched && sched_fn->sched_queue(queue->s.index))
+	if (sched && _odp_sched_fn->sched_queue(queue->s.index))
 		ODP_ABORT("schedule_queue failed\n");
 
 	return num_enq;
 }
 
-int sched_queue_deq(uint32_t queue_index, odp_event_t ev[], int max_num,
-		    int update_status)
+int _odp_sched_queue_deq(uint32_t queue_index, odp_event_t ev[], int max_num,
+			 int update_status)
 {
 	int num_deq, status;
 	ring_st_t *ring_st;
@@ -828,7 +828,7 @@ int sched_queue_deq(uint32_t queue_index, odp_event_t ev[], int max_num,
 		 * Inform scheduler about a destroyed queue. */
 		if (queue->s.status == QUEUE_STATUS_DESTROYED) {
 			queue->s.status = QUEUE_STATUS_FREE;
-			sched_fn->destroy_queue(queue_index);
+			_odp_sched_fn->destroy_queue(queue_index);
 		}
 
 		UNLOCK(queue);
@@ -873,7 +873,7 @@ static int sched_queue_enq(odp_queue_t handle, odp_buffer_hdr_t *buf_hdr)
 		return -1;
 }
 
-int sched_queue_empty(uint32_t queue_index)
+int _odp_sched_queue_empty(uint32_t queue_index)
 {
 	queue_entry_t *queue = qentry_from_index(queue_index);
 	int ret = 0;
@@ -916,7 +916,7 @@ static int queue_init(queue_entry_t *queue, const char *name,
 		queue->s.name[ODP_QUEUE_NAME_LEN - 1] = 0;
 	}
 	memcpy(&queue->s.param, param, sizeof(odp_queue_param_t));
-	if (queue->s.param.sched.lock_count > sched_fn->max_ordered_locks())
+	if (queue->s.param.sched.lock_count > _odp_sched_fn->max_ordered_locks())
 		return -1;
 
 	if (queue_type == ODP_QUEUE_TYPE_SCHED)
@@ -930,7 +930,7 @@ static int queue_init(queue_entry_t *queue, const char *name,
 
 	queue_size = param->size;
 	if (queue_size == 0)
-		queue_size = queue_glb->config.default_queue_size;
+		queue_size = _odp_queue_glb->config.default_queue_size;
 
 	if (queue_size < MIN_QUEUE_SIZE)
 		queue_size = MIN_QUEUE_SIZE;
@@ -938,12 +938,12 @@ static int queue_init(queue_entry_t *queue, const char *name,
 	/* Round up if not already a power of two */
 	queue_size = ROUNDUP_POWER2_U32(queue_size);
 
-	if (queue_size > queue_glb->config.max_queue_size) {
+	if (queue_size > _odp_queue_glb->config.max_queue_size) {
 		ODP_ERR("Too large queue size %u\n", queue_size);
 		return -1;
 	}
 
-	offset = queue->s.index * (uint64_t)queue_glb->config.max_queue_size;
+	offset = queue->s.index * (uint64_t)_odp_queue_glb->config.max_queue_size;
 
 	/* Single-producer / single-consumer plain queue has simple and
 	 * lock-free implementation */
@@ -962,7 +962,7 @@ static int queue_init(queue_entry_t *queue, const char *name,
 	queue->s.orig_dequeue_multi = error_dequeue_multi;
 
 	if (spsc) {
-		queue_spsc_init(queue, queue_size);
+		_odp_queue_spsc_init(queue, queue_size);
 	} else {
 		if (queue_type == ODP_QUEUE_TYPE_PLAIN) {
 			queue->s.enqueue            = plain_queue_enq;
@@ -971,7 +971,7 @@ static int queue_init(queue_entry_t *queue, const char *name,
 			queue->s.dequeue_multi      = plain_queue_deq_multi;
 			queue->s.orig_dequeue_multi = plain_queue_deq_multi;
 
-			queue->s.ring_data = &queue_glb->ring_data[offset];
+			queue->s.ring_data = &_odp_queue_glb->ring_data[offset];
 			queue->s.ring_mask = queue_size - 1;
 			ring_mpmc_init(&queue->s.ring_mpmc);
 
@@ -979,7 +979,7 @@ static int queue_init(queue_entry_t *queue, const char *name,
 			queue->s.enqueue            = sched_queue_enq;
 			queue->s.enqueue_multi      = sched_queue_enq_multi;
 
-			queue->s.ring_data = &queue_glb->ring_data[offset];
+			queue->s.ring_data = &_odp_queue_glb->ring_data[offset];
 			queue->s.ring_mask = queue_size - 1;
 			ring_st_init(&queue->s.ring_st);
 		}
@@ -1119,7 +1119,7 @@ static odp_event_t queue_api_deq(odp_queue_t handle)
 }
 
 /* API functions */
-_odp_queue_api_fn_t queue_basic_api = {
+_odp_queue_api_fn_t _odp_queue_basic_api = {
 	.queue_create = queue_create,
 	.queue_destroy = queue_destroy,
 	.queue_lookup = queue_lookup,
@@ -1141,7 +1141,7 @@ _odp_queue_api_fn_t queue_basic_api = {
 };
 
 /* Functions towards internal components */
-queue_fn_t queue_basic_fn = {
+queue_fn_t _odp_queue_basic_fn = {
 	.init_global = queue_init_global,
 	.term_global = queue_term_global,
 	.init_local = queue_init_local,

--- a/platform/linux-generic/odp_queue_if.c
+++ b/platform/linux-generic/odp_queue_if.c
@@ -23,13 +23,13 @@ const _odp_queue_api_fn_t *_odp_queue_api;
 
 #include <odp/visibility_end.h>
 
-extern const _odp_queue_api_fn_t queue_scalable_api;
-extern const queue_fn_t queue_scalable_fn;
+extern const _odp_queue_api_fn_t _odp_queue_scalable_api;
+extern const queue_fn_t _odp_queue_scalable_fn;
 
-extern const _odp_queue_api_fn_t queue_basic_api;
-extern const queue_fn_t queue_basic_fn;
+extern const _odp_queue_api_fn_t _odp_queue_basic_api;
+extern const queue_fn_t _odp_queue_basic_fn;
 
-const queue_fn_t *queue_fn;
+const queue_fn_t *_odp_queue_fn;
 
 odp_queue_t odp_queue_create(const char *name, const odp_queue_param_t *param)
 {
@@ -109,20 +109,20 @@ int _odp_queue_init_global(void)
 		sched = _ODP_SCHEDULE_DEFAULT;
 
 	if (!strcmp(sched, "basic") || !strcmp(sched, "sp")) {
-		queue_fn = &queue_basic_fn;
-		_odp_queue_api = &queue_basic_api;
+		_odp_queue_fn = &_odp_queue_basic_fn;
+		_odp_queue_api = &_odp_queue_basic_api;
 	} else if (!strcmp(sched, "scalable")) {
-		queue_fn = &queue_scalable_fn;
-		_odp_queue_api = &queue_scalable_api;
+		_odp_queue_fn = &_odp_queue_scalable_fn;
+		_odp_queue_api = &_odp_queue_scalable_api;
 	} else {
 		ODP_ABORT("Unknown scheduler specified via ODP_SCHEDULER\n");
 		return -1;
 	}
 
-	return queue_fn->init_global();
+	return _odp_queue_fn->init_global();
 }
 
 int _odp_queue_term_global(void)
 {
-	return queue_fn->term_global();
+	return _odp_queue_fn->term_global();
 }

--- a/platform/linux-generic/odp_queue_lf.c
+++ b/platform/linux-generic/odp_queue_lf.c
@@ -302,8 +302,8 @@ static int queue_lf_deq_multi(odp_queue_t handle, odp_buffer_hdr_t **buf_hdr,
 	return 1;
 }
 
-uint32_t queue_lf_init_global(uint32_t *queue_lf_size,
-			      queue_lf_func_t *lf_func)
+uint32_t _odp_queue_lf_init_global(uint32_t *queue_lf_size,
+				   queue_lf_func_t *lf_func)
 {
 	odp_shm_t shm;
 	int lockfree;
@@ -339,7 +339,7 @@ uint32_t queue_lf_init_global(uint32_t *queue_lf_size,
 	return QUEUE_LF_NUM;
 }
 
-void queue_lf_term_global(void)
+void _odp_queue_lf_term_global(void)
 {
 	odp_shm_t shm;
 
@@ -362,7 +362,7 @@ static void init_queue(queue_lf_t *queue_lf)
 		atomic_zero_u128(&queue_lf->node[i].u128);
 }
 
-void *queue_lf_create(queue_entry_t *queue)
+void *_odp_queue_lf_create(queue_entry_t *queue)
 {
 	int i;
 	queue_lf_t *queue_lf = NULL;
@@ -388,14 +388,14 @@ void *queue_lf_create(queue_entry_t *queue)
 	return queue_lf;
 }
 
-void queue_lf_destroy(void *queue_lf_ptr)
+void _odp_queue_lf_destroy(void *queue_lf_ptr)
 {
 	queue_lf_t *queue_lf = queue_lf_ptr;
 
 	queue_lf->used = 0;
 }
 
-uint32_t queue_lf_length(void *queue_lf_ptr)
+uint32_t _odp_queue_lf_length(void *queue_lf_ptr)
 {
 	queue_lf_t *queue_lf = queue_lf_ptr;
 	ring_lf_node_t node_val;
@@ -410,7 +410,7 @@ uint32_t queue_lf_length(void *queue_lf_ptr)
 	return num;
 }
 
-uint32_t queue_lf_max_length(void)
+uint32_t _odp_queue_lf_max_length(void)
 {
 	return RING_LF_SIZE;
 }

--- a/platform/linux-generic/odp_queue_spsc.c
+++ b/platform/linux-generic/odp_queue_spsc.c
@@ -116,7 +116,7 @@ static odp_buffer_hdr_t *queue_spsc_deq(odp_queue_t handle)
 		return NULL;
 }
 
-void queue_spsc_init(queue_entry_t *queue, uint32_t queue_size)
+void _odp_queue_spsc_init(queue_entry_t *queue, uint32_t queue_size)
 {
 	uint64_t offset;
 
@@ -126,9 +126,9 @@ void queue_spsc_init(queue_entry_t *queue, uint32_t queue_size)
 	queue->s.dequeue_multi = queue_spsc_deq_multi;
 	queue->s.orig_dequeue_multi = queue_spsc_deq_multi;
 
-	offset = queue->s.index * (uint64_t)queue_glb->config.max_queue_size;
+	offset = queue->s.index * (uint64_t)_odp_queue_glb->config.max_queue_size;
 
-	queue->s.ring_data = &queue_glb->ring_data[offset];
+	queue->s.ring_data = &_odp_queue_glb->ring_data[offset];
 	queue->s.ring_mask = queue_size - 1;
 	ring_spsc_init(&queue->s.ring_spsc);
 }

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -479,7 +479,7 @@ static int schedule_term_global(void)
 					odp_event_t events[1];
 					int num;
 
-					num = sched_queue_deq(qi, events, 1, 1);
+					num = _odp_sched_queue_deq(qi, events, 1, 1);
 
 					if (num > 0)
 						ODP_ERR("Queue not empty\n");
@@ -674,7 +674,7 @@ static void schedule_pktio_start(int pktio_index, int num_pktin,
 		ODP_ASSERT(pktin_idx[i] <= MAX_PKTIN_INDEX);
 
 		/* Start polling */
-		sched_queue_set_status(qi, QUEUE_STATUS_SCHED);
+		_odp_sched_queue_set_status(qi, QUEUE_STATUS_SCHED);
 		schedule_sched_queue(qi);
 	}
 }
@@ -805,7 +805,7 @@ static int schedule_term_local(void)
 static void schedule_config_init(odp_schedule_config_t *config)
 {
 	config->num_queues = CONFIG_MAX_SCHED_QUEUES;
-	config->queue_size = queue_glb->config.max_queue_size;
+	config->queue_size = _odp_queue_glb->config.max_queue_size;
 }
 
 static int schedule_config(const odp_schedule_config_t *config)
@@ -912,7 +912,7 @@ static inline int poll_pktin(uint32_t qi, int direct_recv,
 	pktio_index = sched->queue[qi].pktio_index;
 	pktin_index = sched->queue[qi].pktin_index;
 
-	num = sched_cb_pktin_poll(pktio_index, pktin_index, hdr_tbl, max_num);
+	num = _odp_sched_cb_pktin_poll(pktio_index, pktin_index, hdr_tbl, max_num);
 
 	if (num == 0)
 		return 0;
@@ -925,10 +925,10 @@ static inline int poll_pktin(uint32_t qi, int direct_recv,
 		num_pktin = sched->pktio[pktio_index].num_pktin;
 		odp_spinlock_unlock(&sched->pktio_lock);
 
-		sched_queue_set_status(qi, QUEUE_STATUS_NOTSCHED);
+		_odp_sched_queue_set_status(qi, QUEUE_STATUS_NOTSCHED);
 
 		if (num_pktin == 0)
-			sched_cb_pktio_stop_finalize(pktio_index);
+			_odp_sched_cb_pktio_stop_finalize(pktio_index);
 
 		return num;
 	}
@@ -1028,7 +1028,7 @@ static inline int do_schedule_grp(odp_queue_t *out_queue, odp_event_t out_ev[],
 
 			pktin = queue_is_pktin(qi);
 
-			num = sched_queue_deq(qi, ev_tbl, max_deq, !pktin);
+			num = _odp_sched_queue_deq(qi, ev_tbl, max_deq, !pktin);
 
 			if (odp_unlikely(num < 0)) {
 				/* Destroyed queue. Continue scheduling the same
@@ -1583,14 +1583,14 @@ static int schedule_capability(odp_schedule_capability_t *capa)
 	capa->max_groups = schedule_num_grps();
 	capa->max_prios = schedule_num_prio();
 	capa->max_queues = CONFIG_MAX_SCHED_QUEUES;
-	capa->max_queue_size = queue_glb->config.max_queue_size;
+	capa->max_queue_size = _odp_queue_glb->config.max_queue_size;
 	capa->max_flow_id = BUF_HDR_MAX_FLOW_ID;
 
 	return 0;
 }
 
 /* Fill in scheduler interface */
-const schedule_fn_t schedule_basic_fn = {
+const schedule_fn_t _odp_schedule_basic_fn = {
 	.pktio_start = schedule_pktio_start,
 	.thr_add = schedule_thr_add,
 	.thr_rem = schedule_thr_rem,
@@ -1610,7 +1610,7 @@ const schedule_fn_t schedule_basic_fn = {
 };
 
 /* Fill in scheduler API calls */
-const schedule_api_t schedule_basic_api = {
+const schedule_api_t _odp_schedule_basic_api = {
 	.schedule_wait_time       = schedule_wait_time,
 	.schedule_capability      = schedule_capability,
 	.schedule_config_init     = schedule_config_init,

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -13,34 +13,34 @@
 #include <stdlib.h>
 #include <string.h>
 
-extern const schedule_fn_t schedule_sp_fn;
-extern const schedule_api_t schedule_sp_api;
+extern const schedule_fn_t _odp_schedule_sp_fn;
+extern const schedule_api_t _odp_schedule_sp_api;
 
-extern const schedule_fn_t schedule_basic_fn;
-extern const schedule_api_t schedule_basic_api;
+extern const schedule_fn_t _odp_schedule_basic_fn;
+extern const schedule_api_t _odp_schedule_basic_api;
 
-extern const schedule_fn_t  schedule_scalable_fn;
-extern const schedule_api_t schedule_scalable_api;
+extern const schedule_fn_t  _odp_schedule_scalable_fn;
+extern const schedule_api_t _odp_schedule_scalable_api;
 
-const schedule_fn_t *sched_fn;
-const schedule_api_t *sched_api;
+const schedule_fn_t *_odp_sched_fn;
+const schedule_api_t *_odp_sched_api;
 int _odp_schedule_configured;
 
 uint64_t odp_schedule_wait_time(uint64_t ns)
 {
-	return sched_api->schedule_wait_time(ns);
+	return _odp_sched_api->schedule_wait_time(ns);
 }
 
 int odp_schedule_capability(odp_schedule_capability_t *capa)
 {
-	return sched_api->schedule_capability(capa);
+	return _odp_sched_api->schedule_capability(capa);
 }
 
 void odp_schedule_config_init(odp_schedule_config_t *config)
 {
 	memset(config, 0, sizeof(*config));
 
-	sched_api->schedule_config_init(config);
+	_odp_sched_api->schedule_config_init(config);
 }
 
 int odp_schedule_config(const odp_schedule_config_t *config)
@@ -58,7 +58,7 @@ int odp_schedule_config(const odp_schedule_config_t *config)
 		config = &defconfig;
 	}
 
-	ret = sched_api->schedule_config(config);
+	ret = _odp_sched_api->schedule_config(config);
 
 	if (ret >= 0)
 		_odp_schedule_configured = 1;
@@ -70,7 +70,7 @@ odp_event_t odp_schedule(odp_queue_t *from, uint64_t wait)
 {
 	ODP_ASSERT(_odp_schedule_configured);
 
-	return sched_api->schedule(from, wait);
+	return _odp_sched_api->schedule(from, wait);
 }
 
 int odp_schedule_multi(odp_queue_t *from, uint64_t wait, odp_event_t events[],
@@ -78,127 +78,127 @@ int odp_schedule_multi(odp_queue_t *from, uint64_t wait, odp_event_t events[],
 {
 	ODP_ASSERT(_odp_schedule_configured);
 
-	return sched_api->schedule_multi(from, wait, events, num);
+	return _odp_sched_api->schedule_multi(from, wait, events, num);
 }
 
 int odp_schedule_multi_wait(odp_queue_t *from, odp_event_t events[], int num)
 {
-	return sched_api->schedule_multi_wait(from, events, num);
+	return _odp_sched_api->schedule_multi_wait(from, events, num);
 }
 
 int odp_schedule_multi_no_wait(odp_queue_t *from, odp_event_t events[], int num)
 {
-	return sched_api->schedule_multi_no_wait(from, events, num);
+	return _odp_sched_api->schedule_multi_no_wait(from, events, num);
 }
 
 void odp_schedule_pause(void)
 {
-	return sched_api->schedule_pause();
+	return _odp_sched_api->schedule_pause();
 }
 
 void odp_schedule_resume(void)
 {
-	return sched_api->schedule_resume();
+	return _odp_sched_api->schedule_resume();
 }
 
 void odp_schedule_release_atomic(void)
 {
-	return sched_api->schedule_release_atomic();
+	return _odp_sched_api->schedule_release_atomic();
 }
 
 void odp_schedule_release_ordered(void)
 {
-	return sched_api->schedule_release_ordered();
+	return _odp_sched_api->schedule_release_ordered();
 }
 
 void odp_schedule_prefetch(int num)
 {
-	return sched_api->schedule_prefetch(num);
+	return _odp_sched_api->schedule_prefetch(num);
 }
 
 int odp_schedule_min_prio(void)
 {
-	return sched_api->schedule_min_prio();
+	return _odp_sched_api->schedule_min_prio();
 }
 
 int odp_schedule_max_prio(void)
 {
-	return sched_api->schedule_max_prio();
+	return _odp_sched_api->schedule_max_prio();
 }
 
 int odp_schedule_default_prio(void)
 {
-	return sched_api->schedule_default_prio();
+	return _odp_sched_api->schedule_default_prio();
 }
 
 int odp_schedule_num_prio(void)
 {
-	return sched_api->schedule_num_prio();
+	return _odp_sched_api->schedule_num_prio();
 }
 
 odp_schedule_group_t odp_schedule_group_create(const char *name,
 					       const odp_thrmask_t *mask)
 {
-	return sched_api->schedule_group_create(name, mask);
+	return _odp_sched_api->schedule_group_create(name, mask);
 }
 
 int odp_schedule_group_destroy(odp_schedule_group_t group)
 {
-	return sched_api->schedule_group_destroy(group);
+	return _odp_sched_api->schedule_group_destroy(group);
 }
 
 odp_schedule_group_t odp_schedule_group_lookup(const char *name)
 {
-	return sched_api->schedule_group_lookup(name);
+	return _odp_sched_api->schedule_group_lookup(name);
 }
 
 int odp_schedule_group_join(odp_schedule_group_t group,
 			    const odp_thrmask_t *mask)
 {
-	return sched_api->schedule_group_join(group, mask);
+	return _odp_sched_api->schedule_group_join(group, mask);
 }
 
 int odp_schedule_group_leave(odp_schedule_group_t group,
 			     const odp_thrmask_t *mask)
 {
-	return sched_api->schedule_group_leave(group, mask);
+	return _odp_sched_api->schedule_group_leave(group, mask);
 }
 
 int odp_schedule_group_thrmask(odp_schedule_group_t group,
 			       odp_thrmask_t *thrmask)
 {
-	return sched_api->schedule_group_thrmask(group, thrmask);
+	return _odp_sched_api->schedule_group_thrmask(group, thrmask);
 }
 
 int odp_schedule_group_info(odp_schedule_group_t group,
 			    odp_schedule_group_info_t *info)
 {
-	return sched_api->schedule_group_info(group, info);
+	return _odp_sched_api->schedule_group_info(group, info);
 }
 
 void odp_schedule_order_lock(uint32_t lock_index)
 {
-	return sched_api->schedule_order_lock(lock_index);
+	return _odp_sched_api->schedule_order_lock(lock_index);
 }
 
 void odp_schedule_order_unlock(uint32_t lock_index)
 {
-	return sched_api->schedule_order_unlock(lock_index);
+	return _odp_sched_api->schedule_order_unlock(lock_index);
 }
 
 void odp_schedule_order_unlock_lock(uint32_t unlock_index, uint32_t lock_index)
 {
-	sched_api->schedule_order_unlock_lock(unlock_index, lock_index);
+	_odp_sched_api->schedule_order_unlock_lock(unlock_index, lock_index);
 }
 
 void odp_schedule_order_lock_start(uint32_t lock_index)
 {
-	sched_api->schedule_order_lock_start(lock_index);
+	_odp_sched_api->schedule_order_lock_start(lock_index);
 }
 
 void odp_schedule_order_lock_wait(uint32_t lock_index)
 {
-	sched_api->schedule_order_lock_wait(lock_index);
+	_odp_sched_api->schedule_order_lock_wait(lock_index);
 }
 
 int _odp_schedule_init_global(void)
@@ -211,23 +211,23 @@ int _odp_schedule_init_global(void)
 	ODP_PRINT("Using scheduler '%s'\n", sched);
 
 	if (!strcmp(sched, "basic")) {
-		sched_fn = &schedule_basic_fn;
-		sched_api = &schedule_basic_api;
+		_odp_sched_fn = &_odp_schedule_basic_fn;
+		_odp_sched_api = &_odp_schedule_basic_api;
 	} else if (!strcmp(sched, "sp")) {
-		sched_fn = &schedule_sp_fn;
-		sched_api = &schedule_sp_api;
+		_odp_sched_fn = &_odp_schedule_sp_fn;
+		_odp_sched_api = &_odp_schedule_sp_api;
 	} else if (!strcmp(sched, "scalable")) {
-		sched_fn = &schedule_scalable_fn;
-		sched_api = &schedule_scalable_api;
+		_odp_sched_fn = &_odp_schedule_scalable_fn;
+		_odp_sched_api = &_odp_schedule_scalable_api;
 	} else {
 		ODP_ABORT("Unknown scheduler specified via ODP_SCHEDULER\n");
 		return -1;
 	}
 
-	return sched_fn->init_global();
+	return _odp_sched_fn->init_global();
 }
 
 int _odp_schedule_term_global(void)
 {
-	return sched_fn->term_global();
+	return _odp_sched_fn->term_global();
 }

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -240,7 +240,7 @@ static int term_global(void)
 		int report = 1;
 
 		if (sched_global->queue_cmd[qi].s.init) {
-			while (sched_queue_deq(qi, &event, 1, 1) > 0) {
+			while (_odp_sched_queue_deq(qi, &event, 1, 1) > 0) {
 				if (report) {
 					ODP_ERR("Queue not empty\n");
 					report = 0;
@@ -268,7 +268,7 @@ static int term_local(void)
 static void schedule_config_init(odp_schedule_config_t *config)
 {
 	config->num_queues = CONFIG_MAX_SCHED_QUEUES;
-	config->queue_size = queue_glb->config.max_queue_size;
+	config->queue_size = _odp_queue_glb->config.max_queue_size;
 }
 
 static int schedule_config(const odp_schedule_config_t *config)
@@ -571,7 +571,7 @@ static int schedule_multi(odp_queue_t *from, uint64_t wait,
 
 	if (sched_local.cmd) {
 		/* Continue scheduling if queue is not empty */
-		if (sched_queue_empty(sched_local.cmd->s.index) == 0)
+		if (_odp_sched_queue_empty(sched_local.cmd->s.index) == 0)
 			add_tail(sched_local.cmd);
 
 		sched_local.cmd = NULL;
@@ -598,13 +598,13 @@ static int schedule_multi(odp_queue_t *from, uint64_t wait,
 			odp_queue_t *queue = cmd->s.queue;
 
 			for (i = 0; i < num_pktin; i++) {
-				num_pkt = sched_cb_pktin_poll(pktio_idx,
-							      pktin_idx[i],
-							      hdr_tbl, max_num);
+				num_pkt = _odp_sched_cb_pktin_poll(pktio_idx,
+								   pktin_idx[i],
+								   hdr_tbl, max_num);
 
 				if (num_pkt < 0) {
 					/* Pktio stopped or closed. */
-					sched_cb_pktio_stop_finalize(pktio_idx);
+					_odp_sched_cb_pktio_stop_finalize(pktio_idx);
 					break;
 				}
 
@@ -646,7 +646,7 @@ static int schedule_multi(odp_queue_t *from, uint64_t wait,
 		}
 
 		qi  = cmd->s.index;
-		num = sched_queue_deq(qi, events, 1, 1);
+		num = _odp_sched_queue_deq(qi, events, 1, 1);
 
 		if (num <= 0) {
 			timer_run(1);
@@ -981,13 +981,13 @@ static int schedule_capability(odp_schedule_capability_t *capa)
 	capa->max_groups = num_grps();
 	capa->max_prios = schedule_num_prio();
 	capa->max_queues = CONFIG_MAX_SCHED_QUEUES;
-	capa->max_queue_size = queue_glb->config.max_queue_size;
+	capa->max_queue_size = _odp_queue_glb->config.max_queue_size;
 
 	return 0;
 }
 
 /* Fill in scheduler interface */
-const schedule_fn_t schedule_sp_fn = {
+const schedule_fn_t _odp_schedule_sp_fn = {
 	.pktio_start   = pktio_start,
 	.thr_add       = thr_add,
 	.thr_rem       = thr_rem,
@@ -1006,7 +1006,7 @@ const schedule_fn_t schedule_sp_fn = {
 };
 
 /* Fill in scheduler API calls */
-const schedule_api_t schedule_sp_api = {
+const schedule_api_t _odp_schedule_sp_api = {
 	.schedule_wait_time       = schedule_wait_time,
 	.schedule_capability      = schedule_capability,
 	.schedule_config_init     = schedule_config_init,

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -392,7 +392,7 @@ int _odp_system_info_init(void)
 	if (file != NULL) {
 		/* Read CPU model, and set max cpu frequency
 		 * if not set from cpufreq. */
-		cpuinfo_parser(file, &odp_global_ro.system_info);
+		_odp_cpuinfo_parser(file, &odp_global_ro.system_info);
 		fclose(file);
 	} else {
 		_odp_dummy_cpuinfo(&odp_global_ro.system_info);
@@ -577,7 +577,7 @@ void odp_sys_info_print(void)
 	str[len] = '\0';
 	ODP_PRINT("%s", str);
 
-	sys_info_print_arch();
+	_odp_sys_info_print_arch();
 }
 
 void odp_sys_config_print(void)

--- a/platform/linux-generic/odp_thread.c
+++ b/platform/linux-generic/odp_thread.c
@@ -140,10 +140,10 @@ int _odp_thread_init_local(odp_thread_type_t type)
 	group_worker = 1;
 	group_control = 1;
 
-	if (sched_fn->get_config) {
+	if (_odp_sched_fn->get_config) {
 		schedule_config_t schedule_config;
 
-		sched_fn->get_config(&schedule_config);
+		_odp_sched_fn->get_config(&schedule_config);
 		group_all = schedule_config.group_enable.all;
 		group_worker = schedule_config.group_enable.worker;
 		group_control = schedule_config.group_enable.control;
@@ -172,13 +172,13 @@ int _odp_thread_init_local(odp_thread_type_t type)
 	_odp_this_thread = &thread_globals->thr[id];
 
 	if (group_all)
-		sched_fn->thr_add(ODP_SCHED_GROUP_ALL, id);
+		_odp_sched_fn->thr_add(ODP_SCHED_GROUP_ALL, id);
 
 	if (type == ODP_THREAD_WORKER && group_worker)
-		sched_fn->thr_add(ODP_SCHED_GROUP_WORKER, id);
+		_odp_sched_fn->thr_add(ODP_SCHED_GROUP_WORKER, id);
 
 	if (type == ODP_THREAD_CONTROL && group_control)
-		sched_fn->thr_add(ODP_SCHED_GROUP_CONTROL, id);
+		_odp_sched_fn->thr_add(ODP_SCHED_GROUP_CONTROL, id);
 
 	return 0;
 }
@@ -194,23 +194,23 @@ int _odp_thread_term_local(void)
 	group_worker = 1;
 	group_control = 1;
 
-	if (sched_fn->get_config) {
+	if (_odp_sched_fn->get_config) {
 		schedule_config_t schedule_config;
 
-		sched_fn->get_config(&schedule_config);
+		_odp_sched_fn->get_config(&schedule_config);
 		group_all = schedule_config.group_enable.all;
 		group_worker = schedule_config.group_enable.worker;
 		group_control = schedule_config.group_enable.control;
 	}
 
 	if (group_all)
-		sched_fn->thr_rem(ODP_SCHED_GROUP_ALL, id);
+		_odp_sched_fn->thr_rem(ODP_SCHED_GROUP_ALL, id);
 
 	if (type == ODP_THREAD_WORKER && group_worker)
-		sched_fn->thr_rem(ODP_SCHED_GROUP_WORKER, id);
+		_odp_sched_fn->thr_rem(ODP_SCHED_GROUP_WORKER, id);
 
 	if (type == ODP_THREAD_CONTROL && group_control)
-		sched_fn->thr_rem(ODP_SCHED_GROUP_CONTROL, id);
+		_odp_sched_fn->thr_rem(ODP_SCHED_GROUP_CONTROL, id);
 
 	odp_spinlock_lock(&thread_globals->lock);
 	num = free_id(id);

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -513,7 +513,7 @@ static inline odp_timer_t timer_alloc(timer_pool_t *tp,
 						 _ODP_MEMMODEL_RLS);
 		hdl = tp_idx_to_handle(tp, idx);
 		/* Add timer to queue */
-		queue_fn->timer_add(queue);
+		_odp_queue_fn->timer_add(queue);
 	} else {
 		__odp_errno = ENFILE; /* Reusing file table overflow */
 		hdl = ODP_TIMER_INVALID;
@@ -534,7 +534,7 @@ static inline odp_buffer_t timer_free(timer_pool_t *tp, uint32_t idx)
 	odp_buffer_t old_buf = timer_set_unused(tp, idx);
 
 	/* Remove timer from queue */
-	queue_fn->timer_rem(tim->queue);
+	_odp_queue_fn->timer_rem(tim->queue);
 
 	/* Destroy timer */
 	timer_fini(tim, &tp->tick_buf[idx]);

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2031,9 +2031,9 @@ static int tm_enqueue(tm_system_t *tm_system,
 
 	work_item.queue_num = tm_queue_obj->queue_num;
 	work_item.pkt = pkt;
-	sched_fn->order_lock();
+	_odp_sched_fn->order_lock();
 	rc = input_work_queue_append(tm_system, &work_item);
-	sched_fn->order_unlock();
+	_odp_sched_fn->order_unlock();
 
 	if (rc < 0) {
 		ODP_DBG("%s work queue full\n", __func__);
@@ -3985,8 +3985,8 @@ odp_tm_queue_t odp_tm_queue_create(odp_tm_t odp_tm,
 
 		queue_obj->queue = queue;
 		odp_queue_context_set(queue, queue_obj, sizeof(tm_queue_obj_t));
-		queue_fn->set_enq_deq_fn(queue, queue_tm_reenq,
-					 queue_tm_reenq_multi, NULL, NULL);
+		_odp_queue_fn->set_enq_deq_fn(queue, queue_tm_reenq,
+					      queue_tm_reenq_multi, NULL, NULL);
 
 		tm_system->queue_num_tbl[queue_obj->queue_num - 1] = queue_obj;
 

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -605,10 +605,10 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 				rte_pktmbuf_free(mbuf);
 				continue;
 			}
-			if (cls_classify_packet(pktio_entry,
-						(const uint8_t *)data,
-						pkt_len, pkt_len, &pool,
-						&parsed_hdr, false))
+			if (_odp_cls_classify_packet(pktio_entry,
+						     (const uint8_t *)data,
+						     pkt_len, pkt_len, &pool,
+						     &parsed_hdr, false))
 				goto fail;
 		}
 
@@ -898,10 +898,10 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 				rte_pktmbuf_free(mbuf);
 				continue;
 			}
-			if (cls_classify_packet(pktio_entry,
-						(const uint8_t *)data,
-						pkt_len, pkt_len, &pool,
-						&parsed_hdr, false)) {
+			if (_odp_cls_classify_packet(pktio_entry,
+						     (const uint8_t *)data,
+						     pkt_len, pkt_len, &pool,
+						     &parsed_hdr, false)) {
 				ODP_ERR("Unable to classify packet\n");
 				rte_pktmbuf_free(mbuf);
 				continue;
@@ -1022,7 +1022,7 @@ static uint32_t dpdk_vdev_mtu_get(uint16_t port_id)
 		return 0;
 	}
 
-	mtu = mtu_get_fd(sockfd, ifr.ifr_name);
+	mtu = _odp_mtu_get_fd(sockfd, ifr.ifr_name);
 	close(sockfd);
 	return mtu;
 }
@@ -1073,7 +1073,7 @@ static int dpdk_vdev_promisc_mode_get(uint16_t port_id)
 		return -1;
 	}
 
-	mode = promisc_mode_get_fd(sockfd, ifr.ifr_name);
+	mode = _odp_promisc_mode_get_fd(sockfd, ifr.ifr_name);
 	close(sockfd);
 	return mode;
 }
@@ -1096,7 +1096,7 @@ static int dpdk_vdev_promisc_mode_set(uint16_t port_id, int enable)
 		return -1;
 	}
 
-	mode = promisc_mode_set_fd(sockfd, ifr.ifr_name, enable);
+	mode = _odp_promisc_mode_set_fd(sockfd, ifr.ifr_name, enable);
 	close(sockfd);
 	return mode;
 }

--- a/platform/linux-generic/pktio/ethtool_rss.c
+++ b/platform/linux-generic/pktio/ethtool_rss.c
@@ -53,8 +53,8 @@ static inline int get_rss_hash_options(int fd, const char *name,
 	return 0;
 }
 
-int rss_conf_get_fd(int fd, const char *name,
-		    odp_pktin_hash_proto_t *hash_proto)
+int _odp_rss_conf_get_fd(int fd, const char *name,
+			 odp_pktin_hash_proto_t *hash_proto)
 {
 	uint64_t options;
 	int rss_enabled = 0;
@@ -131,14 +131,14 @@ static inline int set_rss_hash(int fd, const char *name,
 	return 0;
 }
 
-int rss_conf_set_fd(int fd, const char *name,
-		    const odp_pktin_hash_proto_t *hash_proto)
+int _odp_rss_conf_set_fd(int fd, const char *name,
+			 const odp_pktin_hash_proto_t *hash_proto)
 {
 	uint64_t options;
 	odp_pktin_hash_proto_t cur_hash;
 
 	/* Compare to currently set hash protocols */
-	rss_conf_get_fd(fd, name, &cur_hash);
+	_odp_rss_conf_get_fd(fd, name, &cur_hash);
 
 	if (hash_proto->proto.ipv4_udp && !cur_hash.proto.ipv4_udp) {
 		options = RXH_IP_SRC | RXH_IP_DST | RXH_L4_B_0_1 | RXH_L4_B_2_3;
@@ -173,8 +173,8 @@ int rss_conf_set_fd(int fd, const char *name,
 	return 0;
 }
 
-int rss_conf_get_supported_fd(int fd, const char *name,
-			      odp_pktin_hash_proto_t *hash_proto)
+int _odp_rss_conf_get_supported_fd(int fd, const char *name,
+				   odp_pktin_hash_proto_t *hash_proto)
 {
 	uint64_t options;
 	int rss_supported = 0;
@@ -220,7 +220,7 @@ int rss_conf_get_supported_fd(int fd, const char *name,
 	return rss_supported;
 }
 
-void rss_conf_print(const odp_pktin_hash_proto_t *hash_proto)
+void _odp_rss_conf_print(const odp_pktin_hash_proto_t *hash_proto)
 {	int max_len = 512;
 	char str[max_len];
 	int len = 0;

--- a/platform/linux-generic/pktio/io_ops.c
+++ b/platform/linux-generic/pktio/io_ops.c
@@ -12,7 +12,7 @@
  * will be picked.
  * Array must be NULL terminated */
 const pktio_if_ops_t * const pktio_if_ops[]  = {
-	&loopback_pktio_ops,
+	&_odp_loopback_pktio_ops,
 #ifdef _ODP_PKTIO_DPDK
 	&dpdk_pktio_ops,
 #endif
@@ -20,12 +20,12 @@ const pktio_if_ops_t * const pktio_if_ops[]  = {
 	&netmap_pktio_ops,
 #endif
 #ifdef _ODP_PKTIO_PCAP
-	&pcap_pktio_ops,
+	&_odp_pcap_pktio_ops,
 #endif
-	&ipc_pktio_ops,
-	&tap_pktio_ops,
-	&null_pktio_ops,
-	&sock_mmap_pktio_ops,
-	&sock_mmsg_pktio_ops,
+	&_odp_ipc_pktio_ops,
+	&_odp_tap_pktio_ops,
+	&_odp_null_pktio_ops,
+	&_odp_sock_mmap_pktio_ops,
+	&_odp_sock_mmsg_pktio_ops,
 	NULL
 };

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -964,7 +964,7 @@ static int ipc_close(pktio_entry_t *pktio_entry)
 	return 0;
 }
 
-const pktio_if_ops_t ipc_pktio_ops = {
+const pktio_if_ops_t _odp_ipc_pktio_ops = {
 	.name = "ipc",
 	.print = NULL,
 	.init_global = NULL,

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -144,9 +144,9 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 				pkt_addr = odp_packet_data(pkt);
 			}
 
-			ret = cls_classify_packet(pktio_entry, pkt_addr,
-						  pkt_len, seg_len,
-						  &new_pool, pkt_hdr, true);
+			ret = _odp_cls_classify_packet(pktio_entry, pkt_addr,
+						       pkt_len, seg_len,
+						       &new_pool, pkt_hdr, true);
 			if (ret) {
 				failed++;
 				odp_packet_free(pkt);
@@ -167,9 +167,9 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 				pkt_hdr = packet_hdr(new_pkt);
 			}
 		} else {
-			packet_parse_layer(pkt_hdr,
-					   pktio_entry->s.config.parser.layer,
-					   pktio_entry->s.in_chksums);
+			_odp_packet_parse_layer(pkt_hdr,
+						pktio_entry->s.config.parser.layer,
+						pktio_entry->s.in_chksums);
 		}
 
 		packet_set_ts(pkt_hdr, ts);
@@ -473,7 +473,7 @@ static int loop_init_global(void)
 	return 0;
 }
 
-const pktio_if_ops_t loopback_pktio_ops = {
+const pktio_if_ops_t _odp_loopback_pktio_ops = {
 	.name = "loop",
 	.print = NULL,
 	.init_global = loop_init_global,

--- a/platform/linux-generic/pktio/null.c
+++ b/platform/linux-generic/pktio/null.c
@@ -192,7 +192,7 @@ static int null_link_info(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_link_
 	return 0;
 }
 
-const pktio_if_ops_t null_pktio_ops = {
+const pktio_if_ops_t _odp_null_pktio_ops = {
 	.name = "null",
 	.print = NULL,
 	.init_global = null_init_global,

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -281,9 +281,9 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 		if (pktio_cls_enabled(pktio_entry)) {
 			odp_packet_t new_pkt;
 
-			ret = cls_classify_packet(pktio_entry, data,
-						  pkt_len, pkt_len,
-						  &new_pool, pkt_hdr, true);
+			ret = _odp_cls_classify_packet(pktio_entry, data,
+						       pkt_len, pkt_len,
+						       &new_pool, pkt_hdr, true);
 			if (ret) {
 				odp_packet_free(pkt);
 				continue;
@@ -300,9 +300,9 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 				pkt_hdr = packet_hdr(new_pkt);
 			}
 		} else {
-			packet_parse_layer(pkt_hdr,
-					   pktio_entry->s.config.parser.layer,
-					   pktio_entry->s.in_chksums);
+			_odp_packet_parse_layer(pkt_hdr,
+						pktio_entry->s.config.parser.layer,
+						pktio_entry->s.in_chksums);
 		}
 		pktio_entry->s.stats.in_octets += pkt_hdr->frame_len;
 
@@ -497,7 +497,7 @@ static int pcapif_link_info(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_lin
 	return 0;
 }
 
-const pktio_if_ops_t pcap_pktio_ops = {
+const pktio_if_ops_t _odp_pcap_pktio_ops = {
 	.name = "pcap",
 	.print = NULL,
 	.init_global = pcapif_init_global,

--- a/platform/linux-generic/pktio/pktio_common.c
+++ b/platform/linux-generic/pktio/pktio_common.c
@@ -48,10 +48,10 @@ static int sock_recv_mq_tmo_select(pktio_entry_t * const *entry,
 	return 0;
 }
 
-int sock_recv_mq_tmo_try_int_driven(const struct odp_pktin_queue_t queues[],
-				    unsigned int num_q, unsigned int *from,
-				    odp_packet_t packets[], int num,
-				    uint64_t usecs, int *trial_successful)
+int _odp_sock_recv_mq_tmo_try_int_driven(const struct odp_pktin_queue_t queues[],
+					 unsigned int num_q, unsigned int *from,
+					 odp_packet_t packets[], int num,
+					 uint64_t usecs, int *trial_successful)
 {
 	unsigned int i;
 	pktio_entry_t *entry[num_q];

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -137,11 +137,11 @@ static int sock_setup_pkt(pktio_entry_t *pktio_entry, const char *netdev,
 	}
 	if_idx = ethreq.ifr_ifindex;
 
-	err = mac_addr_get_fd(sockfd, netdev, pkt_sock->if_mac);
+	err = _odp_mac_addr_get_fd(sockfd, netdev, pkt_sock->if_mac);
 	if (err != 0)
 		goto error;
 
-	pkt_sock->mtu = mtu_get_fd(sockfd, netdev);
+	pkt_sock->mtu = _odp_mtu_get_fd(sockfd, netdev);
 	if (!pkt_sock->mtu)
 		goto error;
 
@@ -156,8 +156,8 @@ static int sock_setup_pkt(pktio_entry_t *pktio_entry, const char *netdev,
 		goto error;
 	}
 
-	pktio_entry->s.stats_type = sock_stats_type_fd(pktio_entry,
-						       pkt_sock->sockfd);
+	pktio_entry->s.stats_type = _odp_sock_stats_type_fd(pktio_entry,
+							    pkt_sock->sockfd);
 	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED)
 		ODP_DBG("pktio: %s unsupported stats\n", pktio_entry->s.name);
 
@@ -264,10 +264,10 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			if (msgvec[i].msg_hdr.msg_iov->iov_len < pkt_len)
 				seg_len = msgvec[i].msg_hdr.msg_iov->iov_len;
 
-			if (cls_classify_packet(pktio_entry, base, pkt_len,
-						seg_len, &pool, pkt_hdr,
-						true)) {
-				ODP_ERR("cls_classify_packet failed");
+			if (_odp_cls_classify_packet(pktio_entry, base, pkt_len,
+						     seg_len, &pool, pkt_hdr,
+						     true)) {
+				ODP_ERR("_odp_cls_classify_packet failed");
 				odp_packet_free(pkt);
 				continue;
 			}
@@ -291,9 +291,9 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 		pkt_hdr->input = pktio_entry->s.handle;
 
 		if (!pktio_cls_enabled(pktio_entry))
-			packet_parse_layer(pkt_hdr,
-					   pktio_entry->s.config.parser.layer,
-					   pktio_entry->s.in_chksums);
+			_odp_packet_parse_layer(pkt_hdr,
+						pktio_entry->s.config.parser.layer,
+						pktio_entry->s.in_chksums);
 
 		packet_set_ts(pkt_hdr, ts);
 
@@ -486,25 +486,25 @@ static int sock_mac_addr_get(pktio_entry_t *pktio_entry,
 static int sock_promisc_mode_set(pktio_entry_t *pktio_entry,
 				 odp_bool_t enable)
 {
-	return promisc_mode_set_fd(pkt_priv(pktio_entry)->sockfd,
-				   pktio_entry->s.name, enable);
+	return _odp_promisc_mode_set_fd(pkt_priv(pktio_entry)->sockfd,
+					pktio_entry->s.name, enable);
 }
 
 static int sock_promisc_mode_get(pktio_entry_t *pktio_entry)
 {
-	return promisc_mode_get_fd(pkt_priv(pktio_entry)->sockfd,
-				   pktio_entry->s.name);
+	return _odp_promisc_mode_get_fd(pkt_priv(pktio_entry)->sockfd,
+					pktio_entry->s.name);
 }
 
 static int sock_link_status(pktio_entry_t *pktio_entry)
 {
-	return link_status_fd(pkt_priv(pktio_entry)->sockfd,
-			      pktio_entry->s.name);
+	return _odp_link_status_fd(pkt_priv(pktio_entry)->sockfd,
+				   pktio_entry->s.name);
 }
 
 static int sock_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *info)
 {
-	return link_info_fd(pkt_priv(pktio_entry)->sockfd, pktio_entry->s.name, info);
+	return _odp_link_info_fd(pkt_priv(pktio_entry)->sockfd, pktio_entry->s.name, info);
 }
 
 static int sock_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
@@ -533,7 +533,7 @@ static int sock_stats(pktio_entry_t *pktio_entry,
 		return 0;
 	}
 
-	return sock_stats_fd(pktio_entry, stats, pkt_priv(pktio_entry)->sockfd);
+	return _odp_sock_stats_fd(pktio_entry, stats, pkt_priv(pktio_entry)->sockfd);
 }
 
 static int sock_stats_reset(pktio_entry_t *pktio_entry)
@@ -544,7 +544,7 @@ static int sock_stats_reset(pktio_entry_t *pktio_entry)
 		return 0;
 	}
 
-	return sock_stats_reset_fd(pktio_entry, pkt_priv(pktio_entry)->sockfd);
+	return _odp_sock_stats_reset_fd(pktio_entry, pkt_priv(pktio_entry)->sockfd);
 }
 
 static int sock_init_global(void)
@@ -560,7 +560,7 @@ static int sock_init_global(void)
 	return 0;
 }
 
-const pktio_if_ops_t sock_mmsg_pktio_ops = {
+const pktio_if_ops_t _odp_sock_mmsg_pktio_ops = {
 	.name = "socket",
 	.print = NULL,
 	.init_global = sock_init_global,

--- a/platform/linux-generic/pktio/socket_common.c
+++ b/platform/linux-generic/pktio/socket_common.c
@@ -48,7 +48,7 @@ struct ethtool_link_settings {
  * ODP_PACKET_SOCKET_MMAP:
  * ODP_PACKET_NETMAP:
  */
-int mac_addr_get_fd(int fd, const char *name, unsigned char mac_dst[])
+int _odp_mac_addr_get_fd(int fd, const char *name, unsigned char mac_dst[])
 {
 	struct ifreq ethreq;
 	int ret;
@@ -73,7 +73,7 @@ int mac_addr_get_fd(int fd, const char *name, unsigned char mac_dst[])
  * ODP_PACKET_SOCKET_MMAP:
  * ODP_PACKET_NETMAP:
  */
-uint32_t mtu_get_fd(int fd, const char *name)
+uint32_t _odp_mtu_get_fd(int fd, const char *name)
 {
 	struct ifreq ifr;
 	int ret;
@@ -92,7 +92,7 @@ uint32_t mtu_get_fd(int fd, const char *name)
 /*
  * ODP_PACKET_NETMAP:
  */
-int mtu_set_fd(int fd, const char *name, int mtu)
+int _odp_mtu_set_fd(int fd, const char *name, int mtu)
 {
 	struct ifreq ifr;
 	int ret;
@@ -115,7 +115,7 @@ int mtu_set_fd(int fd, const char *name, int mtu)
  * ODP_PACKET_SOCKET_MMAP:
  * ODP_PACKET_NETMAP:
  */
-int promisc_mode_set_fd(int fd, const char *name, int enable)
+int _odp_promisc_mode_set_fd(int fd, const char *name, int enable)
 {
 	struct ifreq ifr;
 	int ret;
@@ -149,7 +149,7 @@ int promisc_mode_set_fd(int fd, const char *name, int enable)
  * ODP_PACKET_SOCKET_MMAP:
  * ODP_PACKET_NETMAP:
  */
-int promisc_mode_get_fd(int fd, const char *name)
+int _odp_promisc_mode_get_fd(int fd, const char *name)
 {
 	struct ifreq ifr;
 	int ret;
@@ -166,7 +166,7 @@ int promisc_mode_get_fd(int fd, const char *name)
 	return !!(ifr.ifr_flags & IFF_PROMISC);
 }
 
-int link_status_fd(int fd, const char *name)
+int _odp_link_status_fd(int fd, const char *name)
 {
 	struct ifreq ifr;
 	int ret;
@@ -185,7 +185,7 @@ int link_status_fd(int fd, const char *name)
 	return ODP_PKTIO_LINK_STATUS_DOWN;
 }
 
-int link_info_fd(int fd, const char *name, odp_pktio_link_info_t *info)
+int _odp_link_info_fd(int fd, const char *name, odp_pktio_link_info_t *info)
 {
 	struct ethtool_link_settings hcmd = {.cmd = ETHTOOL_GLINKSETTINGS};
 	struct ethtool_link_settings *ecmd;
@@ -193,7 +193,7 @@ int link_info_fd(int fd, const char *name, odp_pktio_link_info_t *info)
 	struct ifreq ifr;
 	int status;
 
-	status = link_status_fd(fd, name);
+	status = _odp_link_status_fd(fd, name);
 	if (status < 0)
 		return -1;
 

--- a/platform/linux-generic/pktio/stats/ethtool_stats.c
+++ b/platform/linux-generic/pktio/stats/ethtool_stats.c
@@ -164,7 +164,7 @@ static int ethtool_stats(int fd, struct ifreq *ifr, odp_pktio_stats_t *stats)
 	return 0;
 }
 
-int ethtool_stats_get_fd(int fd, const char *name, odp_pktio_stats_t *stats)
+int _odp_ethtool_stats_get_fd(int fd, const char *name, odp_pktio_stats_t *stats)
 {
 	struct ifreq ifr;
 

--- a/platform/linux-generic/pktio/stats/packet_io_stats.c
+++ b/platform/linux-generic/pktio/stats/packet_io_stats.c
@@ -10,7 +10,7 @@
 
 #include <string.h>
 
-int sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd)
+int _odp_sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd)
 {
 	int err = 0;
 	odp_pktio_stats_t cur_stats;
@@ -24,11 +24,11 @@ int sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd)
 	memset(&cur_stats, 0, sizeof(odp_pktio_stats_t));
 
 	if (pktio_entry->s.stats_type == STATS_ETHTOOL) {
-		(void)ethtool_stats_get_fd(fd,
-					   pktio_entry->s.name,
-					   &cur_stats);
+		(void)_odp_ethtool_stats_get_fd(fd,
+						pktio_entry->s.name,
+						&cur_stats);
 	} else if (pktio_entry->s.stats_type == STATS_SYSFS) {
-		err = sysfs_stats(pktio_entry, &cur_stats);
+		err = _odp_sysfs_stats(pktio_entry, &cur_stats);
 		if (err != 0)
 			ODP_ERR("stats error\n");
 	}
@@ -40,9 +40,9 @@ int sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd)
 	return err;
 }
 
-int sock_stats_fd(pktio_entry_t *pktio_entry,
-		  odp_pktio_stats_t *stats,
-		  int fd)
+int _odp_sock_stats_fd(pktio_entry_t *pktio_entry,
+		       odp_pktio_stats_t *stats,
+		       int fd)
 {
 	odp_pktio_stats_t cur_stats;
 	int ret = 0;
@@ -52,11 +52,11 @@ int sock_stats_fd(pktio_entry_t *pktio_entry,
 
 	memset(&cur_stats, 0, sizeof(odp_pktio_stats_t));
 	if (pktio_entry->s.stats_type == STATS_ETHTOOL) {
-		(void)ethtool_stats_get_fd(fd,
-					   pktio_entry->s.name,
-					   &cur_stats);
+		(void)_odp_ethtool_stats_get_fd(fd,
+						pktio_entry->s.name,
+						&cur_stats);
 	} else if (pktio_entry->s.stats_type == STATS_SYSFS) {
-		sysfs_stats(pktio_entry, &cur_stats);
+		_odp_sysfs_stats(pktio_entry, &cur_stats);
 	}
 
 	stats->in_octets = cur_stats.in_octets -
@@ -82,14 +82,14 @@ int sock_stats_fd(pktio_entry_t *pktio_entry,
 	return ret;
 }
 
-pktio_stats_type_t sock_stats_type_fd(pktio_entry_t *pktio_entry, int fd)
+pktio_stats_type_t _odp_sock_stats_type_fd(pktio_entry_t *pktio_entry, int fd)
 {
 	odp_pktio_stats_t cur_stats;
 
-	if (!ethtool_stats_get_fd(fd, pktio_entry->s.name, &cur_stats))
+	if (!_odp_ethtool_stats_get_fd(fd, pktio_entry->s.name, &cur_stats))
 		return STATS_ETHTOOL;
 
-	if (!sysfs_stats(pktio_entry, &cur_stats))
+	if (!_odp_sysfs_stats(pktio_entry, &cur_stats))
 		return STATS_SYSFS;
 
 	return STATS_UNSUPPORTED;

--- a/platform/linux-generic/pktio/stats/sysfs_stats.c
+++ b/platform/linux-generic/pktio/stats/sysfs_stats.c
@@ -41,8 +41,8 @@ static int sysfs_get_val(const char *fname, uint64_t *val)
 	return 0;
 }
 
-int sysfs_stats(pktio_entry_t *pktio_entry,
-		odp_pktio_stats_t *stats)
+int _odp_sysfs_stats(pktio_entry_t *pktio_entry,
+		     odp_pktio_stats_t *stats)
 {
 	char fname[256];
 	const char *dev = pktio_entry->s.name;

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -167,10 +167,10 @@ static int tap_pktio_open(odp_pktio_t id ODP_UNUSED,
 		goto tap_err;
 	}
 
-	mtu = mtu_get_fd(skfd, devname + 4);
+	mtu = _odp_mtu_get_fd(skfd, devname + 4);
 	if (mtu == 0) {
 		__odp_errno = errno;
-		ODP_ERR("mtu_get_fd failed: %s\n", strerror(errno));
+		ODP_ERR("_odp_mtu_get_fd failed: %s\n", strerror(errno));
 		goto sock_err;
 	}
 
@@ -279,9 +279,9 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
 
 	if (pktio_cls_enabled(pktio_entry)) {
-		if (cls_classify_packet(pktio_entry, data, len, len,
-					&pkt_priv(pktio_entry)->pool,
-					&parsed_hdr, true)) {
+		if (_odp_cls_classify_packet(pktio_entry, data, len, len,
+					     &pkt_priv(pktio_entry)->pool,
+					     &parsed_hdr, true)) {
 			return ODP_PACKET_INVALID;
 		}
 	}
@@ -305,9 +305,9 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 	if (pktio_cls_enabled(pktio_entry))
 		copy_packet_cls_metadata(&parsed_hdr, pkt_hdr);
 	else
-		packet_parse_layer(pkt_hdr,
-				   pktio_entry->s.config.parser.layer,
-				   pktio_entry->s.in_chksums);
+		_odp_packet_parse_layer(pkt_hdr,
+					pktio_entry->s.config.parser.layer,
+					pktio_entry->s.in_chksums);
 
 	packet_set_ts(pkt_hdr, ts);
 	pkt_hdr->input = pktio_entry->s.handle;
@@ -430,8 +430,8 @@ static uint32_t tap_mtu_get(pktio_entry_t *pktio_entry)
 {
 	uint32_t ret;
 
-	ret =  mtu_get_fd(pkt_priv(pktio_entry)->skfd,
-			  pktio_entry->s.name + 4);
+	ret =  _odp_mtu_get_fd(pkt_priv(pktio_entry)->skfd,
+			       pktio_entry->s.name + 4);
 	if (ret > 0)
 		pkt_priv(pktio_entry)->mtu = ret;
 
@@ -441,14 +441,14 @@ static uint32_t tap_mtu_get(pktio_entry_t *pktio_entry)
 static int tap_promisc_mode_set(pktio_entry_t *pktio_entry,
 				odp_bool_t enable)
 {
-	return promisc_mode_set_fd(pkt_priv(pktio_entry)->skfd,
-				   pktio_entry->s.name + 4, enable);
+	return _odp_promisc_mode_set_fd(pkt_priv(pktio_entry)->skfd,
+					pktio_entry->s.name + 4, enable);
 }
 
 static int tap_promisc_mode_get(pktio_entry_t *pktio_entry)
 {
-	return promisc_mode_get_fd(pkt_priv(pktio_entry)->skfd,
-				   pktio_entry->s.name + 4);
+	return _odp_promisc_mode_get_fd(pkt_priv(pktio_entry)->skfd,
+					pktio_entry->s.name + 4);
 }
 
 static int tap_mac_addr_get(pktio_entry_t *pktio_entry, void *mac_addr)
@@ -469,13 +469,13 @@ static int tap_mac_addr_set(pktio_entry_t *pktio_entry, const void *mac_addr)
 
 static int tap_link_status(pktio_entry_t *pktio_entry)
 {
-	return link_status_fd(pkt_priv(pktio_entry)->skfd,
-			      pktio_entry->s.name + 4);
+	return _odp_link_status_fd(pkt_priv(pktio_entry)->skfd,
+				   pktio_entry->s.name + 4);
 }
 
 static int tap_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *info)
 {
-	return link_info_fd(pkt_priv(pktio_entry)->skfd, pktio_entry->s.name + 4, info);
+	return _odp_link_info_fd(pkt_priv(pktio_entry)->skfd, pktio_entry->s.name + 4, info);
 }
 
 static int tap_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
@@ -497,7 +497,7 @@ static int tap_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 	return 0;
 }
 
-const pktio_if_ops_t tap_pktio_ops = {
+const pktio_if_ops_t _odp_tap_pktio_ops = {
 	.name = "tap",
 	.print = NULL,
 	.init_global = NULL,


### PR DESCRIPTION
Rename some symbols that are global in the static library, in order to
avoid clashes with application code. The prefix "`_odp_`" is added to
the existing names.

This patch renames most of the global symbols, a few more still remain
to be renamed.

Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

v2: Rebase.

v3: Fix checkpatch warnings.

v4: Squash.

v5: Rebase and remove conflicting renames.

v6: Use prefix "`_odp_`" instead of "`__odp_`".

v7: Rebase.
