### PR TITLE
[PATCH v2] test: performance: skip duplicate test runs

### DIFF
--- a/test/performance/odp_sched_latency_run.sh
+++ b/test/performance/odp_sched_latency_run.sh
@@ -14,9 +14,13 @@ ALL=0
 run()
 {
 	echo odp_sched_latency_run starts requesting $1 worker threads
-	echo ===============================================
+	echo =========================================================
 
-	$TEST_DIR/odp_sched_latency${EXEEXT} -c $1 || exit $?
+	if [ $(nproc) -lt $1 ]; then
+		echo "Not enough CPU cores. Skipping test."
+	else
+		$TEST_DIR/odp_sched_latency${EXEEXT} -c $1 || exit $?
+	fi
 }
 
 run 1

--- a/test/performance/odp_scheduling_run.sh
+++ b/test/performance/odp_scheduling_run.sh
@@ -14,14 +14,17 @@ ALL=0
 run()
 {
 	echo odp_scheduling_run starts requesting $1 worker threads
-	echo ===============================================
+	echo ======================================================
 
-	$TEST_DIR/odp_scheduling${EXEEXT} -c $1
-
-	RET_VAL=$?
-	if [ $RET_VAL -ne 0 ]; then
-		echo odp_scheduling FAILED
-		exit $RET_VAL
+	if [ $(nproc) -lt $1 ]; then
+		echo "Not enough CPU cores. Skipping test."
+	else
+		$TEST_DIR/odp_scheduling${EXEEXT} -c $1
+		RET_VAL=$?
+		if [ $RET_VAL -ne 0 ]; then
+			echo odp_scheduling FAILED
+			exit $RET_VAL
+		fi
 	fi
 }
 


### PR DESCRIPTION
Scheduling performance and latency test applications are run multiple times
during 'make check' with a different number of worker threads. Skip test
runs if there are not enough CPU cores available.

Signed-off-by: Matias Elo <matias.elo@nokia.com>