### PR TITLE
[PATCH v3] Increase the maximum number of IPsec SAs and crypto sessions

### DIFF
--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2019-2020, Nokia
+ * Copyright (c) 2019-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -146,6 +146,13 @@ extern "C" {
 
 /* Enable pool statistics collection */
 #define CONFIG_POOL_STATISTICS 1
+
+/*
+ * Maximum number of IPsec SAs. The actual maximum number can be further
+ * limited by the number of sessions supported by the crypto subsystem and
+ * is reported by odp_ipsec_capability().
+ */
+#define CONFIG_IPSEC_MAX_NUM_SA 4000
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -86,11 +86,6 @@ int _odp_ipsec_status_send(odp_queue_t queue,
 /* 32 is minimum required by the standard. We do not support more */
 #define IPSEC_ANTIREPLAY_WS	32
 
-/**
- * Maximum number of available SAs
- */
-#define ODP_CONFIG_IPSEC_SAS	8
-
 struct ipsec_sa_s {
 	odp_atomic_u32_t state ODP_ALIGNED_CACHE;
 
@@ -239,6 +234,9 @@ uint32_t _odp_ipsec_cipher_iv_len(odp_cipher_alg_t cipher);
 
 /* Return digest length required for the cipher for IPsec use */
 uint32_t _odp_ipsec_auth_digest_len(odp_auth_alg_t auth);
+
+/* Return the maximum number of SAs supported by the implementation */
+uint32_t _odp_ipsec_max_num_sa(void);
 
 /*
  * Get SA entry from handle without obtaining a reference

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -37,7 +37,7 @@
 #define _ODP_HAVE_CHACHA20_POLY1305 0
 #endif
 
-#define MAX_SESSIONS 32
+#define MAX_SESSIONS 4000
 #define AES_BLOCK_SIZE 16
 #define AES_KEY_LENGTH 16
 

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2017-2018, Linaro Limited
+ * Copyright (c) 2018-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -121,7 +122,7 @@ int odp_ipsec_capability(odp_ipsec_capability_t *capa)
 
 	capa->proto_ah = ODP_SUPPORT_YES;
 
-	capa->max_num_sa = ODP_CONFIG_IPSEC_SAS;
+	capa->max_num_sa = _odp_ipsec_max_num_sa();
 
 	capa->max_antireplay_ws = IPSEC_ANTIREPLAY_WS;
 
@@ -215,7 +216,7 @@ void odp_ipsec_config_init(odp_ipsec_config_t *config)
 	memset(config, 0, sizeof(odp_ipsec_config_t));
 	config->inbound_mode = ODP_IPSEC_OP_MODE_SYNC;
 	config->outbound_mode = ODP_IPSEC_OP_MODE_SYNC;
-	config->max_num_sa = ODP_CONFIG_IPSEC_SAS;
+	config->max_num_sa = _odp_ipsec_max_num_sa();
 	config->inbound.default_queue = ODP_QUEUE_INVALID;
 	config->inbound.lookup.min_spi = 0;
 	config->inbound.lookup.max_spi = UINT32_MAX;
@@ -224,7 +225,7 @@ void odp_ipsec_config_init(odp_ipsec_config_t *config)
 
 int odp_ipsec_config(const odp_ipsec_config_t *config)
 {
-	if (ODP_CONFIG_IPSEC_SAS < config->max_num_sa)
+	if (config->max_num_sa > _odp_ipsec_max_num_sa())
 		return -1;
 
 	*ipsec_config = *config;

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -1154,6 +1154,7 @@ int ipsec_config(odp_instance_t ODP_UNUSED inst)
 		return 0;
 
 	odp_ipsec_config_init(&ipsec_config);
+	ipsec_config.max_num_sa = capa.max_num_sa;
 	ipsec_config.inbound_mode = suite_context.inbound_op_mode;
 	ipsec_config.outbound_mode = suite_context.outbound_op_mode;
 	ipsec_config.outbound.all_chksum = ~0;


### PR DESCRIPTION
- linux-gen: ipsec: increase the maximum number of SAs
- linux-gen: ipsec: do not alloc per-thread memory for too many threads
- validation: ipsec: test maximum number of SAs
- validation: ipsec: enable antireplay service and lifetimes
- linux-gen: crypto: increase the maximum number of sessions to 4000

Also, update copyrights in the affected files not only for this change but for earlier changes for which the update was not done.

This PR depends (logically, not textually) on PR 1188 (api: ipsec: define more default values & improve SA info API).