### PR TITLE
[PATCH v2] configure: allow user to override *FLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,11 +240,10 @@ AC_ARG_ENABLE([abi-compat],
 	ODP_LIBSO_VERSION=0:0:0
 
 	# do not use -march=native with clang (due to possible failures on
-	# clang optimizations) or when user have defined CFLAGS (may contain
-	# another -march option).
+	# clang optimizations).
 	$CC --version | grep -q clang
 
-	if test $? -ne 0 -a $user_cflags -eq 0; then
+	if test $? -ne 0; then
 		ODP_CHECK_CFLAG([-march=native])
 	fi
     fi])
@@ -443,9 +442,9 @@ DX_INIT_DOXYGEN($PACKAGE_NAME,
 ##########################################################################
 # Default include setup
 ##########################################################################
-CFLAGS="$CFLAGS $ODP_CFLAGS"
-CXXFLAGS="$CXXFLAGS $ODP_CXXFLAGS"
-LDFLAGS="$LDFLAGS $ODP_LTO_FLAGS"
+CFLAGS="$ODP_CFLAGS $CFLAGS"
+CXXFLAGS="$ODP_CXXFLAGS $CXXFLAGS"
+LDFLAGS="$ODP_LTO_FLAGS $LDFLAGS"
 
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([include/Makefile


### PR DESCRIPTION
```
Place user provided options at the end of CFLAGS, CXXFLAGS and
LDFLAGS, so that they override other options.

This way we also don't have to refrain from using the -march option
just because user has provided some CFLAGS.

Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
v2:
- Add reviewed-by tag.
- Rebase.
