### PR TITLE
[PATCH v4] traffic_mngr: linux-gen and validation compliance fixes.

### DIFF
--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -302,6 +302,10 @@ int _odp_sock_recv_mq_tmo_try_int_driven(const struct odp_pktin_queue_t queues[]
 					 uint64_t usecs,
 					 int *trial_successful);
 
+/* Setup PKTOUT with single queue for TM */
+int _odp_pktio_pktout_tm_config(odp_pktio_t pktio_hdl,
+				odp_pktout_queue_t *queue, bool reconf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/odp_name_table.c
+++ b/platform/linux-generic/odp_name_table.c
@@ -376,6 +376,7 @@ static void name_tbl_entry_free(name_tbl_entry_t *name_tbl_entry)
 	memset(name_tbl_entry, 0, sizeof(name_tbl_entry_t));
 	name_tbl_entry->next_entry = name_tbl->free_list_head;
 	name_tbl->free_list_head   = name_tbl_entry;
+	name_tbl_entry->name_tbl_id = name_tbl_id;
 }
 
 static hash_tbl_entry_t make_hash_tbl_entry(name_tbl_entry_t *name_tbl_entry,

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -3065,6 +3065,7 @@ int odp_tm_destroy(odp_tm_t odp_tm)
 	_odp_queue_pool_destroy(tm_system->_odp_int_queue_pool);
 	_odp_timer_wheel_destroy(tm_system->_odp_int_timer_wheel);
 
+	_odp_int_name_tbl_delete(tm_system->name_tbl_id);
 	tm_system_free(tm_system);
 	return 0;
 }
@@ -3573,7 +3574,7 @@ int odp_tm_wred_destroy(odp_tm_wred_t wred_profile)
 		return -1;
 
 	return tm_common_profile_destroy(wred_profile,
-					 ODP_INVALID_NAME);
+					 wred_params->name_tbl_id);
 }
 
 int odp_tm_wred_params_read(odp_tm_wred_t wred_profile,

--- a/test/common/odp_cunit_common.c
+++ b/test/common/odp_cunit_common.c
@@ -259,11 +259,40 @@ int odp_cunit_print_inactive(void)
 			continue;
 
 		if (first) {
-			printf("\n\n  Inactive tests:\n");
+			printf("\n\nSuite: %s\n", sinfo->name);
+			printf("  Inactive tests:\n");
 			first = 0;
 		}
 
 		printf("    %s\n", tinfo->name);
+	}
+
+	return 0;
+}
+
+int odp_cunit_set_inactive(void)
+{
+	CU_pSuite cur_suite;
+	CU_pTest ptest;
+	odp_suiteinfo_t *sinfo;
+	odp_testinfo_t *tinfo;
+
+	cur_suite = CU_get_current_suite();
+	if (cur_suite == NULL)
+		return -1;
+
+	sinfo = cunit_get_suite_info(cur_suite->pName);
+	if (sinfo == NULL)
+		return -1;
+
+	for (tinfo = sinfo->testinfo_tbl; tinfo->name; tinfo++) {
+		ptest = CU_get_test_by_name(tinfo->name, cur_suite);
+		if (ptest == NULL) {
+			fprintf(stderr, "%s: test not found: %s\n",
+				__func__, tinfo->name);
+			return -1;
+		}
+		CU_set_test_active(ptest, false);
 	}
 
 	return 0;

--- a/test/common/odp_cunit_common.h
+++ b/test/common/odp_cunit_common.h
@@ -105,6 +105,7 @@ void odp_cunit_register_global_term(int (*func_term_ptr)(odp_instance_t inst));
 
 int odp_cunit_ret(int val);
 int odp_cunit_print_inactive(void);
+int odp_cunit_set_inactive(void);
 
 /*
  * Wrapper for CU_ASSERT_FATAL implementation to show the compiler that


### PR DESCRIPTION
commit 03db2a3cb430937694c752581185020d2b9049ff
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Sat Mar 27 14:40:44 2021 +0530

    linux-generic: pktio: add internal API to configure pktout for TM
    
    Add internal routine to support configuring pktout when in TM mode.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 9127eb2fd70eca739c7213ae1f188a353dd10234
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Thu Nov 5 06:22:55 2020 +0530

    linux-gen: tm: fix issues related to name table cleanup
    
    Name table entry was not cleaned up properly in destroy path
    of tm profile/node/system. This patch fixes the same.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit fd3d1acb96103fd74809121788eafc1935af9007
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Sat Mar 27 14:17:29 2021 +0530

    validation: traffic_mngr: use pktout mode as TM for Tx
    
    Use ODP_PKTOUT_MODE_TM for pktio that is used for Tx. This is
    as per TM spec. Also change suite init/term to handle cases where
    TM is not supported by platform which can only be known when
    odp_pktio_open() with out mode as TM fails.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 08071d0787a7027cc9e6602a5cff786ff77032fd
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 22:41:56 2020 +0530

    test: cunit: add API to deactivate all test cases
    
    In test suite init, it is possible to detect that a given test suite
    is not applicable. Hence provide an API to deactivate all the
    test cases of a given test suite.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

