### PR TITLE
[PATCH v3] linux-gen: thread: read maximum number of threads from config file

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.14"
+config_file_version = "0.1.15"
 
 # System options
 system: {
@@ -29,6 +29,12 @@ system: {
 	# odp_cpu_hz_max_id() calls on platforms where max frequency isn't
 	# available using standard Linux methods.
 	cpu_mhz_max = 1400
+
+	# Maximum number of ODP threads that can be created.
+	# odp_thread_count_max() returns this value or the build time
+	# maximum ODP_THREAD_COUNT_MAX, whichever is lower. This setting
+	# can be used to reduce thread related resource usage.
+	thread_count_max = 256
 }
 
 # Shared memory options

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -3,7 +3,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [14])
+m4_define([_odp_config_version_minor], [15])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.14"
+config_file_version = "0.1.15"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/packet_align.conf
+++ b/platform/linux-generic/test/packet_align.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.14"
+config_file_version = "0.1.15"
 
 pool: {
 	pkt: {

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.14"
+config_file_version = "0.1.15"
 
 # Shared memory options
 shm: {


### PR DESCRIPTION
Add system:thread_count_max config parameter that can be used to reduce
the maximum number of threads below the build time configured maximum.
This can be used to reduce thread related resource consumption such
as thread-local memory.

Most code still uses the build time limit, ODP_THREAD_COUNT_MAX, so this
change merely enables possible later optimizations in those cases.

ODP-DPDK will already benefit from this change as the number of queue
pairs for a crypto device can be lowered to match the actual number of
threads without ODP-DPDK having worry about possible sharing of the
queue pairs between threads.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>