### PR TITLE
validation: pktio: evaluate bad checksum

### DIFF
--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -2767,6 +2767,28 @@ static void pktio_test_chksum_in_udp(void)
 			  pktio_test_chksum_in_udp_test);
 }
 
+static void pktio_test_chksum_bad_in_udp_prep(odp_packet_t pkt)
+{
+	odph_udphdr_t *hdr;
+
+	/* Insert incorrect checksum */
+	pktio_test_chksum_in_udp_prep(pkt);
+	hdr = odp_packet_l4_ptr(pkt, NULL);
+	hdr->chksum ^= 1;
+}
+
+static void pktio_test_chksum_bad_in_udp_test(odp_packet_t pkt)
+{
+	CU_ASSERT(odp_packet_l4_chksum_status(pkt) == ODP_PACKET_CHKSUM_BAD);
+}
+
+static void pktio_test_chksum_bad_in_udp(void)
+{
+	pktio_test_chksum(pktio_test_chksum_in_udp_config,
+			  pktio_test_chksum_bad_in_udp_prep,
+			  pktio_test_chksum_bad_in_udp_test);
+}
+
 static int pktio_check_chksum_in_sctp(void)
 {
 	odp_pktio_t pktio;
@@ -2824,6 +2846,28 @@ static void pktio_test_chksum_in_sctp(void)
 	pktio_test_chksum_sctp(pktio_test_chksum_in_sctp_config,
 			       pktio_test_chksum_in_sctp_prep,
 			       pktio_test_chksum_in_sctp_test);
+}
+
+static void pktio_test_chksum_bad_in_sctp_prep(odp_packet_t pkt)
+{
+	odph_sctphdr_t *hdr;
+
+	/* Insert incorrect checksum */
+	pktio_test_chksum_in_sctp_prep(pkt);
+	hdr = odp_packet_l4_ptr(pkt, NULL);
+	hdr->chksum ^= 1;
+}
+
+static void pktio_test_chksum_bad_in_sctp_test(odp_packet_t pkt)
+{
+	CU_ASSERT(odp_packet_l4_chksum_status(pkt) == ODP_PACKET_CHKSUM_BAD);
+}
+
+static void pktio_test_chksum_bad_in_sctp(void)
+{
+	pktio_test_chksum_sctp(pktio_test_chksum_in_sctp_config,
+			       pktio_test_chksum_bad_in_sctp_prep,
+			       pktio_test_chksum_bad_in_sctp_test);
 }
 
 static int pktio_check_chksum_out_ipv4(void)
@@ -3632,7 +3676,11 @@ odp_testinfo_t pktio_suite_unsegmented[] = {
 				  pktio_check_chksum_in_ipv4),
 	ODP_TEST_INFO_CONDITIONAL(pktio_test_chksum_in_udp,
 				  pktio_check_chksum_in_udp),
+	ODP_TEST_INFO_CONDITIONAL(pktio_test_chksum_bad_in_udp,
+				  pktio_check_chksum_in_udp),
 	ODP_TEST_INFO_CONDITIONAL(pktio_test_chksum_in_sctp,
+				  pktio_check_chksum_in_sctp),
+	ODP_TEST_INFO_CONDITIONAL(pktio_test_chksum_bad_in_sctp,
 				  pktio_check_chksum_in_sctp),
 	ODP_TEST_INFO_CONDITIONAL(pktio_test_chksum_out_ipv4_no_ovr,
 				  pktio_check_chksum_out_ipv4),


### PR DESCRIPTION
Add tests for validating bad checksum in udp and sctp packets.

Signed-off-by: Gowrishankar Muthukrishnan <gmuthukrishn@marvell.com>
Change-Id: I875f82c0a454be339ea44e710701199c0f230e5b