### PR TITLE
[PATCH v1] linux-gen: introduce _ODP_UNALIGNED macro

### DIFF
--- a/platform/linux-generic/arch/aarch64/odp_cpu.h
+++ b/platform/linux-generic/arch/aarch64/odp_cpu.h
@@ -59,4 +59,8 @@ do {							     \
 #include "odp_atomic.h"
 #include "odp_cpu_idling.h"
 
+#ifdef __ARM_FEATURE_UNALIGNED
+#define _ODP_UNALIGNED
+#endif
+
 #endif  /* PLATFORM_LINUXGENERIC_ARCH_ARM_ODP_CPU_H */

--- a/platform/linux-generic/arch/x86/odp_cpu.h
+++ b/platform/linux-generic/arch/x86/odp_cpu.h
@@ -1,0 +1,14 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef ODP_X86_CPU_H_
+#define ODP_X86_CPU_H_
+
+#include <default/odp_cpu.h>
+
+#define _ODP_UNALIGNED
+
+#endif


### PR DESCRIPTION
The _ODP_UNALIGNED pre-processor macro is defined if the CPU features
efficient unaligned memory access.

Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>