### PR TITLE
[PATCH v2] linux-gen: random: remove _odp_random_openssl_test_data()

### DIFF
--- a/platform/linux-generic/include/odp_random_openssl_internal.h
+++ b/platform/linux-generic/include/odp_random_openssl_internal.h
@@ -16,7 +16,6 @@ extern "C" {
 #include <odp/api/random.h>
 
 odp_random_kind_t _odp_random_openssl_max_kind(void);
-int32_t _odp_random_openssl_test_data(uint8_t *buf, uint32_t len, uint64_t *seed);
 int32_t _odp_random_openssl_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind);
 int _odp_random_openssl_init_local(void);
 int _odp_random_openssl_term_local(void);

--- a/platform/linux-generic/odp_random.c
+++ b/platform/linux-generic/odp_random.c
@@ -29,8 +29,6 @@ int32_t odp_random_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
 
 int32_t odp_random_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
 {
-	if (_ODP_OPENSSL)
-		return _odp_random_openssl_test_data(buf, len, seed);
 	return _odp_random_std_test_data(buf, len, seed);
 }
 

--- a/platform/linux-generic/odp_random_openssl.c
+++ b/platform/linux-generic/odp_random_openssl.c
@@ -36,27 +36,6 @@ int32_t _odp_random_openssl_data(uint8_t *buf, uint32_t len,
 		return -1;
 	}
 }
-
-int32_t _odp_random_openssl_test_data(uint8_t *buf, uint32_t len,
-				      uint64_t *seed)
-{
-	union {
-		uint32_t rand_word;
-		uint8_t rand_byte[4];
-	} u;
-	uint32_t i = 0, j;
-	uint32_t seed32 = (*seed) & 0xffffffff;
-
-	while (i < len) {
-		u.rand_word = rand_r(&seed32);
-
-		for (j = 0; j < 4 && i < len; j++, i++)
-			*buf++ = u.rand_byte[j];
-	}
-
-	*seed = seed32;
-	return len;
-}
 #else
 /* Dummy functions for building without OpenSSL support */
 odp_random_kind_t _odp_random_openssl_max_kind(void)
@@ -67,13 +46,6 @@ odp_random_kind_t _odp_random_openssl_max_kind(void)
 int32_t _odp_random_openssl_data(uint8_t *buf ODP_UNUSED,
 				 uint32_t len ODP_UNUSED,
 				 odp_random_kind_t kind ODP_UNUSED)
-{
-	return -1;
-}
-
-int32_t _odp_random_openssl_test_data(uint8_t *buf ODP_UNUSED,
-				      uint32_t len ODP_UNUSED,
-				      uint64_t *seed ODP_UNUSED)
 {
 	return -1;
 }


### PR DESCRIPTION
```
Not all bits returned by _odp_random_openssl_test_data() are random,
depending on RAND_MAX. And OpenSSL doesn't seem to provide repeatable
random bits.

Remove _odp_random_openssl_test_data() and use
_odp_random_std_test_data() instead.

Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
v2:
- Added reviewed-by: Petri.
