### PR TITLE
[PATCH v3] api: tm: support shaper packet mode

### DIFF
--- a/example/traffic_mgmt/odp_traffic_mgmt.c
+++ b/example/traffic_mgmt/odp_traffic_mgmt.c
@@ -62,8 +62,8 @@ static const odp_init_t ODP_INIT_PARAMS = {
 
 static profile_params_set_t COMPANY_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 50  * MBPS,  .commit_burst      = 1000000,
-		.peak_bps   = 0,           .peak_burst        = 0,
+		.commit_rate = 50  * MBPS, .commit_burst      = 1000000,
+		.peak_rate   = 0,          .peak_burst        = 0,
 		.dual_rate  = FALSE,       .shaper_len_adjust = 20
 	},
 
@@ -95,8 +95,8 @@ static profile_params_set_t COMPANY_PROFILE_PARAMS = {
 
 static profile_params_set_t COS0_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 1 * MBPS,  .commit_burst      = 100000,
-		.peak_bps   = 4 * MBPS,  .peak_burst        = 200000,
+		.commit_rate = 1 * MBPS, .commit_burst      = 100000,
+		.peak_rate   = 4 * MBPS, .peak_burst        = 200000,
 		.dual_rate  = FALSE,     .shaper_len_adjust = 20
 	},
 
@@ -128,8 +128,8 @@ static profile_params_set_t COS0_PROFILE_PARAMS = {
 
 static profile_params_set_t COS1_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 500  * KBPS,  .commit_burst      = 50000,
-		.peak_bps   = 1500 * KBPS,  .peak_burst        = 150000,
+		.commit_rate = 500  * KBPS, .commit_burst      = 50000,
+		.peak_rate   = 1500 * KBPS, .peak_burst        = 150000,
 		.dual_rate  = FALSE,        .shaper_len_adjust = 20
 	},
 
@@ -161,8 +161,8 @@ static profile_params_set_t COS1_PROFILE_PARAMS = {
 
 static profile_params_set_t COS2_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 200 * KBPS,  .commit_burst      = 20000,
-		.peak_bps   = 400 * KBPS,  .peak_burst        = 40000,
+		.commit_rate = 200 * KBPS, .commit_burst      = 20000,
+		.peak_rate   = 400 * KBPS, .peak_burst        = 40000,
 		.dual_rate  = FALSE,       .shaper_len_adjust = 20
 	},
 
@@ -194,8 +194,8 @@ static profile_params_set_t COS2_PROFILE_PARAMS = {
 
 static profile_params_set_t COS3_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 100 * KBPS,  .commit_burst      = 5000,
-		.peak_bps   = 0,           .peak_burst        = 0,
+		.commit_rate = 100 * KBPS, .commit_burst      = 5000,
+		.peak_rate   = 0,          .peak_burst        = 0,
 		.dual_rate  = FALSE,       .shaper_len_adjust = 20
 	},
 
@@ -272,8 +272,8 @@ static uint32_t create_profile_set(profile_params_set_t *profile_params_set,
 
 	odp_tm_shaper_params_init(&shaper_params);
 	shaper                          = &profile_params_set->shaper_params;
-	shaper_params.commit_bps        = shaper->commit_bps   * shaper_scale;
-	shaper_params.peak_bps          = shaper->peak_bps     * shaper_scale;
+	shaper_params.commit_rate       = shaper->commit_rate  * shaper_scale;
+	shaper_params.peak_rate         = shaper->peak_rate    * shaper_scale;
 	shaper_params.commit_burst      = shaper->commit_burst * shaper_scale;
 	shaper_params.peak_burst        = shaper->peak_burst   * shaper_scale;
 	shaper_params.dual_rate         = shaper->dual_rate;

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -758,7 +758,8 @@ typedef struct {
 	 * not TRUE while packets per second when packet mode is TRUE.
 	 */
 	union {
-		uint64_t commit_bps; /**< Commit information rate in bps */
+		/**< @deprecated Use commit_rate instead */
+		uint64_t ODP_DEPRECATE(commit_bps);
 		uint64_t commit_rate; /**< Commit information rate */
 	};
 
@@ -767,7 +768,8 @@ typedef struct {
 	 * not TRUE while in packets per second when packet mode is TRUE.
 	 */
 	union {
-		uint64_t peak_bps; /**< Peak information rate in bps */
+		/**< @deprecated Use peak_rate instead */
+		uint64_t ODP_DEPRECATE(peak_bps);
 		uint64_t peak_rate; /**< Peak information rate */
 	};
 

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -224,6 +224,10 @@ typedef struct {
 	 * all support TM shaping, */
 	odp_bool_t tm_node_shaper_supported;
 
+	/** tm_node_shaper_packet_mode indicates that tm_nodes at this level
+	 * support shaper in packet mode */
+	odp_bool_t tm_node_shaper_packet_mode;
+
 	/** tm_node_wred_supported indicates that the tm_nodes at this level
 	 * support some form of Random Early Detection. */
 	odp_bool_t tm_node_wred_supported;
@@ -284,6 +288,10 @@ typedef struct {
 	 * algorithms for delaying packets - which is what TM shapers are
 	 * expected to do. */
 	odp_bool_t tm_queue_shaper_supported;
+
+	/** tm_queue_shaper_packet_mode indicates that tm_queues support
+	 * shaper in packet mode */
+	odp_bool_t tm_queue_shaper_packet_mode;
 
 	/** tm_queue_wred_supported indicates that the tm_queues support some
 	 * form of Random Early Detection. */
@@ -746,20 +754,32 @@ typedef enum {
  */
 typedef struct {
 	/** The committed information rate for this shaper profile.  The units
-	 * for this integer are always in bits per second. */
-	uint64_t commit_bps;
+	 * for this integer is in bits per second when packet_mode is
+	 * not TRUE while packets per second when packet mode is TRUE.
+	 */
+	union {
+		uint64_t commit_bps; /**< Commit information rate in bps */
+		uint64_t commit_rate; /**< Commit information rate */
+	};
 
 	/** The peak information rate for this shaper profile.  The units for
-	 * this integer are always in bits per second. */
-	uint64_t peak_bps;
+	 * this integer is in bits per second when packet_mode is
+	 * not TRUE while in packets per second when packet mode is TRUE.
+	 */
+	union {
+		uint64_t peak_bps; /**< Peak information rate in bps */
+		uint64_t peak_rate; /**< Peak information rate */
+	};
 
 	/** The commit burst tolerance for this shaper profile.  The units for
-	 * this field are always bits.  This value sets an upper limit for the
+	 * this field is bits when packet_mode is not TRUE and packets when
+	 * packet_mode is TRUE.  This value sets an upper limit for the
 	 * size of the commitCnt. */
 	uint32_t commit_burst;
 
 	/** The peak burst tolerance for this shaper profile.  The units for
-	 * this field are always bits.  This value sets an upper limit for the
+	 * this field in bits when packet_mode is not TRUE and packets
+	 * when packet_mode is TRUE. This value sets an upper limit for the
 	 * size of the peakCnt. */
 	uint32_t peak_burst;
 
@@ -771,7 +791,9 @@ typedef struct {
 	 * to a value approximating the "time" (in units of bytes) taken by
 	 * the Ethernet preamble and Inter Frame Gap.  Traditionally this
 	 * would be the value 20 (8 + 12), but in same cases can be as low as
-	 * 9 (4 + 5). */
+	 * 9 (4 + 5).
+	 * This field is ignored when packet_mode is TRUE.
+	 */
 	int8_t shaper_len_adjust;
 
 	/** If dual_rate is TRUE it indicates the desire for the
@@ -780,6 +802,12 @@ typedef struct {
 	 * implementation specific, but in any case require a non-zero set of
 	 * both commit and peak parameters. */
 	odp_bool_t dual_rate;
+
+	/** If packet_mode is TRUE it indicates that shaper should work
+	 * in packet mode ignoring lengths of packet and hence shaping
+	 * traffic in packet's per second as opposed to bits per second.
+	 */
+	odp_bool_t packet_mode;
 } odp_tm_shaper_params_t;
 
 /** odp_tm_shaper_params_init() must be called to initialize any

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -611,8 +611,8 @@ static void tm_shaper_params_cvt_to(const odp_tm_shaper_params_t *shaper_params,
 	uint32_t min_time_delta;
 	int64_t  commit_burst, peak_burst;
 
-	commit_rate = tm_bps_to_rate(shaper_params->commit_bps);
-	if ((shaper_params->commit_bps == 0) || (commit_rate == 0)) {
+	commit_rate = tm_bps_to_rate(shaper_params->commit_rate);
+	if ((shaper_params->commit_rate == 0) || (commit_rate == 0)) {
 		tm_shaper_params->max_commit_time_delta = 0;
 		tm_shaper_params->max_peak_time_delta   = 0;
 		tm_shaper_params->commit_rate           = 0;
@@ -629,8 +629,8 @@ static void tm_shaper_params_cvt_to(const odp_tm_shaper_params_t *shaper_params,
 	max_commit_time_delta = tm_max_time_delta(commit_rate);
 	commit_burst = (int64_t)shaper_params->commit_burst;
 
-	peak_rate = tm_bps_to_rate(shaper_params->peak_bps);
-	if ((shaper_params->peak_bps == 0) || (peak_rate == 0)) {
+	peak_rate = tm_bps_to_rate(shaper_params->peak_rate);
+	if ((shaper_params->peak_rate == 0) || (peak_rate == 0)) {
 		peak_rate = 0;
 		max_peak_time_delta = 0;
 		peak_burst = 0;
@@ -670,8 +670,8 @@ static void tm_shaper_params_cvt_from(tm_shaper_params_t     *tm_shaper_params,
 	commit_burst = tm_shaper_params->max_commit >> (26 - 3);
 	peak_burst = tm_shaper_params->max_peak >> (26 - 3);
 
-	odp_shaper_params->commit_bps = commit_bps;
-	odp_shaper_params->peak_bps = peak_bps;
+	odp_shaper_params->commit_rate = commit_bps;
+	odp_shaper_params->peak_rate = peak_bps;
 	odp_shaper_params->commit_burst = (uint32_t)commit_burst;
 	odp_shaper_params->peak_burst = (uint32_t)peak_burst;
 	odp_shaper_params->shaper_len_adjust = tm_shaper_params->len_adjust;
@@ -3210,6 +3210,10 @@ odp_tm_shaper_t odp_tm_shaper_create(const char *name,
 	tm_shaper_params_t *profile_obj;
 	odp_tm_shaper_t     shaper_handle;
 	_odp_int_name_t     name_tbl_id;
+
+	/* We don't support shaper in packet mode */
+	if (params->packet_mode)
+		return ODP_TM_INVALID;
 
 	profile_obj = tm_common_profile_create(name, TM_SHAPER_PROFILE,
 					       &shaper_handle, &name_tbl_id);

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -2185,9 +2185,9 @@ static void check_shaper_profile(char *shaper_name, uint32_t shaper_idx)
 	memset(&shaper_params, 0, sizeof(shaper_params));
 	rc = odp_tm_shaper_params_read(profile, &shaper_params);
 	CU_ASSERT(rc == 0);
-	CU_ASSERT(approx_eq64(shaper_params.commit_bps,
+	CU_ASSERT(approx_eq64(shaper_params.commit_rate,
 			      shaper_idx * MIN_COMMIT_BW));
-	CU_ASSERT(approx_eq64(shaper_params.peak_bps,
+	CU_ASSERT(approx_eq64(shaper_params.peak_rate,
 			      shaper_idx * MIN_PEAK_BW));
 	CU_ASSERT(approx_eq32(shaper_params.commit_burst,
 			      shaper_idx * MIN_COMMIT_BURST));
@@ -2212,8 +2212,8 @@ static void traffic_mngr_test_shaper_profile(void)
 	for (idx = 1; idx <= NUM_SHAPER_TEST_PROFILES; idx++) {
 		snprintf(shaper_name, sizeof(shaper_name),
 			 "shaper_profile_%" PRIu32, idx);
-		shaper_params.commit_bps   = idx * MIN_COMMIT_BW;
-		shaper_params.peak_bps     = idx * MIN_PEAK_BW;
+		shaper_params.commit_rate  = idx * MIN_COMMIT_BW;
+		shaper_params.peak_rate    = idx * MIN_PEAK_BW;
 		shaper_params.commit_burst = idx * MIN_COMMIT_BURST;
 		shaper_params.peak_burst   = idx * MIN_PEAK_BURST;
 
@@ -2471,8 +2471,8 @@ static int set_shaper(const char    *node_name,
 	}
 
 	odp_tm_shaper_params_init(&shaper_params);
-	shaper_params.commit_bps        = commit_bps;
-	shaper_params.peak_bps          = 0;
+	shaper_params.commit_rate       = commit_bps;
+	shaper_params.peak_rate         = 0;
 	shaper_params.commit_burst      = commit_burst_in_bits;
 	shaper_params.peak_burst        = 0;
 	shaper_params.shaper_len_adjust = 0;


### PR DESCRIPTION
Depends on below series in order:
1. #1234 

commit a1a8a434f111ed1180102b82d2ced898c70bd14e
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Dec 30 00:02:07 2020 +0530

    api: tm: deprecate shaper cir and pir bps fields
    
    Deprecate commit_bps and peak_bps fields as they only related to
    byte mode and not packet mode. Instead commit_rate and peak_rate fields
    can be used in odp_tm_shaper_params_t
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 1f641ef097927992fc41ee4099a03ba5ed5b841f
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Dec 30 00:16:38 2020 +0530

    validation: tm: use commit_rate and peak_rate in shaper params
    
    Use commit_rate and peak_rate in odp_tm_shaper_params_t instead of
    commit_bps and peak_bps.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 6e56a6ea5eddba061cdd5da8b6bc74e0561702bc
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Dec 30 00:12:19 2020 +0530

    example: tm: use commit_rate and peak_rate in shaper param
    
    Use commit_rate and peak_rate in shaper params instead of commit_bps
    and peak_bps.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 19e48fdfba32e05282b1def12b6fdc63fabc53cf
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Dec 30 00:10:15 2020 +0530

    linux-gen: tm: use commit_rate and peak_rate in shaper param
    
    Use commit_rate and peak_rate fields in odp_tm_shaper_params_t instead
    of commit_bps and peak_bps as *_rate fields denote rate in BPS when
    byte mode is set and PPS when packet mode is set.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 0a62b0a26fef9c35897e5e26ea27c9319f32b845
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Fri Nov 6 20:48:35 2020 +0530

    api: tm: add option to enable packet mode in shaper
    
    Similar to using packet/frame count in scheduling
    algorithm and weight in units of number of packets,
    add option to enable packet mode in shaper
    by introducing a boolean flag in shaper profile params.
    When packet mode is set to TRUE, commit/peak rate is
    in PPS (packets per second) and commit/peak burst is in
    Packets.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>
