### PR TITLE
[PATCH v3] Pull request for timer example fixes

### DIFF
--- a/example/timer/odp_timer_simple.c
+++ b/example/timer/odp_timer_simple.c
@@ -83,6 +83,7 @@ int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 		goto err;
 	}
 
+	odp_timer_pool_start();
 	/* Configure scheduler */
 	odp_schedule_config(NULL);
 

--- a/test/performance/odp_timer_perf.c
+++ b/test/performance/odp_timer_perf.c
@@ -207,6 +207,7 @@ static int set_num_cpu(test_global_t *global)
 static int create_timer_pools(test_global_t *global)
 {
 	odp_timer_capability_t timer_capa;
+	odp_timer_res_capability_t timer_res_capa;
 	odp_timer_pool_param_t timer_pool_param;
 	odp_timer_pool_t tp;
 	odp_queue_param_t queue_param;
@@ -257,17 +258,24 @@ static int create_timer_pools(test_global_t *global)
 		return -1;
 	}
 
+	memset(&timer_res_capa, 0, sizeof(odp_timer_res_capability_t));
+	timer_res_capa.res_ns = res_ns;
+	if (odp_timer_res_capability(ODP_CLOCK_CPU, &timer_res_capa)) {
+		printf("Error: timer resolution capability failed\n");
+		return -1;
+	}
+
 	if (res_ns < timer_capa.max_res.res_ns) {
 		printf("Error: too high resolution\n");
 		return -1;
 	}
 
-	if (START_NS < timer_capa.max_res.min_tmo) {
+	if (START_NS < timer_res_capa.min_tmo) {
 		printf("Error: too short min timeout\n");
 		return -1;
 	}
 
-	if (max_tmo_ns > timer_capa.max_res.max_tmo) {
+	if (max_tmo_ns > timer_res_capa.max_tmo) {
 		printf("Error: too long max timeout\n");
 		return -1;
 	}


### PR DESCRIPTION
## test: performance: timer: fix timeout check

Currently, the max and min timeout are being validated against the
minimum resolution supported by the timer implementation, instead
it should be validated against the required timer resolution.

Reviewed-by: Petri Savolainen <petri.savolainen@nokia.com>
Signed-off-by: Pavan Nikhilesh <pbhagavatula@marvell.com>

## example: timer_simple: fix missing timer start

Fix missing timer pool start before allocating and setting timers.

Reviewed-by: Petri Savolainen <petri.savolainen@nokia.com>
Signed-off-by: Pavan Nikhilesh <pbhagavatula@marvell.com>
