### PR TITLE
[PATCH v2] validation: tm: increase wait time in traffic_mngr_test_scheduler()

### DIFF
--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -2701,7 +2701,7 @@ static int test_sched_queue_priority(const char *shaper_name,
 	for (priority = NUM_PRIORITIES - 1; 0 <= priority; priority--)
 		pkts_sent += send_pkts(tm_queues[priority], num_pkts);
 
-	busy_wait(1000000);   /* wait 1 millisecond */
+	busy_wait(100 * ODP_TIME_MSEC_IN_NS);
 
 	/* Disable the shaper, so as to get the pkts out quicker. */
 	set_shaper(node_name, shaper_name, 0, 0);
@@ -2807,7 +2807,7 @@ static int test_sched_node_priority(const char *shaper_name,
 		}
 	}
 
-	busy_wait(1000000);   /* wait 1 millisecond */
+	busy_wait(100 * ODP_TIME_MSEC_IN_NS);
 
 	/* Disable the shaper, so as to get the pkts out quicker. */
 	set_shaper(node_name, shaper_name, 0, 0);


### PR DESCRIPTION
CI runs the validation suite with a small number of shared CPU cores.
Increase the wait time in traffic_mngr_test_scheduler() test to avoid
occasional failures in CI test runs caused by limited CPU capacity.

Signed-off-by: Matias Elo <matias.elo@nokia.com>