### PR TITLE
[PATCH v1] example: tm: prevent redefinition of _GNU_SOURCE

### DIFF
--- a/example/traffic_mgmt/odp_traffic_mgmt.c
+++ b/example/traffic_mgmt/odp_traffic_mgmt.c
@@ -6,7 +6,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <execinfo.h>
 #include <inttypes.h>


### PR DESCRIPTION
Prevent failure if _GNU_SOURCE has been already defined.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reviewed-by: Jere Leppänen <jere.leppanen@nokia.com>