### PR TITLE
[PATCH v1] api: increment ODP API version to 1.27.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ([2.5])
 # ODP API version
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
-m4_define([odpapi_major_version], [26])
+m4_define([odpapi_major_version], [27])
 m4_define([odpapi_minor_version], [0])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],


### PR DESCRIPTION
Increment API version number to reflect the following changes:

Backward-incompatible:
- IPsec post-processing happens in the odp_ipsec_result() function that
  must be called at least once before packet data or metadata may be
  accessed.

Backward-compatible:
- New 128-bit atomic operations: init, store, load, and CAS
- Clarify that atomic CAS operations are strong type
- New odp_ipsec_test_sa_update() function for SA testing
- odp_ipsec_sa_info() may return non-exact copy of SA parameters
- Specify default values for more IPsec SA parameter fields
- Changed odp_timer_alloc() user context pointer argument to const
- New odp_timer_pool_print() function for printing timer pool debug
  information
- New odp_timer_print() function for printing timer debug information
- New odp_timeout_print() function for printing timeout debug information
- New odp_queue_print_all() function for printing debug information about
  all queues

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reviewed-by: Petri Savolainen <petri.savolainen@nokia.com>