### PR TITLE
[PATCH v8] api: pool: add support for statistics and indexes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ AC_SUBST(ODP_VERSION_API_MINOR)
 ##########################################################################
 m4_define([odph_version_generation], [1])
 m4_define([odph_version_major], [0])
-m4_define([odph_version_minor], [3])
+m4_define([odph_version_minor], [4])
 
 m4_define([odph_version],
     [odph_version_generation.odph_version_major.odph_version_minor])

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.5])
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [25])
-m4_define([odpapi_minor_version], [1])
+m4_define([odpapi_minor_version], [2])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -45,6 +45,85 @@ extern "C" {
 #define ODP_POOL_MAX_SUBPARAMS  7
 
 /**
+ * Pool statistics counters options
+ *
+ * Pool statistics counters listed in a bit field structure.
+ */
+typedef union odp_pool_stats_opt_t {
+	/** Option flags */
+	struct {
+		/** @see odp_pool_stats_t::available */
+		uint64_t available          : 1;
+
+		/** @see odp_pool_stats_t::alloc_ops */
+		uint64_t alloc_ops          : 1;
+
+		/** @see odp_pool_stats_t::alloc_fails */
+		uint64_t alloc_fails        : 1;
+
+		/** @see odp_pool_stats_t::free_ops */
+		uint64_t free_ops           : 1;
+
+		/** @see odp_pool_stats_t::total_ops */
+		uint64_t total_ops          : 1;
+
+		/** @see odp_pool_stats_t::cache_available */
+		uint64_t cache_available    : 1;
+
+		/** @see odp_pool_stats_t::cache_alloc_ops */
+		uint64_t cache_alloc_ops    : 1;
+
+		/** @see odp_pool_stats_t::cache_free_ops */
+		uint64_t cache_free_ops     : 1;
+	} bit;
+
+	/** All bits of the bit field structure
+	 *
+	 *  This field can be used to set/clear all flags, or for bitwise
+	 *  operations over the entire structure. */
+	uint64_t all;
+
+} odp_pool_stats_opt_t;
+
+/**
+ * Pool statistics counters
+ *
+ * In addition to API alloc and free calls, statistics counters may be updated
+ * by alloc/free operations from implementation internal software or hardware
+ * components.
+ */
+typedef struct odp_pool_stats_t {
+	/** The number of available events in the pool */
+	uint64_t available;
+
+	/** The number of alloc operations from the pool. Includes both
+	 *  successful and failed operations (pool empty). */
+	uint64_t alloc_ops;
+
+	/** The number of failed alloc operations (pool empty) */
+	uint64_t alloc_fails;
+
+	/** The number of free operations to the pool */
+	uint64_t free_ops;
+
+	/** The total number of alloc and free operations. Includes both
+	 *  successful and failed operations (pool empty). */
+	uint64_t total_ops;
+
+	/** The number of available events in the local caches of all threads
+	 *  using the pool */
+	uint64_t cache_available;
+
+	/** The number of successful alloc operations from pool caches (returned
+	 *  at least one event). */
+	uint64_t cache_alloc_ops;
+
+	/** The number of free operations, which stored events to pool caches. */
+	uint64_t cache_free_ops;
+
+} odp_pool_stats_t;
+
+/**
  * Pool capabilities
  */
 typedef struct odp_pool_capability_t {
@@ -76,6 +155,9 @@ typedef struct odp_pool_capability_t {
 
 		/** Maximum size of thread local cache */
 		uint32_t max_cache_size;
+
+		/** Supported statistics counters */
+		odp_pool_stats_opt_t stats;
 	} buf;
 
 	/** Packet pool capabilities  */
@@ -161,6 +243,9 @@ typedef struct odp_pool_capability_t {
 
 		/** Maximum size of thread local cache */
 		uint32_t max_cache_size;
+
+		/** Supported statistics counters */
+		odp_pool_stats_opt_t stats;
 	} pkt;
 
 	/** Timeout pool capabilities  */
@@ -179,6 +264,9 @@ typedef struct odp_pool_capability_t {
 
 		/** Maximum size of thread local cache */
 		uint32_t max_cache_size;
+
+		/** Supported statistics counters */
+		odp_pool_stats_opt_t stats;
 	} tmo;
 
 	/** Vector pool capabilities */
@@ -200,6 +288,9 @@ typedef struct odp_pool_capability_t {
 
 		/** Maximum size of thread local cache */
 		uint32_t max_cache_size;
+
+		/** Supported statistics counters */
+		odp_pool_stats_opt_t stats;
 	} vector;
 
 } odp_pool_capability_t;
@@ -395,6 +486,14 @@ typedef struct odp_pool_param_t {
 		uint32_t cache_size;
 	} vector;
 
+	/**
+	 * Configure statistics counters
+	 *
+	 * An application can read the enabled statistics counters using
+	 * odp_pool_stats(). For optimal performance an application should
+	 * enable only the required counters.
+	 */
+	odp_pool_stats_opt_t stats;
 } odp_pool_param_t;
 
 /** Packet pool*/
@@ -560,6 +659,33 @@ unsigned int odp_pool_max_index(void);
  * @retval <0 on failure
  */
 int odp_pool_index(odp_pool_t pool);
+
+/**
+ * Get statistics for pool handle
+ *
+ * Read the statistics counters enabled using odp_pool_stats_opt_t during pool
+ * creation. The inactive counters are set to zero by the implementation.
+ *
+ * @param      pool   Pool handle
+ * @param[out] stats  Output buffer for counters
+ *
+ * @retval  0 on success
+ * @retval <0 on failure
+ */
+int odp_pool_stats(odp_pool_t pool, odp_pool_stats_t *stats);
+
+/**
+ * Reset statistics for pool handle
+ *
+ * Reset all statistics counters to zero except: odp_pool_stats_t::available,
+ * odp_pool_stats_t::cache_available
+ *
+ * @param pool    Pool handle
+ *
+ * @retval  0 on success
+ * @retval <0 on failure
+ */
+int odp_pool_stats_reset(odp_pool_t pool);
 
 /**
  * @}

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -542,6 +542,26 @@ uint64_t odp_pool_to_u64(odp_pool_t hdl);
 void odp_pool_param_init(odp_pool_param_t *param);
 
 /**
+ * Maximum pool index
+ *
+ * Return the maximum pool index. Pool indexes (e.g. returned by odp_pool_index())
+ * range from zero to this maximum value.
+ *
+ * @return Maximum pool index
+ */
+unsigned int odp_pool_max_index(void);
+
+/**
+ * Get pool index
+ *
+ * @param pool    Pool handle
+ *
+ * @return Pool index (0..odp_pool_max_index())
+ * @retval <0 on failure
+ */
+int odp_pool_index(odp_pool_t pool);
+
+/**
  * @}
  */
 

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -149,6 +149,9 @@ extern "C" {
 /* Maximum packet vector size */
 #define CONFIG_PACKET_VECTOR_MAX_SIZE 256
 
+/* Enable pool statistics collection */
+#define CONFIG_POOL_STATISTICS 1
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -84,6 +84,14 @@ typedef struct pool_t {
 	pool_destroy_cb_fn ext_destroy;
 	void            *ext_desc;
 
+	struct ODP_CACHE_ALIGNED {
+		odp_atomic_u64_t alloc_ops;
+		odp_atomic_u64_t alloc_fails;
+		odp_atomic_u64_t free_ops;
+		odp_atomic_u64_t cache_alloc_ops;
+		odp_atomic_u64_t cache_free_ops;
+	} stats;
+
 	pool_cache_t     local_cache[ODP_THREAD_COUNT_MAX];
 
 	odp_shm_t        ring_shm;

--- a/platform/linux-generic/include/odp_ring_internal.h
+++ b/platform/linux-generic/include/odp_ring_internal.h
@@ -72,6 +72,7 @@ static inline int cas_mo_u32(odp_atomic_u32_t *atom, uint32_t *old_val,
 #undef _RING_DEQ_MULTI
 #undef _RING_ENQ
 #undef _RING_ENQ_MULTI
+#undef _RING_LEN
 
 /* Remap generic types and function names to ring data type specific ones. One
  * should never use the generic names (e.g. _RING_INIT) directly. */
@@ -85,6 +86,7 @@ static inline int cas_mo_u32(odp_atomic_u32_t *atom, uint32_t *old_val,
 	#define _RING_DEQ_MULTI ring_u32_deq_multi
 	#define _RING_ENQ ring_u32_enq
 	#define _RING_ENQ_MULTI ring_u32_enq_multi
+	#define _RING_LEN ring_u32_len
 #elif _ODP_RING_TYPE == _ODP_RING_TYPE_PTR
 	#define _ring_gen_t ring_ptr_t
 	#define _ring_data_t void *
@@ -94,6 +96,7 @@ static inline int cas_mo_u32(odp_atomic_u32_t *atom, uint32_t *old_val,
 	#define _RING_DEQ_MULTI ring_ptr_deq_multi
 	#define _RING_ENQ ring_ptr_enq
 	#define _RING_ENQ_MULTI ring_ptr_enq_multi
+	#define _RING_LEN ring_ptr_len
 #endif
 
 /* Initialize ring */
@@ -242,6 +245,14 @@ static inline void _RING_ENQ_MULTI(_ring_gen_t *ring, uint32_t mask,
 
 	/* Release the new writer tail, readers acquire it. */
 	odp_atomic_store_rel_u32(&ring->r.w_tail, old_head + num);
+}
+
+static inline uint32_t _RING_LEN(_ring_gen_t *ring)
+{
+	uint32_t head = odp_atomic_load_u32(&ring->r.r_head);
+	uint32_t tail = odp_atomic_load_u32(&ring->r.w_tail);
+
+	return tail - head;
 }
 
 #ifdef __cplusplus

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -1306,6 +1306,22 @@ uint64_t odp_pool_to_u64(odp_pool_t hdl)
 	return _odp_pri(hdl);
 }
 
+unsigned int odp_pool_max_index(void)
+{
+	return ODP_CONFIG_POOLS - 1;
+}
+
+int odp_pool_index(odp_pool_t pool_hdl)
+{
+	pool_t *pool;
+
+	ODP_ASSERT(pool_hdl != ODP_POOL_INVALID);
+
+	pool = pool_entry_from_hdl(pool_hdl);
+
+	return pool->pool_idx;
+}
+
 static pool_t *find_pool(odp_buffer_hdr_t *buf_hdr)
 {
 	int i;


### PR DESCRIPTION
V2:
- Added new `odp_pool_stats_t.alloc_fails` counter and clarified definitions of several other counters
- Tweaked `odp_pool_stats()` and `odp_pool_stats_reset()` documentations