### PR TITLE
[PATCH v11] linux-gen: queue_lf: move aarch64 specific code to arch files

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -281,7 +281,10 @@ endif
 noinst_HEADERS += arch/arm/odp_atomic.h \
 		  arch/arm/odp_cpu.h \
 		  arch/arm/odp_cpu_idling.h \
-		  arch/arm/odp_llsc.h
+		  arch/arm/odp_llsc.h \
+		  arch/default/odp_atomic.h \
+		  arch/default/odp_cpu.h \
+		  arch/default/odp_cpu_idling.h
 endif
 if ARCH_IS_AARCH64
 __LIB__libodp_linux_la_SOURCES += arch/aarch64/odp_atomic.c \
@@ -317,7 +320,8 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/default/odp/api/abi/atomic_inlines.h \
 				arch/default/odp/api/abi/cpu.h
 endif
-noinst_HEADERS += arch/default/odp_cpu.h \
+noinst_HEADERS += arch/default/odp_atomic.h \
+		  arch/default/odp_cpu.h \
 		  arch/default/odp_cpu_idling.h
 endif
 if ARCH_IS_MIPS64
@@ -334,7 +338,8 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/default/odp/api/abi/atomic_inlines.h \
 				arch/mips64/odp/api/abi/cpu.h
 endif
-noinst_HEADERS += arch/default/odp_cpu.h \
+noinst_HEADERS += arch/default/odp_atomic.h \
+		  arch/default/odp_cpu.h \
 		  arch/default/odp_cpu_idling.h
 endif
 if ARCH_IS_POWERPC
@@ -351,7 +356,8 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/default/odp/api/abi/atomic_inlines.h \
 				arch/powerpc/odp/api/abi/cpu.h
 endif
-noinst_HEADERS += arch/default/odp_cpu.h \
+noinst_HEADERS += arch/default/odp_atomic.h \
+		  arch/default/odp_cpu.h \
 		  arch/default/odp_cpu_idling.h
 endif
 if ARCH_IS_X86
@@ -372,6 +378,7 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 endif
 noinst_HEADERS += arch/x86/cpu_flags.h \
 		  arch/x86/odp_cpu.h \
+		  arch/default/odp_atomic.h \
 		  arch/default/odp_cpu.h \
 		  arch/default/odp_cpu_idling.h
 endif

--- a/platform/linux-generic/arch/aarch64/odp_atomic.h
+++ b/platform/linux-generic/arch/aarch64/odp_atomic.h
@@ -217,4 +217,28 @@ static inline __int128 __lockfree_load_16(__int128 *var, int mo)
 	return old;
 }
 
+typedef unsigned __int128 _u128_t;
+
+static inline _u128_t lockfree_load_u128(_u128_t *atomic)
+{
+	return __lockfree_load_16((__int128 *)atomic, __ATOMIC_RELAXED);
+}
+
+static inline int lockfree_cas_acq_rel_u128(_u128_t *atomic,
+					    _u128_t old_val,
+					    _u128_t new_val)
+{
+	return __lockfree_compare_exchange_16((__int128 *)atomic,
+					      (__int128 *)&old_val,
+					      new_val,
+					      0,
+					      __ATOMIC_ACQ_REL,
+					      __ATOMIC_RELAXED);
+}
+
+static inline int lockfree_check_u128(void)
+{
+	return 1;
+}
+
 #endif  /* PLATFORM_LINUXGENERIC_ARCH_ARM_ODP_ATOMIC_H */

--- a/platform/linux-generic/arch/default/odp_atomic.h
+++ b/platform/linux-generic/arch/default/odp_atomic.h
@@ -1,0 +1,36 @@
+/* Copyright (c) 2021, Arm Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_DEFAULT_ATOMIC_H_
+#define ODP_DEFAULT_ATOMIC_H_
+
+#ifdef __SIZEOF_INT128__
+
+typedef unsigned __int128 _u128_t;
+
+static inline _u128_t lockfree_load_u128(_u128_t *atomic)
+{
+	return __atomic_load_n(atomic, __ATOMIC_RELAXED);
+}
+
+static inline int lockfree_cas_acq_rel_u128(_u128_t *atomic,
+					    _u128_t old_val,
+					    _u128_t new_val)
+{
+	return __atomic_compare_exchange_n(atomic, &old_val, new_val,
+					   0 /* strong */,
+					   __ATOMIC_ACQ_REL,
+					   __ATOMIC_RELAXED);
+}
+
+static inline int lockfree_check_u128(void)
+{
+	return __atomic_is_lock_free(16, NULL);
+}
+
+#endif
+
+#endif

--- a/platform/linux-generic/arch/default/odp_cpu.h
+++ b/platform/linux-generic/arch/default/odp_cpu.h
@@ -20,6 +20,7 @@
 #define atomic_store_release(loc, val, ro) \
 	__atomic_store_n(loc, val, __ATOMIC_RELEASE)
 
+#include "odp_atomic.h"
 #include "odp_cpu_idling.h"
 
 #endif


### PR DESCRIPTION
odp_queue_lf.c and odp_bitset.h contain aarch64 specific code which causes the build to fail on arm4 systems when the --disable-host-optimization flag is enabled. These patches separate out the default and aarch64 specific code to the arch-specific files and resolve the build issues.