### PR TITLE
[PATCH v2] m4: odp_dpdk: add missing libm dependency

### DIFF
--- a/m4/odp_dpdk.m4
+++ b/m4/odp_dpdk.m4
@@ -20,6 +20,7 @@ AS_CASE([$cur_driver],
     [rte_pmd_snow3g], [AS_VAR_APPEND([DPDK_LIBS], [" -lsso_snow3g"])],
     [rte_pmd_zuc], [AS_VAR_APPEND([DPDK_LIBS], [" -lsso_zuc"])],
     [rte_pmd_qat], [AS_VAR_APPEND([DPDK_LIBS], [" -lcrypto"])],
+    [rte_pmd_octeontx2], [AS_VAR_APPEND([DPDK_LIBS], [" -lm"])],
     [rte_pmd_openssl], [AS_VAR_APPEND([DPDK_LIBS], [" -lcrypto"])])
 done
 ])


### PR DESCRIPTION
DPDK PMD driver rte_pmd_octeontx2 has dependency to libm.

Signed-off-by: Matias Elo <matias.elo@nokia.com>