### PR TITLE
[PATCH v2] test: call global and local init in odp_api_from_cpp

### DIFF
--- a/test/miscellaneous/odp_api_from_cpp.cpp
+++ b/test/miscellaneous/odp_api_from_cpp.cpp
@@ -4,8 +4,16 @@
 
 int main(int argc ODP_UNUSED, const char *argv[] ODP_UNUSED)
 {
+	odp_instance_t inst;
+
+	odp_init_global(&inst, NULL, NULL);
+	odp_init_local(inst, ODP_THREAD_WORKER);
+
 	std::cout << "\tODP API version: " << odp_version_api_str() << std::endl;
 	std::cout << "\tODP implementation version: " << odp_version_impl_str() << std::endl;
+
+	odp_term_local();
+	odp_term_global(inst);
 
 	return 0;
 }


### PR DESCRIPTION
Test odp_api_from_cpp may call odp_init_[global,local] so that
platform specific initialization (eg tracing ODP API calls) can be
executed as well.

Signed-off-by: Gowrishankar Muthukrishnan <gmuthukrishn@marvell.com>