### PR TITLE
[PATCH v2] validation: ipsec: fix termination when inline processing is not supported

### DIFF
--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -1113,7 +1113,9 @@ int ipsec_term(odp_instance_t inst)
 {
 	odp_pool_t pool = suite_context.pool;
 	odp_queue_t out_queue = suite_context.queue;
-	odp_pktio_t pktio = suite_context.pktio;
+	/* suite_context.pktio is set to ODP_PKTIO_INVALID by ipsec_suite_init()
+	   if inline processing is not supported. */
+	odp_pktio_t pktio = odp_pktio_lookup("loop");
 
 	if (ODP_PKTIO_INVALID != pktio) {
 		if (odp_pktio_close(pktio))


### PR DESCRIPTION
When inline IPsec processing is not supported, suite_context.pktio is set
to ODP_PKTIO_INVALID by ipsec_suite_init(). Use odp_pktio_lookup() to get
the loop pktio device handle during test termination to properly close the
device.

Signed-off-by: Matias Elo <matias.elo@nokia.com>