### PR TITLE
[PATCH v2] api: atomic cas strong

### DIFF
--- a/include/odp/api/spec/atomic.h
+++ b/include/odp/api/spec/atomic.h
@@ -193,9 +193,10 @@ void odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t new_min);
  * Compare and swap atomic uint32 variable
  *
  * Compares value of atomic variable to the value pointed by 'old_val'.
- * If values are equal, the operation writes 'new_val' into the atomic variable
- * and returns success. If they are not equal, the operation writes current
- * value of atomic variable into 'old_val' and returns failure.
+ * If the values are equal, the operation writes 'new_val' into the atomic variable
+ * and returns success. The operation returns failure only when the values are
+ * not equal (strong CAS operation). The current value of atomic variable is written
+ * into 'old_val' on failure.
  *
  * @param         atom      Pointer to atomic variable
  * @param[in,out] old_val   Pointer to the old value of the atomic variable.
@@ -203,10 +204,8 @@ void odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t new_min);
  * @param         new_val   New value to be written into the atomic variable
  *
  * @return 0 on failure, !0 on success
- *
  */
-int odp_atomic_cas_u32(odp_atomic_u32_t *atom, uint32_t *old_val,
-		       uint32_t new_val);
+int odp_atomic_cas_u32(odp_atomic_u32_t *atom, uint32_t *old_val, uint32_t new_val);
 
 /**
  * Exchange value of atomic uint32 variable
@@ -349,9 +348,10 @@ void odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t new_min);
  * Compare and swap atomic uint64 variable
  *
  * Compares value of atomic variable to the value pointed by 'old_val'.
- * If values are equal, the operation writes 'new_val' into the atomic variable
- * and returns success. If they are not equal, the operation writes current
- * value of atomic variable into 'old_val' and returns failure.
+ * If the values are equal, the operation writes 'new_val' into the atomic variable
+ * and returns success. The operation returns failure only when the values are
+ * not equal (strong CAS operation). The current value of atomic variable is written
+ * into 'old_val' on failure.
  *
  * @param         atom      Pointer to atomic variable
  * @param[in,out] old_val   Pointer to the old value of the atomic variable.
@@ -360,8 +360,7 @@ void odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t new_min);
  *
  * @return 0 on failure, !0 on success
  */
-int odp_atomic_cas_u64(odp_atomic_u64_t *atom, uint64_t *old_val,
-		       uint64_t new_val);
+int odp_atomic_cas_u64(odp_atomic_u64_t *atom, uint64_t *old_val, uint64_t new_val);
 
 /**
  * Exchange value of atomic uint64 variable
@@ -414,9 +413,10 @@ void odp_atomic_store_u128(odp_atomic_u128_t *atom, odp_u128_t val);
  * Compare and swap atomic odp_u128_t variable
  *
  * Compares value of atomic variable to the value pointed by 'old_val'.
- * If values are equal, the operation writes 'new_val' into the atomic variable
- * and returns success. If they are not equal, the operation writes current
- * value of atomic variable into 'old_val' and returns failure.
+ * If the values are equal, the operation writes 'new_val' into the atomic variable
+ * and returns success. The operation returns failure only when the values are
+ * not equal (strong CAS operation). The current value of atomic variable is written
+ * into 'old_val' on failure.
  *
  * @param         atom      Pointer to atomic variable
  * @param[in,out] old_val   Pointer to the old value of the atomic variable.
@@ -425,8 +425,7 @@ void odp_atomic_store_u128(odp_atomic_u128_t *atom, odp_u128_t val);
  *
  * @return 0 on failure, !0 on success
  */
-int odp_atomic_cas_u128(odp_atomic_u128_t *atom, odp_u128_t *old_val,
-			odp_u128_t new_val);
+int odp_atomic_cas_u128(odp_atomic_u128_t *atom, odp_u128_t *old_val, odp_u128_t new_val);
 
 /*
  * 32-bit operations in non-RELAXED memory ordering


### PR DESCRIPTION
Specify explicitly that atomic CAS operations are strong (do not return failure spuriously). This goes on top of PR 1080.