### PR TITLE
[PATCH v3] example: ipsec: fix verification of output stream

### DIFF
--- a/example/ipsec_crypto/odp_ipsec_stream.c
+++ b/example/ipsec_crypto/odp_ipsec_stream.c
@@ -425,6 +425,13 @@ odp_bool_t verify_ipv4_packet(stream_db_entry_t *stream,
 	/* Find IPsec headers if any and compare against entry */
 	hdr_len = locate_ipsec_headers(ip, &ah, &esp);
 
+	/* Verify if the packet is IPsec encapsulated or is cleartext as
+	 * expected
+	 */
+	if (((stream->output.entry && (!ah && !esp))) ||
+	    (stream->input.entry && (ah || esp)))
+		return FALSE;
+
 	/* Cleartext packet */
 	if (!ah && !esp)
 		goto clear_packet;


### PR DESCRIPTION
Report failure in verifying output stream in case the received
packets are not IPsec processed as configured.
Without this, the verify succeeds even when the input stream
is directly forwarded to the output interface of the stream entry.

Signed-off-by: Aakash Sasidharan <asasidharan@marvell.com>