### PR TITLE
[PATCH v7] github_ci: add Coverity job and script

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,25 @@
+name: Coverity Scan
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Once every day at 00:00 UTC
+env:
+  CC: gcc
+  ARCH: x86_64
+  CONTAINER_NAMESPACE: ghcr.io/opendataplane/odp-docker-images
+  OS: ubuntu_20.04
+  COVERITY_EMAIL: odp@lists.opendataplane.org
+  COVERITY_PROJECT: ODP
+
+jobs:
+  Coverity-analysis:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g
+               -e CC="${CC}" -e GITHUB_SHA="${GITHUB_SHA}"
+               -e COVERITY_TOKEN="${{ secrets.COVERITY_TOKEN }}"
+               -e COVERITY_EMAIL="${COVERITY_EMAIL}"
+               -e COVERITY_PROJECT="${COVERITY_PROJECT}"
+               ${CONTAINER_NAMESPACE}:odp-ci-${OS}-${ARCH}-coverity-linux-generic
+               /odp/scripts/ci/coverity.sh

--- a/scripts/ci/coverity.sh
+++ b/scripts/ci/coverity.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"/../..
+./bootstrap
+./configure --enable-debug=full
+
+make clean
+
+cov-build --dir coverity-build make -j $(nproc)
+
+tar czf odp-coverity.tgz coverity-build
+
+curl --form token="${COVERITY_TOKEN}" \
+  --form email="${COVERITY_EMAIL}" \
+  --form file=@odp-coverity.tgz \
+  --form version="${GITHUB_SHA}" \
+  --form description="GitHub Actions ODP Coverity Build" \
+  "https://scan.coverity.com/builds?project=${COVERITY_PROJECT}"


### PR DESCRIPTION
Add just an Ubuntu20.04 Coverity job scheduled daily, as for static analysis we don't need multiple different build. The build is without DPDK as we don't need that for static analysis.

Signed-off-by: Juraj Linkeš <juraj.linkes@pantheon.tech>