### PR TITLE
[PATCH v5] api: ipsec: allow L2 hdr to be provided in packet for inline outbound operation

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -1297,7 +1297,13 @@ typedef struct odp_ipsec_out_inline_param_t {
 	struct {
 		/** Points to first byte of outer headers to be copied in
 		 *  front of the outgoing IPSEC packet. Implementation copies
-		 *  the headers during odp_ipsec_out_inline() call. */
+		 *  the headers during odp_ipsec_out_inline() call.
+		 *
+		 *  Null value indicates that the outer headers are in the
+		 *  packet data, starting at L2 offset and ending at the byte
+		 *  before L3 offset. In this case, value of 'len' field must
+		 *  be greater than zero and set to L3 offset minus L2 offset.
+		 */
 		const uint8_t *ptr;
 
 		/** Outer header length in bytes */

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -58,6 +58,7 @@ typedef struct {
 	odp_bool_t display_algo;
 	odp_bool_t lookup;
 	odp_bool_t ah;
+	odp_bool_t inline_hdr_in_packet;
 	enum ipsec_test_stats stats;
 } ipsec_test_flags;
 

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -535,6 +535,19 @@ static void test_esp_out_in_all_basic(void)
 	printf("\n  ");
 }
 
+static int is_out_mode_inline(void)
+{
+	return suite_context.outbound_op_mode == ODP_IPSEC_OP_MODE_INLINE;
+}
+
+static void test_esp_out_in_all_hdr_in_packet(void)
+{
+	ipsec_test_flags flags = {
+		.inline_hdr_in_packet = true,
+	};
+	test_esp_out_in_all(&flags);
+}
+
 static void test_ah_out_in(struct auth_param *auth)
 {
 	int auth_keylen = auth->key ? 8 * auth->key->length : 0;
@@ -1432,6 +1445,8 @@ odp_testinfo_t ipsec_out_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(test_sa_info,
 				  ipsec_check_esp_aes_cbc_128_sha1),
 	ODP_TEST_INFO(test_esp_out_in_all_basic),
+	ODP_TEST_INFO_CONDITIONAL(test_esp_out_in_all_hdr_in_packet,
+				  is_out_mode_inline),
 	ODP_TEST_INFO(test_ah_out_in_all),
 	ODP_TEST_INFO(test_ipsec_stats),
 	ODP_TEST_INFO_NULL,


### PR DESCRIPTION
This PR contains an updated version of the API change from PR 1137 and linux-gen implementation. A validation test would conflict with PR 1060 and is therefore left out from this PR.

@anoobj, I changed the API text as proposed by Petri and also tweaked the commit message. Please check that it is ok for you.