### PR TITLE
[PATCH v2] don't run tests in parallel

### DIFF
--- a/example/packet/Makefile.am
+++ b/example/packet/Makefile.am
@@ -35,3 +35,5 @@ clean-local:
 			rm -f $(builddir)/$$f; \
 		done \
 	fi
+
+.NOTPARALLEL:

--- a/example/timer/Makefile.am
+++ b/example/timer/Makefile.am
@@ -14,3 +14,5 @@ if test_example
 TESTS  = odp_timer_accuracy \
 	odp_timer_simple
 endif
+
+.NOTPARALLEL:

--- a/helper/test/Makefile.am
+++ b/helper/test/Makefile.am
@@ -65,3 +65,5 @@ clean-local:
 			rm -f $(builddir)/$$f; \
 		done \
 	fi
+
+.NOTPARALLEL:

--- a/platform/linux-generic/test/Makefile.am
+++ b/platform/linux-generic/test/Makefile.am
@@ -89,3 +89,5 @@ clean-local:
 			rm -f $(builddir)/$$f; \
 		done \
 	fi
+
+.NOTPARALLEL:

--- a/scripts/ci/distcheck.sh
+++ b/scripts/ci/distcheck.sh
@@ -16,4 +16,4 @@ export CI="true"
 # Additional configure flags for distcheck
 export DISTCHECK_CONFIGURE_FLAGS="${CONF}"
 
-make distcheck
+make -j $(nproc) distcheck

--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -86,3 +86,5 @@ clean-local:
 			rm -f $(builddir)/$$f; \
 		done \
 	fi
+
+.NOTPARALLEL:

--- a/test/validation/api/Makefile.am
+++ b/test/validation/api/Makefile.am
@@ -88,3 +88,5 @@ if test_installdir
 installcheck-local:
 	$(DESTDIR)/$(testdir)/run-test.sh $(TESTNAME)
 endif
+
+.NOTPARALLEL:


### PR DESCRIPTION
```
ci: use multiple jobs for distcheck
    
    Use $(nproc) jobs to run distcheck in CI.
    
    Signed-off-by: Jere Leppä?nen <jere.leppanen@nokia.com>

don't run tests in parallel
    
    Explicitly prevent tests from being run in parallel when the -j option
    is used with make check.
    
    Using the .NOTPARALLEL special target is the only easy way to ensure
    that tests are run one by one. Unfortunately this also prevents
    parallel builds for the tests.
    
    Signed-off-by: Jere Leppä?nen <jere.leppanen@nokia.com>
```
v2:
- Add "build:" tag to subject line of first commit.
- Rebase.
- Add reviewed-by tags.
