### PR TITLE
[PATCH v5] api: ipsec: add print APIs

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -1627,6 +1627,23 @@ int odp_ipsec_sa_mtu_update(odp_ipsec_sa_t sa, uint32_t mtu);
 void *odp_ipsec_sa_context(odp_ipsec_sa_t sa);
 
 /**
+ * Print global IPSEC configuration info
+ *
+ * Print implementation-defined information about the global IPSEC
+ * configuration.
+ */
+void odp_ipsec_print(void);
+
+/**
+ * Print IPSEC SA info
+ *
+ * @param sa      SA handle
+ *
+ * Print implementation-defined IPSEC SA debug information to the ODP log.
+ */
+void odp_ipsec_sa_print(odp_ipsec_sa_t sa);
+
+/**
  * @}
  */
 

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -2033,3 +2033,19 @@ int _odp_ipsec_term_global(void)
 
 	return 0;
 }
+
+void odp_ipsec_print(void)
+{
+	ODP_PRINT("\nIPSEC print\n");
+	ODP_PRINT("-----------\n");
+	ODP_PRINT("  max number of SA %u\n", ipsec_config->max_num_sa);
+}
+
+void odp_ipsec_sa_print(odp_ipsec_sa_t sa)
+{
+	ipsec_sa_t *ipsec_sa = _odp_ipsec_sa_entry_from_hdl(sa);
+
+	ODP_PRINT("\nIPSEC SA print\n");
+	ODP_PRINT("--------------\n");
+	ODP_PRINT("  SPI              %u\n", ipsec_sa->spi);
+}

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -308,6 +308,12 @@ int ipsec_check_esp_aes_cbc_128_null(void)
 				ODP_AUTH_ALG_NULL, 0);
 }
 
+int ipsec_check_esp_aes_cbc_128_sha1(void)
+{
+	return  ipsec_check_esp(ODP_CIPHER_ALG_AES_CBC, 128,
+				ODP_AUTH_ALG_SHA1_HMAC, 160);
+}
+
 int ipsec_check_esp_aes_cbc_128_sha256(void)
 {
 	return  ipsec_check_esp(ODP_CIPHER_ALG_AES_CBC, 128,

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -92,6 +92,7 @@ int ipsec_check(odp_bool_t ah,
 int ipsec_check_ah_sha256(void);
 int ipsec_check_esp_null_sha256(void);
 int ipsec_check_esp_aes_cbc_128_null(void);
+int ipsec_check_esp_aes_cbc_128_sha1(void);
 int ipsec_check_esp_aes_cbc_128_sha256(void);
 int ipsec_check_esp_aes_ctr_128_null(void);
 int ipsec_check_esp_aes_gcm_128(void);

--- a/test/validation/api/ipsec/ipsec_test_in.c
+++ b/test/validation/api/ipsec/ipsec_test_in.c
@@ -1597,6 +1597,31 @@ static void test_in_ipv6_esp_udp_null_sha256_lookup(void)
 	ipsec_sa_destroy(sa);
 }
 
+static void test_ipsec_print(void)
+{
+	odp_ipsec_print();
+}
+
+static void test_ipsec_sa_print(void)
+{
+	odp_ipsec_sa_param_t param_in;
+	odp_ipsec_sa_t in_sa;
+
+	ipsec_sa_param_fill(&param_in,
+			    true, false, 123, NULL,
+			    ODP_CIPHER_ALG_AES_CBC, &key_a5_128,
+			    ODP_AUTH_ALG_SHA1_HMAC, &key_5a_160,
+			    NULL, NULL);
+
+	in_sa = odp_ipsec_sa_create(&param_in);
+
+	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, in_sa);
+
+	odp_ipsec_sa_print(in_sa);
+
+	ipsec_sa_destroy(in_sa);
+}
+
 static void ipsec_test_capability(void)
 {
 	odp_ipsec_capability_t capa;
@@ -1700,5 +1725,8 @@ odp_testinfo_t ipsec_in_suite[] = {
 				  ipsec_check_esp_null_sha256),
 	ODP_TEST_INFO_CONDITIONAL(test_in_ipv6_esp_udp_null_sha256_lookup,
 				  ipsec_check_esp_null_sha256),
+	ODP_TEST_INFO(test_ipsec_print),
+	ODP_TEST_INFO_CONDITIONAL(test_ipsec_sa_print,
+				  ipsec_check_esp_aes_cbc_128_sha1),
 	ODP_TEST_INFO_NULL,
 };


### PR DESCRIPTION
Add API to print implementation defined information about specified SA.
When SA specified is invalid, implementation may choose to print global
IPSEC configuration and other related information.

Signed-off-by: Sachin Yaligar <syaligar@marvell.com>
Signed-off-by: Aakash Sasidharan <asasidharan@marvell.com>