### PR TITLE
validation: pktio: fix segment length pool param

### DIFF
--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -140,7 +140,8 @@ static void set_pool_len(odp_pool_param_t *params, odp_pool_capability_t *capa)
 
 	len = (capa->pkt.max_len && capa->pkt.max_len < PKT_BUF_SIZE) ?
 			capa->pkt.max_len : PKT_BUF_SIZE;
-	seg_len = capa->pkt.max_seg_len ? capa->pkt.max_seg_len : PKT_BUF_SIZE;
+	seg_len = (capa->pkt.max_seg_len && capa->pkt.max_seg_len < PKT_BUF_SIZE) ?
+			capa->pkt.max_seg_len : PKT_BUF_SIZE;
 
 	switch (pool_segmentation) {
 	case PKT_POOL_SEGMENTED:


### PR DESCRIPTION
During pool creation segment length (param.pkt.seg_len) gets
initialised with max segment length possible (which could go
up to max packet length supported in case of single segmented
buffer), while packet length (param.pkt.len) value gets
initialised with PKT_BUF_SIZE. With this initialisation
seg length becomes much greater than packet length i.e.
(param.pkt.seg_len > param.pkt.len).

With given pool params, expectation is to support param.pkt.num
packets of param.pkt.len with first buffer segment size as
param.pkt.seg_len, which is not feasible.

Signed-off-by: Harman Kalra <hkalra@marvell.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>
