### PR TITLE
[PATCH v2] IPsec validation test cleanup

### DIFF
--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -1016,8 +1016,6 @@ static int ipsec_out_tunnel_ipv4(odp_packet_t *pkt,
 	odp_packet_copy_from_mem(*pkt, state->ip_offset,
 				 _ODP_IPV4HDR_LEN, &out_ip);
 
-	odp_packet_l4_offset_set(*pkt, state->ip_offset + _ODP_IPV4HDR_LEN);
-
 	state->ip = odp_packet_l3_ptr(*pkt, NULL);
 	state->ip_hdr_len = _ODP_IPV4HDR_LEN;
 	if (state->is_ipv4)
@@ -1076,8 +1074,6 @@ static int ipsec_out_tunnel_ipv6(odp_packet_t *pkt,
 
 	odp_packet_copy_from_mem(*pkt, state->ip_offset,
 				 sizeof(out_ip), &out_ip);
-
-	odp_packet_l4_offset_set(*pkt, state->ip_offset + _ODP_IPV6HDR_LEN);
 
 	state->ip = odp_packet_l3_ptr(*pkt, NULL);
 	state->ip_hdr_len = _ODP_IPV6HDR_LEN;

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -575,7 +575,7 @@ static int ipsec_send_in_one(const ipsec_test_part *part,
 						odp_event_types(ev, &subtype));
 				CU_ASSERT_EQUAL(ODP_EVENT_PACKET_BASIC,
 						subtype);
-				CU_ASSERT(part->in[i].status.error.sa_lookup);
+				CU_ASSERT(part->out[i].status.error.sa_lookup);
 
 				pkto[i++] = odp_ipsec_packet_from_event(ev);
 				continue;
@@ -588,7 +588,7 @@ static int ipsec_send_in_one(const ipsec_test_part *part,
 						odp_event_types(ev, &subtype));
 				CU_ASSERT_EQUAL(ODP_EVENT_PACKET_IPSEC,
 						subtype);
-				CU_ASSERT(!part->in[i].status.error.sa_lookup);
+				CU_ASSERT(!part->out[i].status.error.sa_lookup);
 
 				pkto[i] = odp_ipsec_packet_from_event(ev);
 				CU_ASSERT(odp_packet_subtype(pkto[i]) ==
@@ -844,13 +844,13 @@ void ipsec_check_in_one(const ipsec_test_part *part, odp_ipsec_sa_t sa)
 		if (ODP_EVENT_PACKET_IPSEC !=
 		    odp_event_subtype(odp_packet_to_event(pkto[i]))) {
 			/* Inline packet went through loop */
-			CU_ASSERT_EQUAL(1, part->in[i].status.error.sa_lookup);
+			CU_ASSERT_EQUAL(1, part->out[i].status.error.sa_lookup);
 		} else {
 			CU_ASSERT_EQUAL(0, odp_ipsec_result(&result, pkto[i]));
-			CU_ASSERT_EQUAL(part->in[i].status.error.all,
+			CU_ASSERT_EQUAL(part->out[i].status.error.all,
 					result.status.error.all);
 
-			if (part->in[i].status.error.all != 0) {
+			if (part->out[i].status.error.all != 0) {
 				odp_packet_free(pkto[i]);
 				return;
 			}
@@ -866,16 +866,16 @@ void ipsec_check_in_one(const ipsec_test_part *part, odp_ipsec_sa_t sa)
 				CU_ASSERT_EQUAL(IPSEC_SA_CTX,
 						odp_ipsec_sa_context(sa));
 		}
-		ipsec_check_packet(part->in[i].pkt_res,
+		ipsec_check_packet(part->out[i].pkt_res,
 				   pkto[i],
 				   false);
-		if (part->in[i].pkt_res != NULL &&
-		    part->in[i].l3_type != _ODP_PROTO_L3_TYPE_UNDEF)
-			CU_ASSERT_EQUAL(part->in[i].l3_type,
+		if (part->out[i].pkt_res != NULL &&
+		    part->out[i].l3_type != _ODP_PROTO_L3_TYPE_UNDEF)
+			CU_ASSERT_EQUAL(part->out[i].l3_type,
 					odp_packet_l3_type(pkto[i]));
-		if (part->in[i].pkt_res != NULL &&
-		    part->in[i].l4_type != _ODP_PROTO_L4_TYPE_UNDEF)
-			CU_ASSERT_EQUAL(part->in[i].l4_type,
+		if (part->out[i].pkt_res != NULL &&
+		    part->out[i].l4_type != _ODP_PROTO_L4_TYPE_UNDEF)
+			CU_ASSERT_EQUAL(part->out[i].l4_type,
 					odp_packet_l4_type(pkto[i]));
 		odp_packet_free(pkto[i]);
 	}

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -105,6 +105,9 @@ void ipsec_sa_param_fill(odp_ipsec_sa_param_t *param,
 void ipsec_sa_destroy(odp_ipsec_sa_t sa);
 odp_packet_t ipsec_packet(const ipsec_test_packet *itp);
 void ipsec_check_in_one(const ipsec_test_part *part, odp_ipsec_sa_t sa);
+int ipsec_check_out(const ipsec_test_part *part,
+		    odp_ipsec_sa_t sa,
+		    odp_packet_t *pkto);
 void ipsec_check_out_one(const ipsec_test_part *part, odp_ipsec_sa_t sa);
 void ipsec_check_out_in_one(const ipsec_test_part *part,
 			    odp_ipsec_sa_t sa,

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -70,10 +70,14 @@ typedef struct {
 } ipsec_test_flags;
 
 typedef struct {
-	const ipsec_test_packet *pkt_in;
 	ipsec_test_flags flags;
+
+	/* Input for the inbound or outbound IPsec operation */
+	const ipsec_test_packet *pkt_in;
 	int num_opt;
 	odp_ipsec_out_opt_t opt;
+
+	/* Expected output */
 	int num_pkt;
 	struct {
 		odp_ipsec_op_status_t status;
@@ -82,12 +86,6 @@ typedef struct {
 		odp_proto_l4_type_t l4_type;
 		uint32_t seq_num;
 	} out[1];
-	struct {
-		odp_ipsec_op_status_t status;
-		const ipsec_test_packet *pkt_res;
-		odp_proto_l3_type_t l3_type;
-		odp_proto_l4_type_t l4_type;
-	} in[1];
 } ipsec_test_part;
 
 void ipsec_sa_param_fill(odp_ipsec_sa_param_t *param,

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -109,9 +109,6 @@ int ipsec_check_out(const ipsec_test_part *part,
 		    odp_ipsec_sa_t sa,
 		    odp_packet_t *pkto);
 void ipsec_check_out_one(const ipsec_test_part *part, odp_ipsec_sa_t sa);
-void ipsec_check_out_in_one(const ipsec_test_part *part,
-			    odp_ipsec_sa_t sa,
-			    odp_ipsec_sa_t sa_in);
 int ipsec_test_sa_update_seq_num(odp_ipsec_sa_t sa, uint32_t seq_num);
 
 int ipsec_check(odp_bool_t ah,

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -57,20 +57,13 @@ enum ipsec_test_stats {
 };
 
 typedef struct {
-	odp_bool_t display_algo;
 	odp_bool_t lookup;
-	odp_bool_t ah;
 	odp_bool_t inline_hdr_in_packet;
 	odp_bool_t test_sa_seq_num;
-	odp_bool_t v6;
-	odp_bool_t tunnel;
-	odp_bool_t tunnel_is_v6;
-	odp_bool_t udp_encap;
-	enum ipsec_test_stats stats;
-} ipsec_test_flags;
+} ipsec_test_part_flags_t;
 
 typedef struct {
-	ipsec_test_flags flags;
+	ipsec_test_part_flags_t flags;
 
 	/* Input for the inbound or outbound IPsec operation */
 	const ipsec_test_packet *pkt_in;

--- a/test/validation/api/ipsec/ipsec_test_in.c
+++ b/test/validation/api/ipsec/ipsec_test_in.c
@@ -27,7 +27,7 @@ static void test_in_ipv4_ah_sha256(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -62,7 +62,7 @@ static void test_in_ipv4_ah_sha256_tun_ipv4(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_tun_ipv4_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -97,7 +97,7 @@ static void test_in_ipv4_ah_sha256_tun_ipv6(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_tun_ipv6_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -129,7 +129,7 @@ static void test_in_ipv4_ah_sha256_tun_ipv4_notun(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_tun_ipv4_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -162,7 +162,7 @@ static void test_in_ipv4_esp_null_sha256(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -194,7 +194,7 @@ static void test_in_ipv4_esp_aes_cbc_null(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_aes_cbc_null_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -226,7 +226,7 @@ static void test_in_ipv4_esp_aes_cbc_sha1(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_aes_cbc_sha1_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -258,7 +258,7 @@ static void test_in_ipv4_esp_aes_cbc_sha256(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_aes_cbc_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -290,7 +290,7 @@ static void test_in_ipv4_esp_aes_cbc_sha384(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_aes_cbc_sha384_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -322,7 +322,7 @@ static void test_in_ipv4_esp_aes_cbc_sha512(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_aes_cbc_sha512_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -354,7 +354,7 @@ static void test_in_ipv4_esp_aes_ctr_null(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_aes_ctr_null_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -389,7 +389,7 @@ static void test_in_ipv4_ah_sha256_lookup(void)
 			.lookup = 1,
 		},
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -424,7 +424,7 @@ static void test_in_ipv4_esp_null_sha256_lookup(void)
 			.lookup = 1,
 		},
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -459,7 +459,7 @@ static void test_in_ipv4_esp_null_sha256_tun_ipv4(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_tun_ipv4_null_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -494,7 +494,7 @@ static void test_in_ipv4_esp_null_sha256_tun_ipv6(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_tun_ipv6_null_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -527,7 +527,7 @@ static void test_in_ipv4_esp_udp_null_sha256(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_udp_null_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -563,7 +563,7 @@ static void test_in_ipv4_esp_udp_null_sha256_lookup(void)
 			.lookup = 1,
 		},
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -596,7 +596,7 @@ static void test_in_ipv4_ah_sha256_noreplay(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -608,7 +608,7 @@ static void test_in_ipv4_ah_sha256_noreplay(void)
 	ipsec_test_part test_1235 = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1235,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -647,7 +647,7 @@ static void test_in_ipv4_ah_sha256_replay(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -658,12 +658,12 @@ static void test_in_ipv4_ah_sha256_replay(void)
 
 	test_repl.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1;
 	test_repl.num_pkt = 1;
-	test_repl.in[0].status.error.antireplay = 1;
+	test_repl.out[0].status.error.antireplay = 1;
 
 	ipsec_test_part test_1235 = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1235,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -699,7 +699,7 @@ static void test_in_ipv4_esp_null_sha256_noreplay(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -711,7 +711,7 @@ static void test_in_ipv4_esp_null_sha256_noreplay(void)
 	ipsec_test_part test_1235 = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1235,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -757,30 +757,16 @@ static void test_in_ipv4_esp_null_sha256_replay(void)
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
 			  .pkt_res = &pkt_ipv4_icmp_0 },
 		},
-		.in = {
-			{ .status.warn.all = 0,
-			  .status.error.all = 0,
-			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
-			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_res = &pkt_ipv4_icmp_0 },
-		},
 	};
 
 	test_repl.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1;
 	test_repl.num_pkt = 1;
-	test_repl.in[0].status.error.antireplay = 1;
+	test_repl.out[0].status.error.antireplay = 1;
 
 	ipsec_test_part test_1235 = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1235,
 		.num_pkt = 1,
 		.out = {
-			{ .status.warn.all = 0,
-			  .status.error.all = 0,
-			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
-			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_res = &pkt_ipv4_icmp_0 },
-		},
-		.in = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -822,7 +808,7 @@ static void test_in_ipv4_ah_esp_pkt(void)
 
 	test.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1;
 	test.num_pkt = 1;
-	test.in[0].status.error.proto = 1;
+	test.out[0].status.error.proto = 1;
 
 	ipsec_check_in_one(&test, sa);
 
@@ -854,7 +840,7 @@ static void test_in_ipv4_esp_ah_pkt(void)
 
 	test.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1;
 	test.num_pkt = 1;
-	test.in[0].status.error.proto = 1;
+	test.out[0].status.error.proto = 1;
 
 	ipsec_check_in_one(&test, sa);
 
@@ -882,7 +868,7 @@ static void test_in_ipv4_ah_esp_pkt_lookup(void)
 	test.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1;
 	test.flags.lookup = 1;
 	test.num_pkt = 1;
-	test.in[0].status.error.sa_lookup = 1;
+	test.out[0].status.error.sa_lookup = 1;
 
 	ipsec_check_in_one(&test, ODP_IPSEC_SA_INVALID);
 
@@ -910,7 +896,7 @@ static void test_in_ipv4_esp_ah_pkt_lookup(void)
 	test.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1;
 	test.flags.lookup = 1;
 	test.num_pkt = 1;
-	test.in[0].status.error.sa_lookup = 1;
+	test.out[0].status.error.sa_lookup = 1;
 
 	ipsec_check_in_one(&test, ODP_IPSEC_SA_INVALID);
 
@@ -937,7 +923,7 @@ static void test_in_ipv4_ah_sha256_bad1(void)
 
 	test.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1_bad1;
 	test.num_pkt = 1;
-	test.in[0].status.error.auth = 1;
+	test.out[0].status.error.auth = 1;
 
 	ipsec_check_in_one(&test, sa);
 
@@ -964,7 +950,7 @@ static void test_in_ipv4_ah_sha256_bad2(void)
 
 	test.pkt_in = &pkt_ipv4_icmp_0_ah_sha256_1_bad2;
 	test.num_pkt = 1;
-	test.in[0].status.error.auth = 1;
+	test.out[0].status.error.auth = 1;
 
 	ipsec_check_in_one(&test, sa);
 
@@ -991,7 +977,7 @@ static void test_in_ipv4_esp_null_sha256_bad1(void)
 
 	test.pkt_in = &pkt_ipv4_icmp_0_esp_null_sha256_1_bad1;
 	test.num_pkt = 1;
-	test.in[0].status.error.auth = 1;
+	test.out[0].status.error.auth = 1;
 
 	ipsec_check_in_one(&test, sa);
 
@@ -1016,7 +1002,7 @@ static void test_in_ipv4_rfc3602_5_esp(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_rfc3602_5_esp,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -1048,7 +1034,7 @@ static void test_in_ipv4_rfc3602_6_esp(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_rfc3602_6_esp,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -1083,7 +1069,7 @@ static void test_in_ipv4_rfc3602_7_esp(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_rfc3602_7_esp,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -1118,7 +1104,7 @@ static void test_in_ipv4_rfc3602_8_esp(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_rfc3602_8_esp,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -1153,7 +1139,7 @@ static void test_in_ipv4_mcgrew_gcm_2_esp(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_mcgrew_gcm_test_2_esp,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -1188,7 +1174,7 @@ static void test_in_ipv4_mcgrew_gcm_3_esp(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_mcgrew_gcm_test_3_esp,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -1223,7 +1209,7 @@ static void test_in_ipv4_mcgrew_gcm_4_esp(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_mcgrew_gcm_test_4_esp,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -1263,7 +1249,7 @@ static void test_in_ipv4_mcgrew_gcm_12_esp(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_mcgrew_gcm_test_12_esp,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_NONE,
@@ -1295,7 +1281,7 @@ static void test_in_ipv4_mcgrew_gcm_12_esp_notun(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_mcgrew_gcm_test_12_esp,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -1330,7 +1316,7 @@ static void test_in_ipv4_mcgrew_gcm_15_esp(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_mcgrew_gcm_test_15_esp,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -1365,7 +1351,7 @@ static void test_in_ipv4_rfc7634_chacha(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_rfc7634_esp,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -1397,7 +1383,7 @@ static void test_in_ipv4_ah_aes_gmac_128(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_ah_aes_gmac_128_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -1429,7 +1415,7 @@ static void test_in_ipv4_esp_null_aes_gmac_128(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv4_icmp_0_esp_null_aes_gmac_128_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
@@ -1461,7 +1447,7 @@ static void test_in_ipv6_ah_sha256(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_ah_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
@@ -1496,7 +1482,7 @@ static void test_in_ipv6_ah_sha256_tun_ipv4(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_ah_tun_ipv4_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
@@ -1531,7 +1517,7 @@ static void test_in_ipv6_ah_sha256_tun_ipv6(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_ah_tun_ipv6_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
@@ -1563,7 +1549,7 @@ static void test_in_ipv6_esp_null_sha256(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_esp_null_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
@@ -1598,7 +1584,7 @@ static void test_in_ipv6_esp_null_sha256_tun_ipv4(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_esp_tun_ipv4_null_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
@@ -1633,7 +1619,7 @@ static void test_in_ipv6_esp_null_sha256_tun_ipv6(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_esp_tun_ipv6_null_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
@@ -1666,7 +1652,7 @@ static void test_in_ipv6_esp_udp_null_sha256(void)
 	ipsec_test_part test = {
 		.pkt_in = &pkt_ipv6_icmp_0_esp_udp_null_sha256_1,
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,
@@ -1702,7 +1688,7 @@ static void test_in_ipv6_esp_udp_null_sha256_lookup(void)
 			.lookup = 1,
 		},
 		.num_pkt = 1,
-		.in = {
+		.out = {
 			{ .status.warn.all = 0,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV6,

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -1132,27 +1132,18 @@ static void test_out_ipv6_esp_udp_null_sha256(void)
 	ipsec_sa_destroy(sa);
 }
 
-static void test_out_dummy_esp_null_sha256_tun_ipv4(void)
+static void test_out_dummy_esp_null_sha256_tun(odp_ipsec_tunnel_param_t tunnel)
 {
-	odp_ipsec_tunnel_param_t tunnel;
 	odp_ipsec_sa_param_t param;
 	odp_ipsec_sa_t sa;
 	odp_ipsec_sa_t sa2;
-	uint32_t src = IPV4ADDR(10, 0, 111, 2);
-	uint32_t dst = IPV4ADDR(10, 0, 222, 2);
 	ipsec_test_part test;
 	ipsec_test_part test_empty;
 
 	memset(&test, 0, sizeof(ipsec_test_part));
 	memset(&test_empty, 0, sizeof(ipsec_test_part));
 
-	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
-	tunnel.type = ODP_IPSEC_TUNNEL_IPV4;
-	tunnel.ipv4.src_addr = &src;
-	tunnel.ipv4.dst_addr = &dst;
-	tunnel.ipv4.ttl = 64;
-
-	/* This test will not work properly inbound inline mode.
+	/* This test will not work properly in inbound inline mode.
 	 * Packet might be dropped and we will not check for that. */
 	if (suite_context.inbound_op_mode == ODP_IPSEC_OP_MODE_INLINE)
 		return;
@@ -1200,14 +1191,24 @@ static void test_out_dummy_esp_null_sha256_tun_ipv4(void)
 	ipsec_sa_destroy(sa);
 }
 
+static void test_out_dummy_esp_null_sha256_tun_ipv4(void)
+{
+	odp_ipsec_tunnel_param_t tunnel;
+	uint32_t src = IPV4ADDR(10, 0, 111, 2);
+	uint32_t dst = IPV4ADDR(10, 0, 222, 2);
+
+	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
+	tunnel.type = ODP_IPSEC_TUNNEL_IPV4;
+	tunnel.ipv4.src_addr = &src;
+	tunnel.ipv4.dst_addr = &dst;
+	tunnel.ipv4.ttl = 64;
+
+	test_out_dummy_esp_null_sha256_tun(tunnel);
+}
+
 static void test_out_dummy_esp_null_sha256_tun_ipv6(void)
 {
 	odp_ipsec_tunnel_param_t tunnel;
-	odp_ipsec_sa_param_t param;
-	odp_ipsec_sa_t sa;
-	odp_ipsec_sa_t sa2;
-	ipsec_test_part test;
-	ipsec_test_part test_empty;
 	uint8_t src[16] = {
 		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 		0x02, 0x11, 0x43, 0xff, 0xfe, 0x4a, 0xd7, 0x0a,
@@ -1217,61 +1218,13 @@ static void test_out_dummy_esp_null_sha256_tun_ipv6(void)
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16,
 	};
 
-	memset(&test, 0, sizeof(ipsec_test_part));
-	memset(&test_empty, 0, sizeof(ipsec_test_part));
-
 	memset(&tunnel, 0, sizeof(odp_ipsec_tunnel_param_t));
 	tunnel.type = ODP_IPSEC_TUNNEL_IPV6;
 	tunnel.ipv6.src_addr = src;
 	tunnel.ipv6.dst_addr = dst;
 	tunnel.ipv6.hlimit = 64;
 
-	/* This test will not work properly inbound inline mode.
-	 * Packet might be dropped and we will not check for that. */
-	if (suite_context.inbound_op_mode == ODP_IPSEC_OP_MODE_INLINE)
-		return;
-
-	ipsec_sa_param_fill(&param,
-			    false, false, 123, &tunnel,
-			    ODP_CIPHER_ALG_NULL, NULL,
-			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL, NULL);
-
-	sa = odp_ipsec_sa_create(&param);
-
-	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa);
-
-	ipsec_sa_param_fill(&param,
-			    true, false, 123, &tunnel,
-			    ODP_CIPHER_ALG_NULL, NULL,
-			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL, NULL);
-
-	sa2 = odp_ipsec_sa_create(&param);
-
-	CU_ASSERT_NOT_EQUAL_FATAL(ODP_IPSEC_SA_INVALID, sa2);
-
-	test.pkt_in = &pkt_test_nodata;
-	test.num_opt = 1;
-	test.opt .flag.tfc_dummy = 1;
-	test.opt.tfc_pad_len = 16;
-	test.num_pkt = 1;
-	test.out[0].l3_type = ODP_PROTO_L3_TYPE_IPV4;
-	test.out[0].l4_type = ODP_PROTO_L4_TYPE_NO_NEXT;
-
-	test_empty.pkt_in = &pkt_test_empty;
-	test_empty.num_opt = 1;
-	test_empty.opt.flag.tfc_dummy = 1;
-	test_empty.opt.tfc_pad_len = 16;
-	test_empty.num_pkt = 1;
-	test_empty.out[0].l3_type = ODP_PROTO_L3_TYPE_IPV4;
-	test_empty.out[0].l4_type = ODP_PROTO_L4_TYPE_NO_NEXT;
-
-	ipsec_check_out_in_one(&test, sa, sa2);
-	ipsec_check_out_in_one(&test_empty, sa, sa2);
-
-	ipsec_sa_destroy(sa2);
-	ipsec_sa_destroy(sa);
+	test_out_dummy_esp_null_sha256_tun(tunnel);
 }
 
 static void test_out_ipv4_udp_esp_null_sha256(void)

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -6,8 +6,9 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include "ipsec.h"
+#include <odp/helper/odph_api.h>
 
+#include "ipsec.h"
 #include "test_vectors.h"
 
 struct cipher_param {
@@ -385,6 +386,71 @@ static void test_ipsec_stats_test_assert(odp_ipsec_stats_t *stats,
 	CU_ASSERT_EQUAL(stats->mtu_err, 0);
 	CU_ASSERT_EQUAL(stats->hard_exp_bytes_err, 0);
 	CU_ASSERT_EQUAL(stats->hard_exp_pkts_err, 0);
+}
+
+static void ipsec_pkt_proto_err_set(odp_packet_t pkt)
+{
+	uint32_t l3_off = odp_packet_l3_offset(pkt);
+	odph_ipv4hdr_t ip;
+
+	/* Simulate proto error by corrupting protocol field */
+
+	odp_packet_copy_to_mem(pkt, l3_off, sizeof(ip), &ip);
+
+	if (ip.proto == ODPH_IPPROTO_ESP)
+		ip.proto = ODPH_IPPROTO_AH;
+	else
+		ip.proto = ODPH_IPPROTO_ESP;
+
+	odp_packet_copy_from_mem(pkt, l3_off, sizeof(ip), &ip);
+}
+
+static void ipsec_pkt_auth_err_set(odp_packet_t pkt)
+{
+	uint32_t data, len;
+
+	/* Simulate auth error by corrupting ICV */
+
+	len = odp_packet_len(pkt);
+	odp_packet_copy_to_mem(pkt, len - sizeof(data), sizeof(data), &data);
+	data = ~data;
+	odp_packet_copy_from_mem(pkt, len - sizeof(data), sizeof(data), &data);
+}
+
+static void ipsec_check_out_in_one(const ipsec_test_part *part,
+				   odp_ipsec_sa_t sa,
+				   odp_ipsec_sa_t sa_in)
+{
+	int num_out = part->num_pkt;
+	odp_packet_t pkto[num_out];
+	int i;
+
+	num_out = ipsec_check_out(part, sa, pkto);
+
+	for (i = 0; i < num_out; i++) {
+		ipsec_test_part part_in = *part;
+		ipsec_test_packet pkt_in;
+
+		CU_ASSERT_FATAL(odp_packet_len(pkto[i]) <=
+				sizeof(pkt_in.data));
+
+		if (part->flags.stats == IPSEC_TEST_STATS_PROTO_ERR)
+			ipsec_pkt_proto_err_set(pkto[i]);
+
+		if (part->flags.stats == IPSEC_TEST_STATS_AUTH_ERR)
+			ipsec_pkt_auth_err_set(pkto[i]);
+
+		pkt_in.len = odp_packet_len(pkto[i]);
+		pkt_in.l2_offset = odp_packet_l2_offset(pkto[i]);
+		pkt_in.l3_offset = odp_packet_l3_offset(pkto[i]);
+		pkt_in.l4_offset = odp_packet_l4_offset(pkto[i]);
+		odp_packet_copy_to_mem(pkto[i], 0,
+				       pkt_in.len,
+				       pkt_in.data);
+		part_in.pkt_in = &pkt_in;
+		ipsec_check_in_one(&part_in, sa_in);
+		odp_packet_free(pkto[i]);
+	}
 }
 
 static void test_out_in_common(ipsec_test_flags *flags,

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -471,7 +471,7 @@ static void test_out_in_common(ipsec_test_flags *flags,
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_res = &pkt_ipv4_icmp_0 },
+			},
 		},
 		.in = {
 			{ .status.warn.all = 0,
@@ -486,7 +486,6 @@ static void test_out_in_common(ipsec_test_flags *flags,
 		test.pkt_in = &pkt_ipv6_icmp_0;
 		test.out[0].l3_type = ODP_PROTO_L3_TYPE_IPV6;
 		test.out[0].l4_type = ODP_PROTO_L4_TYPE_ICMPV6;
-		test.out[0].pkt_res = &pkt_ipv6_icmp_0;
 		test.in[0].l3_type = ODP_PROTO_L3_TYPE_IPV6;
 		test.in[0].l4_type = ODP_PROTO_L4_TYPE_ICMPV6;
 		test.in[0].pkt_res = &pkt_ipv6_icmp_0;
@@ -1361,7 +1360,7 @@ static void test_sa_info(void)
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_res = &pkt_ipv4_icmp_0 },
+			},
 		},
 	};
 
@@ -1568,7 +1567,7 @@ static void test_max_num_sa(void)
 			  .status.error.all = 0,
 			  .l3_type = ODP_PROTO_L3_TYPE_IPV4,
 			  .l4_type = ODP_PROTO_L4_TYPE_ICMPV4,
-			  .pkt_res = &pkt_ipv4_icmp_0 },
+			},
 		},
 		.in = {
 			{ .status.warn.all = 0,


### PR DESCRIPTION
This commit has several patches that clean up the IPsec validation test code and also fix a couple of issues in there. There is also one small change in linux-gen, made possible by a fix in the validation code.

The main change is to decouple the combined output+input tests from the lower level generic test code that will now invoke and check one IPsec packet operation at a time. Combining several operations in one test is now done at the test case level.

@anoobj could you perhaps review these changes and consider rebasing your reassembly validation code on top of this if things look ok?
