### PR TITLE
[PATCH v18] api: packet_io: introduce generic protocol stats framework with Tx per-packet stats offload

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -37,6 +37,7 @@ odpapiinclude_HEADERS = \
 	odp/api/packet_io_stats.h \
 	odp/api/protocols.h \
 	odp/api/pool.h \
+	odp/api/proto_stats.h \
 	odp/api/queue.h \
 	odp/api/queue_types.h \
 	odp/api/random.h \
@@ -92,6 +93,7 @@ odpapispecinclude_HEADERS = \
 		  odp/api/spec/protocols.h \
 		  odp/api/spec/pool.h \
 		  odp/api/spec/pool_types.h \
+		  odp/api/spec/proto_stats.h \
 		  odp/api/spec/queue.h \
 		  odp/api/spec/queue_types.h \
 		  odp/api/spec/random.h \
@@ -144,6 +146,7 @@ odpapiabidefaultinclude_HEADERS = \
 	odp/api/abi-default/packet_types.h \
 	odp/api/abi-default/packet_flags.h \
 	odp/api/abi-default/packet_io.h \
+	odp/api/abi-default/proto_stats.h \
 	odp/api/abi-default/pool.h \
 	odp/api/abi-default/queue.h \
 	odp/api/abi-default/queue_types.h \
@@ -193,6 +196,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm32-linux/odp/api/abi/packet_flags.h \
 	odp/arch/arm32-linux/odp/api/abi/packet_io.h \
 	odp/arch/arm32-linux/odp/api/abi/pool.h \
+	odp/arch/arm32-linux/odp/api/abi/proto_stats.h \
 	odp/arch/arm32-linux/odp/api/abi/queue.h \
 	odp/arch/arm32-linux/odp/api/abi/queue_types.h \
 	odp/arch/arm32-linux/odp/api/abi/rwlock.h \
@@ -237,6 +241,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm64-linux/odp/api/abi/packet_flags.h \
 	odp/arch/arm64-linux/odp/api/abi/packet_io.h \
 	odp/arch/arm64-linux/odp/api/abi/pool.h \
+	odp/arch/arm64-linux/odp/api/abi/proto_stats.h \
 	odp/arch/arm64-linux/odp/api/abi/queue.h \
 	odp/arch/arm64-linux/odp/api/abi/queue_types.h \
 	odp/arch/arm64-linux/odp/api/abi/rwlock.h \
@@ -281,6 +286,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/default-linux/odp/api/abi/packet_flags.h \
 	odp/arch/default-linux/odp/api/abi/packet_io.h \
 	odp/arch/default-linux/odp/api/abi/pool.h \
+	odp/arch/default-linux/odp/api/abi/proto_stats.h \
 	odp/arch/default-linux/odp/api/abi/queue.h \
 	odp/arch/default-linux/odp/api/abi/queue_types.h \
 	odp/arch/default-linux/odp/api/abi/rwlock.h \
@@ -325,6 +331,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/mips64-linux/odp/api/abi/packet_flags.h \
 	odp/arch/mips64-linux/odp/api/abi/packet_io.h \
 	odp/arch/mips64-linux/odp/api/abi/pool.h \
+	odp/arch/mips64-linux/odp/api/abi/proto_stats.h \
 	odp/arch/mips64-linux/odp/api/abi/queue.h \
 	odp/arch/mips64-linux/odp/api/abi/queue_types.h \
 	odp/arch/mips64-linux/odp/api/abi/rwlock.h \
@@ -369,6 +376,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/power64-linux/odp/api/abi/packet_flags.h \
 	odp/arch/power64-linux/odp/api/abi/packet_io.h \
 	odp/arch/power64-linux/odp/api/abi/pool.h \
+	odp/arch/power64-linux/odp/api/abi/proto_stats.h \
 	odp/arch/power64-linux/odp/api/abi/queue.h \
 	odp/arch/power64-linux/odp/api/abi/queue_types.h \
 	odp/arch/power64-linux/odp/api/abi/rwlock.h \
@@ -413,6 +421,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_32-linux/odp/api/abi/packet_flags.h \
 	odp/arch/x86_32-linux/odp/api/abi/packet_io.h \
 	odp/arch/x86_32-linux/odp/api/abi/pool.h \
+	odp/arch/x86_32-linux/odp/api/abi/proto_stats.h \
 	odp/arch/x86_32-linux/odp/api/abi/queue.h \
 	odp/arch/x86_32-linux/odp/api/abi/queue_types.h \
 	odp/arch/x86_32-linux/odp/api/abi/rwlock.h \
@@ -457,6 +466,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_64-linux/odp/api/abi/packet_flags.h \
 	odp/arch/x86_64-linux/odp/api/abi/packet_io.h \
 	odp/arch/x86_64-linux/odp/api/abi/pool.h \
+	odp/arch/x86_64-linux/odp/api/abi/proto_stats.h \
 	odp/arch/x86_64-linux/odp/api/abi/queue.h \
 	odp/arch/x86_64-linux/odp/api/abi/queue_types.h \
 	odp/arch/x86_64-linux/odp/api/abi/rwlock.h \

--- a/include/odp/api/abi-default/proto_stats.h
+++ b/include/odp/api/abi-default/proto_stats.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2021 Marvell.
+ */
+
+/**
+ * @file
+ *
+ * ODP Proto Stats
+ */
+
+#ifndef ODP_ABI_PROTO_STATS_H_
+#define ODP_ABI_PROTO_STATS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/std_types.h>
+
+/** @internal Dummy type for strong typing */
+typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_proto_stats_t;
+
+/** @ingroup odp_proto_stats
+ *  Operations on a proto stats object.
+ *  @{
+ */
+
+typedef _odp_abi_proto_stats_t *odp_proto_stats_t;
+
+#define ODP_PROTO_STATS_INVALID ((odp_proto_stats_t)0)
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/api/proto_stats.h
+++ b/include/odp/api/proto_stats.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2021 Marvell.
+ */
+
+/**
+ * @file
+ *
+ * ODP proto stats
+ */
+
+#ifndef ODP_API_PROTO_STATS_H_
+#define ODP_API_PROTO_STATS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/std_types.h>
+#include <odp/api/abi/queue.h>
+#include <odp/api/abi/proto_stats.h>
+
+#include <odp/api/spec/proto_stats.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 
+#include <odp/api/proto_stats.h>
 #include <odp/api/time.h>
 #include <odp/api/packet_types.h>
 
@@ -2029,6 +2030,61 @@ int odp_packet_tx_compl_request(odp_packet_t pkt, const odp_packet_tx_compl_opt_
  * @retval 0         TX completion event is not requested
  */
 int odp_packet_has_tx_compl_request(odp_packet_t pkt);
+
+/**
+ * Packet proto stats options.
+ */
+typedef struct odp_packet_proto_stats_opt_t {
+	/** Packet proto stats object handle
+	 *
+	 * Stats in the packet proto stats object will be updated.
+	 */
+	odp_proto_stats_t stat;
+
+	/** Octet counter 0 adjust */
+	int32_t oct_count0_adj;
+
+	/** Octet counter 1 adjust */
+	int32_t oct_count1_adj;
+} odp_packet_proto_stats_opt_t;
+
+/**
+ * Request packet proto stats.
+ *
+ * The statistics enabled in the proto stats object are updated for the packet in
+ * packet output when the packet is transmitted or dropped. The statistics update
+ * is done as the last step of output processing after possible packet
+ * transformations (e.g. fragmentation, IPsec) that may occur. If a packet is
+ * fragmented or segmented to multiple packets as part of output processing, all
+ * the resulting packets inherit the proto stats object association from the
+ * original packet.
+ *
+ * The relevant octet counts will be updated with the actual packet length at
+ * the time of transmission or drop plus the respective adjustment value passed
+ * in the 'opt' parameter. The octet counts thus include possible additional
+ * headers added by ODP during packet output (e.g. ESP header added by inline
+ * outbound IPsec processing). Ethernet padding and FCS are not included in the
+ * octet counts. The adjustment value is added only if the respective capability
+ * field is true and otherwise ignored.
+ *
+ * @param pkt   Packet handle
+ * @param opt   Proto stats options. If NULL, then proto stats update is
+ *              disabled for this packet.
+ *
+ * @see odp_proto_stats_capability_t::tx
+ */
+void odp_packet_proto_stats_request(odp_packet_t pkt, odp_packet_proto_stats_opt_t *opt);
+
+/**
+ * Get proto stats object.
+ *
+ * Get the proto stats object associated with the given packet.
+ *
+ * @param pkt Packet handle
+ *
+ * @return Proto stats object handle or ODP_PROTO_STATS_INVALID if not set.
+ */
+odp_proto_stats_t odp_packet_proto_stats(odp_packet_t pkt);
 
 /*
  *

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -25,6 +25,7 @@ extern "C" {
 #include <odp/api/reassembly.h>
 #include <odp/api/time.h>
 #include <odp/api/packet.h>
+#include <odp/api/proto_stats.h>
 
 /** @defgroup odp_packet_io ODP PACKET IO
  *  Packet IO interfaces.
@@ -505,6 +506,9 @@ typedef union odp_pktout_config_opt_t {
 		 * 1: Application may request packet TX completion events
 		 */
 		uint64_t tx_compl_ena : 1;
+
+		/** Enable packet protocol stats update */
+		uint64_t proto_stats_ena : 1;
 
 	} bit;
 

--- a/include/odp/api/spec/proto_stats.h
+++ b/include/odp/api/spec/proto_stats.h
@@ -25,14 +25,67 @@ extern "C" {
  * Invalid proto stats handle
  */
 
+/** ODP proto stats counters
+ *
+ * Statistics that can be enabled in proto stats object. For Tx stats counters,
+ * Pktout config `odp_pktout_config_opt_t::bit::proto_stats_ena` needs to be
+ * enabled.
+ *
+ * Tx packet and octet sent/drop statistics might include packets sent/dropped via
+ * Traffic Manager or Tx packet Aging or due to any other Tx errors. It is
+ * implementation specific as to what all Tx sent/drop events are accounted for.
+ */
+typedef union odp_proto_stats_counters_t {
+	/** Option flags */
+	struct {
+		/** Tx packet sent count */
+		uint64_t tx_pkts : 1;
+
+		/** Tx packet drop count */
+		uint64_t tx_pkt_drops : 1;
+
+		/** Tx packet sent Octet counter 0 */
+		uint64_t tx_oct_count0 : 1;
+
+		/** Tx packet drop Octet counter 0 */
+		uint64_t tx_oct_count0_drops : 1;
+
+		/** Tx packet sent octet counter 1 */
+		uint64_t tx_oct_count1 : 1;
+
+		/** Tx packet drop octet counter 1 */
+		uint64_t tx_oct_count1_drops : 1;
+	} bit;
+
+	/** All bits of the bit field structure
+	 *
+	 * This field can be used to set/clear all flags, or bitwise
+	 * operations over the entire structure.
+	 */
+	uint64_t all_bits;
+} odp_proto_stats_counters_t;
+
 /** ODP proto stats params */
 typedef struct odp_proto_stats_param_t {
+	/** Stats counters to enable */
+	odp_proto_stats_counters_t counters;
 } odp_proto_stats_param_t;
 
 /**
  * Proto stats capabilities
  */
 typedef struct odp_proto_stats_capability_t {
+	/** Tx capabilities */
+	struct {
+		/** Stats counters supported */
+		odp_proto_stats_counters_t counters;
+
+		/** Packet adjust support for Octet counter 0 */
+		odp_bool_t oct_count0_adj;
+
+		/** Packet adjust support for Octet counter 1 */
+		odp_bool_t oct_count1_adj;
+	} tx;
 } odp_proto_stats_capability_t;
 
 /**
@@ -92,6 +145,13 @@ odp_proto_stats_t odp_proto_stats_lookup(const char *name);
  *
  * Destroy a proto stats object already created.
  *
+ * Before destroying proto stats object having tx statistics enabled,
+ * for all PKTIO devices to which packets were Tx'ed earlier with
+ * this proto stats object, odp_pktio_stop() must be called. Additionally,
+ * existing packets that refer to the proto stats object being destroyed
+ * must not be sent at the same time as or after the proto stats object
+ * destruction.
+ *
  * @param stat Proto stats handle
  *
  * @retval 0 on success
@@ -101,6 +161,23 @@ int odp_proto_stats_destroy(odp_proto_stats_t stat);
 
 /** ODP proto stats counters */
 typedef struct odp_proto_stats_data_t {
+	/** Packet sent count */
+	uint64_t tx_pkts;
+
+	/** Packet drop count */
+	uint64_t tx_pkt_drops;
+
+	/** Packet sent Octet counter 0 */
+	uint64_t tx_oct_count0;
+
+	/** Packet drop Octet counter 0 */
+	uint64_t tx_oct_count0_drops;
+
+	/** Packet sent octet counter 1 */
+	uint64_t tx_oct_count1;
+
+	/** Packet drop octet counter 1 */
+	uint64_t tx_oct_count1_drops;
 } odp_proto_stats_data_t;
 
 /**

--- a/include/odp/api/spec/proto_stats.h
+++ b/include/odp/api/spec/proto_stats.h
@@ -1,0 +1,139 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2021 Marvell.
+ */
+
+/**
+ * @file
+ *
+ * ODP Proto Stats
+ */
+
+#ifndef ODP_API_SPEC_PROTO_STATS_H_
+#define ODP_API_SPEC_PROTO_STATS_H_
+#include <odp/visibility_begin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup odp_proto_stats
+ *  @{
+ */
+
+/**
+ * @def ODP_PROTO_STATS_INVALID
+ * Invalid proto stats handle
+ */
+
+/** ODP proto stats params */
+typedef struct odp_proto_stats_param_t {
+} odp_proto_stats_param_t;
+
+/**
+ * Proto stats capabilities
+ */
+typedef struct odp_proto_stats_capability_t {
+} odp_proto_stats_capability_t;
+
+/**
+ * Initialize proto stats parameters
+ *
+ * Initialize an odp_proto_stats_param_t to its default values.
+ * By default all the statistics are disabled.
+ *
+ * @param param   Proto stats parameter pointer.
+ */
+void odp_proto_stats_param_init(odp_proto_stats_param_t *param);
+
+/**
+ * Get proto stats capability
+ *
+ * Get supported protocol statistics and metadata for a PKTIO.
+ *
+ * @param      pktio  Packet IO handle
+ * @param[out] capa   Pointer where capabilities are updated
+ *
+ * @retval 0 on success
+ * @retval <0 on failure
+ */
+int odp_proto_stats_capability(odp_pktio_t pktio, odp_proto_stats_capability_t *capa);
+
+/**
+ * Create a proto stats object
+ *
+ * Create a proto stats object with given name and parameters.
+ * A proto stats object can be created with any set of statistics but only the
+ * statistics that are supported by a PKTIO are updated in a proto stats object
+ * for that PKTIO associated packets. Same proto stats object can be used with
+ * any PKTIO.
+ *
+ * @param name  Object name
+ * @param param Proto stats parameters
+ *
+ * @return Proto stats object handle
+ * @retval ODP_PROTO_STATS_INVALID on failure
+ */
+odp_proto_stats_t odp_proto_stats_create(const char *name, const odp_proto_stats_param_t *param);
+
+/**
+ * Lookup a proto stats object by name
+ *
+ * Lookup an already created proto stats object by name.
+ *
+ * @param name Proto stats object name
+ *
+ * @return Proto stats object handle
+ * @retval ODP_PROTO_STATS_INVALID on failure
+ */
+odp_proto_stats_t odp_proto_stats_lookup(const char *name);
+
+/**
+ * Destroy a proto stats object
+ *
+ * Destroy a proto stats object already created.
+ *
+ * @param stat Proto stats handle
+ *
+ * @retval 0 on success
+ * @retval <0 on failure
+ */
+int odp_proto_stats_destroy(odp_proto_stats_t stat);
+
+/** ODP proto stats counters */
+typedef struct odp_proto_stats_data_t {
+} odp_proto_stats_data_t;
+
+/**
+ * Get all proto stats counters
+ *
+ * Get current values of all counters of the proto stats object.
+ * The values of counters that are not enabled in the proto stats object are undefined.
+ *
+ * @param      stat   Proto stats object handle
+ * @param[out] data   Pointer to a caller allocated structure where the statistics will
+ *                    be written to.
+ *
+ * @retval =0 on success
+ * @retval <0 on failure
+ */
+int odp_proto_stats(odp_proto_stats_t stat, odp_proto_stats_data_t *data);
+
+/**
+ * Print proto stats object info to ODP log.
+ *
+ * Print implementation-defined proto stats debug information to ODP log.
+ *
+ * @param stat Proto stats object handle
+ */
+void odp_proto_stats_print(odp_proto_stats_t stat);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <odp/visibility_end.h>
+#endif

--- a/include/odp/arch/arm32-linux/odp/api/abi/proto_stats.h
+++ b/include/odp/arch/arm32-linux/odp/api/abi/proto_stats.h
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2021 Marvell.
+ */
+
+#include <odp/api/abi-default/proto_stats.h>

--- a/include/odp/arch/arm64-linux/odp/api/abi/proto_stats.h
+++ b/include/odp/arch/arm64-linux/odp/api/abi/proto_stats.h
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2021 Marvell.
+ */
+
+#include <odp/api/abi-default/proto_stats.h>

--- a/include/odp/arch/default-linux/odp/api/abi/proto_stats.h
+++ b/include/odp/arch/default-linux/odp/api/abi/proto_stats.h
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2021 Marvell.
+ */
+
+#include <odp/api/abi-default/proto_stats.h>

--- a/include/odp/arch/mips64-linux/odp/api/abi/proto_stats.h
+++ b/include/odp/arch/mips64-linux/odp/api/abi/proto_stats.h
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2021 Marvell.
+ */
+
+#include <odp/api/abi-default/proto_stats.h>

--- a/include/odp/arch/power64-linux/odp/api/abi/proto_stats.h
+++ b/include/odp/arch/power64-linux/odp/api/abi/proto_stats.h
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2021 Marvell.
+ */
+
+#include <odp/api/abi-default/proto_stats.h>

--- a/include/odp/arch/x86_32-linux/odp/api/abi/proto_stats.h
+++ b/include/odp/arch/x86_32-linux/odp/api/abi/proto_stats.h
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2021 Marvell.
+ */
+
+#include <odp/api/abi-default/proto_stats.h>

--- a/include/odp/arch/x86_64-linux/odp/api/abi/proto_stats.h
+++ b/include/odp/arch/x86_64-linux/odp/api/abi/proto_stats.h
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2021 Marvell.
+ */
+
+#include <odp/api/abi-default/proto_stats.h>

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -70,6 +70,7 @@ odpapiabiarchinclude_HEADERS += \
 		  include-abi/odp/api/abi/packet_types.h \
 		  include-abi/odp/api/abi/packet_flags.h \
 		  include-abi/odp/api/abi/packet_io.h \
+		  include-abi/odp/api/abi/proto_stats.h \
 		  include-abi/odp/api/abi/pool.h \
 		  include-abi/odp/api/abi/queue.h \
 		  include-abi/odp/api/abi/queue_types.h \

--- a/platform/linux-generic/include-abi/odp/api/abi/proto_stats.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/proto_stats.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2021 Marvell.
+ */
+
+/**
+ * @file
+ *
+ * ODP proto stats
+ */
+
+#ifndef ODP_API_ABI_PROTO_STATS_H_
+#define ODP_API_ABI_PROTO_STATS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/std_types.h>
+#include <odp/api/plat/strong_types.h>
+
+/** @ingroup odp_proto_stats
+ *  @{
+ */
+
+typedef ODP_HANDLE_T(odp_proto_stats_t);
+
+#define ODP_PROTO_STATS_INVALID _odp_cast_scalar(odp_proto_stats_t, 0)
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -18,6 +18,7 @@
 #include <odp/api/plat/byteorder_inlines.h>
 #include <odp/api/packet_io.h>
 #include <odp/api/plat/pktio_inlines.h>
+#include <odp/api/proto_stats.h>
 
 /* Inlined API functions */
 #include <odp/api/plat/event_inlines.h>
@@ -3105,4 +3106,17 @@ odp_packet_t odp_packet_reassemble(odp_pool_t pool_hdl, odp_packet_buf_t pkt_buf
 	packet_parse_reset(pkt_hdr, 1);
 
 	return packet_handle(pkt_hdr);
+}
+
+void odp_packet_proto_stats_request(odp_packet_t pkt, odp_packet_proto_stats_opt_t *opt)
+{
+	(void)pkt;
+	(void)opt;
+}
+
+odp_proto_stats_t odp_packet_proto_stats(odp_packet_t pkt)
+{
+	(void)pkt;
+
+	return ODP_PROTO_STATS_INVALID;
 }

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -30,6 +30,7 @@
 #include <odp/api/plat/queue_inlines.h>
 #include <odp_libconfig_internal.h>
 #include <odp_event_vector_internal.h>
+#include <odp/api/proto_stats.h>
 
 #include <string.h>
 #include <inttypes.h>
@@ -3346,4 +3347,64 @@ int odp_pktout_send_lso(odp_pktout_queue_t queue, const odp_packet_t packet[], i
 	}
 
 	return i;
+}
+
+void
+odp_proto_stats_param_init(odp_proto_stats_param_t *param)
+{
+	if (param)
+		memset(param, 0, sizeof(*param));
+}
+
+int
+odp_proto_stats_capability(odp_pktio_t pktio, odp_proto_stats_capability_t *capa)
+{
+	(void)pktio;
+
+	if (capa == NULL)
+		return -EINVAL;
+
+	memset(capa, 0, sizeof(*capa));
+
+	return 0;
+}
+
+odp_proto_stats_t
+odp_proto_stats_lookup(const char *name)
+{
+	(void)name;
+
+	return ODP_PROTO_STATS_INVALID;
+}
+
+odp_proto_stats_t
+odp_proto_stats_create(const char *name, const odp_proto_stats_param_t *param)
+{
+	(void)name;
+	(void)param;
+
+	return ODP_PROTO_STATS_INVALID;
+}
+
+int
+odp_proto_stats_destroy(odp_proto_stats_t stat)
+{
+	(void)stat;
+
+	return 0;
+}
+
+int
+odp_proto_stats(odp_proto_stats_t stat, odp_proto_stats_data_t *data)
+{
+	(void)stat;
+	(void)data;
+
+	return 0;
+}
+
+void
+odp_proto_stats_print(odp_proto_stats_t stat)
+{
+	(void)stat;
 }


### PR DESCRIPTION
commit 192b077eb422c0064c04e6715226e579765cc086
Author: Jerin Jacob <jerinj@marvell.com>
Date:   Mon Feb 15 15:37:43 2021 +0530

    api: packet: add proto stats meta data support
    
    Add metadata operations needed on per-packet basis for Packet IO
    protocol stats feature on Tx
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>
    Signed-off-by: Jerin Jacob <jerinj@marvell.com>

commit 8b2a99509e3eac33f3a435072ba7562dbfd585f0
Author: Jerin Jacob <jerinj@marvell.com>
Date:   Mon Feb 15 15:35:30 2021 +0530

    api: pktio: add support for Tx proto stats
    
    Add support for Packet IO protocol stats feature on Tx. A packet is
    associated with a proto stats object and when packet reaches
    terminal state in pktout queue, those stats are updated. Proto stats
    needs to be requested per-packet with by default it being disabled.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>
    Signed-off-by: Jerin Jacob <jerinj@marvell.com>

commit c90b3abebef6ba77a10bb98777e8e45e12eca4a2
Author: Jerin Jacob <jerinj@marvell.com>
Date:   Mon Feb 15 15:29:42 2021 +0530

    api: proto_stats: introduce generic protocol stats framework
    
    Add generic protocol stats framework where protocol stats object
    supports basic operations like creation, lookup, access and destroy
    of stats object is supported. Each object supports a set of
    stats based on object params. Layout of the stats is implementation
    defined.
    
    This framework is added so that in platforms where the layout of
    stats is platform dependent and different for various HW blocks / modes
    it is easier to integrate. This generic framework is also useful
    when we have to associate stats objects to fast path with minimal
    overhead as it is as close to HW implementation as possible.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>
    Signed-off-by: Jerin Jacob <jerinj@marvell.com>


Example usage of Tx protocol stats feature:

```
   # Enable Tx protocol stats feature on PKTIO
   config.pktout.bit.proto_stats = 1;
   odp_pktio_config(pktio, &config);
	
   # Create a stats object to count pkts and drop count
   params.mode = ODP_PROTO_STATS_MODE_TX_PKT;
   odp_proto_stats_t stat = odp_proto_stats_create("Tx IP packets", &params);

   # Associate a stats object to a packet and enable proto stats update for this packet
   odp_packet_proto_stats_set(pkt, stat);
   
   # Send the packet
   odp_pktout_send(pktout_queue, &pkt, 1) ;

   # Access stats
   uint64_t *stat_base = odp_proto_stats(stat, &max_index);
   uint8_t tx_pkt_sent_index = odp_proto_stats_index(stat, ODP_PROTO_STATS_ID_TX_PKT);
   uint8_t tx_pkt_drop_index = odp_proto_stats_index(stat, ODP_PROTO_STATS_ID_TX_PKT_DROP);

   stat_base[tx_pkt_sent_index];
   stat_base[tx_pkt_drop_index];
   
```