### PR TITLE
[PATCH v9] linux-gen: improve software checksum implementation

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -352,6 +352,7 @@ if !ODP_ABI_COMPAT
 odpapiabiarchinclude_HEADERS += arch/x86/odp/api/abi/cpu.h
 endif
 noinst_HEADERS += arch/x86/cpu_flags.h \
+		  arch/x86/odp_cpu.h \
 		  arch/default/odp_cpu.h \
 		  arch/default/odp_cpu_idling.h
 endif

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -96,6 +96,7 @@ noinst_HEADERS = \
 		  include/odp_atomic_internal.h \
 		  include/odp_bitset.h \
 		  include/odp_buffer_internal.h \
+		  include/odp_chksum_internal.h \
 		  include/odp_classification_datamodel.h \
 		  include/odp_classification_internal.h \
 		  include/odp_config_internal.h \

--- a/platform/linux-generic/arch/aarch64/odp_cpu.h
+++ b/platform/linux-generic/arch/aarch64/odp_cpu.h
@@ -59,4 +59,10 @@ do {							     \
 #include "odp_atomic.h"
 #include "odp_cpu_idling.h"
 
+#ifdef __ARM_FEATURE_UNALIGNED
+#define _ODP_UNALIGNED 1
+#else
+#define _ODP_UNALIGNED 0
+#endif
+
 #endif  /* PLATFORM_LINUXGENERIC_ARCH_ARM_ODP_CPU_H */

--- a/platform/linux-generic/arch/aarch64/odp_cpu_idling.h
+++ b/platform/linux-generic/arch/aarch64/odp_cpu_idling.h
@@ -30,12 +30,6 @@ static inline int wfe(void)
 	return 1;
 }
 
-static inline void doze(void)
-{
-	/* When using WFE do not stall the pipeline using other means */
-	odp_cpu_pause();
-}
-
 #define monitor128(addr, mo) lld((addr), (mo))
 #define monitor64(addr, mo) ll64((addr), (mo))
 #define monitor32(addr, mo) ll32((addr), (mo))

--- a/platform/linux-generic/arch/arm/odp_cpu.h
+++ b/platform/linux-generic/arch/arm/odp_cpu.h
@@ -52,4 +52,10 @@ static inline void _odp_dmb(void)
 #include "odp_atomic.h"
 #include "odp_cpu_idling.h"
 
+#ifdef __ARM_FEATURE_UNALIGNED
+#define _ODP_UNALIGNED 1
+#else
+#define _ODP_UNALIGNED 0
+#endif
+
 #endif  /* PLATFORM_LINUXGENERIC_ARCH_ARM_ODP_CPU_H */

--- a/platform/linux-generic/arch/arm/odp_cpu_idling.h
+++ b/platform/linux-generic/arch/arm/odp_cpu_idling.h
@@ -30,12 +30,6 @@ static inline int wfe(void)
 	return 1;
 }
 
-static inline void doze(void)
-{
-	/* When using WFE do not stall the pipeline using other means */
-	odp_cpu_pause();
-}
-
 #define monitor128(addr, mo) lld((addr), (mo))
 #define monitor64(addr, mo) ll64((addr), (mo))
 #define monitor32(addr, mo) ll32((addr), (mo))

--- a/platform/linux-generic/arch/default/odp_cpu.h
+++ b/platform/linux-generic/arch/default/odp_cpu.h
@@ -9,6 +9,10 @@
 #ifndef ODP_DEFAULT_CPU_H_
 #define ODP_DEFAULT_CPU_H_
 
+#ifndef _ODP_UNALIGNED
+#define _ODP_UNALIGNED 0
+#endif
+
 /******************************************************************************
  * Atomics
  *****************************************************************************/

--- a/platform/linux-generic/arch/default/odp_cpu_idling.h
+++ b/platform/linux-generic/arch/default/odp_cpu_idling.h
@@ -28,9 +28,4 @@ static inline int wfe(void)
 #define monitor32(addr, mo) __atomic_load_n((addr), (mo))
 #define monitor8(addr, mo) __atomic_load_n((addr), (mo))
 
-static inline void doze(void)
-{
-	odp_cpu_pause();
-}
-
 #endif

--- a/platform/linux-generic/arch/x86/odp_cpu.h
+++ b/platform/linux-generic/arch/x86/odp_cpu.h
@@ -1,0 +1,14 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef ODP_X86_CPU_H_
+#define ODP_X86_CPU_H_
+
+#define _ODP_UNALIGNED 1
+
+#include <default/odp_cpu.h>
+
+#endif

--- a/platform/linux-generic/include/odp_chksum_internal.h
+++ b/platform/linux-generic/include/odp_chksum_internal.h
@@ -1,0 +1,189 @@
+/* Copyright (c) 2020, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:	BSD-3-Clause
+ */
+
+#ifndef ODP_CHKSUM_INTERNAL_H_
+#define ODP_CHKSUM_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/hints.h>
+#include <odp/api/byteorder.h>
+#include <odp_cpu.h>
+#include <stdint.h>
+
+/*
+ * Compute the final Internet checksum (RFC 1071) based on a partial
+ * sum. A partial sum can be obtained e.g. by calling
+ * chksum_partial().
+ */
+static inline uint16_t chksum_finalize(uint64_t sum)
+{
+	sum = (sum >> 32) + (sum & 0xffffffff);
+	sum = (sum >> 16) + (sum & 0xffff);
+	/*
+	 * The final & 0xffff is intentionally omitted, the extra bits
+	 * are discarded by the implicit cast to the return type.
+	 */
+	return (sum >> 16) + sum;
+}
+
+/*
+ * Compute a partial checksum. Several partial checksums may be summed
+ * together. The final checksum may be obtained by calling
+ * chksum_finalize(). Parameter offset is the offset of this segment
+ * of data from the start of IP header.
+ *
+ * This implementation
+ *
+ * - Accepts unaligned data.
+ *
+ * - Accepts data at any byte offset from the start of IP header,
+ *   including odd offsets.
+ *
+ * - Uses unaligned memory access only if available.
+ *
+ * - Is optimized (for skylake, cn96, a53) by trial and error.
+ *
+ * The following did not improve performance (in synthetic tests):
+ *
+ * - 2 or 4 sub-sums in the main loop (to break dependency chains).
+ *
+ * - Aligning to 8 bytes instead of 4 (for ldp instruction). This
+ *   makes the main loop faster on a53 (only), but the extra
+ *   conditional branch has its cost.
+ *
+ * - __builtin_assume_aligned().
+ */
+static uint64_t chksum_partial(const void *addr, uint32_t len, uint32_t offset)
+{
+	const uint8_t *b;
+	const uint16_t *w;
+	const uint32_t *d;
+	uint64_t sum = 0;
+
+	/*
+	 * Offset is either even or odd, the rest of it doesn't
+	 * matter.
+	 */
+	offset &= 1;
+
+	if (_ODP_UNALIGNED) {
+		/*
+		 * We have efficient unaligned access. Just read
+		 * dwords starting at the given address.
+		 */
+		d = (const uint32_t *)addr;
+	} else {
+		/*
+		 * We must avoid unaligned access, so align to 4 bytes
+		 * by summing up the first up to 3 bytes.
+		 */
+		b = (const uint8_t *)addr;
+
+		if (odp_unlikely((uintptr_t)b & 1) && len >= 1) {
+			/*
+			 * Align to 2 bytes by handling an odd
+			 * byte. Since addr is unaligned, the first
+			 * byte goes into the second byte of the sum.
+			 */
+			sum += odp_cpu_to_be_16(*b++);
+			len -= 1;
+
+			/* An odd byte negates the effect of offset. */
+			offset ^= 1;
+		}
+
+		/*
+		 * This cast increases alignment, but it's OK, since
+		 * we've made sure that the pointer value is aligned.
+		 */
+		w = (const uint16_t *)(uintptr_t)b;
+
+		if ((uintptr_t)w & 2 && len >= 2) {
+			/* Align bytes by handling an odd word. */
+			sum += *w++;
+			len -= 2;
+		}
+
+		/* Increases alignment. */
+		d = (const uint32_t *)(uintptr_t)w;
+	}
+
+	while (len >= 32)  {
+		/* 8 dwords or 32 bytes per round. */
+
+		sum += *d++;
+		sum += *d++;
+		sum += *d++;
+		sum += *d++;
+
+		sum += *d++;
+		sum += *d++;
+		sum += *d++;
+		sum += *d++;
+
+		len -= 32;
+	}
+
+	/* Last up to 7 dwords. */
+	switch (len >> 2) {
+	case 7:
+		sum += *d++;
+		/* FALLTHROUGH */
+	case 6:
+		sum += *d++;
+		/* FALLTHROUGH */
+	case 5:
+		sum += *d++;
+		/* FALLTHROUGH */
+	case 4:
+		sum += *d++;
+		/* FALLTHROUGH */
+	case 3:
+		sum += *d++;
+		/* FALLTHROUGH */
+	case 2:
+		sum += *d++;
+		/* FALLTHROUGH */
+	case 1:
+		sum += *d++;
+		/* FALLTHROUGH */
+	default:
+		break;
+	}
+
+	len &= 3;
+
+	w = (const uint16_t *)d;
+	if (len > 1)  {
+		/* Last word. */
+		sum += *w++;
+		len -= 2;
+	}
+
+	if (len) {
+		/* Last byte. */
+		b = (const uint8_t *)w;
+		sum += odp_cpu_to_be_16((uint16_t)*b << 8);
+	}
+
+	/*
+	 * If offset is odd, our sum is byte-flipped and we need to
+	 * flip odd and even bytes.
+	 */
+	if (odp_unlikely(offset))
+		sum = ((sum & 0xff00ff00ff00ff) << 8) | ((sum & 0xff00ff00ff00ff00) >> 8);
+
+	return sum;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/odp_chksum.c
+++ b/platform/linux-generic/odp_chksum.c
@@ -6,31 +6,9 @@
 
 #include <odp/api/chksum.h>
 #include <odp/api/std_types.h>
+#include <odp_chksum_internal.h>
 
-/* Simple implementation of ones complement sum.
- * Based on RFC1071 and its errata.
- */
 uint16_t odp_chksum_ones_comp16(const void *p, uint32_t len)
 {
-	uint32_t sum = 0;
-	const uint16_t *data = p;
-
-	while (len > 1) {
-		sum += *data++;
-		len -= 2;
-	}
-
-	/* Add left-over byte, if any */
-	if (len > 0) {
-		uint16_t left_over = 0;
-
-		*(uint8_t *)&left_over = *(const uint8_t *)data;
-		sum += left_over;
-	}
-
-	/* Fold 32-bit sum to 16 bits */
-	while (sum >> 16)
-		sum = (sum & 0xffff) + (sum >> 16);
-
-	return sum;
+	return chksum_finalize(chksum_partial(p, len, 0));
 }

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -15,6 +15,7 @@
 #include <odp/api/sync.h>
 #include <odp/api/plat/sync_inlines.h>
 #include <odp/api/traffic_mngr.h>
+#include <odp/api/cpu.h>
 
 #include <odp_config_internal.h>
 #include <odp_debug_internal.h>
@@ -465,7 +466,7 @@ static int queue_destroy(odp_queue_t handle)
 		sevl();
 		while (wfe() && monitor32((uint32_t *)&q->qschst.numevts,
 					  __ATOMIC_RELAXED) != 0)
-			doze();
+			odp_cpu_pause();
 	}
 
 	if (q->schedq != NULL) {
@@ -573,7 +574,7 @@ static inline int _odp_queue_enq(sched_elem_t *q,
 		sevl();
 		while (wfe() && monitor32(&q->cons_write,
 					  __ATOMIC_RELAXED) != old_write)
-			doze();
+			odp_cpu_pause();
 	}
 
 	/* Signal consumers that events are available (release events)
@@ -803,7 +804,7 @@ inline int _odp_queue_deq(sched_elem_t *q, odp_buffer_hdr_t *buf_hdr[], int num)
 		sevl();
 		while (wfe() && monitor32(&q->prod_read,
 					  __ATOMIC_RELAXED) != old_read)
-			doze();
+			odp_cpu_pause();
 	}
 
 	/* Signal producers that empty slots are available

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -227,7 +227,7 @@ void _odp_sched_update_enq(sched_elem_t *q, uint32_t actual)
 			while (wfe() &&
 			       monitor8(&q->qschst.cur_ticket,
 					__ATOMIC_ACQUIRE) != ticket)
-				doze();
+				odp_cpu_pause();
 		}
 		/* Enqueue at end of scheduler queue */
 		/* We are here because of empty-to-non-empty transition
@@ -375,7 +375,7 @@ sched_update_deq(sched_elem_t *q,
 			while (wfe() &&
 			       monitor8(&q->qschst.cur_ticket,
 					__ATOMIC_ACQUIRE) != ticket)
-				doze();
+				odp_cpu_pause();
 		}
 		/* We are here because of non-empty-to-empty transition or
 		 * WRR budget exhausted
@@ -502,7 +502,7 @@ static inline void sched_update_popd(sched_elem_t *elem)
 		sevl();
 		while (wfe() && monitor8(&elem->qschst.cur_ticket,
 					 __ATOMIC_ACQUIRE) != ticket)
-			doze();
+			odp_cpu_pause();
 	}
 	sched_update_popd_sc(elem);
 	atomic_store_release(&elem->qschst.cur_ticket, ticket + 1,
@@ -1074,7 +1074,7 @@ restart_same:
 				while (wfe() &&
 				       monitor32(&rwin->turn, __ATOMIC_ACQUIRE)
 						!= sn)
-					doze();
+					odp_cpu_pause();
 			}
 #ifdef CONFIG_QSCHST_LOCK
 			LOCK(&elem->qschlock);
@@ -1162,7 +1162,7 @@ static void schedule_order_lock(uint32_t lock_index)
 		while (wfe() &&
 		       monitor32(&rctx->rwin->olock[lock_index],
 				 __ATOMIC_ACQUIRE) != rctx->sn)
-			doze();
+			odp_cpu_pause();
 	}
 }
 
@@ -1579,7 +1579,7 @@ static int schedule_group_destroy(odp_schedule_group_t group)
 			       !bitset_is_eql(wanted,
 					      bitset_monitor(&sg->thr_actual[p],
 							     __ATOMIC_RELAXED)))
-				doze();
+				odp_cpu_pause();
 		}
 		/* Else ignore because no ODP queues on this prio */
 	}
@@ -2157,7 +2157,7 @@ static void order_lock(void)
 		 */
 		while (wfe() &&
 		       monitor32(&rwin->hc.head, __ATOMIC_ACQUIRE) != sn)
-			doze();
+			odp_cpu_pause();
 	}
 }
 


### PR DESCRIPTION
```
linux-gen: improve software checksum implementation
    
    Improve software checksum implementation and put it in a separate
    header file so that it may be easily called from multiple places.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

linux-gen: packet: use new software checksum functions
    
    Use new software checksum functions and clean up the related code.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```

v1:
- Draft.
- Probably need to revise usage of __ARM_FEATURE_UNALIGNED macro.

v2:
- Include "introduce _ODP_UNALIGNED" commit.
- Use _ODP_UNALIGNED instead of __ARM_FEATURE_UNALIGNED.

v3:
- Add arch/x86/odp_cpu.h in linux-generic/Makefile.am.
- Rebase.

v4:
- Add "linux-gen: include odp/api/cpu.h where odp_cpu_pause() is called".

v5:
- Add _ODP_UNALIGNED also for arch/arm.
- Draft -> open.

v6:
- De-doxygenify comments.
- Add validation tests for pseudorandom data and very long data.
- Rebase.

v7:
- Validation tests: Fix pointer casts and pointer mask types.

v8:
- Remove doze().
- Constant values as suggested by Petri.
- Test data lengths from 1 to over 9000 in chksum_ones_complement_pseudorandom().

v9:
- Add reviewed-by tags.
