### PR TITLE
[PATCH v2] linux-gen: build: fix ipsec example application test stage

### DIFF
--- a/platform/linux-generic/test/Makefile.am
+++ b/platform/linux-generic/test/Makefile.am
@@ -9,15 +9,21 @@ endif
 
 SUBDIRS =
 
-if test_vald
-TESTS = validation/api/pktio/pktio_run.sh \
-	validation/api/pktio/pktio_run_tap.sh \
-	validation/api/shmem/shmem_linux$(EXEEXT) \
-	ipsec/ipsec_api_example.sh \
+if WITH_EXAMPLES
+TESTS = ipsec/ipsec_api_example.sh \
 	ipsec/ipsec_crypto_example.sh
 
 dist_check_SCRIPTS = ipsec/ipsec_api_example.sh \
 		     ipsec/ipsec_crypto_example.sh
+else
+TESTS =
+dist_check_SCRIPTS =
+endif
+
+if test_vald
+TESTS += validation/api/pktio/pktio_run.sh \
+	 validation/api/pktio/pktio_run_tap.sh \
+	 validation/api/shmem/shmem_linux$(EXEEXT)
 
 test_SCRIPTS = $(dist_check_SCRIPTS)
 


### PR DESCRIPTION
IPsec example applications are not part of the validation test suite.
Previously, running 'make check' failed if ODP had been built without
example applications.

Signed-off-by: Matias Elo <matias.elo@nokia.com>