### PR TITLE
[PATCH v9] helper: add CLI helper API and implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ include/odp/autoheader_build.h
 include/odp/autoheader_external.h
 include/odp/autoheader_internal.h
 include/odp/stamp-h*
+helper/include/odp/helper/autoheader_external.h
+helper/include/odp/helper/stamp-h*
 lib/
 libtool
 ltmain.sh

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AS_IF([test "$ac_cv_env_CFLAGS_set" = ""], [user_cflags=0], [user_cflags=1])
 # Initialize automake
 AM_INIT_AUTOMAKE([1.9 tar-pax subdir-objects foreign nostdinc -Wall -Werror])
 AC_CONFIG_SRCDIR([include/odp/api/spec/init.h])
-AM_CONFIG_HEADER([include/odp/autoheader_build.h include/odp/autoheader_external.h include/odp/autoheader_internal.h])
+AM_CONFIG_HEADER([include/odp/autoheader_build.h include/odp/autoheader_external.h include/odp/autoheader_internal.h helper/include/odp/helper/autoheader_external.h])
 
 AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE
@@ -356,15 +356,6 @@ AS_IF([test "x$enable_debug" != "xno"], [ODP_DEBUG=1],
 AC_DEFINE_UNQUOTED([ODP_DEBUG], [$ODP_DEBUG],
 		   [Define to 1 to include additional debug code])
 
-AC_ARG_ENABLE([helper-debug],
-    [AS_HELP_STRING([--enable-helper-debug],
-		    [helpers include additional debugging code [default=disabled]])],
-    [], [AS_IF([test "x$enable_debug" = "xfull"], [enable_helper_debug=yes],
-    [enable_helper_debug=no])])
-AS_IF([test "x$enable_helper_debug" != "xno"], [ODPH_DEBUG=1], [ODPH_DEBUG=0])
-AC_DEFINE_UNQUOTED([ODPH_DEBUG], [$ODPH_DEBUG],
-		   [Define to 1 to include additional helper debug code])
-
 ##########################################################################
 # Enable/disable ODP_DEBUG_PRINT
 ##########################################################################
@@ -377,16 +368,6 @@ AS_IF([test "x$enable_debug_print" != "xno"], [ODP_DEBUG_PRINT=1],
       [ODP_DEBUG_PRINT=0])
 AC_DEFINE_UNQUOTED([ODP_DEBUG_PRINT], [$ODP_DEBUG_PRINT],
 		   [Define to 1 to display debug information])
-
-AC_ARG_ENABLE([helper-debug-print],
-    [AS_HELP_STRING([--enable-helper-debug-print],
-		    [display helper debugging information [default=disabled]])],
-    [], [AS_IF([test "x$enable_debug" = "xfull"], [enable_helper_debug_print=yes],
-	       [enable_helper_debug_print=no])])
-AS_IF([test "x$enable_helper_debug_print" != "xno"], [ODPH_DEBUG_PRINT=1],
-      [ODPH_DEBUG_PRINT=0])
-AC_DEFINE_UNQUOTED([ODPH_DEBUG_PRINT], [$ODPH_DEBUG_PRINT],
-		   [Define to 1 to display helper debug information])
 
 debug_settings="ODP_DEBUG=${ODP_DEBUG}, ODP_DEBUG_PRINT=${ODP_DEBUG_PRINT}, \
 ODPH_DEBUG=${ODPH_DEBUG}, ODPH_DEBUG_PRINT=${ODPH_DEBUG_PRINT}"

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ AC_SUBST(ODP_VERSION_API_MINOR)
 ##########################################################################
 m4_define([odph_version_generation], [1])
 m4_define([odph_version_major], [0])
-m4_define([odph_version_minor], [5])
+m4_define([odph_version_minor], [6])
 
 m4_define([odph_version],
     [odph_version_generation.odph_version_major.odph_version_minor])

--- a/configure.ac
+++ b/configure.ac
@@ -332,6 +332,7 @@ AM_CONDITIONAL([HAVE_DOXYGEN], [test "x${DOXYGEN}" = "xdoxygen"])
 AM_CONDITIONAL([user_guide], [test "x${user_guides}" = "xyes" ])
 AM_CONDITIONAL([HAVE_MSCGEN], [test "x${MSCGEN}" = "xmscgen"])
 AM_CONDITIONAL([helper_linux], [test x$helper_linux = xyes ])
+AM_CONDITIONAL([helper_cli], [test x$helper_cli = xyes ])
 AM_CONDITIONAL([ARCH_IS_ARM], [test "x${ARCH_DIR}" = "xarm"])
 AM_CONDITIONAL([ARCH_IS_AARCH64], [test "x${ARCH_DIR}" = "xaarch64"])
 AM_CONDITIONAL([ARCH_IS_DEFAULT], [test "x${ARCH_DIR}" = "xdefault"])
@@ -479,6 +480,7 @@ AC_MSG_RESULT([
 	ARCH_ABI		${ARCH_ABI}
 	with_platform:		${with_platform}
 	helper_linux:		${helper_linux}
+	helper_cli:		${helper_cli}
 	prefix:			${prefix}
 	sysconfdir:		${sysconfdir}
 	libdir:			${libdir}

--- a/doc/application-api-guide/examples.dox
+++ b/doc/application-api-guide/examples.dox
@@ -10,6 +10,11 @@
  */
 
 /**
+ * @example odp_cli.c
+ * CLI example application
+ */
+
+/**
  * @example odp_debug.c
  * Debug example application
  */

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -18,3 +18,7 @@ SUBDIRS = classifier \
 if HAVE_DW_ATOMIC_CMP_EXC
 SUBDIRS += ipfragreass
 endif
+
+if helper_cli
+SUBDIRS += cli
+endif

--- a/example/cli/.gitignore
+++ b/example/cli/.gitignore
@@ -1,0 +1,3 @@
+odp_cli
+*.log
+*.trs

--- a/example/cli/Makefile.am
+++ b/example/cli/Makefile.am
@@ -1,0 +1,31 @@
+include $(top_srcdir)/example/Makefile.inc
+
+bin_PROGRAMS = odp_cli
+
+odp_cli_SOURCES = odp_cli.c
+
+if test_example
+TESTS = odp_cli_run.sh
+endif
+
+EXTRA_DIST = odp_cli_run.sh
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/example/cli/odp_cli.c
+++ b/example/cli/odp_cli.c
@@ -1,0 +1,176 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/*
+ * ODP CLI Helper Example
+ *
+ * This example shows how to start and stop ODP CLI using the CLI helper
+ * API functions. This example application can also be used to try out
+ * the CLI by connecting to a running application with a telnet client.
+ */
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include <stdio.h>
+#include <stdint.h>
+#include <signal.h>
+
+typedef struct {
+	int time;
+	char *addr;
+	uint16_t port;
+} options_t;
+
+static void usage(const char *prog)
+{
+	printf("\n"
+	       "Usage: %s [options]\n"
+	       "\n"
+	       "OPTIONS:\n"
+	       "  -t, --time <sec>        Keep CLI open for <sec> seconds. (default -1 (infinite))\n"
+	       "  -a, --address <addr>    Bind listening socket to IP address <addr>.\n"
+	       "  -p, --port <port>       Bind listening socket to port <port>.\n"
+	       "\n"
+	       "ODP helper defaults are used for address and port, if the options are\n"
+	       "not given.\n"
+	       "\n",
+	       prog);
+}
+
+static void parse_args(int argc, char *argv[], options_t *opt)
+{
+	static const struct option longopts[] = {
+		{ "time", required_argument, NULL, 't' },
+		{ "address", required_argument, NULL, 'a' },
+		{ "port", required_argument, NULL, 'p' },
+		{ "help", no_argument, NULL, 'h' },
+		{ NULL, 0, NULL, 0 }
+	};
+
+	static const char *shortopts = "+t:a:p:h";
+
+	while (1) {
+		int c = getopt_long(argc, argv, shortopts, longopts, NULL);
+
+		if (c == -1)
+			break; /* No more options */
+
+		switch (c) {
+		case 't':
+			opt->time = atoi(optarg);
+			break;
+		case 'a':
+			opt->addr = optarg;
+			break;
+		case 'p':
+			opt->port = atoi(optarg);
+			break;
+		default:
+			usage(argv[0]);
+			exit(EXIT_SUCCESS);
+			break;
+		}
+	}
+
+	optind = 1; /* reset 'extern optind' from the getopt lib */
+}
+
+static volatile int shutdown_sig;
+
+static void sig_handler(int signo)
+{
+	(void)signo;
+
+	shutdown_sig = 1;
+}
+
+int main(int argc, char *argv[])
+{
+	signal(SIGINT, sig_handler);
+
+	odph_helper_options_t helper_options;
+
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		ODPH_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_t init;
+
+	odp_init_param_init(&init);
+	init.mem_model = helper_options.mem_model;
+
+	options_t opt = {
+		.time = -1,
+		.addr = NULL,
+		.port = 0,
+	};
+
+	parse_args(argc, argv, &opt);
+
+	/* Initialize ODP. */
+
+	odp_instance_t inst;
+
+	if (odp_init_global(&inst, &init, NULL)) {
+		ODPH_ERR("Global init failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (odp_init_local(inst, ODP_THREAD_CONTROL)) {
+		ODPH_ERR("Local init failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	/* Prepare CLI parameters. */
+
+	odph_cli_param_t cli_param;
+
+	odph_cli_param_init(&cli_param);
+
+	if (opt.addr)
+		cli_param.address = opt.addr;
+
+	if (opt.port)
+		cli_param.port = opt.port;
+
+	/* Start CLI server. */
+	if (odph_cli_start(inst, &cli_param)) {
+		ODPH_ERR("CLI start failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	printf("CLI server started on %s:%d\n", cli_param.address, cli_param.port);
+
+	/* Wait for the given number of seconds. */
+	for (int i = 0; (opt.time < 0 || i < opt.time) && !shutdown_sig; i++)
+		odp_time_wait_ns(ODP_TIME_SEC_IN_NS);
+
+	printf("Stopping CLI server.\n");
+
+	/* Stop CLI server. */
+	if (odph_cli_stop()) {
+		ODPH_ERR("CLI stop failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	/* Terminate ODP. */
+
+	if (odp_term_local()) {
+		ODPH_ERR("Local term failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (odp_term_global(inst)) {
+		ODPH_ERR("Global term failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	return 0;
+}

--- a/example/cli/odp_cli_run.sh
+++ b/example/cli/odp_cli_run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Copyright (c) 2021, Nokia
+# All rights reserved.
+#
+# SPDX-License-Identifier:     BSD-3-Clause
+#
+
+./odp_cli${EXEEXT} -t 2

--- a/example/m4/configure.m4
+++ b/example/m4/configure.m4
@@ -20,6 +20,7 @@ AC_ARG_ENABLE([test-example],
 AM_CONDITIONAL([test_example], [test x$test_example = xyes ])
 
 AC_CONFIG_FILES([example/classifier/Makefile
+		 example/cli/Makefile
 		 example/debug/Makefile
 		 example/generator/Makefile
 		 example/hello/Makefile

--- a/helper/Makefile.am
+++ b/helper/Makefile.am
@@ -5,7 +5,8 @@ pkgconfig_DATA = libodphelper.pc
 
 AM_CPPFLAGS = \
 	$(ODP_INCLUDES) \
-	$(HELPER_INCLUDES)
+	$(HELPER_INCLUDES) \
+	$(LIBCLI_CPPFLAGS)
 AM_CFLAGS = $(PTHREAD_CFLAGS)
 
 AM_LDFLAGS = -version-number '$(ODPHELPER_LIBSO_VERSION)'

--- a/helper/Makefile.am
+++ b/helper/Makefile.am
@@ -44,6 +44,11 @@ helperlinuxinclude_HEADERS = \
 		  include/odp/helper/linux/process.h
 endif
 
+if helper_cli
+helperinclude_HEADERS += \
+		  include/odp/helper/cli.h
+endif
+
 noinst_HEADERS = \
 		 include/odph_list_internal.h
 
@@ -64,6 +69,12 @@ __LIB__libodphelper_la_SOURCES += \
 				linux/thread.c
 endif
 
+if helper_cli
+__LIB__libodphelper_la_SOURCES += \
+				cli.c
+endif
+
 __LIB__libodphelper_la_LIBADD = $(PTHREAD_LIBS)
+__LIB__libodphelper_la_LIBADD += $(LIBCLI_LIBS)
 
 lib_LTLIBRARIES = $(LIB)/libodphelper.la

--- a/helper/Makefile.am
+++ b/helper/Makefile.am
@@ -12,6 +12,7 @@ AM_LDFLAGS = -version-number '$(ODPHELPER_LIBSO_VERSION)'
 
 helperincludedir = $(includedir)/odp/helper/
 helperinclude_HEADERS = \
+		  include/odp/helper/autoheader_external.h\
 		  include/odp/helper/chksum.h\
 		  include/odp/helper/odph_debug.h \
 		  include/odp/helper/eth.h\

--- a/helper/cli.c
+++ b/helper/cli.c
@@ -1,0 +1,499 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/helper/cli.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+#include <libcli.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <errno.h>
+#include <poll.h>
+
+/* Socketpair socket roles. */
+enum {
+	SP_READ = 0,
+	SP_WRITE = 1,
+};
+
+typedef struct {
+	volatile int cli_fd;
+	/* Server thread will exit if this is false. */
+	volatile int run;
+	/* Socketpair descriptors. */
+	int sp[2];
+	int listen_fd;
+	/* This lock guards cli_fd and run, which must be accessed atomically. */
+	odp_spinlock_t lock;
+	odph_thread_t thr_server;
+} cli_shm_t;
+
+static const char *shm_name = "_odp_cli";
+
+static const odph_cli_param_t param_default = {
+	.address = "127.0.0.1",
+	.port = 55555,
+};
+
+void odph_cli_param_init(odph_cli_param_t *param)
+{
+	*param = param_default;
+}
+
+static int cmd_show_cpu(struct cli_def *cli, const char *command ODP_UNUSED,
+			char *argv[] ODP_UNUSED, int argc ODP_UNUSED)
+{
+	for (int c = 0; c < odp_cpu_count(); c++) {
+		cli_print(cli, "% 4d: %s %.03f / %.03f GHz", c,
+			  odp_cpu_model_str_id(c),
+			  (float)odp_cpu_hz_id(c) / 1000000000.0,
+			  (float)odp_cpu_hz_max_id(c) / 1000000000.0);
+	}
+
+	return CLI_OK;
+}
+
+static int cmd_show_version(struct cli_def *cli, const char *command ODP_UNUSED,
+			    char *argv[] ODP_UNUSED, int argc ODP_UNUSED)
+{
+	cli_print(cli, "ODP API version: %s", odp_version_api_str());
+	cli_print(cli, "ODP implementation name: %s", odp_version_impl_name());
+	cli_print(cli, "ODP implementation version: %s",
+		  odp_version_impl_str());
+
+	return CLI_OK;
+}
+
+/*
+ * Check that number of given arguments matches required number of
+ * arguments. Print error messages if this is not the case. Return 0
+ * on success, -1 otherwise.
+ */
+static int check_num_args(struct cli_def *cli, int argc, int req_argc)
+{
+	if (argc < req_argc) {
+		cli_error(cli, "%% Incomplete command.");
+		return -1;
+	}
+
+	if (argc > req_argc) {
+		cli_error(cli, "%% Extra parameter given to command.");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int cmd_call_odp_ipsec_print(struct cli_def *cli,
+				    const char *command ODP_UNUSED,
+				    char *argv[] ODP_UNUSED, int argc)
+{
+	if (check_num_args(cli, argc, 0))
+		return CLI_ERROR;
+
+	odp_ipsec_print();
+
+	return CLI_OK;
+}
+
+static int cmd_call_odp_shm_print_all(struct cli_def *cli,
+				      const char *command ODP_UNUSED,
+				      char *argv[] ODP_UNUSED, int argc)
+{
+	if (check_num_args(cli, argc, 0))
+		return CLI_ERROR;
+
+	odp_shm_print_all();
+
+	return CLI_OK;
+}
+
+static int cmd_call_odp_sys_config_print(struct cli_def *cli,
+					 const char *command ODP_UNUSED,
+					 char *argv[] ODP_UNUSED, int argc)
+{
+	if (check_num_args(cli, argc, 0))
+		return CLI_ERROR;
+
+	odp_sys_config_print();
+
+	return CLI_OK;
+}
+
+static int cmd_call_odp_sys_info_print(struct cli_def *cli,
+				       const char *command ODP_UNUSED,
+				       char *argv[] ODP_UNUSED, int argc)
+{
+	if (check_num_args(cli, argc, 0))
+		return CLI_ERROR;
+
+	odp_sys_info_print();
+
+	return CLI_OK;
+}
+
+static int cmd_call_odp_pktio_print(struct cli_def *cli,
+				    const char *command ODP_UNUSED,
+				    char *argv[], int argc)
+{
+	if (check_num_args(cli, argc, 1))
+		return CLI_ERROR;
+
+	odp_pktio_t hdl = odp_pktio_lookup(argv[0]);
+
+	if (hdl == ODP_PKTIO_INVALID) {
+		cli_error(cli, "%% Name not found.");
+		return CLI_ERROR;
+	}
+
+	odp_pktio_print(hdl);
+
+	return CLI_OK;
+}
+
+static int cmd_call_odp_pool_print(struct cli_def *cli,
+				   const char *command ODP_UNUSED, char *argv[],
+				   int argc)
+{
+	if (check_num_args(cli, argc, 1))
+		return CLI_ERROR;
+
+	odp_pool_t hdl = odp_pool_lookup(argv[0]);
+
+	if (hdl == ODP_POOL_INVALID) {
+		cli_error(cli, "%% Name not found.");
+		return CLI_ERROR;
+	}
+
+	odp_pool_print(hdl);
+
+	return CLI_OK;
+}
+
+static int cmd_call_odp_queue_print(struct cli_def *cli,
+				    const char *command ODP_UNUSED,
+				    char *argv[], int argc)
+{
+	if (check_num_args(cli, argc, 1))
+		return CLI_ERROR;
+
+	odp_queue_t hdl = odp_queue_lookup(argv[0]);
+
+	if (hdl == ODP_QUEUE_INVALID) {
+		cli_error(cli, "%% Name not found.");
+		return CLI_ERROR;
+	}
+
+	odp_queue_print(hdl);
+
+	return CLI_OK;
+}
+
+static int cmd_call_odp_shm_print(struct cli_def *cli,
+				  const char *command ODP_UNUSED, char *argv[],
+				  int argc)
+{
+	if (check_num_args(cli, argc, 1))
+		return CLI_ERROR;
+
+	odp_shm_t hdl = odp_shm_lookup(argv[0]);
+
+	if (hdl == ODP_SHM_INVALID) {
+		cli_error(cli, "%% Name not found.");
+		return CLI_ERROR;
+	}
+
+	odp_shm_print(hdl);
+
+	return CLI_OK;
+}
+
+static struct cli_def *create_cli(void)
+{
+	struct cli_command *c;
+	struct cli_def *cli;
+
+	cli = cli_init();
+	cli_set_banner(cli, NULL);
+	cli_set_hostname(cli, "ODP");
+
+	c = cli_register_command(cli, NULL, "show", NULL,
+				 PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
+				 "Show information.");
+	cli_register_command(cli, c, "cpu", cmd_show_cpu,
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
+			     "Show CPU information.");
+	cli_register_command(cli, c, "version", cmd_show_version,
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
+			     "Show version information.");
+
+	c = cli_register_command(cli, NULL, "call", NULL,
+				 PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
+				 "Call ODP API function.");
+	cli_register_command(cli, c, "odp_ipsec_print",
+			     cmd_call_odp_ipsec_print,
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
+	cli_register_command(cli, c, "odp_pktio_print",
+			     cmd_call_odp_pktio_print,
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
+	cli_register_command(cli, c, "odp_pool_print",
+			     cmd_call_odp_pool_print,
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
+	cli_register_command(cli, c, "odp_queue_print",
+			     cmd_call_odp_queue_print,
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
+	cli_register_command(cli, c, "odp_shm_print_all",
+			     cmd_call_odp_shm_print_all,
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
+	cli_register_command(cli, c, "odp_shm_print",
+			     cmd_call_odp_shm_print,
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
+	cli_register_command(cli, c, "odp_sys_config_print",
+			     cmd_call_odp_sys_config_print,
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
+	cli_register_command(cli, c, "odp_sys_info_print",
+			     cmd_call_odp_sys_info_print,
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
+
+	return cli;
+}
+
+static int cli_server(void *arg ODP_UNUSED)
+{
+	cli_shm_t *shm = NULL;
+	odp_shm_t shm_hdl = odp_shm_lookup(shm_name);
+
+	if (shm_hdl != ODP_SHM_INVALID)
+		shm = (cli_shm_t *)odp_shm_addr(shm_hdl);
+
+	if (!shm) {
+		ODPH_ERR("Error: can't start cli server (shm %s not found)\n", shm_name);
+		return -1;
+	}
+
+	struct cli_def *cli = create_cli();
+
+	while (1) {
+		struct pollfd pfd[2] = {
+			{ .fd = shm->sp[SP_READ], .events = POLLIN, },
+			{ .fd = shm->listen_fd, .events = POLLIN, },
+		};
+
+		if (poll(pfd, 2, -1) < 0) {
+			ODPH_ERR("Error: poll(): %s\n", strerror(errno));
+			break;
+		}
+
+		/*
+		 * If we have an event on a socketpair socket, it's
+		 * time to exit.
+		 */
+		if (pfd[0].revents)
+			break;
+
+		/*
+		 * If we don't have an event on the listening socket, poll
+		 * again.
+		 */
+		if (!pfd[1].revents)
+			continue;
+
+		int fd = accept(shm->listen_fd, NULL, 0);
+
+		if (fd < 0) {
+			if (errno == EAGAIN || errno == EINTR)
+				continue;
+
+			ODPH_ERR("Error: accept(): %s\n", strerror(errno));
+			break;
+		}
+
+		odp_spinlock_lock(&shm->lock);
+		if (!shm->run) {
+			/*
+			 * odph_cli_stop() has been called. Close the
+			 * socket we just accepted and exit.
+			 */
+			close(fd);
+			odp_spinlock_unlock(&shm->lock);
+			break;
+		}
+		shm->cli_fd = fd;
+		odp_spinlock_unlock(&shm->lock);
+		/*
+		 * cli_loop() returns only when client is disconnected. One
+		 * possible reason for disconnect is odph_cli_stop().
+		 */
+		cli_loop(cli, shm->cli_fd);
+		close(shm->cli_fd);
+	}
+
+	cli_done(cli);
+
+	return 0;
+}
+
+int odph_cli_start(const odp_instance_t instance,
+		   const odph_cli_param_t *param_in)
+{
+	if (odp_shm_lookup(shm_name) != ODP_SHM_INVALID) {
+		ODPH_ERR("Error: cli server already running (shm %s exists)\n", shm_name);
+		return -1;
+	}
+
+	cli_shm_t *shm = NULL;
+	odp_shm_t shm_hdl = odp_shm_reserve(shm_name, sizeof(cli_shm_t), 64,
+					    ODP_SHM_SW_ONLY);
+
+	if (shm_hdl != ODP_SHM_INVALID)
+		shm = (cli_shm_t *)odp_shm_addr(shm_hdl);
+
+	if (!shm) {
+		ODPH_ERR("Error: failed to reserve shm %s\n", shm_name);
+		return -1;
+	}
+
+	memset(shm, 0, sizeof(cli_shm_t));
+	odp_spinlock_init(&shm->lock);
+	shm->sp[SP_READ] = shm->sp[SP_WRITE] = -1;
+	shm->listen_fd = -1;
+	shm->cli_fd = -1;
+	shm->run = 1;
+
+	if (socketpair(PF_LOCAL, SOCK_STREAM, 0, shm->sp)) {
+		ODPH_ERR("Error: socketpair(): %s\n", strerror(errno));
+		goto error;
+	}
+
+	/* Create listening socket. */
+
+	shm->listen_fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (shm->listen_fd < 0) {
+		ODPH_ERR("Error: socket(): %s\n", strerror(errno));
+		goto error;
+	}
+
+	int on = 1;
+
+	if (setsockopt(shm->listen_fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on))) {
+		ODPH_ERR("Error: setsockopt(): %s\n", strerror(errno));
+		goto error;
+	}
+
+	struct sockaddr_in addr;
+
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(param_in->port);
+
+	switch (inet_pton(AF_INET, param_in->address, &addr.sin_addr)) {
+	case -1:
+		ODPH_ERR("Error: inet_pton(): %s\n", strerror(errno));
+		goto error;
+	case 0:
+		ODPH_ERR("Error: inet_pton(): illegal address format\n");
+		goto error;
+	}
+
+	if (bind(shm->listen_fd, (struct sockaddr *)&addr, sizeof(addr))) {
+		ODPH_ERR("Error: bind(): %s\n", strerror(errno));
+		goto error;
+	}
+
+	if (listen(shm->listen_fd, 1)) {
+		ODPH_ERR("Error: listen(): %s\n", strerror(errno));
+		goto error;
+	}
+
+	/* Create server thread. */
+
+	odp_cpumask_t cpumask;
+	odph_thread_common_param_t thr_common;
+	odph_thread_param_t thr_param;
+
+	if (odp_cpumask_default_control(&cpumask, 1) != 1) {
+		ODPH_ERR("Error: odp_cpumask_default_control() failed\n");
+		goto error;
+	}
+
+	memset(&thr_common, 0, sizeof(thr_common));
+	thr_common.instance = instance;
+	thr_common.cpumask = &cpumask;
+
+	memset(&thr_param, 0, sizeof(thr_param));
+	thr_param.thr_type = ODP_THREAD_CONTROL;
+	thr_param.start = cli_server;
+
+	memset(&shm->thr_server, 0, sizeof(shm->thr_server));
+
+	if (odph_thread_create(&shm->thr_server, &thr_common, &thr_param, 1) != 1) {
+		ODPH_ERR("Error: odph_thread_create() failed\n");
+		goto error;
+	}
+
+	return 0;
+
+error:
+	close(shm->sp[SP_READ]);
+	close(shm->sp[SP_WRITE]);
+	close(shm->listen_fd);
+	close(shm->cli_fd);
+	shm->run = 0;
+	return -1;
+}
+
+int odph_cli_stop(void)
+{
+	cli_shm_t *shm = NULL;
+	odp_shm_t shm_hdl = odp_shm_lookup(shm_name);
+
+	if (shm_hdl != ODP_SHM_INVALID)
+		shm = (cli_shm_t *)odp_shm_addr(shm_hdl);
+
+	if (!shm) {
+		ODPH_ERR("Error: cli server not running (shm %s not found)\n", shm_name);
+		return -1;
+	}
+
+	odp_spinlock_lock(&shm->lock);
+	shm->run = 0;
+	/*
+	 * Close the current cli connection. This stops cli_loop().
+	 */
+	close(shm->cli_fd);
+	odp_spinlock_unlock(&shm->lock);
+
+	/*
+	 * Send a message to the server thread in order to break it out of a
+	 * blocking poll() call.
+	 */
+	int stop = 1;
+	int sent = send(shm->sp[SP_WRITE], &stop,
+			sizeof(stop), MSG_DONTWAIT | MSG_NOSIGNAL);
+
+	if (sent != sizeof(stop)) {
+		ODPH_ERR("Error: send() = %d: %s\n", sent, strerror(errno));
+		return -1;
+	}
+
+	if (odph_thread_join(&shm->thr_server, 1) != 1) {
+		ODPH_ERR("Error: odph_thread_join() failed\n");
+		return -1;
+	}
+
+	close(shm->sp[SP_READ]);
+	close(shm->sp[SP_WRITE]);
+	close(shm->listen_fd);
+
+	if (odp_shm_free(shm_hdl)) {
+		ODPH_ERR("Error: odp_shm_free() failed\n");
+		return -1;
+	}
+
+	return 0;
+}

--- a/helper/include/odp/helper/autoheader_external.h.in
+++ b/helper/include/odp/helper/autoheader_external.h.in
@@ -1,0 +1,11 @@
+
+#ifndef ODPH_AUTOHEADER_EXTERNAL_H_
+#define ODPH_AUTOHEADER_EXTERNAL_H_
+
+/* Define to 1 to include additional helper debug code */
+#undef ODPH_DEBUG
+
+/* Define to 1 to display helper debug information */
+#undef ODPH_DEBUG_PRINT
+
+#endif

--- a/helper/include/odp/helper/autoheader_external.h.in
+++ b/helper/include/odp/helper/autoheader_external.h.in
@@ -2,6 +2,9 @@
 #ifndef ODPH_AUTOHEADER_EXTERNAL_H_
 #define ODPH_AUTOHEADER_EXTERNAL_H_
 
+/* Define to 1 to enable CLI helper */
+#undef ODPH_CLI
+
 /* Define to 1 to include additional helper debug code */
 #undef ODPH_DEBUG
 

--- a/helper/include/odp/helper/cli.h
+++ b/helper/include/odp/helper/cli.h
@@ -1,0 +1,92 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP CLI helper API
+ *
+ * This API allows control of ODP CLI server, which may be connected to
+ * using a telnet client. CLI commands may be used to get information
+ * from an ODP instance, for debugging purposes.
+ *
+ * Many CLI commands output the information to the console, or wherever
+ * ODP logs have been directed to in global init.
+ */
+
+#ifndef ODPH_CLI_H_
+#define ODPH_CLI_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp_api.h>
+#include <odp/helper/ip.h>
+#include <stdint.h>
+
+/**
+ * @addtogroup odph_cli ODPH CLI
+ * @{
+ */
+
+/** ODP CLI server parameters */
+typedef struct {
+	/**
+	 * A character string containing an IP address. Default is
+	 * "127.0.0.1".
+	 */
+	const char *address;
+	/** TCP port. Default is 55555. */
+	uint16_t port;
+} odph_cli_param_t;
+
+/**
+ * Initialize CLI server params
+ *
+ * Initialize an odph_cli_param_t to its default values for all
+ * fields.
+ *
+ * @param[out] param Pointer to parameter structure
+ */
+void odph_cli_param_init(odph_cli_param_t *param);
+
+/**
+ * Start CLI server
+ *
+ * Upon successful return from this function, the CLI server will be
+ * accepting client connections. This function spawns a new thread of
+ * type ODP_THREAD_CONTROL using odp_cpumask_default_control().
+ *
+ * @param instance ODP instance
+ * @param param CLI server parameters to use
+ * @retval 0 Success
+ * @retval <0 Failure
+ */
+int odph_cli_start(const odp_instance_t instance,
+		   const odph_cli_param_t *param);
+
+/**
+ * Stop CLI server
+ *
+ * Stop accepting new client connections and disconnect currently
+ * connected client. This function terminates the control thread
+ * created in odph_cli_start().
+ *
+ * @retval 0 Success
+ * @retval <0 Failure
+ */
+int odph_cli_stop(void);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/helper/include/odp/helper/odph_api.h
+++ b/helper/include/odp/helper/odph_api.h
@@ -38,6 +38,12 @@ extern "C" {
 #include <odp/helper/udp.h>
 #include <odp/helper/version.h>
 
+#include <odp/helper/autoheader_external.h>
+
+#ifdef ODPH_CLI
+#include <odp/helper/cli.h>
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/helper/include/odp/helper/odph_debug.h
+++ b/helper/include/odp/helper/odph_debug.h
@@ -15,7 +15,7 @@
 #ifndef ODPH_DEBUG_H_
 #define ODPH_DEBUG_H_
 
-#include <odp/autoheader_external.h>
+#include <odp/helper/autoheader_external.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/helper/libodphelper.pc.in
+++ b/helper/libodphelper.pc.in
@@ -7,5 +7,5 @@ Name: libodphelper
 Description: Helper for the ODP packet processing engine
 Version: @PKGCONFIG_VERSION@
 Libs: -L${libdir} -lodphelper
-Libs.private:
+Libs.private: @LIBCLI_LIBS@
 Cflags: -I${includedir}

--- a/helper/m4/configure.m4
+++ b/helper/m4/configure.m4
@@ -17,5 +17,30 @@ AC_ARG_ENABLE([helper-linux],
     [helper_linux=$enableval],
     [helper_linux=yes])
 
+##########################################################################
+# Enable/disable ODPH_DEBUG
+##########################################################################
+AC_ARG_ENABLE([helper-debug],
+    [AS_HELP_STRING([--enable-helper-debug],
+		    [helpers include additional debugging code [default=disabled]])],
+    [], [AS_IF([test "x$enable_debug" = "xfull"], [enable_helper_debug=yes],
+    [enable_helper_debug=no])])
+AS_IF([test "x$enable_helper_debug" != "xno"], [ODPH_DEBUG=1], [ODPH_DEBUG=0])
+AC_DEFINE_UNQUOTED([ODPH_DEBUG], [$ODPH_DEBUG],
+		   [Define to 1 to include additional helper debug code])
+
+##########################################################################
+# Enable/disable ODPH_DEBUG_PRINT
+##########################################################################
+AC_ARG_ENABLE([helper-debug-print],
+    [AS_HELP_STRING([--enable-helper-debug-print],
+		    [display helper debugging information [default=disabled]])],
+    [], [AS_IF([test "x$enable_debug" = "xfull"], [enable_helper_debug_print=yes],
+	       [enable_helper_debug_print=no])])
+AS_IF([test "x$enable_helper_debug_print" != "xno"], [ODPH_DEBUG_PRINT=1],
+      [ODPH_DEBUG_PRINT=0])
+AC_DEFINE_UNQUOTED([ODPH_DEBUG_PRINT], [$ODPH_DEBUG_PRINT],
+		   [Define to 1 to display helper debug information])
+
 AC_CONFIG_FILES([helper/libodphelper.pc
 		 helper/test/Makefile])

--- a/helper/m4/configure.m4
+++ b/helper/m4/configure.m4
@@ -1,4 +1,9 @@
 ##########################################################################
+# Include m4 files
+##########################################################################
+m4_include([helper/m4/libcli.m4])
+
+##########################################################################
 # Enable/disable test-helper
 ##########################################################################
 AC_ARG_ENABLE([test-helper],
@@ -41,21 +46,6 @@ AS_IF([test "x$enable_helper_debug_print" != "xno"], [ODPH_DEBUG_PRINT=1],
       [ODPH_DEBUG_PRINT=0])
 AC_DEFINE_UNQUOTED([ODPH_DEBUG_PRINT], [$ODPH_DEBUG_PRINT],
 		   [Define to 1 to display helper debug information])
-
-#########################################################################
-# If libcli is available, enable CLI helper
-#########################################################################
-helper_cli=no
-AC_CHECK_HEADER(libcli.h,
-    [AC_CHECK_LIB(cli, cli_init, [helper_cli=yes], [], [-lcrypt])],
-    [])
-
-LIBCLI_LIBS=""
-AS_IF([test "x$helper_cli" != "xno"],
-    [AC_DEFINE_UNQUOTED([ODPH_CLI], [1], [Define to 1 to enable CLI helper])
-        LIBCLI_LIBS="-lcli -lcrypt"])
-
-AC_SUBST([LIBCLI_LIBS])
 
 AC_CONFIG_FILES([helper/libodphelper.pc
 		 helper/test/Makefile])

--- a/helper/m4/configure.m4
+++ b/helper/m4/configure.m4
@@ -42,5 +42,20 @@ AS_IF([test "x$enable_helper_debug_print" != "xno"], [ODPH_DEBUG_PRINT=1],
 AC_DEFINE_UNQUOTED([ODPH_DEBUG_PRINT], [$ODPH_DEBUG_PRINT],
 		   [Define to 1 to display helper debug information])
 
+#########################################################################
+# If libcli is available, enable CLI helper
+#########################################################################
+helper_cli=no
+AC_CHECK_HEADER(libcli.h,
+    [AC_CHECK_LIB(cli, cli_init, [helper_cli=yes], [], [-lcrypt])],
+    [])
+
+LIBCLI_LIBS=""
+AS_IF([test "x$helper_cli" != "xno"],
+    [AC_DEFINE_UNQUOTED([ODPH_CLI], [1], [Define to 1 to enable CLI helper])
+        LIBCLI_LIBS="-lcli -lcrypt"])
+
+AC_SUBST([LIBCLI_LIBS])
+
 AC_CONFIG_FILES([helper/libodphelper.pc
 		 helper/test/Makefile])

--- a/helper/m4/libcli.m4
+++ b/helper/m4/libcli.m4
@@ -1,0 +1,43 @@
+##########################################################################
+# Set optional libcli path
+##########################################################################
+AC_ARG_WITH([libcli-path],
+    [AS_HELP_STRING([--with-libcli-path=DIR],
+        [path to libcli libs and headers [default=system]])],
+    [libcli_path_given=yes
+        LIBCLI_CPPFLAGS="-I$withval/include"
+        LIBCLI_LIBS="-L$withval/lib"
+        LIBCLI_RPATH="-R$withval/lib"],
+    [])
+
+##########################################################################
+# Save and set temporary compilation flags
+##########################################################################
+OLD_CPPFLAGS=$CPPFLAGS
+OLD_LIBS=$LIBS
+CPPFLAGS="$LIBCLI_CPPFLAGS $CPPFLAGS"
+LIBS="$LIBCLI_LIBS $LIBS"
+
+#########################################################################
+# If libcli is available, enable CLI helper
+#########################################################################
+helper_cli=no
+AC_CHECK_HEADER(libcli.h,
+    [AC_CHECK_LIB(cli, cli_init, [helper_cli=yes], [], [-lcrypt])],
+    [AS_IF([test "x$libcli_path_given" = "xyes"],
+        [AC_MSG_ERROR([libcli not found at the specified path (--with-libcli-path)])])])
+
+AS_IF([test "x$helper_cli" != "xno"],
+    [AC_DEFINE_UNQUOTED([ODPH_CLI], [1], [Define to 1 to enable CLI helper])
+        LIBCLI_LIBS="$LIBCLI_RPATH $LIBCLI_LIBS -lcli -lcrypt"],
+    [LIBCLI_CPPFLAGS=""
+        LIBCLI_LIBS=""])
+
+##########################################################################
+# Restore old saved variables
+##########################################################################
+LIBS=$OLD_LIBS
+CPPFLAGS=$OLD_CPPFLAGS
+
+AC_SUBST([LIBCLI_CPPFLAGS])
+AC_SUBST([LIBCLI_LIBS])

--- a/helper/test/.gitignore
+++ b/helper/test/.gitignore
@@ -1,6 +1,7 @@
 *.trs
 *.log
 chksum
+cli
 cuckootable
 iplookuptable
 odpthreads

--- a/helper/test/Makefile.am
+++ b/helper/test/Makefile.am
@@ -19,6 +19,11 @@ linux_pthread_SOURCES = linux/pthread.c
 linux_process_SOURCES = linux/process.c
 endif
 
+if helper_cli
+EXECUTABLES += cli
+cli_SOURCES = cli.c
+endif
+
 COMPILE_ONLY = odpthreads
 
 TESTSCRIPTS = odpthreads_as_processes \

--- a/helper/test/cli.c
+++ b/helper/test/cli.c
@@ -1,0 +1,62 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+int main(int argc, char *argv[])
+{
+	odp_instance_t instance;
+	odph_helper_options_t helper_options;
+	odp_init_t init_param;
+
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		ODPH_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	memset(&instance, 0, sizeof(instance));
+
+	if (odp_init_global(&instance, NULL, NULL)) {
+		ODPH_ERR("Error: ODP global init failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (odp_init_local(instance, ODP_THREAD_CONTROL)) {
+		ODPH_ERR("Error: ODP local init failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odph_cli_param_t cli_param;
+
+	odph_cli_param_init(&cli_param);
+
+	if (odph_cli_start(instance, &cli_param)) {
+		ODPH_ERR("Error: odph_cli_start() failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (odph_cli_stop()) {
+		ODPH_ERR("Error: odph_cli_stop() failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (odp_term_local()) {
+		ODPH_ERR("Error: ODP local term failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (odp_term_global(instance)) {
+		ODPH_ERR("Error: ODP global term failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/helper/test/debug.c
+++ b/helper/test/debug.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/autoheader_external.h>
+#include <odp/helper/autoheader_external.h>
 
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>

--- a/include/odp/autoheader_external.h.in
+++ b/include/odp/autoheader_external.h.in
@@ -8,10 +8,4 @@
 /* Define to 1 to display debug information */
 #undef ODP_DEBUG_PRINT
 
-/* Define to 1 to include additional helper debug code */
-#undef ODPH_DEBUG
-
-/* Define to 1 to display helper debug information */
-#undef ODPH_DEBUG_PRINT
-
 #endif

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -27,7 +27,7 @@ m4_include([platform/linux-generic/m4/odp_netmap.m4])
 m4_include([platform/linux-generic/m4/odp_dpdk.m4])
 ODP_SCHEDULER
 
-AS_VAR_APPEND([PLAT_DEP_LIBS], ["${LIBCONFIG_LIBS} ${OPENSSL_LIBS} ${DPDK_LIBS_LT}"])
+AS_VAR_APPEND([PLAT_DEP_LIBS], ["${LIBCONFIG_LIBS} ${OPENSSL_LIBS} ${DPDK_LIBS_LT} ${LIBCLI_LIBS}"])
 
 # Add text to the end of configure with platform specific settings.
 # Make sure it's aligned same as other lines in configure.ac.


### PR DESCRIPTION
```
helper: add CLI helper API and implementation
    
    CLI helper API allows starting and stopping ODP CLI server, which may
    be connected to using a telnet client. CLI commands may be used to get
    information from an ODP instance, for debugging purposes.
    
    This implementation depends on libcli. If libcli is not available, CLI
    helper is automatically excluded.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

helper: test: implement CLI helper test
    
    Test CLI helper by starting and stopping the ODP CLI server.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

example: add CLI helper example
    
    This example shows how to start and stop ODP CLI using the CLI helper
    API functions.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
v2:
- Fix missing initializer.
- Add configure option --with-libcli-path.

v3:
- Fix missing initializer even more.

v4:
- Add LIBCLI_LIBS to Libs.private in helper/libodphelper.pc.in.
- example: Stay open indefinitely by default.
- example: Add odp_cli_run.sh script.
- example: Print "CLI server started" message.
- example: Rename option "num" to "time".
- example: Use odph_options().
- example: Use ODPH_ERR() and exit(EXIT_FAILURE).
- Define ODPH_IPV4ADDRSTR_LEN and ODPH_IPV6ADDRSTR_LEN in ip.h.
- Document default values in odph_cli_param_init().
- Document thread creation and termination.
- Minor CLI helper API documentation cleanups.
- Use shm.

v5:
- example: Add odp_cli_run.sh to dist.

v6:
- Create autoheader_external for helper.
- Include cli.h conditionally in odph_api.h.
- Move documentation of default values from *_param_init() to *_param_t, according to convention.

v7:
- Fix various linking issues with --with-libcli-path option.
- Fail is --with-libcli-path option given and libcli not found.
- Add help string "<name>" to commands that have that parameter.
- Change odph_cli_param_t.address to const char *.
- Rebase.

v8:
- odp_cli_run.sh: Run cli server for two seconds.
- configure: Move libcli logic to a separate libcli.m4 file.
- example/cli: Add signal handler for SIGINT.
- helper/cli.c: Check return value of odp_shm_lookup() calls.
- Increment libodphelper version.
- example/cli: Print a message before stopping cli server.
- helper/cli.c: Free shm in odph_cli_stop().
