### PR TITLE
[PATCH v2] api: packet: introduce max flow hash value constant

### DIFF
--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1913,7 +1913,8 @@ uint32_t odp_packet_flow_hash(odp_packet_t pkt);
  *
  * Store the packet flow hash for the packet and sets the flow hash flag. This
  * enables (but does not require!) application to reflect packet header
- * changes in the hash.
+ * changes in the hash. Maximum hash value that can be set is defined by
+ * pktio capability 'max_flow_hash'.
  *
  * @param      pkt              Packet handle
  * @param      flow_hash        Hash value to set
@@ -1923,6 +1924,8 @@ uint32_t odp_packet_flow_hash(odp_packet_t pkt);
  * change how the platform handles this packet after it.
  * @note The application is not required to keep this hash valid for new or
  * modified packets.
+ *
+ * @see odp_pktio_capability_t::max_flow_hash
  */
 void odp_packet_flow_hash_set(odp_packet_t pkt, uint32_t flow_hash);
 

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -845,6 +845,15 @@ typedef struct odp_pktio_capability_t {
 		uint32_t max_output;
 	} maxlen;
 
+	/** Maximum flow hash value.
+	 *
+	 * This defines the maximum flow hash value that an application can set.
+	 * Attempts to set flow hash value greater than this limit will fail.
+	 *
+	 * @see odp_packet_flow_hash_set()
+	 */
+	uint32_t max_flow_hash;
+
 } odp_pktio_capability_t;
 
 /**

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1829,6 +1829,8 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 		capa->vector.max_tmo_ns = 0;
 		capa->vector.min_tmo_ns = 0;
 	}
+	/* Setting up max flow hash capability. */
+	capa->max_flow_hash = UINT32_MAX;
 
 	return ret;
 }

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -659,6 +659,8 @@ static void packet_test_basic_metadata(void)
 	odp_packet_t pkt = test_packet;
 	odp_time_t ts;
 	odp_packet_data_range_t range;
+	odp_pktio_t pktio;
+	odp_pktio_capability_t capa;
 
 	CU_ASSERT_PTR_NOT_NULL(odp_packet_head(pkt));
 	CU_ASSERT_PTR_NOT_NULL(odp_packet_data(pkt));
@@ -673,9 +675,13 @@ static void packet_test_basic_metadata(void)
 	odp_packet_ones_comp(pkt, &range);
 	CU_ASSERT(range.length == 0);
 
-	odp_packet_flow_hash_set(pkt, UINT32_MAX);
+	pktio = odp_pktio_open("loop", odp_packet_pool(pkt), NULL);
+	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
+	CU_ASSERT_FATAL(odp_pktio_capability(pktio, &capa) == 0);
+
+	odp_packet_flow_hash_set(pkt, capa.max_flow_hash);
 	CU_ASSERT(odp_packet_has_flow_hash(pkt));
-	CU_ASSERT(odp_packet_flow_hash(pkt) == UINT32_MAX);
+	CU_ASSERT(odp_packet_flow_hash(pkt) == capa.max_flow_hash);
 	odp_packet_has_flow_hash_clr(pkt);
 	CU_ASSERT(!odp_packet_has_flow_hash(pkt));
 
@@ -687,6 +693,7 @@ static void packet_test_basic_metadata(void)
 	CU_ASSERT(!odp_time_cmp(ts, odp_packet_ts(pkt)));
 	odp_packet_has_ts_clr(pkt);
 	CU_ASSERT(!odp_packet_has_ts(pkt));
+	CU_ASSERT(odp_pktio_close(pktio) == 0);
 }
 
 static void packet_test_length(void)


### PR DESCRIPTION
## api: packet: introduce max flow hash pktio capability

Introducing max flow hash value as pktio capability, which
defines the maximum flow hash that can be set by the
application. This capability is required as some platforms
may have limitation on maximum flow hash value that can be
set.

Signed-off-by: Harman Kalra <hkalra@marvell.com>

## linux-gen: pktio: max flow hash value

Defining maximum flow hash pktio capability for linux
generic platform.

Signed-off-by: Harman Kalra <hkalra@marvell.com>

## validation: pktio: use maximum flow hash capability

Some platforms may have limitation on size of flow hash value
that can be set, using max_flow_hash pktio capability to set
platform defined max flow hash value.

Signed-off-by: Harman Kalra <hkalra@marvell.com>
