### PR TITLE
[PATCH v1] parallel make check improvements

### DIFF
--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -18,3 +18,32 @@ SUBDIRS = classifier \
 if HAVE_DW_ATOMIC_CMP_EXC
 SUBDIRS += ipfragreass
 endif
+
+if test_example
+TESTS = \
+	debug/odp_debug \
+	generator/generator_run.sh \
+	hello/odp_hello \
+	sysinfo/odp_sysinfo \
+	time/odp_time_global \
+	timer/odp_timer_accuracy \
+	timer/odp_timer_simple \
+	traffic_mgmt/odp_traffic_mgmt
+
+if HAVE_DW_ATOMIC_CMP_EXC
+TESTS += ipfragreass/odp_ipfragreass
+endif
+
+if ODP_PKTIO_PCAP
+TESTS += \
+	classifier/odp_classifier_run.sh \
+	l2fwd_simple/l2fwd_simple_run.sh \
+	l3fwd/odp_l3fwd_run.sh \
+	packet/packet_dump_run.sh \
+	packet/pktio_run.sh \
+	ping/ping_run.sh \
+	simple_pipeline/simple_pipeline_run.sh \
+	switch/switch_run.sh
+endif
+
+endif

--- a/example/classifier/Makefile.am
+++ b/example/classifier/Makefile.am
@@ -4,11 +4,6 @@ bin_PROGRAMS = odp_classifier
 
 odp_classifier_SOURCES = odp_classifier.c
 
-if test_example
-if ODP_PKTIO_PCAP
-TESTS = odp_classifier_run.sh
-endif
-endif
 EXTRA_DIST = odp_classifier_run.sh udp64.pcap
 
 # If building out-of-tree, make check will not copy the scripts and data to the

--- a/example/classifier/odp_classifier_run.sh
+++ b/example/classifier/odp_classifier_run.sh
@@ -6,11 +6,12 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+cd "$(dirname "$0")"
+
 if  [ -f ./pktio_env ]; then
 	. ./pktio_env
 else
-	echo "BUG: unable to find pktio_env!"
-	echo "pktio_env has to be in current directory"
+	echo "ERROR: file not found: $(pwd)/pktio"
 	exit 1
 fi
 

--- a/example/debug/Makefile.am
+++ b/example/debug/Makefile.am
@@ -3,7 +3,3 @@ include $(top_srcdir)/example/Makefile.inc
 bin_PROGRAMS = odp_debug
 
 odp_debug_SOURCES = odp_debug.c
-
-if test_example
-TESTS = odp_debug
-endif

--- a/example/generator/Makefile.am
+++ b/example/generator/Makefile.am
@@ -6,9 +6,6 @@ odp_generator_SOURCES = odp_generator.c
 
 TEST_EXTENSIONS = .sh
 
-if test_example
-TESTS = generator_run.sh
-endif
 EXTRA_DIST = generator_run.sh
 
 # If building out-of-tree, make check will not copy the scripts and data to the

--- a/example/generator/generator_run.sh
+++ b/example/generator/generator_run.sh
@@ -6,11 +6,12 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+cd "$(dirname "$0")"
+
 if  [ -f ./pktio_env ]; then
 	. ./pktio_env
 else
-	echo "BUG: unable to find pktio_env!"
-	echo "pktio_env has to be in current directory"
+	echo "ERROR: file not found: $(pwd)/pktio"
 	exit 1
 fi
 

--- a/example/hello/Makefile.am
+++ b/example/hello/Makefile.am
@@ -3,7 +3,3 @@ include $(top_srcdir)/example/Makefile.inc
 bin_PROGRAMS = odp_hello
 
 odp_hello_SOURCES = odp_hello.c
-
-if test_example
-TESTS = odp_hello
-endif

--- a/example/ipfragreass/Makefile.am
+++ b/example/ipfragreass/Makefile.am
@@ -14,7 +14,3 @@ odp_ipfragreass_SOURCES = odp_ipfragreass.c \
 			  odp_ipfragreass_helpers.h \
 			  odp_ipfragreass_ip.h \
 			  odp_ipfragreass_reassemble.h
-
-if test_example
-TESTS = odp_ipfragreass
-endif

--- a/example/l2fwd_simple/Makefile.am
+++ b/example/l2fwd_simple/Makefile.am
@@ -4,11 +4,6 @@ bin_PROGRAMS = odp_l2fwd_simple
 
 odp_l2fwd_simple_SOURCES = odp_l2fwd_simple.c
 
-if test_example
-if ODP_PKTIO_PCAP
-TESTS = l2fwd_simple_run.sh
-endif
-endif
 EXTRA_DIST = l2fwd_simple_run.sh udp64.pcap
 
 # If building out-of-tree, make check will not copy the scripts and data to the

--- a/example/l2fwd_simple/l2fwd_simple_run.sh
+++ b/example/l2fwd_simple/l2fwd_simple_run.sh
@@ -6,11 +6,12 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+cd "$(dirname "$0")"
+
 if  [ -f ./pktio_env ]; then
   . ./pktio_env
 else
-  echo "BUG: unable to find pktio_env!"
-  echo "pktio_env has to be in current directory"
+  echo "ERROR: file not found: $(pwd)/pktio"
   exit 1
 fi
 

--- a/example/l3fwd/Makefile.am
+++ b/example/l3fwd/Makefile.am
@@ -9,11 +9,6 @@ odp_l3fwd_SOURCES = \
 		    odp_l3fwd_db.h \
 		    odp_l3fwd_lpm.h
 
-if test_example
-if ODP_PKTIO_PCAP
-TESTS = odp_l3fwd_run.sh
-endif
-endif
 EXTRA_DIST = odp_l3fwd_run.sh udp64.pcap
 
 # If building out-of-tree, make check will not copy the scripts and data to the

--- a/example/l3fwd/odp_l3fwd_run.sh
+++ b/example/l3fwd/odp_l3fwd_run.sh
@@ -6,11 +6,12 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+cd "$(dirname "$0")"
+
 if  [ -f ./pktio_env ]; then
 	. ./pktio_env
 else
-	echo "BUG: unable to find pktio_env!"
-	echo "pktio_env has to be in current directory"
+	echo "ERROR: file not found: $(pwd)/pktio"
 	exit 1
 fi
 

--- a/example/packet/Makefile.am
+++ b/example/packet/Makefile.am
@@ -7,11 +7,6 @@ odp_packet_dump_SOURCES = odp_packet_dump.c
 
 odp_pktio_SOURCES = odp_pktio.c
 
-if test_example
-if ODP_PKTIO_PCAP
-TESTS = packet_dump_run.sh pktio_run.sh
-endif
-endif
 EXTRA_DIST = packet_dump_run.sh pktio_run.sh udp64.pcap
 
 # If building out-of-tree, make check will not copy the scripts and data to the

--- a/example/packet/packet_dump_run.sh
+++ b/example/packet/packet_dump_run.sh
@@ -6,11 +6,12 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+cd "$(dirname "$0")"
+
 if  [ -f ./pktio_env ]; then
   . ./pktio_env
 else
-  echo "BUG: unable to find pktio_env!"
-  echo "pktio_env has to be in current directory"
+  echo "ERROR: file not found: $(pwd)/pktio"
   exit 1
 fi
 

--- a/example/packet/pktio_run.sh
+++ b/example/packet/pktio_run.sh
@@ -6,11 +6,12 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+cd "$(dirname "$0")"
+
 if  [ -f ./pktio_env ]; then
 	. ./pktio_env
 else
-        echo "BUG: unable to find pktio_env!"
-        echo "pktio_env has to be in current directory"
+	echo "ERROR: file not found: $(pwd)/pktio"
         exit 1
 fi
 

--- a/example/ping/Makefile.am
+++ b/example/ping/Makefile.am
@@ -4,11 +4,6 @@ bin_PROGRAMS = odp_ping
 
 odp_ping_SOURCES = odp_ping.c
 
-if test_example
-if ODP_PKTIO_PCAP
-TESTS = ping_run.sh
-endif
-endif
 EXTRA_DIST = ping_run.sh icmp_echo_req.pcap
 
 # If building out-of-tree, make check will not copy the scripts and data to the

--- a/example/ping/ping_run.sh
+++ b/example/ping/ping_run.sh
@@ -6,11 +6,12 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+cd "$(dirname "$0")"
+
 if  [ -f ./pktio_env ]; then
 	. ./pktio_env
 else
-        echo "BUG: unable to find pktio_env!"
-        echo "pktio_env has to be in current directory"
+	echo "ERROR: file not found: $(pwd)/pktio"
         exit 1
 fi
 

--- a/example/simple_pipeline/Makefile.am
+++ b/example/simple_pipeline/Makefile.am
@@ -4,11 +4,6 @@ bin_PROGRAMS = odp_simple_pipeline
 
 odp_simple_pipeline_SOURCES = odp_simple_pipeline.c
 
-if test_example
-if ODP_PKTIO_PCAP
-TESTS = simple_pipeline_run.sh
-endif
-endif
 EXTRA_DIST = simple_pipeline_run.sh udp64.pcap
 
 # If building out-of-tree, make check will not copy the scripts and data to the

--- a/example/simple_pipeline/simple_pipeline_run.sh
+++ b/example/simple_pipeline/simple_pipeline_run.sh
@@ -6,16 +6,17 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
-# Exit code expected by automake for skipped tests
-TEST_SKIPPED=77
+cd "$(dirname "$0")"
 
 if  [ -f ./pktio_env ]; then
   . ./pktio_env
 else
-  echo "BUG: unable to find pktio_env!"
-  echo "pktio_env has to be in current directory"
+  echo "ERROR: file not found: $(pwd)/pktio"
   exit 1
 fi
+
+# Exit code expected by automake for skipped tests
+TEST_SKIPPED=77
 
 if [ $(nproc --all) -lt 3 ]; then
   echo "Not enough CPU cores. Skipping test."

--- a/example/switch/Makefile.am
+++ b/example/switch/Makefile.am
@@ -4,11 +4,6 @@ bin_PROGRAMS = odp_switch
 
 odp_switch_SOURCES = odp_switch.c
 
-if test_example
-if ODP_PKTIO_PCAP
-TESTS = switch_run.sh
-endif
-endif
 EXTRA_DIST = switch_run.sh udp64.pcap
 
 # If building out-of-tree, make check will not copy the scripts and data to the

--- a/example/switch/switch_run.sh
+++ b/example/switch/switch_run.sh
@@ -6,15 +6,16 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
-RETVAL=0
+cd "$(dirname "$0")"
 
 if  [ -f ./pktio_env ]; then
   . ./pktio_env
 else
-  echo "BUG: unable to find pktio_env!"
-  echo "pktio_env has to be in current directory"
+  echo "ERROR: file not found: $(pwd)/pktio"
   exit 1
 fi
+
+RETVAL=0
 
 setup_interfaces
 

--- a/example/sysinfo/Makefile.am
+++ b/example/sysinfo/Makefile.am
@@ -3,7 +3,3 @@ include $(top_srcdir)/example/Makefile.inc
 bin_PROGRAMS = odp_sysinfo
 
 odp_sysinfo_SOURCES = odp_sysinfo.c
-
-if test_example
-TESTS = odp_sysinfo
-endif

--- a/example/time/Makefile.am
+++ b/example/time/Makefile.am
@@ -2,8 +2,4 @@ include $(top_srcdir)/example/Makefile.inc
 
 bin_PROGRAMS = odp_time_global
 
-if test_example
-TESTS = odp_time_global
-endif
-
 odp_time_global_SOURCES = time_global_test.c

--- a/example/timer/Makefile.am
+++ b/example/timer/Makefile.am
@@ -9,8 +9,3 @@ odp_timer_accuracy_SOURCES = odp_timer_accuracy.c
 odp_timer_simple_SOURCES = odp_timer_simple.c
 
 odp_timer_test_SOURCES = odp_timer_test.c
-
-if test_example
-TESTS  = odp_timer_accuracy \
-	odp_timer_simple
-endif

--- a/example/traffic_mgmt/Makefile.am
+++ b/example/traffic_mgmt/Makefile.am
@@ -2,8 +2,4 @@ include $(top_srcdir)/example/Makefile.inc
 
 bin_PROGRAMS = odp_traffic_mgmt
 
-if test_example
-TESTS = odp_traffic_mgmt
-endif
-
 odp_traffic_mgmt_SOURCES = odp_traffic_mgmt.c

--- a/scripts/ci/check.sh
+++ b/scripts/ci/check.sh
@@ -12,6 +12,6 @@ cd "$(dirname "$0")"/../..
 # Ignore possible failures there because these tests depends on measurements
 # and systems might differ in performance.
 export CI="true"
-make check
+make -j $(nproc) check
 
 umount /mnt/huge

--- a/scripts/ci/distcheck.sh
+++ b/scripts/ci/distcheck.sh
@@ -16,4 +16,4 @@ export CI="true"
 # Additional configure flags for distcheck
 export DISTCHECK_CONFIGURE_FLAGS="${CONF}"
 
-make distcheck
+make -j $(nproc) distcheck

--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -84,3 +84,5 @@ clean-local:
 			rm -f $(builddir)/$$f; \
 		done \
 	fi
+
+.NOTPARALLEL:

--- a/test/validation/api/Makefile.am
+++ b/test/validation/api/Makefile.am
@@ -32,7 +32,7 @@ SUBDIRS = $(ODP_MODULES)
 include $(top_srcdir)/test/Makefile.inc
 TESTS_ENVIRONMENT += TEST_DIR=${top_builddir}/test/validation
 
-TESTS = \
+TESTS_PARALLEL = \
 	atomic/atomic_main$(EXEEXT) \
 	barrier/barrier_main$(EXEEXT) \
 	buffer/buffer_main$(EXEEXT) \
@@ -67,9 +67,13 @@ TESTS = \
 	thread/thread_main$(EXEEXT) \
 	time/time_main$(EXEEXT) \
 	timer/timer_main$(EXEEXT) \
-	traffic_mngr/traffic_mngr_main$(EXEEXT) \
 	shmem/shmem_main$(EXEEXT) \
 	system/system_main$(EXEEXT)
+
+TESTS = $(TESTS_PARALLEL) \
+	traffic_mngr/traffic_mngr_main$(EXEEXT)
+
+traffic_mngr/traffic_mngr_main$(EXEEXT): | $(TESTS_PARALLEL:=.log)
 
 TESTNAME = validation
 


### PR DESCRIPTION
```
validation: traffic_mngr: don't run in parallel
    
    Don't run the traffic_mngr validation test in parallel with other
    tests. Doing so often causes the traffic shaper test to fail due to
    intervals between received packets being outside the acceptable range.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

test: perf: don't run performance tests in parallel
    
    Don't run performance tests in parallel during make check, as doing so
    may affect the results.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

example: allow scripts to be run with an arbitrary cwd
    
    Make all of the example run scripts cd to the script's directory
    before doing anything else, so that they may be run regardless of the
    current working directory.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

example: run in parallel during make check
    
    Run all examples in parallel during make check (if running them is
    enabled).
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

ci: use multiple jobs for check and distcheck
    
    Use $(nproc) jobs to run make check and make distcheck in CI.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
