### PR TITLE
[PATCH v6] api: ipsec: define more default values & improve SA info API

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -522,13 +522,13 @@ typedef struct odp_ipsec_ipv4_param_t {
 	/** IPv4 destination address (NETWORK ENDIAN) */
 	void *dst_addr;
 
-	/** IPv4 Differentiated Services Code Point */
+	/** IPv4 Differentiated Services Code Point. The default value is 0. */
 	uint8_t dscp;
 
-	/** IPv4 Don't Fragment bit */
+	/** IPv4 Don't Fragment bit. The default value is 0. */
 	uint8_t df;
 
-	/** IPv4 Time To Live */
+	/** IPv4 Time To Live. The default value is 255. */
 	uint8_t ttl;
 
 } odp_ipsec_ipv4_param_t;
@@ -541,13 +541,13 @@ typedef struct odp_ipsec_ipv6_param_t {
 	/** IPv6 destination address (NETWORK ENDIAN) */
 	void *dst_addr;
 
-	/** IPv6 flow label */
+	/** IPv6 flow label. The default value is 0. */
 	uint32_t flabel;
 
-	/** IPv6 Differentiated Services Code Point */
+	/** IPv6 Differentiated Services Code Point. The default value is 0. */
 	uint8_t dscp;
 
-	/** IPv6 hop limit */
+	/** IPv6 hop limit. The default value is 255. */
 	uint8_t hlimit;
 
 } odp_ipsec_ipv6_param_t;
@@ -561,11 +561,11 @@ typedef struct odp_ipsec_ipv6_param_t {
  * pointers and copied byte-by-byte from memory to the packet.
  */
 typedef struct odp_ipsec_tunnel_param_t {
-	/** Tunnel type: IPv4 or IPv6 */
+	/** Tunnel type: IPv4 or IPv6. The default is IPv4. */
 	odp_ipsec_tunnel_type_t type;
 
-	/** Variant mappings for tunnel parameters */
-	union {
+	/** Tunnel type specific parameters */
+	struct {
 		/** IPv4 header parameters */
 		odp_ipsec_ipv4_param_t ipv4;
 
@@ -581,7 +581,7 @@ typedef struct odp_ipsec_sa_opt_t {
 	/** Extended Sequence Numbers (ESN)
 	  *
 	  * * 1: Use extended (64 bit) sequence numbers
-	  * * 0: Use normal sequence numbers
+	  * * 0: Use normal sequence numbers (the default value)
 	  */
 	uint32_t esn : 1;
 
@@ -589,7 +589,7 @@ typedef struct odp_ipsec_sa_opt_t {
 	  *
 	  * * 1: Do UDP encapsulation/decapsulation so that IPSEC packets can
 	  *      traverse through NAT boxes.
-	  * * 0: No UDP encapsulation
+	  * * 0: No UDP encapsulation (the default value)
 	  */
 	uint32_t udp_encap : 1;
 
@@ -599,7 +599,7 @@ typedef struct odp_ipsec_sa_opt_t {
 	  *      the outer IP header in encapsulation, and vice versa in
 	  *      decapsulation.
 	  * * 0: Use values from odp_ipsec_tunnel_param_t in encapsulation and
-	  *      do not change DSCP field in decapsulation.
+	  *      do not change DSCP field in decapsulation (the default value).
 	  */
 	uint32_t copy_dscp : 1;
 
@@ -607,7 +607,7 @@ typedef struct odp_ipsec_sa_opt_t {
 	  *
 	  * * 1: Copy IPv6 flow label from inner IPv6 header to the
 	  *      outer IPv6 header.
-	  * * 0: Use value from odp_ipsec_tunnel_param_t
+	  * * 0: Use value from odp_ipsec_tunnel_param_t (the default value)
 	  */
 	uint32_t copy_flabel : 1;
 
@@ -615,7 +615,7 @@ typedef struct odp_ipsec_sa_opt_t {
 	  *
 	  * * 1: Copy the DF bit from the inner IPv4 header to the outer
 	  *      IPv4 header.
-	  * * 0: Use value from odp_ipsec_tunnel_param_t
+	  * * 0: Use value from odp_ipsec_tunnel_param_t (the default value)
 	  */
 	uint32_t copy_df : 1;
 
@@ -624,7 +624,7 @@ typedef struct odp_ipsec_sa_opt_t {
 	  * * 1: In tunnel mode, decrement inner packet IPv4 TTL or
 	  *      IPv6 Hop Limit after tunnel decapsulation, or before tunnel
 	  *      encapsulation.
-	  * * 0: Inner packet is not modified.
+	  * * 0: Inner packet is not modified (the default value)
 	  */
 	uint32_t dec_ttl : 1;
 
@@ -639,6 +639,8 @@ typedef struct odp_ipsec_sa_opt_t {
  * lifetime expiration is reported: only once, first N or all packets following
  * the limit crossing. Any number of limits may be used simultaneously.
  * Use zero when there is no limit.
+ *
+ * The default value is zero (i.e. no limit) for all the limits.
  */
 typedef struct odp_ipsec_lifetime_t {
 	/** Soft expiry limits for the session */
@@ -739,7 +741,7 @@ typedef struct odp_ipsec_sa_param_t {
 	/** IPSEC SA direction: inbound or outbound */
 	odp_ipsec_dir_t dir;
 
-	/** IPSEC protocol: ESP or AH */
+	/** IPSEC protocol: ESP or AH. The default value is ODP_IPSEC_ESP. */
 	odp_ipsec_protocol_t proto;
 
 	/** IPSEC protocol mode: transport or tunnel */
@@ -782,10 +784,12 @@ typedef struct odp_ipsec_sa_param_t {
 	uint32_t context_len;
 
 	/** IPSEC SA direction dependent parameters */
-	union {
+	struct {
 		/** Inbound specific parameters */
 		struct {
-			/** SA lookup mode */
+			/** SA lookup mode
+			 *  The default value is ODP_IPSEC_LOOKUP_DISABLED.
+			 */
 			odp_ipsec_lookup_mode_t lookup_mode;
 
 			/** Additional SA lookup parameters. Values are
@@ -802,7 +806,7 @@ typedef struct odp_ipsec_sa_param_t {
 			} lookup_param;
 
 			/** Minimum anti-replay window size. Use 0 to disable
-			 *  anti-replay service.
+			 *  anti-replay service. The default value is 0.
 			 */
 			uint32_t antireplay_ws;
 
@@ -835,7 +839,9 @@ typedef struct odp_ipsec_sa_param_t {
 			/** Parameters for tunnel mode */
 			odp_ipsec_tunnel_param_t tunnel;
 
-			/** Fragmentation mode */
+			/** Fragmentation mode
+			 *  The default value is ODP_IPSEC_FRAG_DISABLED.
+			 */
 			odp_ipsec_frag_mode_t frag_mode;
 
 			/** MTU for outbound IP fragmentation offload

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -884,7 +884,14 @@ typedef struct odp_ipsec_stats_t {
  * IPSEC SA information
  */
 typedef struct odp_ipsec_sa_info_t {
-	/** Copy of IPSEC Security Association (SA) parameters */
+	/** IPsec SA parameters
+	 *
+	 * This is not necessarily an exact copy of the actual parameter
+	 * structure used in SA creation. The fields that were relevant
+	 * for the SA in the creation phase will have the same values,
+	 * but other fields, such as tunnel parameters for a transport
+	 * mode SA, will have undefined values.
+	 */
 	odp_ipsec_sa_param_t param;
 
 	/** IPSEC SA direction dependent parameters */

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -318,6 +318,8 @@ void odp_ipsec_sa_param_init(odp_ipsec_sa_param_t *param)
 {
 	memset(param, 0, sizeof(odp_ipsec_sa_param_t));
 	param->dest_queue = ODP_QUEUE_INVALID;
+	param->outbound.tunnel.ipv4.ttl = 255;
+	param->outbound.tunnel.ipv6.hlimit = 255;
 }
 
 /* Return IV length required for the cipher for IPsec use */

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -1427,6 +1427,53 @@ static void ipsec_test_capability(void)
 	CU_ASSERT(odp_ipsec_capability(&capa) == 0);
 }
 
+static void ipsec_test_default_values(void)
+{
+	odp_ipsec_config_t config;
+	odp_ipsec_sa_param_t sa_param;
+
+	memset(&config, 0x55, sizeof(config));
+	memset(&sa_param, 0x55, sizeof(sa_param));
+
+	odp_ipsec_config_init(&config);
+	CU_ASSERT(config.inbound.lookup.min_spi == 0);
+	CU_ASSERT(config.inbound.lookup.max_spi == UINT32_MAX);
+	CU_ASSERT(config.inbound.lookup.spi_overlap == 0);
+	CU_ASSERT(config.inbound.retain_outer == ODP_PROTO_LAYER_NONE);
+	CU_ASSERT(config.inbound.parse_level == ODP_PROTO_LAYER_NONE);
+	CU_ASSERT(config.inbound.chksums.all_chksum == 0);
+	CU_ASSERT(config.outbound.all_chksum == 0);
+	CU_ASSERT(!config.stats_en);
+
+	odp_ipsec_sa_param_init(&sa_param);
+	CU_ASSERT(sa_param.proto == ODP_IPSEC_ESP);
+	CU_ASSERT(sa_param.crypto.cipher_alg == ODP_CIPHER_ALG_NULL);
+	CU_ASSERT(sa_param.crypto.auth_alg == ODP_AUTH_ALG_NULL);
+	CU_ASSERT(sa_param.opt.esn == 0);
+	CU_ASSERT(sa_param.opt.udp_encap == 0);
+	CU_ASSERT(sa_param.opt.copy_dscp == 0);
+	CU_ASSERT(sa_param.opt.copy_flabel == 0);
+	CU_ASSERT(sa_param.opt.copy_df == 0);
+	CU_ASSERT(sa_param.opt.dec_ttl == 0);
+	CU_ASSERT(sa_param.lifetime.soft_limit.bytes == 0);
+	CU_ASSERT(sa_param.lifetime.soft_limit.packets == 0);
+	CU_ASSERT(sa_param.lifetime.hard_limit.bytes == 0);
+	CU_ASSERT(sa_param.lifetime.hard_limit.packets == 0);
+	CU_ASSERT(sa_param.context == NULL);
+	CU_ASSERT(sa_param.context_len == 0);
+	CU_ASSERT(sa_param.inbound.lookup_mode == ODP_IPSEC_LOOKUP_DISABLED);
+	CU_ASSERT(sa_param.inbound.antireplay_ws == 0);
+	CU_ASSERT(sa_param.inbound.pipeline == ODP_IPSEC_PIPELINE_NONE);
+	CU_ASSERT(sa_param.outbound.tunnel.type == ODP_IPSEC_TUNNEL_IPV4);
+	CU_ASSERT(sa_param.outbound.tunnel.ipv4.dscp == 0);
+	CU_ASSERT(sa_param.outbound.tunnel.ipv4.df == 0);
+	CU_ASSERT(sa_param.outbound.tunnel.ipv4.ttl == 255);
+	CU_ASSERT(sa_param.outbound.tunnel.ipv6.flabel == 0);
+	CU_ASSERT(sa_param.outbound.tunnel.ipv6.dscp == 0);
+	CU_ASSERT(sa_param.outbound.tunnel.ipv6.hlimit == 255);
+	CU_ASSERT(sa_param.outbound.frag_mode == ODP_IPSEC_FRAG_DISABLED);
+}
+
 static void test_ipsec_stats(void)
 {
 	ipsec_test_flags flags;
@@ -1450,6 +1497,7 @@ static void test_ipsec_stats(void)
 
 odp_testinfo_t ipsec_out_suite[] = {
 	ODP_TEST_INFO(ipsec_test_capability),
+	ODP_TEST_INFO(ipsec_test_default_values),
 	ODP_TEST_INFO_CONDITIONAL(test_out_ipv4_ah_sha256,
 				  ipsec_check_ah_sha256),
 	ODP_TEST_INFO_CONDITIONAL(test_out_ipv4_ah_sha256_tun_ipv4,


### PR DESCRIPTION
Define default values for more fields of odp_ipsec_sa_param_t so that applications do not always have to explicitly initialize as many fields after the odp_ipsec_sa_param_init() call.

The current validation tests do not actually set all the parameters that they should. It can cause test failures in implementations that set the implementation-defined values differently from linux-gen. This API change makes the needed fix there smaller.
