### PR TITLE
[PATCH v6] example: debug: fix timer pool configuration

### DIFF
--- a/example/debug/odp_debug.c
+++ b/example/debug/odp_debug.c
@@ -346,6 +346,7 @@ static int timer_debug(void)
 	odp_pool_t pool;
 	odp_pool_param_t pool_param;
 	odp_timeout_t timeout;
+	odp_timer_res_capability_t timer_res_capa;
 	odp_timer_capability_t timer_capa;
 	odp_timer_pool_t timer_pool;
 	odp_timer_pool_param_t timer_param;
@@ -382,8 +383,15 @@ static int timer_debug(void)
 	if (timer_capa.max_tmo.max_tmo < max_tmo)
 		max_tmo = timer_capa.max_tmo.max_tmo;
 
-	if (timer_capa.max_tmo.res_ns > res)
-		res = timer_capa.max_tmo.res_ns;
+	memset(&timer_res_capa, 0, sizeof(odp_timer_res_capability_t));
+	timer_res_capa.max_tmo = max_tmo;
+	if (odp_timer_res_capability(ODP_CLOCK_CPU, &timer_res_capa)) {
+		ODPH_ERR("Timer resolution capability failed\n");
+		return -1;
+	}
+
+	if (timer_res_capa.res_ns > res)
+		res = timer_res_capa.res_ns;
 
 	memset(&timer_param, 0, sizeof(timer_param));
 	timer_param.res_ns  = res;


### PR DESCRIPTION
Currently, the max and min timeout are being configured with the
minimum resolution supported by the timer implementation, instead
retrieve the resolution and min timeout supported for the given
max timeout and configure them accordingly.

Signed-off-by: Pavan Nikhilesh <pbhagavatula@marvell.com>
Reviewed-by: Petri Savolainen <petri.savolainen@nokia.com>
