### PR TITLE
[PATCH v2] github_ci: change ubuntu 16.04 test to build-only

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -170,7 +170,7 @@ jobs:
       fail-fast: false
       matrix:
         cc: [gcc, clang]
-        os: ['centos_7', 'centos_8']
+        os: ['centos_7', 'centos_8', 'ubuntu_16.04']
     steps:
       - uses: actions/checkout@v2
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
@@ -247,7 +247,7 @@ jobs:
       fail-fast: false
       matrix:
         cc: [gcc, clang]
-        os: ['ubuntu_16.04', 'ubuntu_20.04']
+        os: ['ubuntu_20.04']
     steps:
       - uses: actions/checkout@v2
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"


### PR DESCRIPTION
Ubuntu 16.04 is reaching EOL in April. Save CI resourches by testing only
compilation with this OS.

Signed-off-by: Matias Elo <matias.elo@nokia.com>