### PR TITLE
[PATCH v1] validation: pktio: skip enabling inline IPsec

### DIFF
--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1564,6 +1564,10 @@ static void pktio_test_pktio_config(void)
 	CU_ASSERT_FATAL(odp_pktio_capability(pktio, &capa) == 0);
 
 	config = capa.config;
+
+	config.inbound_ipsec = 0;
+	config.outbound_ipsec = 0;
+
 	CU_ASSERT(odp_pktio_config(pktio, &config) == 0);
 
 	CU_ASSERT_FATAL(odp_pktio_close(pktio) == 0);


### PR DESCRIPTION
Inline IPsec functionality is not required for pktio tests.
Disable features that are not required.

Signed-off-by: Vidya Sagar Velumuri <vvelumuri@marvell.com>