### PR TITLE
[PATCH v5] linux-gen: rename remaining global symbols in the static library

### DIFF
--- a/helper/Makefile.am
+++ b/helper/Makefile.am
@@ -79,3 +79,16 @@ __LIB__libodphelper_la_LIBADD = $(PTHREAD_LIBS)
 __LIB__libodphelper_la_LIBADD += $(LIBCLI_LIBS)
 
 lib_LTLIBRARIES = $(LIB)/libodphelper.la
+
+CHECK_GLOBALS_REGEX = " odph_"
+
+TESTS_ENVIRONMENT = \
+	LIBTOOL="$(LIBTOOL)" \
+	NM="$(NM)" \
+	LIB="$(LIB)" \
+	lib_LTLIBRARIES="$(lib_LTLIBRARIES)" \
+	CHECK_GLOBALS_REGEX=$(CHECK_GLOBALS_REGEX)
+
+dist_check_SCRIPTS = check-globals.sh
+
+TESTS = $(dist_check_SCRIPTS)

--- a/helper/check-globals.sh
+++ b/helper/check-globals.sh
@@ -1,0 +1,1 @@
+../scripts/check-globals.sh

--- a/platform/Makefile.inc
+++ b/platform/Makefile.inc
@@ -17,9 +17,9 @@ lib_LTLIBRARIES =
 AM_LDFLAGS = -version-number '$(ODP_LIBSO_VERSION)'
 
 if ODP_ABI_COMPAT
-AM_LDFLAGS += -export-symbols-regex '^(_deprecated_)?odp_'
+AM_LDFLAGS += -export-symbols-regex '^(odp_|_deprecated_odp_)'
 else
-AM_LDFLAGS += -export-symbols-regex '^(_deprecated_)?_?odp_'
+AM_LDFLAGS += -export-symbols-regex '^(odp_|_odp_|_deprecated_odp_)'
 endif
 
 AM_CFLAGS = "-DODP_VERSION_BUILD=$(VERSION)"

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -373,3 +373,16 @@ __LIB__libodp_linux_la_LIBADD += $(TIMER_LIBS)
 if ODP_PKTIO_PCAP
 __LIB__libodp_linux_la_LIBADD += $(PCAP_LIBS)
 endif
+
+CHECK_GLOBALS_REGEX = " (odp_|_odp_|_deprecated_odp_|miniz_|mz_|tdefl_|tinfl_|mp_hdlr_init_odp_pool_ops)"
+
+TESTS_ENVIRONMENT = \
+	LIBTOOL="$(LIBTOOL)" \
+	NM="$(NM)" \
+	LIB="$(LIB)" \
+	lib_LTLIBRARIES="$(lib_LTLIBRARIES)" \
+	CHECK_GLOBALS_REGEX=$(CHECK_GLOBALS_REGEX)
+
+dist_check_SCRIPTS = check-globals.sh
+
+TESTS = $(dist_check_SCRIPTS)

--- a/platform/linux-generic/check-globals.sh
+++ b/platform/linux-generic/check-globals.sh
@@ -1,0 +1,1 @@
+../../scripts/check-globals.sh

--- a/platform/linux-generic/include/odp_errno_define.h
+++ b/platform/linux-generic/include/odp_errno_define.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif
 
-extern __thread int __odp_errno;
+extern __thread int _odp_errno;
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -300,8 +300,8 @@ static inline void packet_set_len(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 int _odp_packet_copy_md_to_packet(odp_packet_t srcpkt, odp_packet_t dstpkt);
 
 /* Packet alloc of pktios */
-int packet_alloc_multi(odp_pool_t pool_hdl, uint32_t len,
-		       odp_packet_t pkt[], int max_num);
+int _odp_packet_alloc_multi(odp_pool_t pool_hdl, uint32_t len,
+			    odp_packet_t pkt[], int max_num);
 
 /* Perform packet parse up to a given protocol layer */
 int _odp_packet_parse_layer(odp_packet_hdr_t *pkt_hdr,

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -265,8 +265,8 @@ static inline void _odp_pktio_tx_ts_set(pktio_entry_t *entry)
 	odp_atomic_store_u64(&entry->s.tx_ts, ts_val.u64);
 }
 
-extern const pktio_if_ops_t netmap_pktio_ops;
-extern const pktio_if_ops_t dpdk_pktio_ops;
+extern const pktio_if_ops_t _odp_netmap_pktio_ops;
+extern const pktio_if_ops_t _odp_dpdk_pktio_ops;
 extern const pktio_if_ops_t _odp_sock_mmsg_pktio_ops;
 extern const pktio_if_ops_t _odp_sock_mmap_pktio_ops;
 extern const pktio_if_ops_t _odp_loopback_pktio_ops;
@@ -276,7 +276,7 @@ extern const pktio_if_ops_t _odp_pcap_pktio_ops;
 extern const pktio_if_ops_t _odp_tap_pktio_ops;
 extern const pktio_if_ops_t _odp_null_pktio_ops;
 extern const pktio_if_ops_t _odp_ipc_pktio_ops;
-extern const pktio_if_ops_t * const pktio_if_ops[];
+extern const pktio_if_ops_t * const _odp_pktio_if_ops[];
 
 /**
  * Try interrupt-driven receive

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -160,8 +160,8 @@ static inline odp_buffer_hdr_t *buf_hdr_from_index_u32(uint32_t u32)
 	return buf_hdr_from_index(pool, buffer_idx);
 }
 
-int buffer_alloc_multi(pool_t *pool, odp_buffer_hdr_t *buf_hdr[], int num);
-void buffer_free_multi(odp_buffer_hdr_t *buf_hdr[], int num_free);
+int _odp_buffer_alloc_multi(pool_t *pool, odp_buffer_hdr_t *buf_hdr[], int num);
+void _odp_buffer_free_multi(odp_buffer_hdr_t *buf_hdr[], int num_free);
 int _odp_buffer_is_valid(odp_buffer_t buf);
 
 #ifdef __cplusplus

--- a/platform/linux-generic/include/odp_timer_internal.h
+++ b/platform/linux-generic/include/odp_timer_internal.h
@@ -40,13 +40,13 @@ typedef struct {
 
 /* A larger decrement value should be used after receiving events compared to
  * an 'empty' call. */
-void _timer_run_inline(int dec);
+void _odp_timer_run_inline(int dec);
 
 /* Static inline wrapper to minimize modification of schedulers. */
 static inline void timer_run(int dec)
 {
 	if (odp_global_rw->inline_timers)
-		_timer_run_inline(dec);
+		_odp_timer_run_inline(dec);
 }
 
 #endif

--- a/platform/linux-generic/odp_errno.c
+++ b/platform/linux-generic/odp_errno.c
@@ -9,24 +9,24 @@
 #include <stdio.h>
 #include <odp_debug_internal.h>
 
-__thread int __odp_errno;
+__thread int _odp_errno;
 
 int odp_errno(void)
 {
-	return __odp_errno;
+	return _odp_errno;
 }
 
 void odp_errno_zero(void)
 {
-	__odp_errno = 0;
+	_odp_errno = 0;
 }
 
 void odp_errno_print(const char *str)
 {
 	if (str != NULL)
-		ODP_PRINT("%s %s\n", str, strerror(__odp_errno));
+		ODP_PRINT("%s %s\n", str, strerror(_odp_errno));
 	else
-		ODP_PRINT("%s\n", strerror(__odp_errno));
+		ODP_PRINT("%s\n", strerror(_odp_errno));
 }
 
 const char *odp_errno_str(int errnum)

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -405,11 +405,11 @@ static inline odp_packet_hdr_t *alloc_segments(pool_t *pool, int num)
 	odp_packet_hdr_t *pkt_hdr[num];
 	int ret;
 
-	ret = buffer_alloc_multi(pool, (odp_buffer_hdr_t **)pkt_hdr, num);
+	ret = _odp_buffer_alloc_multi(pool, (odp_buffer_hdr_t **)pkt_hdr, num);
 
 	if (odp_unlikely(ret != num)) {
 		if (ret > 0)
-			buffer_free_multi((odp_buffer_hdr_t **)pkt_hdr, ret);
+			_odp_buffer_free_multi((odp_buffer_hdr_t **)pkt_hdr, ret);
 
 		return NULL;
 	}
@@ -529,7 +529,7 @@ static inline void packet_free_multi(odp_buffer_hdr_t *hdr[], int num)
 	num -= num_ref;
 
 	if (odp_likely(num))
-		buffer_free_multi(hdr, num);
+		_odp_buffer_free_multi(hdr, num);
 }
 
 static inline void free_all_segments(odp_packet_hdr_t *pkt_hdr, int num)
@@ -626,8 +626,8 @@ static inline int packet_alloc(pool_t *pool, uint32_t len, int max_pkt,
 	odp_packet_hdr_t *hdr_next;
 	odp_packet_hdr_t *hdr;
 
-	num_buf = buffer_alloc_multi(pool, (odp_buffer_hdr_t **)pkt_hdr,
-				     max_buf);
+	num_buf = _odp_buffer_alloc_multi(pool, (odp_buffer_hdr_t **)pkt_hdr,
+					  max_buf);
 
 	/* Failed to allocate all segments */
 	if (odp_unlikely(num_buf != max_buf)) {
@@ -640,7 +640,7 @@ static inline int packet_alloc(pool_t *pool, uint32_t len, int max_pkt,
 			odp_buffer_hdr_t **p;
 
 			p = (odp_buffer_hdr_t **)&pkt_hdr[num_buf - num_free];
-			buffer_free_multi(p, num_free);
+			_odp_buffer_free_multi(p, num_free);
 		}
 
 		if (num == 0)
@@ -673,8 +673,8 @@ static inline int packet_alloc(pool_t *pool, uint32_t len, int max_pkt,
 	return num;
 }
 
-int packet_alloc_multi(odp_pool_t pool_hdl, uint32_t len,
-		       odp_packet_t pkt[], int max_num)
+int _odp_packet_alloc_multi(odp_pool_t pool_hdl, uint32_t len,
+			    odp_packet_t pkt[], int max_num)
 {
 	pool_t *pool = pool_entry_from_hdl(pool_hdl);
 	int num, num_seg;
@@ -692,7 +692,7 @@ odp_packet_t odp_packet_alloc(odp_pool_t pool_hdl, uint32_t len)
 	int num, num_seg;
 
 	if (odp_unlikely(pool->params.type != ODP_POOL_PACKET)) {
-		__odp_errno = EINVAL;
+		_odp_errno = EINVAL;
 		return ODP_PACKET_INVALID;
 	}
 
@@ -715,7 +715,7 @@ int odp_packet_alloc_multi(odp_pool_t pool_hdl, uint32_t len,
 	int num, num_seg;
 
 	if (odp_unlikely(pool->params.type != ODP_POOL_PACKET)) {
-		__odp_errno = EINVAL;
+		_odp_errno = EINVAL;
 		return -1;
 	}
 

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -126,9 +126,9 @@ int _odp_pktio_init_global(void)
 		_odp_pktio_entry_ptr[i] = pktio_entry;
 	}
 
-	for (pktio_if = 0; pktio_if_ops[pktio_if]; ++pktio_if) {
-		if (pktio_if_ops[pktio_if]->init_global)
-			if (pktio_if_ops[pktio_if]->init_global()) {
+	for (pktio_if = 0; _odp_pktio_if_ops[pktio_if]; ++pktio_if) {
+		if (_odp_pktio_if_ops[pktio_if]->init_global)
+			if (_odp_pktio_if_ops[pktio_if]->init_global()) {
 				ODP_ERR("failed to initialized pktio type %d",
 					pktio_if);
 				return -1;
@@ -149,9 +149,9 @@ int _odp_pktio_init_local(void)
 {
 	int pktio_if;
 
-	for (pktio_if = 0; pktio_if_ops[pktio_if]; ++pktio_if) {
-		if (pktio_if_ops[pktio_if]->init_local)
-			if (pktio_if_ops[pktio_if]->init_local()) {
+	for (pktio_if = 0; _odp_pktio_if_ops[pktio_if]; ++pktio_if) {
+		if (_odp_pktio_if_ops[pktio_if]->init_local)
+			if (_odp_pktio_if_ops[pktio_if]->init_local()) {
 				ODP_ERR("failed to initialized pktio type %d",
 					pktio_if);
 				return -1;
@@ -263,8 +263,8 @@ static const char *strip_pktio_type(const char *name, char *type_out)
 		if_name++;
 
 		/* Match if_type to enabled pktio devices */
-		for (pktio_if = 0; pktio_if_ops[pktio_if]; pktio_if++) {
-			if (!strcmp(pktio_type, pktio_if_ops[pktio_if]->name)) {
+		for (pktio_if = 0; _odp_pktio_if_ops[pktio_if]; pktio_if++) {
+			if (!strcmp(pktio_type, _odp_pktio_if_ops[pktio_if]->name)) {
 				if (type_out)
 					strcpy(type_out, pktio_type);
 				/* Some pktio devices expect device names to
@@ -328,14 +328,14 @@ static odp_pktio_t setup_pktio_entry(const char *name, odp_pool_t pool,
 
 	odp_pktio_config_init(&pktio_entry->s.config);
 
-	for (pktio_if = 0; pktio_if_ops[pktio_if]; ++pktio_if) {
+	for (pktio_if = 0; _odp_pktio_if_ops[pktio_if]; ++pktio_if) {
 		/* Only use explicitly defined pktio type */
 		if (strlen(pktio_type) &&
-		    strcmp(pktio_if_ops[pktio_if]->name, pktio_type))
+		    strcmp(_odp_pktio_if_ops[pktio_if]->name, pktio_type))
 			continue;
 
-		ret = pktio_if_ops[pktio_if]->open(hdl, pktio_entry, if_name,
-						   pool);
+		ret = _odp_pktio_if_ops[pktio_if]->open(hdl, pktio_entry, if_name,
+							pool);
 		if (!ret)
 			break;
 	}
@@ -352,7 +352,7 @@ static odp_pktio_t setup_pktio_entry(const char *name, odp_pool_t pool,
 	snprintf(pktio_entry->s.full_name,
 		 sizeof(pktio_entry->s.full_name), "%s", name);
 	pktio_entry->s.state = PKTIO_STATE_OPENED;
-	pktio_entry->s.ops = pktio_if_ops[pktio_if];
+	pktio_entry->s.ops = _odp_pktio_if_ops[pktio_if];
 	unlock_entry(pktio_entry);
 
 	return hdl;
@@ -400,7 +400,7 @@ odp_pktio_t odp_pktio_open(const char *name, odp_pool_t pool,
 	hdl = odp_pktio_lookup(name);
 	if (hdl != ODP_PKTIO_INVALID) {
 		/* interface is already open */
-		__odp_errno = EEXIST;
+		_odp_errno = EEXIST;
 		return ODP_PKTIO_INVALID;
 	}
 
@@ -1062,7 +1062,7 @@ static odp_buffer_hdr_t *pktin_dequeue(odp_queue_t queue)
 
 			ODP_DBG("Interface %s dropped %i packets\n",
 				entry->s.name, num - num_enq);
-			buffer_free_multi(&hdr_tbl[num_enq + 1], num - num_enq);
+			_odp_buffer_free_multi(&hdr_tbl[num_enq + 1], num - num_enq);
 		}
 	}
 
@@ -1116,7 +1116,7 @@ static int pktin_deq_multi(odp_queue_t queue, odp_buffer_hdr_t *buf_hdr[],
 
 			ODP_DBG("Interface %s dropped %i packets\n",
 				entry->s.name, j - num_enq);
-			buffer_free_multi(&buf_hdr[num_enq], j - num_enq);
+			_odp_buffer_free_multi(&buf_hdr[num_enq], j - num_enq);
 		}
 	}
 
@@ -1742,9 +1742,9 @@ int _odp_pktio_term_global(void)
 		unlock_entry(pktio_entry);
 	}
 
-	for (pktio_if = 0; pktio_if_ops[pktio_if]; ++pktio_if) {
-		if (pktio_if_ops[pktio_if]->term)
-			if (pktio_if_ops[pktio_if]->term())
+	for (pktio_if = 0; _odp_pktio_if_ops[pktio_if]; ++pktio_if) {
+		if (_odp_pktio_if_ops[pktio_if]->term)
+			if (_odp_pktio_if_ops[pktio_if]->term())
 				ODP_ABORT("failed to terminate pktio type %d",
 					  pktio_if);
 	}

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -1056,7 +1056,7 @@ int odp_pool_info(odp_pool_t pool_hdl, odp_pool_info_t *info)
 	return 0;
 }
 
-int buffer_alloc_multi(pool_t *pool, odp_buffer_hdr_t *buf_hdr[], int max_num)
+int _odp_buffer_alloc_multi(pool_t *pool, odp_buffer_hdr_t *buf_hdr[], int max_num)
 {
 	uint32_t pool_idx = pool->pool_idx;
 	pool_cache_t *cache = local.cache[pool_idx];
@@ -1171,7 +1171,7 @@ static inline void buffer_free_to_pool(pool_t *pool,
 		odp_atomic_inc_u64(&pool->stats.cache_free_ops);
 }
 
-void buffer_free_multi(odp_buffer_hdr_t *buf_hdr[], int num_total)
+void _odp_buffer_free_multi(odp_buffer_hdr_t *buf_hdr[], int num_total)
 {
 	pool_t *pool;
 	int num;
@@ -1210,7 +1210,7 @@ odp_buffer_t odp_buffer_alloc(odp_pool_t pool_hdl)
 	ODP_ASSERT(ODP_POOL_INVALID != pool_hdl);
 
 	pool = pool_entry_from_hdl(pool_hdl);
-	ret  = buffer_alloc_multi(pool, (odp_buffer_hdr_t **)&buf, 1);
+	ret  = _odp_buffer_alloc_multi(pool, (odp_buffer_hdr_t **)&buf, 1);
 
 	if (odp_likely(ret == 1))
 		return buf;
@@ -1226,17 +1226,17 @@ int odp_buffer_alloc_multi(odp_pool_t pool_hdl, odp_buffer_t buf[], int num)
 
 	pool = pool_entry_from_hdl(pool_hdl);
 
-	return buffer_alloc_multi(pool, (odp_buffer_hdr_t **)buf, num);
+	return _odp_buffer_alloc_multi(pool, (odp_buffer_hdr_t **)buf, num);
 }
 
 void odp_buffer_free(odp_buffer_t buf)
 {
-	buffer_free_multi((odp_buffer_hdr_t **)&buf, 1);
+	_odp_buffer_free_multi((odp_buffer_hdr_t **)&buf, 1);
 }
 
 void odp_buffer_free_multi(const odp_buffer_t buf[], int num)
 {
-	buffer_free_multi((odp_buffer_hdr_t **)(uintptr_t)buf, num);
+	_odp_buffer_free_multi((odp_buffer_hdr_t **)(uintptr_t)buf, num);
 }
 
 int odp_pool_capability(odp_pool_capability_t *capa)

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -762,7 +762,7 @@ static inline void ordered_stash_release(void)
 				num_enq = 0;
 
 			ODP_DBG("Dropped %i packets\n", num - num_enq);
-			buffer_free_multi(&buf_hdr[num_enq], num - num_enq);
+			_odp_buffer_free_multi(&buf_hdr[num_enq], num - num_enq);
 		}
 	}
 	sched_local.ordered.stash_num = 0;
@@ -999,7 +999,7 @@ static inline int poll_pktin(uint32_t qi, int direct_recv,
 			num_enq = 0;
 
 		ODP_DBG("Dropped %i packets\n", num - num_enq);
-		buffer_free_multi(&b_hdr[num_enq], num - num_enq);
+		_odp_buffer_free_multi(&b_hdr[num_enq], num - num_enq);
 	}
 
 	return ret;

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -510,7 +510,7 @@ static inline odp_timer_t timer_alloc(timer_pool_t *tp, odp_queue_t queue, const
 		/* Add timer to queue */
 		_odp_queue_fn->timer_add(queue);
 	} else {
-		__odp_errno = ENFILE; /* Reusing file table overflow */
+		_odp_errno = ENFILE; /* Reusing file table overflow */
 		hdl = ODP_TIMER_INVALID;
 	}
 	odp_spinlock_unlock(&tp->lock);
@@ -966,7 +966,7 @@ static inline void timer_pool_scan_inline(int num, odp_time_t now)
 	}
 }
 
-void _timer_run_inline(int dec)
+void _odp_timer_run_inline(int dec)
 {
 	odp_time_t now;
 	int num = timer_global->highest_tp_idx + 1;
@@ -1284,19 +1284,19 @@ odp_timer_pool_t odp_timer_pool_create(const char *name,
 
 	if ((param->res_ns && param->res_hz) ||
 	    (param->res_ns == 0 && param->res_hz == 0)) {
-		__odp_errno = EINVAL;
+		_odp_errno = EINVAL;
 		return ODP_TIMER_POOL_INVALID;
 	}
 
 	if (param->res_hz == 0 &&
 	    param->res_ns < timer_global->highest_res_ns) {
-		__odp_errno = EINVAL;
+		_odp_errno = EINVAL;
 		return ODP_TIMER_POOL_INVALID;
 	}
 
 	if (param->res_ns == 0 &&
 	    param->res_hz > timer_global->highest_res_hz) {
-		__odp_errno = EINVAL;
+		_odp_errno = EINVAL;
 		return ODP_TIMER_POOL_INVALID;
 	}
 

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -432,8 +432,8 @@ static int pool_dequeue_bulk(struct rte_mempool *mp, void **obj_table,
 	int pkts;
 	int i;
 
-	pkts = packet_alloc_multi(pool, pool_entry->seg_len, packet_tbl,
-				  num);
+	pkts = _odp_packet_alloc_multi(pool, pool_entry->seg_len, packet_tbl,
+				       num);
 
 	if (odp_unlikely(pkts != (int)num)) {
 		if (pkts > 0)
@@ -577,10 +577,10 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 	/* Allocate maximum sized packets */
 	max_len = pkt_dpdk->data_room;
 
-	num = packet_alloc_multi(pool, max_len + frame_offset,
-				 pkt_table, mbuf_num);
+	num = _odp_packet_alloc_multi(pool, max_len + frame_offset,
+				      pkt_table, mbuf_num);
 	if (num != mbuf_num) {
-		ODP_DBG("packet_alloc_multi() unable to allocate all packets: "
+		ODP_DBG("_odp_packet_alloc_multi() unable to allocate all packets: "
 			"%d/%" PRIu16 " allocated\n", num, mbuf_num);
 		for (i = num; i < mbuf_num; i++)
 			rte_pktmbuf_free(mbuf_table[i]);
@@ -805,7 +805,7 @@ static inline int pkt_to_mbuf(pktio_entry_t *pktio_entry,
 
 		if (odp_unlikely(pkt_len > pkt_dpdk->mtu)) {
 			if (i == 0)
-				__odp_errno = EMSGSIZE;
+				_odp_errno = EMSGSIZE;
 			goto fail;
 		}
 
@@ -999,7 +999,7 @@ static inline int pkt_to_mbuf_zero(pktio_entry_t *pktio_entry,
 
 fail:
 	if (i == 0)
-		__odp_errno = EMSGSIZE;
+		_odp_errno = EMSGSIZE;
 	return i;
 }
 
@@ -2063,8 +2063,8 @@ static int dpdk_send(pktio_entry_t *pktio_entry, int index,
 				}
 			}
 		}
-		if (odp_unlikely(tx_pkts == 0 && __odp_errno != 0))
-				return -1;
+		if (odp_unlikely(tx_pkts == 0 && _odp_errno != 0))
+			return -1;
 	} else {
 		if (odp_unlikely(tx_pkts < mbufs)) {
 			for (i = tx_pkts; i < mbufs; i++)
@@ -2072,7 +2072,7 @@ static int dpdk_send(pktio_entry_t *pktio_entry, int index,
 		}
 
 		if (odp_unlikely(tx_pkts == 0)) {
-			if (__odp_errno != 0)
+			if (_odp_errno != 0)
 				return -1;
 		} else {
 			odp_packet_free_multi(pkt_table, tx_pkts);
@@ -2227,7 +2227,7 @@ static int dpdk_stats_reset(pktio_entry_t *pktio_entry)
 	return 0;
 }
 
-const pktio_if_ops_t dpdk_pktio_ops = {
+const pktio_if_ops_t _odp_dpdk_pktio_ops = {
 	.name = "dpdk",
 	.init_global = dpdk_pktio_init_global,
 	.init_local = dpdk_pktio_init_local,

--- a/platform/linux-generic/pktio/io_ops.c
+++ b/platform/linux-generic/pktio/io_ops.c
@@ -11,13 +11,13 @@
  * Order matters. The first implementation to setup successfully
  * will be picked.
  * Array must be NULL terminated */
-const pktio_if_ops_t * const pktio_if_ops[]  = {
+const pktio_if_ops_t * const _odp_pktio_if_ops[]  = {
 	&_odp_loopback_pktio_ops,
 #ifdef _ODP_PKTIO_DPDK
-	&dpdk_pktio_ops,
+	&_odp_dpdk_pktio_ops,
 #endif
 #ifdef _ODP_PKTIO_NETMAP
-	&netmap_pktio_ops,
+	&_odp_netmap_pktio_ops,
 #endif
 #ifdef _ODP_PKTIO_PCAP
 	&_odp_pcap_pktio_ops,

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -130,7 +130,7 @@ static ring_ptr_t *_ring_create(const char *name, uint32_t count,
 	/* count must be a power of 2 */
 	if (!CHECK_IS_POWER2(count)) {
 		ODP_ERR("Requested size is invalid, must be a power of 2\n");
-		__odp_errno = EINVAL;
+		_odp_errno = EINVAL;
 		return NULL;
 	}
 
@@ -145,7 +145,7 @@ static ring_ptr_t *_ring_create(const char *name, uint32_t count,
 		ring_ptr_init(r);
 
 	} else {
-		__odp_errno = ENOMEM;
+		_odp_errno = ENOMEM;
 		ODP_ERR("Cannot reserve memory\n");
 	}
 

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -311,7 +311,7 @@ static int loopback_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 		if (odp_unlikely(pkt_len > pkt_loop->mtu)) {
 			if (nb_tx == 0) {
-				__odp_errno = EMSGSIZE;
+				_odp_errno = EMSGSIZE;
 				return -1;
 			}
 			break;

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -345,7 +345,7 @@ static int netmap_close(pktio_entry_t *pktio_entry)
 	netmap_close_descriptors(pktio_entry);
 
 	if (pkt_nm->sockfd != -1 && close(pkt_nm->sockfd) != 0) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("close(sockfd): %s\n", strerror(errno));
 		return -1;
 	}
@@ -830,8 +830,8 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 	/* Allocate maximum sized packets */
 	max_len = pkt_priv(pktio_entry)->mtu;
 
-	num = packet_alloc_multi(pool, max_len + frame_offset,
-				 pkt_tbl, slot_num);
+	num = _odp_packet_alloc_multi(pool, max_len + frame_offset,
+				      pkt_tbl, slot_num);
 
 	for (i = 0; i < num; i++) {
 		netmap_slot_t slot;
@@ -1121,7 +1121,7 @@ static int netmap_send(pktio_entry_t *pktio_entry, int index,
 
 		if (pkt_len > pkt_nm->mtu) {
 			if (nb_tx == 0)
-				__odp_errno = EMSGSIZE;
+				_odp_errno = EMSGSIZE;
 			break;
 		}
 		for (i = 0; i < NM_INJECT_RETRIES; i++) {
@@ -1158,7 +1158,7 @@ static int netmap_send(pktio_entry_t *pktio_entry, int index,
 		odp_ticketlock_unlock(&pkt_nm->tx_desc_ring[index].s.lock);
 
 	if (odp_unlikely(nb_tx == 0)) {
-		if (__odp_errno != 0)
+		if (_odp_errno != 0)
 			return -1;
 	} else {
 		if (odp_unlikely(tx_ts_idx && nb_tx >= tx_ts_idx))
@@ -1200,7 +1200,7 @@ static int netmap_promisc_mode_set(pktio_entry_t *pktio_entry,
 				   odp_bool_t enable)
 {
 	if (pkt_priv(pktio_entry)->is_virtual) {
-		__odp_errno = ENOTSUP;
+		_odp_errno = ENOTSUP;
 		return -1;
 	}
 
@@ -1273,7 +1273,7 @@ static int netmap_init_global(void)
 	return 0;
 }
 
-const pktio_if_ops_t netmap_pktio_ops = {
+const pktio_if_ops_t _odp_netmap_pktio_ops = {
 	.name = "netmap",
 	.print = netmap_print,
 	.init_global = netmap_init_global,

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -266,8 +266,8 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 		pkt_len = hdr->caplen;
 
-		ret = packet_alloc_multi(pcap->pool, pkt_len + frame_offset,
-					 &pkt, 1);
+		ret = _odp_packet_alloc_multi(pcap->pool, pkt_len + frame_offset,
+					      &pkt, 1);
 		if (odp_unlikely(ret != 1))
 			break;
 

--- a/platform/linux-generic/pktio/socket_common.c
+++ b/platform/linux-generic/pktio/socket_common.c
@@ -57,7 +57,7 @@ int _odp_mac_addr_get_fd(int fd, const char *name, unsigned char mac_dst[])
 	snprintf(ethreq.ifr_name, IF_NAMESIZE, "%s", name);
 	ret = ioctl(fd, SIOCGIFHWADDR, &ethreq);
 	if (ret != 0) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("ioctl(SIOCGIFHWADDR): %s: \"%s\".\n", strerror(errno),
 			ethreq.ifr_name);
 		return -1;
@@ -82,7 +82,7 @@ uint32_t _odp_mtu_get_fd(int fd, const char *name)
 	snprintf(ifr.ifr_name, IF_NAMESIZE, "%s", name);
 	ret = ioctl(fd, SIOCGIFMTU, &ifr);
 	if (ret < 0) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("ioctl(SIOCGIFMTU): %s: \"%s\".\n", strerror(errno),
 			ifr.ifr_name);
 		return 0;
@@ -106,7 +106,7 @@ int _odp_mtu_set_fd(int fd, const char *name, int mtu)
 
 	ret = ioctl(fd, SIOCSIFMTU, &ifr);
 	if (ret < 0) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("ioctl(SIOCSIFMTU): %s: \"%s\".\n", strerror(errno),
 			ifr.ifr_name);
 		return -1;
@@ -127,7 +127,7 @@ int _odp_promisc_mode_set_fd(int fd, const char *name, int enable)
 	snprintf(ifr.ifr_name, IF_NAMESIZE, "%s", name);
 	ret = ioctl(fd, SIOCGIFFLAGS, &ifr);
 	if (ret < 0) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_DBG("ioctl(SIOCGIFFLAGS): %s: \"%s\".\n", strerror(errno),
 			ifr.ifr_name);
 		return -1;
@@ -140,7 +140,7 @@ int _odp_promisc_mode_set_fd(int fd, const char *name, int enable)
 
 	ret = ioctl(fd, SIOCSIFFLAGS, &ifr);
 	if (ret < 0) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_DBG("ioctl(SIOCSIFFLAGS): %s: \"%s\".\n", strerror(errno),
 			ifr.ifr_name);
 		return -1;
@@ -161,7 +161,7 @@ int _odp_promisc_mode_get_fd(int fd, const char *name)
 	snprintf(ifr.ifr_name, IF_NAMESIZE, "%s", name);
 	ret = ioctl(fd, SIOCGIFFLAGS, &ifr);
 	if (ret < 0) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_DBG("ioctl(SIOCGIFFLAGS): %s: \"%s\".\n", strerror(errno),
 			ifr.ifr_name);
 		return -1;
@@ -178,7 +178,7 @@ int _odp_link_status_fd(int fd, const char *name)
 	snprintf(ifr.ifr_name, IF_NAMESIZE, "%s", name);
 	ret = ioctl(fd, SIOCGIFFLAGS, &ifr);
 	if (ret < 0) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_DBG("ioctl(SIOCGIFFLAGS): %s: \"%s\".\n", strerror(errno),
 			ifr.ifr_name);
 		return ODP_PKTIO_LINK_STATUS_UNKNOWN;
@@ -206,7 +206,7 @@ int _odp_link_info_fd(int fd, const char *name, odp_pktio_link_info_t *info)
 	/* Link pause status */
 	ifr.ifr_data = (void *)&pcmd;
 	if (ioctl(fd, SIOCETHTOOL, &ifr) && errno != EOPNOTSUPP) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("ioctl(SIOCETHTOOL): %s: \"%s\".\n", strerror(errno),
 			ifr.ifr_name);
 		return -1;
@@ -219,7 +219,7 @@ int _odp_link_info_fd(int fd, const char *name, odp_pktio_link_info_t *info)
 
 		ifr.ifr_data = (void *)&ecmd_old;
 		if (ioctl(fd, SIOCETHTOOL, &ifr) < 0) {
-			__odp_errno = errno;
+			_odp_errno = errno;
 			ODP_ERR("ioctl(SIOCETHTOOL): %s: \"%s\".\n", strerror(errno), ifr.ifr_name);
 			return -1;
 		}
@@ -277,7 +277,7 @@ int _odp_link_info_fd(int fd, const char *name, odp_pktio_link_info_t *info)
 	*ecmd = hcmd;
 	ifr.ifr_data = (void *)ecmd;
 	if (ioctl(fd, SIOCETHTOOL, &ifr) < 0) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("ioctl(SIOCETHTOOL): %s: \"%s\".\n", strerror(errno),
 			ifr.ifr_name);
 		return -1;

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -109,14 +109,14 @@ static int mmap_pkt_socket(void)
 	int ret, sock = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
 
 	if (sock == -1) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("socket(SOCK_RAW): %s\n", strerror(errno));
 		return -1;
 	}
 
 	ret = setsockopt(sock, SOL_PACKET, PACKET_VERSION, &ver, sizeof(ver));
 	if (ret == -1) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("setsockopt(PACKET_VERSION): %s\n", strerror(errno));
 		close(sock);
 		return -1;
@@ -192,7 +192,7 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 			vlan_len = 4;
 
 		alloc_len = pkt_len + frame_offset + vlan_len;
-		ret = packet_alloc_multi(pool, alloc_len, &pkt, 1);
+		ret = _odp_packet_alloc_multi(pool, alloc_len, &pkt, 1);
 
 		if (odp_unlikely(ret != 1)) {
 			/* Stop receiving packets when pool is empty. Leave
@@ -460,7 +460,7 @@ static int mmap_setup_ring(pkt_sock_mmap_t *pkt_sock, struct ring *ring,
 
 	ret = setsockopt(sock, SOL_PACKET, type, &ring->req, sizeof(ring->req));
 	if (ret == -1) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("setsockopt(pkt mmap): %s\n", strerror(errno));
 		return -1;
 	}
@@ -491,7 +491,7 @@ static int mmap_sock(pkt_sock_mmap_t *pkt_sock)
 		     MAP_SHARED | MAP_LOCKED | MAP_POPULATE, sock, 0);
 
 	if (pkt_sock->mmap_base == MAP_FAILED) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("mmap rx&tx buffer failed: %s\n", strerror(errno));
 		return -1;
 	}
@@ -547,7 +547,7 @@ static int mmap_bind_sock(pkt_sock_mmap_t *pkt_sock, const char *netdev)
 	ret = bind(pkt_sock->sockfd, (struct sockaddr *)&pkt_sock->ll,
 		   sizeof(pkt_sock->ll));
 	if (ret == -1) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("bind(to IF): %s\n", strerror(errno));
 		return -1;
 	}
@@ -567,7 +567,7 @@ static int sock_mmap_close(pktio_entry_t *entry)
 	}
 
 	if (pkt_sock->sockfd != -1 && close(pkt_sock->sockfd) != 0) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("close(sockfd): %s\n", strerror(errno));
 		return -1;
 	}
@@ -641,7 +641,7 @@ static int sock_mmap_open(odp_pktio_t id ODP_UNUSED,
 
 	if_idx = if_nametoindex(netdev);
 	if (if_idx == 0) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("if_nametoindex(): %s\n", strerror(errno));
 		goto error;
 	}

--- a/platform/linux-generic/pktio/stats/ethtool_stats.c
+++ b/platform/linux-generic/pktio/stats/ethtool_stats.c
@@ -48,13 +48,13 @@ static struct ethtool_gstrings *get_stringset(int fd, struct ifreq *ifr)
 		drvinfo.cmd = ETHTOOL_GDRVINFO;
 		ifr->ifr_data = (void *)&drvinfo;
 		if (ioctl(fd, SIOCETHTOOL, ifr)) {
-			__odp_errno = errno;
+			_odp_errno = errno;
 			ODP_ERR("Cannot get stats information\n");
 			return NULL;
 		}
 		len = *(uint32_t *)(void *)((char *)&drvinfo + drvinfo_offset);
 	} else {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		return NULL;
 	}
 
@@ -74,7 +74,7 @@ static struct ethtool_gstrings *get_stringset(int fd, struct ifreq *ifr)
 	strings->len = len;
 	ifr->ifr_data = (void *)strings;
 	if (ioctl(fd, SIOCETHTOOL, ifr)) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		ODP_ERR("Cannot get stats information\n");
 		free(strings);
 		return NULL;
@@ -114,7 +114,7 @@ static int ethtool_stats(int fd, struct ifreq *ifr, odp_pktio_stats_t *stats)
 	ifr->ifr_data = (void *)estats;
 	err = ioctl(fd, SIOCETHTOOL, ifr);
 	if (err < 0) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		free(strings);
 		free(estats);
 		return -1;

--- a/platform/linux-generic/pktio/stats/sysfs_stats.c
+++ b/platform/linux-generic/pktio/stats/sysfs_stats.c
@@ -19,7 +19,7 @@ static int sysfs_get_val(const char *fname, uint64_t *val)
 
 	file = fopen(fname, "rt");
 	if (file == NULL) {
-		__odp_errno = errno;
+		_odp_errno = errno;
 		/* do not print debug err if sysfs is not supported by
 		 * kernel driver.
 		 */

--- a/scripts/check-globals.sh
+++ b/scripts/check-globals.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+#
+# Check that global symbols in a static library conform to a given regex.
+# Only static library is checked, since libtool -export-symbols-regex
+# takes care of dynamic libraries.
+#
+# Required variables:
+# LIBTOOL               Path to libtool.
+# NM                    Path to nm.
+# LIB                   Library directory.
+# lib_LTLIBRARIES       Library .la file.
+# CHECK_GLOBALS_REGEX   Global symbols matching this regex are accepted.
+#
+
+tmpfile=$(mktemp)
+
+# get $objdir
+$LIBTOOL --config > $tmpfile
+. $tmpfile
+
+# get $old_library (static library name)
+. $lib_LTLIBRARIES
+
+echo "$old_library: Checking global symbols, regex: $CHECK_GLOBALS_REGEX"
+
+# get a list of symbols that are global, are not undefined or weak, and
+# do not match the regex
+$NM -g --defined-only $LIB/$objdir/$old_library | \
+        egrep " [uA-T] " | egrep -v "$CHECK_GLOBALS_REGEX" | tee $tmpfile
+
+num=$(cat $tmpfile | wc -l)
+rm -f $tmpfile
+
+if [ "$num" != "0" ]; then
+        echo "$old_library: ($num non-matching symbols)"
+        false
+fi


### PR DESCRIPTION
```
check names of global symbols in static libraries
    
    Add tests to check that global symbols in static libodp-linux and
    libodphelper conform to certain prefix patterns.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

linux-gen: rename remaining global symbols in the static library
    
    Rename the rest of the global symbols in the static library that do
    not have the "_odp_" prefix.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
v2:
- Fix indentation in dpdk.c.
- Rebase.

v3:
- Log the regex being used.
- Add "fixes" tags.

v4:
- Make CHECK_GLOBALS_REGEX more legible.
- Add commit "build: make export-symbols-regex more legible".

v5:
- Add "build:" to subject line of second commit.
- Add reviewed-by tags.
- Rebase.
