### PR TITLE
[PATCH v2] linux-gen: schedule: comment empty functions

### DIFF
--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -1326,6 +1326,7 @@ static inline void order_lock(void)
 
 static void order_unlock(void)
 {
+	/* Nothing to do */
 }
 
 static void schedule_order_lock(uint32_t lock_index)
@@ -1621,9 +1622,9 @@ static int schedule_thr_rem(odp_schedule_group_t group, int thr)
 	return 0;
 }
 
-/* This function is a no-op */
-static void schedule_prefetch(int num ODP_UNUSED)
+static void schedule_prefetch(int num)
 {
+	(void)num;
 }
 
 static int schedule_num_grps(void)

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -2167,6 +2167,7 @@ static void order_lock(void)
  */
 static void order_unlock(void)
 {
+	/* Nothing to do */
 }
 
 static uint32_t schedule_max_ordered_locks(void)

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -751,10 +751,12 @@ static void schedule_resume(void)
 
 static void schedule_release_atomic(void)
 {
+	/* Nothing to do */
 }
 
 static void schedule_release_ordered(void)
 {
+	/* Nothing to do */
 }
 
 static void schedule_prefetch(int num)
@@ -1016,10 +1018,12 @@ static void schedule_order_lock_wait(uint32_t lock_index)
 
 static void order_lock(void)
 {
+	/* Nothing to do */
 }
 
 static void order_unlock(void)
 {
+	/* Nothing to do */
 }
 
 static int schedule_capability(odp_schedule_capability_t *capa)


### PR DESCRIPTION
Static code checker complains about empty functions. Add a line
of code or a comment into each function.
