### PR TITLE
[PATCH v2] linux-gen: fix sched max queues assert

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -198,6 +198,14 @@ jobs:
     - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}"
              -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/out_of_tree.sh
 
+  Build_sched_config:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}"
+               -e CONF="--enable-debug=full" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/sched-basic.conf
+               $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
+
   Run_coverage:
     runs-on: ubuntu-18.04
     steps:

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -432,9 +432,11 @@ static int schedule_init_global(void)
 	ODP_ASSERT(ring_size <= MAX_RING_SIZE);
 	sched->ring_mask = ring_size - 1;
 
-	/* Each ring can hold in maximum ring_size-1 queues. */
+	/* Each ring can hold in maximum ring_size-1 queues. Due to ring size round up,
+	 * total capacity of rings may be larger than CONFIG_MAX_SCHED_QUEUES. */
 	sched->max_queues = sched->ring_mask * sched->config.num_spread;
-	ODP_ASSERT(sched->max_queues <= CONFIG_MAX_SCHED_QUEUES);
+	if (sched->max_queues > CONFIG_MAX_SCHED_QUEUES)
+		sched->max_queues = CONFIG_MAX_SCHED_QUEUES;
 
 	odp_spinlock_init(&sched->mask_lock);
 

--- a/platform/linux-generic/test/sched-basic.conf
+++ b/platform/linux-generic/test/sched-basic.conf
@@ -1,0 +1,8 @@
+# Mandatory fields
+odp_implementation = "linux-generic"
+config_file_version = "0.1.15"
+
+sched_basic: {
+	# Test scheduler with an odd spread value
+	prio_spread = 3
+}


### PR DESCRIPTION
Fix max queues assert calculation. Add a CI job to build and and run ODP init (hello world) with an odd number of spread queues.