### PR TITLE
[PATCH v2] linux-gen: packet: fix packet print

### DIFF
--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -89,7 +89,6 @@ struct ODP_ALIGNED_CACHE odp_buffer_hdr_t {
 
 odp_event_type_t _odp_buffer_event_type(odp_buffer_t buf);
 void _odp_buffer_event_type_set(odp_buffer_t buf, int ev);
-int odp_buffer_snprint(char *str, uint32_t n, odp_buffer_t buf);
 
 static inline odp_buffer_t buf_from_buf_hdr(odp_buffer_hdr_t *hdr)
 {

--- a/platform/linux-generic/odp_buffer.c
+++ b/platform/linux-generic/odp_buffer.c
@@ -34,42 +34,26 @@ uint32_t odp_buffer_size(odp_buffer_t buf)
 	return pool->seg_len;
 }
 
-int odp_buffer_snprint(char *str, uint32_t n, odp_buffer_t buf)
+void odp_buffer_print(odp_buffer_t buf)
 {
 	odp_buffer_hdr_t *hdr;
-	pool_t *pool;
 	int len = 0;
+	int max_len = 512;
+	int n = max_len - 1;
+	char str[max_len];
 
 	if (!odp_buffer_is_valid(buf)) {
-		ODP_PRINT("Buffer is not valid.\n");
-		return len;
+		ODP_ERR("Buffer is not valid.\n");
+		return;
 	}
 
 	hdr = buf_hdl_to_hdr(buf);
-	pool = hdr->pool_ptr;
 
-	len += snprintf(&str[len], n - len,
-			"Buffer\n");
-	len += snprintf(&str[len], n - len,
-			"  pool         %" PRIu64 "\n",
-			odp_pool_to_u64(pool->pool_hdl));
-	len += snprintf(&str[len], n - len,
-			"  addr         %p\n",          hdr->base_data);
-	len += snprintf(&str[len], n - len,
-			"  size         %" PRIu32 "\n", odp_buffer_size(buf));
-	len += snprintf(&str[len], n - len,
-			"  type         %i\n",          hdr->type);
-
-	return len;
-}
-
-void odp_buffer_print(odp_buffer_t buf)
-{
-	int max_len = 512;
-	char str[max_len];
-	int len;
-
-	len = odp_buffer_snprint(str, max_len - 1, buf);
+	len += snprintf(&str[len], n - len, "Buffer\n------\n");
+	len += snprintf(&str[len], n - len, "  pool index    %u\n", hdr->index.pool);
+	len += snprintf(&str[len], n - len, "  buffer index  %u\n", hdr->index.buffer);
+	len += snprintf(&str[len], n - len, "  addr          %p\n", hdr->base_data);
+	len += snprintf(&str[len], n - len, "  size          %u\n", odp_buffer_size(buf));
 	str[len] = 0;
 
 	ODP_PRINT("\n%s\n", str);

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1567,10 +1567,11 @@ void odp_packet_print(odp_packet_t pkt)
 	int len = 0;
 	int n = max_len - 1;
 	odp_packet_hdr_t *hdr = packet_hdr(pkt);
-	odp_buffer_t buf      = packet_to_buffer(pkt);
 
-	len += snprintf(&str[len], n - len, "Packet ");
-	len += odp_buffer_snprint(&str[len], n - len, buf);
+	len += snprintf(&str[len], n - len, "Packet\n------\n");
+	len += snprintf(&str[len], n - len, "  pool index   %u\n", hdr->buf_hdr.index.pool);
+	len += snprintf(&str[len], n - len, "  buf index    %u\n", hdr->buf_hdr.index.buffer);
+	len += snprintf(&str[len], n - len, "  ev subtype   %i\n", hdr->subtype);
 	len += snprintf(&str[len], n - len, "  input_flags  0x%" PRIx64 "\n",
 			hdr->p.input_flags.all);
 	if (hdr->p.input_flags.all) {
@@ -1650,7 +1651,7 @@ void odp_packet_print_data(odp_packet_t pkt, uint32_t offset,
 			"  buf index     %" PRIu32 "\n",
 			hdr->buf_hdr.index.buffer);
 	len += snprintf(&str[len], n - len,
-			"  seg_count      %" PRIu16 "\n", hdr->seg_count);
+			"  seg_count     %" PRIu16 "\n", hdr->seg_count);
 	len += snprintf(&str[len], n - len,
 			"  data len      %" PRIu32 "\n", data_len);
 	len += snprintf(&str[len], n - len,


### PR DESCRIPTION
Packet print function used buffer_snprint, which assumed
that event type is buffer and printed an error on packets.
Re-implemented buffer and packet print functions to not
use buffer_snprint.

