### PR TITLE
[PATCH v2] linux-gen: ipsec: report all outb crypto failures as alg errors

### DIFF
--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -1521,18 +1521,7 @@ static ipsec_sa_t *ipsec_out_single(odp_packet_t pkt,
 	}
 
 	if (!crypto.ok) {
-		if ((crypto.cipher_status.alg_err !=
-		     ODP_CRYPTO_ALG_ERR_NONE) ||
-		    (crypto.cipher_status.hw_err !=
-		     ODP_CRYPTO_HW_ERR_NONE))
-			status->error.alg = 1;
-
-		if ((crypto.auth_status.alg_err !=
-		     ODP_CRYPTO_ALG_ERR_NONE) ||
-		    (crypto.auth_status.hw_err !=
-		     ODP_CRYPTO_HW_ERR_NONE))
-			status->error.auth = 1;
-
+		status->error.alg = 1;
 		goto err;
 	}
 


### PR DESCRIPTION
All outbound crypto failures can be treated as alg errors. ICV errors
won't happen in outbound path.

Signed-off-by: Anoob Joseph <anoobj@marvell.com>