### PR TITLE
[PATCH v1] api: packet: updating documentation for packet input set

### DIFF
--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1539,6 +1539,8 @@ odp_pktio_t odp_packet_input(odp_packet_t pkt);
  * @param pktio Handle to a valid packet input interface or ODP_PKTIO_INVALID.
  *              ODP_PKTIO_INVALID indicates that the packet was not received by
  *              any packet IO interface.
+ *
+ * @note odp_packet_input_set() expects PktIO handle to be in configured state.
  */
 void odp_packet_input_set(odp_packet_t pkt, odp_pktio_t pktio);
 

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -1442,6 +1442,9 @@ static void packet_test_meta_data_copy(void)
 	pktio = odp_pktio_open("loop", pool, NULL);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 
+	CU_ASSERT(odp_pktin_queue_config(pktio, NULL) == 0);
+	CU_ASSERT(odp_pktout_queue_config(pktio, NULL) == 0);
+
 	t1 = odp_time_global();
 
 	pkt = odp_packet_alloc(pool, packet_len);


### PR DESCRIPTION
## api: packet: updating documentation for packet input set

Adding a note to the documentation of odp_packet_input_set() API,
to be sure that PktIO handle is in configured state before passing
it as an argument to the API.

Signed-off-by: Harman Kalra <hkalra@marvell.com>

## validation: packet: configure pktio before packet input set

PktIO handle remains unconfigured after odp_pktio_open() and
to take it into configured state, pktio must be configured for
input and output.
odp_packet_input_set() may fail in some platform if pktio is in
unconfigured state.

Signed-off-by: Harman Kalra <hkalra@marvell.com>