### PR TITLE
[PATCH v5] linux-gen: bitset: move aarch64 specific code to arch files

### DIFF
--- a/platform/linux-generic/arch/aarch64/odp_atomic.h
+++ b/platform/linux-generic/arch/aarch64/odp_atomic.h
@@ -12,6 +12,8 @@
 #error This file should not be included directly, please include odp_cpu.h
 #endif
 
+#include <limits.h>
+
 #ifdef CONFIG_DMBSTR
 
 #define atomic_store_release(loc, val, ro)		\
@@ -239,6 +241,86 @@ static inline int lockfree_cas_acq_rel_u128(_u128_t *atomic,
 static inline int lockfree_check_u128(void)
 {
 	return 1;
+}
+
+/** Atomic bit set operations with memory ordering */
+#if defined(__SIZEOF_INT128__) && __SIZEOF_INT128__ == 16
+typedef __int128 bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_INT128__)
+
+#elif __GCC_ATOMIC_LLONG_LOCK_FREE == 2 && \
+	__SIZEOF_LONG_LONG__ != __SIZEOF_LONG__
+typedef unsigned long long bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_LONG_LONG__)
+
+#elif __GCC_ATOMIC_LONG_LOCK_FREE == 2 && __SIZEOF_LONG__ != __SIZEOF_INT__
+typedef unsigned long bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_LONG__)
+
+#elif __GCC_ATOMIC_INT_LOCK_FREE == 2
+typedef unsigned int bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_INT__)
+
+#else
+/* Target does not support lock-free atomic operations */
+typedef unsigned int bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_INT__)
+#endif
+
+#if ATOM_BITSET_SIZE <= 32
+
+static inline bitset_t bitset_mask(uint32_t bit)
+{
+	return 1UL << bit;
+}
+
+#elif ATOM_BITSET_SIZE <= 64
+
+static inline bitset_t bitset_mask(uint32_t bit)
+{
+	return 1ULL << bit;
+}
+
+#elif ATOM_BITSET_SIZE <= 128
+
+static inline bitset_t bitset_mask(uint32_t bit)
+{
+	if (bit < 64)
+		return 1ULL << bit;
+	else
+		return (unsigned __int128)(1ULL << (bit - 64)) << 64;
+}
+
+#else
+#error Unsupported size of bit sets (ATOM_BITSET_SIZE)
+#endif
+
+static inline bitset_t atom_bitset_load(bitset_t *bs, int mo)
+{
+	return __lockfree_load_16(bs, mo);
+}
+
+static inline void atom_bitset_set(bitset_t *bs, uint32_t bit, int mo)
+{
+	(void)__lockfree_fetch_or_16(bs, bitset_mask(bit), mo);
+}
+
+static inline void atom_bitset_clr(bitset_t *bs, uint32_t bit, int mo)
+{
+	(void)__lockfree_fetch_and_16(bs, ~bitset_mask(bit), mo);
+}
+
+static inline bitset_t atom_bitset_xchg(bitset_t *bs, bitset_t neu, int mo)
+{
+	return __lockfree_exchange_16(bs, neu, mo);
+}
+
+static inline bitset_t atom_bitset_cmpxchg(bitset_t *bs, bitset_t *old,
+					   bitset_t neu, bool weak,
+					   int mo_success, int mo_failure)
+{
+	return __lockfree_compare_exchange_16(bs, old, neu, weak, mo_success,
+					      mo_failure);
 }
 
 #endif  /* PLATFORM_LINUXGENERIC_ARCH_ARM_ODP_ATOMIC_H */

--- a/platform/linux-generic/arch/arm/odp_atomic.h
+++ b/platform/linux-generic/arch/arm/odp_atomic.h
@@ -1,5 +1,4 @@
-/* Copyright (c) 2017, ARM Limited. All rights reserved.
- *
+/* Copyright (c) 2017-2021, ARM Limited. All rights reserved.
  * Copyright (c) 2017-2018, Linaro Limited
  * All rights reserved.
  *
@@ -12,6 +11,8 @@
 #ifndef PLATFORM_LINUXGENERIC_ARCH_ARM_ODP_CPU_H
 #error This file should not be included directly, please include odp_cpu.h
 #endif
+
+#include <limits.h>
 
 #ifdef CONFIG_DMBSTR
 
@@ -27,5 +28,81 @@ do {							\
 	__atomic_store_n(loc, val, __ATOMIC_RELEASE)
 
 #endif  /* CONFIG_DMBSTR */
+
+/** Atomic bit set operations with memory ordering */
+#if __GCC_ATOMIC_LLONG_LOCK_FREE == 2 && \
+	__SIZEOF_LONG_LONG__ != __SIZEOF_LONG__
+typedef unsigned long long bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_LONG_LONG__)
+
+#elif __GCC_ATOMIC_LONG_LOCK_FREE == 2 && __SIZEOF_LONG__ != __SIZEOF_INT__
+typedef unsigned long bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_LONG__)
+
+#elif __GCC_ATOMIC_INT_LOCK_FREE == 2
+typedef unsigned int bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_INT__)
+
+#else
+/* Target does not support lock-free atomic operations */
+typedef unsigned int bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_INT__)
+#endif
+
+#if ATOM_BITSET_SIZE <= 32
+
+static inline bitset_t bitset_mask(uint32_t bit)
+{
+	return 1UL << bit;
+}
+
+#elif ATOM_BITSET_SIZE <= 64
+
+static inline bitset_t bitset_mask(uint32_t bit)
+{
+	return 1ULL << bit;
+}
+
+#elif ATOM_BITSET_SIZE <= 128
+
+static inline bitset_t bitset_mask(uint32_t bit)
+{
+	if (bit < 64)
+		return 1ULL << bit;
+	else
+		return (unsigned __int128)(1ULL << (bit - 64)) << 64;
+}
+
+#else
+#error Unsupported size of bit sets (ATOM_BITSET_SIZE)
+#endif
+
+static inline bitset_t atom_bitset_load(bitset_t *bs, int mo)
+{
+	return __atomic_load_n(bs, mo);
+}
+
+static inline void atom_bitset_set(bitset_t *bs, uint32_t bit, int mo)
+{
+	(void)__atomic_fetch_or(bs, bitset_mask(bit), mo);
+}
+
+static inline void atom_bitset_clr(bitset_t *bs, uint32_t bit, int mo)
+{
+	(void)__atomic_fetch_and(bs, ~bitset_mask(bit), mo);
+}
+
+static inline bitset_t atom_bitset_xchg(bitset_t *bs, bitset_t neu, int mo)
+{
+	return __atomic_exchange_n(bs, neu, mo);
+}
+
+static inline bitset_t atom_bitset_cmpxchg(bitset_t *bs, bitset_t *old,
+					   bitset_t neu, bool weak,
+					   int mo_success, int mo_failure)
+{
+	return __atomic_compare_exchange_n(bs, old, neu, weak, mo_success,
+					   mo_failure);
+}
 
 #endif  /* PLATFORM_LINUXGENERIC_ARCH_ARM_ODP_ATOMIC_H */

--- a/platform/linux-generic/arch/default/odp_atomic.h
+++ b/platform/linux-generic/arch/default/odp_atomic.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Arm Limited
+/* Copyright (c) 2021, ARM Limited
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -32,5 +32,83 @@ static inline int lockfree_check_u128(void)
 }
 
 #endif
+
+#include <limits.h>
+
+/** Atomic bit set operations with memory ordering */
+#if __GCC_ATOMIC_LLONG_LOCK_FREE == 2 && \
+	__SIZEOF_LONG_LONG__ != __SIZEOF_LONG__
+typedef unsigned long long bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_LONG_LONG__)
+
+#elif __GCC_ATOMIC_LONG_LOCK_FREE == 2 && __SIZEOF_LONG__ != __SIZEOF_INT__
+typedef unsigned long bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_LONG__)
+
+#elif __GCC_ATOMIC_INT_LOCK_FREE == 2
+typedef unsigned int bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_INT__)
+
+#else
+/* Target does not support lock-free atomic operations */
+typedef unsigned int bitset_t;
+#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_INT__)
+#endif
+
+#if ATOM_BITSET_SIZE <= 32
+
+static inline bitset_t bitset_mask(uint32_t bit)
+{
+	return 1UL << bit;
+}
+
+#elif ATOM_BITSET_SIZE <= 64
+
+static inline bitset_t bitset_mask(uint32_t bit)
+{
+	return 1ULL << bit;
+}
+
+#elif ATOM_BITSET_SIZE <= 128
+
+static inline bitset_t bitset_mask(uint32_t bit)
+{
+	if (bit < 64)
+		return 1ULL << bit;
+	else
+		return (unsigned __int128)(1ULL << (bit - 64)) << 64;
+}
+
+#else
+#error Unsupported size of bit sets (ATOM_BITSET_SIZE)
+#endif
+
+static inline bitset_t atom_bitset_load(bitset_t *bs, int mo)
+{
+	return __atomic_load_n(bs, mo);
+}
+
+static inline void atom_bitset_set(bitset_t *bs, uint32_t bit, int mo)
+{
+	(void)__atomic_fetch_or(bs, bitset_mask(bit), mo);
+}
+
+static inline void atom_bitset_clr(bitset_t *bs, uint32_t bit, int mo)
+{
+	(void)__atomic_fetch_and(bs, ~bitset_mask(bit), mo);
+}
+
+static inline bitset_t atom_bitset_xchg(bitset_t *bs, bitset_t neu, int mo)
+{
+	return __atomic_exchange_n(bs, neu, mo);
+}
+
+static inline bitset_t atom_bitset_cmpxchg(bitset_t *bs, bitset_t *old,
+					   bitset_t neu, bool weak,
+					   int mo_success, int mo_failure)
+{
+	return __atomic_compare_exchange_n(bs, old, neu, weak, mo_success,
+					   mo_failure);
+}
 
 #endif

--- a/platform/linux-generic/include/odp_bitset.h
+++ b/platform/linux-generic/include/odp_bitset.h
@@ -24,38 +24,7 @@
  * (lock-free) max is 128
  */
 
-/* Find a suitable data type that supports lock-free atomic operations */
-#if defined(__aarch64__) && defined(__SIZEOF_INT128__) && \
-	__SIZEOF_INT128__ == 16
-#define LOCKFREE16
-typedef __int128 bitset_t;
-#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_INT128__)
-
-#elif __GCC_ATOMIC_LLONG_LOCK_FREE == 2 && \
-	__SIZEOF_LONG_LONG__ != __SIZEOF_LONG__
-typedef unsigned long long bitset_t;
-#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_LONG_LONG__)
-
-#elif __GCC_ATOMIC_LONG_LOCK_FREE == 2 && __SIZEOF_LONG__ != __SIZEOF_INT__
-typedef unsigned long bitset_t;
-#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_LONG__)
-
-#elif __GCC_ATOMIC_INT_LOCK_FREE == 2
-typedef unsigned int bitset_t;
-#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_INT__)
-
-#else
-/* Target does not support lock-free atomic operations */
-typedef unsigned int bitset_t;
-#define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_INT__)
-#endif
-
 #if ATOM_BITSET_SIZE <= 32
-
-static inline bitset_t bitset_mask(uint32_t bit)
-{
-	return 1UL << bit;
-}
 
 /* Return first-bit-set with StdC ffs() semantics */
 static inline uint32_t bitset_ffs(bitset_t b)
@@ -71,11 +40,6 @@ static inline bitset_t bitset_monitor(bitset_t *bs, int mo)
 
 #elif ATOM_BITSET_SIZE <= 64
 
-static inline bitset_t bitset_mask(uint32_t bit)
-{
-	return 1ULL << bit;
-}
-
 /* Return first-bit-set with StdC ffs() semantics */
 static inline uint32_t bitset_ffs(bitset_t b)
 {
@@ -89,14 +53,6 @@ static inline bitset_t bitset_monitor(bitset_t *bs, int mo)
 }
 
 #elif ATOM_BITSET_SIZE <= 128
-
-static inline bitset_t bitset_mask(uint32_t bit)
-{
-	if (bit < 64)
-		return 1ULL << bit;
-	else
-		return (unsigned __int128)(1ULL << (bit - 64)) << 64;
-}
 
 /* Return first-bit-set with StdC ffs() semantics */
 static inline uint32_t bitset_ffs(bitset_t b)
@@ -118,60 +74,6 @@ static inline bitset_t bitset_monitor(bitset_t *bs, int mo)
 #else
 #error Unsupported size of bit sets (ATOM_BITSET_SIZE)
 #endif
-
-/* Atomic load with memory ordering */
-static inline bitset_t atom_bitset_load(bitset_t *bs, int mo)
-{
-#ifdef LOCKFREE16
-	return __lockfree_load_16(bs, mo);
-#else
-	return __atomic_load_n(bs, mo);
-#endif
-}
-
-/* Atomic bit set with memory ordering */
-static inline void atom_bitset_set(bitset_t *bs, uint32_t bit, int mo)
-{
-#ifdef LOCKFREE16
-	(void)__lockfree_fetch_or_16(bs, bitset_mask(bit), mo);
-#else
-	(void)__atomic_fetch_or(bs, bitset_mask(bit), mo);
-#endif
-}
-
-/* Atomic bit clear with memory ordering */
-static inline void atom_bitset_clr(bitset_t *bs, uint32_t bit, int mo)
-{
-#ifdef LOCKFREE16
-	(void)__lockfree_fetch_and_16(bs, ~bitset_mask(bit), mo);
-#else
-	(void)__atomic_fetch_and(bs, ~bitset_mask(bit), mo);
-#endif
-}
-
-/* Atomic exchange with memory ordering */
-static inline bitset_t atom_bitset_xchg(bitset_t *bs, bitset_t neu, int mo)
-{
-#ifdef LOCKFREE16
-	return __lockfree_exchange_16(bs, neu, mo);
-#else
-	return __atomic_exchange_n(bs, neu, mo);
-#endif
-}
-
-/* Atomic compare&exchange with memory ordering */
-static inline bitset_t atom_bitset_cmpxchg(bitset_t *bs, bitset_t *old,
-					   bitset_t neu, bool weak,
-					   int mo_success, int mo_failure)
-{
-#ifdef LOCKFREE16
-	return __lockfree_compare_exchange_16(bs, old, neu, weak, mo_success,
-					      mo_failure);
-#else
-	return __atomic_compare_exchange_n(bs, old, neu, weak, mo_success,
-					   mo_failure);
-#endif
-}
 
 /* Return a & ~b */
 static inline bitset_t bitset_andn(bitset_t a, bitset_t b)


### PR DESCRIPTION
On arm64 systems, the build fails with the --disable-host-optimization
compiler flag as it is unable to locate definitions of lockless APIs
used in atomic bit operations since these declarations are present in
arch/aarch64/odp_atomic.h files Consequently, the aarch64 specific code
has been moved to the arch-specific file while the reminder code has been
moved under the default linux-generic implementation.

Signed-off-by: Malvika Gupta <Malvika.Gupta@arm.com>
Reviewed-by: Govindarajan Mohandoss <govindarajan.mohandoss@arm.com>