### PR TITLE
[PATCH v3] github_ci: add build tests for missing compiler optimization levels

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         cc: [gcc, clang]
-        conf: ['', 'CFLAGS=-O3', 'CFLAGS=-O0 --enable-debug --enable-debug-print', '--enable-lto', '--enable-lto --disable-abi-compat', '--enable-pcapng-support']
+        conf: ['', 'CFLAGS=-O3', 'CFLAGS=-O1', 'CFLAGS=-O0 --enable-debug=full', '--enable-lto', '--enable-lto --disable-abi-compat', '--enable-pcapng-support']
         exclude:
           - cc: clang
             conf: '--enable-lto'


### PR DESCRIPTION
Add build only tests for all compiler optimization levels. Additionally,
enable helper debug code and print (--enable-debug=full).

Signed-off-by: Matias Elo <matias.elo@nokia.com>

V3:
- Removed duplicate test for -O2