### PR TITLE
[PATCH v12] api: tm: add start and stop tm API

### DIFF
--- a/example/traffic_mgmt/odp_traffic_mgmt.c
+++ b/example/traffic_mgmt/odp_traffic_mgmt.c
@@ -826,6 +826,13 @@ int main(int argc, char *argv[])
 
 	create_and_config_tm();
 
+	/* Start TM */
+	rc = odp_tm_start(odp_tm_test);
+	if (rc != 0) {
+		printf("Error: odp_tm_start() failed, rc=%d\n", rc);
+		return -1;
+	}
+
 	odp_random_data(random_buf, RANDOM_BUF_LEN, 1);
 	next_rand_byte = 0;
 
@@ -840,6 +847,13 @@ int main(int argc, char *argv[])
 	       pkts_into_tm, pkts_from_tm);
 
 	odp_tm_stats_print(odp_tm_test);
+
+	/* Stop TM */
+	rc = odp_tm_stop(odp_tm_test);
+	if (rc != 0) {
+		printf("Error: odp_tm_stop() failed, rc = %d\n", rc);
+		return -1;
+	}
 
 	rc = destroy_tm_queues();
 	if (rc != 0) {

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -605,6 +605,42 @@ odp_tm_t odp_tm_find(const char            *name,
  */
 int odp_tm_capability(odp_tm_t odp_tm, odp_tm_capabilities_t *capabilities);
 
+/**
+ * Start a TM system
+ *
+ * odp_tm_start() needs to be used to start an already created or found TM
+ * system. By default, all the TM systems are in stopped state.
+ *
+ * @param tm  TM system to be started
+ *
+ * @retval 0  on success
+ * @retval <0 on failure
+ */
+int odp_tm_start(odp_tm_t tm);
+
+/**
+ * Stop a TM system
+ *
+ * odp_tm_stop() can to used to stop a TM system that is already started for the
+ * purpose of reconfiguration that cannot be done dynamically.
+ *
+ * When TM is in the stopped state,
+ * - New packets must not be sent to the TM either directly by TM API or indirectly
+ *   via IPsec outbound inline API. New packets can only be enqueued after
+ *   starting the TM system using odp_tm_start().
+ * - Packets already inflight inside TM or IPSec for transmit may get silently dropped
+ *   or may get transmitted with unspecified TM treatment.
+ *
+ * A following call to odp_tm_start() restarts TM system and its scheduling/shaping
+ * on existing and new packets.
+ *
+ * @param tm  TM system to be stopped
+ *
+ * @retval 0  on success
+ * @retval <0 on failure
+ */
+int odp_tm_stop(odp_tm_t tm);
+
 /** Destroy a TM system.
  *
  * odp_tm_destroy() may be used to destroy TM systems created via

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -331,6 +331,52 @@ typedef struct {
 	/** The per_level array specifies the TM system capabilities that
 	 * can vary based upon the tm_node level. */
 	odp_tm_level_capabilities_t per_level[ODP_TM_MAX_LEVELS];
+
+	/** dynamic_topology_update indicates support for TM system dynamic
+	 * topology update. A dynamic topology update is defined as update to
+	 * a TM system topology while TM system is not in stopped state.
+	 * When TRUE, application can update topology dynamically
+	 * without bringing the TM system to stopped state. When FALSE,
+	 * application has to call odp_tm_stop() before updating the
+	 * topology and odp_tm_start() after completing the update.
+	 */
+	odp_bool_t dynamic_topology_update;
+
+	/** dynamic_shaper_update indicates support for TM system's dynamic
+	 * shaper profile changes. When TRUE, application can update shaper
+	 * profile of a TM queue or TM node dynamically.
+	 * When FALSE, it implies that TM system should be brought to
+	 * stopped state before changing the shaper profile or updating
+	 * the parameters of the shaper profile of any TM node or TM queue.
+	 */
+	odp_bool_t dynamic_shaper_update;
+
+	/** dynamic_sched_update indicates support for TM system's dynamic
+	 * sched profile changes. When TRUE, application can update sched
+	 * profile of a TM queue or TM node dynamically.
+	 * When FALSE, it implies that TM system should be brought to
+	 * stopped state before changing the sched profile or updating
+	 * the parameters of the sched profile of any TM node or TM queue.
+	 */
+	odp_bool_t dynamic_sched_update;
+
+	/** dynamic_wred_update indicates support for TM system's dynamic
+	 * wred profile changes. When TRUE, application can update wred
+	 * profile of a TM queue or TM node dynamically.
+	 * When FALSE, it implies that TM system should be brought to
+	 * stopped state before changing the wred profile or updating
+	 * the parameters of the wred profile of any TM node or TM queue.
+	 */
+	odp_bool_t dynamic_wred_update;
+
+	/** dynamic_threshold_update indicates support for TM system's dynamic
+	 * threshold profile changes. When TRUE, application can update
+	 * threshold profile of a TM queue or TM node dynamically.
+	 * When FALSE, it implies that TM system should be brought to
+	 * stopped state before changing the threshold profile or updating
+	 * the parameters of the threshold profile of any TM node or TM queue.
+	 */
+	odp_bool_t dynamic_threshold_update;
 } odp_tm_capabilities_t;
 
 /** Per Level Requirements
@@ -638,6 +684,12 @@ int odp_tm_start(odp_tm_t tm);
  *
  * @retval 0  on success
  * @retval <0 on failure
+ *
+ * @see odp_tm_capabilities_t::dynamic_topology_update
+ * @see odp_tm_capabilities_t::dynamic_shaper_update
+ * @see odp_tm_capabilities_t::dynamic_sched_update
+ * @see odp_tm_capabilities_t::dynamic_wred_update
+ * @see odp_tm_capabilities_t::dynamic_threshold_update
  */
 int odp_tm_stop(odp_tm_t tm);
 

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2566,6 +2566,12 @@ int odp_tm_capabilities(odp_tm_capabilities_t capabilities[] ODP_UNUSED,
 	cap_ptr->ecn_marking_supported         = true;
 	cap_ptr->drop_prec_marking_supported   = true;
 
+	cap_ptr->dynamic_topology_update  = true;
+	cap_ptr->dynamic_shaper_update    = true;
+	cap_ptr->dynamic_sched_update     = true;
+	cap_ptr->dynamic_wred_update      = true;
+	cap_ptr->dynamic_threshold_update = true;
+
 	for (color = 0; color < ODP_NUM_PACKET_COLORS; color++)
 		cap_ptr->marking_colors_supported[color] = true;
 
@@ -2618,6 +2624,12 @@ static void tm_system_capabilities_set(odp_tm_capabilities_t *cap_ptr,
 	cap_ptr->ecn_marking_supported         = req_ptr->ecn_marking_needed;
 	cap_ptr->drop_prec_marking_supported   =
 					req_ptr->drop_prec_marking_needed;
+
+	cap_ptr->dynamic_topology_update  = true;
+	cap_ptr->dynamic_shaper_update    = true;
+	cap_ptr->dynamic_sched_update     = true;
+	cap_ptr->dynamic_wred_update      = true;
+	cap_ptr->dynamic_threshold_update = true;
 
 	for (color = 0; color < ODP_NUM_PACKET_COLORS; color++)
 		cap_ptr->marking_colors_supported[color] =
@@ -3045,6 +3057,22 @@ int odp_tm_capability(odp_tm_t odp_tm, odp_tm_capabilities_t *capabilities)
 	tm_system = GET_TM_SYSTEM(odp_tm);
 	memcpy(capabilities, &tm_system->capabilities,
 	       sizeof(odp_tm_capabilities_t));
+	return 0;
+}
+
+int odp_tm_start(odp_tm_t odp_tm)
+{
+	(void)odp_tm;
+
+	/* Nothing more to do after TM create */
+	return 0;
+}
+
+int odp_tm_stop(odp_tm_t odp_tm)
+{
+	(void)odp_tm;
+
+	/* Nothing more to do for topology changes */
 	return 0;
 }
 

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -283,6 +283,11 @@ static uint32_t        num_odp_tm_systems;
 
 static odp_tm_capabilities_t tm_capabilities;
 
+static bool dynamic_shaper_update = true;
+static bool dynamic_sched_update = true;
+static bool dynamic_threshold_update = true;
+static bool dynamic_wred_update = true;
+
 static odp_tm_shaper_t    shaper_profiles[NUM_SHAPER_PROFILES];
 static odp_tm_sched_t     sched_profiles[NUM_SCHED_PROFILES];
 static odp_tm_threshold_t threshold_profiles[NUM_THRESHOLD_PROFILES];
@@ -1681,9 +1686,23 @@ static int create_tm_system(void)
 		return -1;
 	}
 
+	/* Update dynamic capability flags from created tm system */
+	dynamic_shaper_update = tm_capabilities.dynamic_shaper_update;
+	dynamic_sched_update = tm_capabilities.dynamic_sched_update;
+	dynamic_threshold_update = tm_capabilities.dynamic_threshold_update;
+	dynamic_wred_update = tm_capabilities.dynamic_wred_update;
+
 	found_odp_tm = odp_tm_find(tm_name, &requirements, &egress);
 	if ((found_odp_tm == ODP_TM_INVALID) || (found_odp_tm != odp_tm)) {
 		ODPH_ERR("odp_tm_find() failed\n");
+		return -1;
+	}
+
+	/* Start TM system */
+	CU_ASSERT((rc = odp_tm_start(odp_tm)) == 0);
+	if (rc != 0) {
+		ODPH_ERR("odp_tm_start() failed for tm: %" PRIx64 "\n",
+			 odp_tm_to_u64(odp_tm));
 		return -1;
 	}
 
@@ -2065,11 +2084,16 @@ static int destroy_tm_systems(void)
 
 	/* Close/free the TM systems. */
 	for (idx = 0; idx < num_odp_tm_systems; idx++) {
+		if (odp_tm_stop(odp_tm_systems[idx]) != 0)
+			return -1;
+
 		if (destroy_tm_subtree(root_node_descs[idx]) != 0)
 			return -1;
 
 		if (odp_tm_destroy(odp_tm_systems[idx]) != 0)
 			return -1;
+
+		odp_tm_systems[idx] = ODP_TM_INVALID;
 	}
 
 	/* Close/free the TM profiles. */
@@ -2081,8 +2105,9 @@ static int destroy_tm_systems(void)
 
 static int traffic_mngr_suite_init(void)
 {
+	odp_tm_capabilities_t capabilities_array[MAX_CAPABILITIES];
 	uint32_t payload_len, copy_len;
-	int ret;
+	int ret, i;
 
 	/* Initialize some global variables. */
 	num_pkts_made   = 0;
@@ -2130,6 +2155,27 @@ static int traffic_mngr_suite_init(void)
 	 */
 	if (ret > 0)
 		goto skip_tests;
+
+	/* Fetch initial dynamic update capabilities, it will be updated
+	 * later after TM system is created.
+	 */
+	ret = odp_tm_capabilities(capabilities_array, MAX_CAPABILITIES);
+	if (ret <= 0)
+		return -1;
+
+	for (i = 0; i < ret; i++) {
+		if (!capabilities_array[i].dynamic_shaper_update)
+			dynamic_shaper_update = false;
+
+		if (!capabilities_array[i].dynamic_sched_update)
+			dynamic_sched_update = false;
+
+		if (!capabilities_array[i].dynamic_threshold_update)
+			dynamic_threshold_update = false;
+
+		if (!capabilities_array[i].dynamic_wred_update)
+			dynamic_wred_update = false;
+	}
 
 	return 0;
 skip_tests:
@@ -2462,6 +2508,7 @@ static int set_shaper(const char    *node_name,
 	odp_tm_shaper_params_t shaper_params;
 	odp_tm_shaper_t        shaper_profile;
 	odp_tm_node_t          tm_node;
+	int rc;
 
 	tm_node = find_tm_node(0, node_name);
 	if (tm_node == ODP_TM_INVALID) {
@@ -2478,6 +2525,13 @@ static int set_shaper(const char    *node_name,
 	shaper_params.shaper_len_adjust = 0;
 	shaper_params.dual_rate         = 0;
 
+	if (!dynamic_shaper_update) {
+		/* Stop TM system before update when dynamic update is not
+		 * supported.
+		 */
+		CU_ASSERT_FATAL(odp_tm_stop(odp_tm_systems[0]) == 0);
+	}
+
 	/* First see if a shaper profile already exists with this name, in
 	 * which case we use that profile, else create a new one. */
 	shaper_profile = odp_tm_shaper_lookup(shaper_name);
@@ -2490,7 +2544,13 @@ static int set_shaper(const char    *node_name,
 		num_shaper_profiles++;
 	}
 
-	return odp_tm_node_shaper_config(tm_node, shaper_profile);
+	rc = odp_tm_node_shaper_config(tm_node, shaper_profile);
+
+	if (!dynamic_shaper_update) {
+		/* Start TM system, post update */
+		CU_ASSERT_FATAL(odp_tm_start(odp_tm_systems[0]) == 0);
+	}
+	return rc;
 }
 
 static int traffic_mngr_check_shaper(void)
@@ -2664,6 +2724,13 @@ static int set_sched_fanin(const char         *node_name,
 	if (node_desc == NULL)
 		return -1;
 
+	if (!dynamic_sched_update) {
+		/* Stop TM system before update when dynamic update is not
+		 * supported.
+		 */
+		CU_ASSERT_FATAL(odp_tm_stop(odp_tm_systems[0]) == 0);
+	}
+
 	fanin_cnt = MIN(node_desc->num_children, FANIN_RATIO);
 	for (fanin = 0; fanin < fanin_cnt; fanin++) {
 		odp_tm_sched_params_init(&sched_params);
@@ -2700,10 +2767,15 @@ static int set_sched_fanin(const char         *node_name,
 		rc = odp_tm_node_sched_config(tm_node, fanin_node,
 					      sched_profile);
 		if (rc != 0)
-			return -1;
+			goto exit;
 	}
 
-	return 0;
+exit:
+	if (!dynamic_sched_update) {
+		/* Start TM system, post update */
+		CU_ASSERT_FATAL(odp_tm_start(odp_tm_systems[0]) == 0);
+	}
+	return rc;
 }
 
 static int test_sched_queue_priority(const char *shaper_name,
@@ -2758,8 +2830,13 @@ static int test_sched_queue_priority(const char *shaper_name,
 
 	busy_wait(100 * ODP_TIME_MSEC_IN_NS);
 
-	/* Disable the shaper, so as to get the pkts out quicker. */
-	set_shaper(node_name, shaper_name, 0, 0);
+	/* Disable the shaper, so as to get the pkts out quicker.
+	 * We cannot do this if dynamic shaper update is not supported. Without
+	 * dynamic update support set_shaper() can cause packet drops due to
+	 * start/stop.
+	 */
+	if (dynamic_shaper_update)
+		set_shaper(node_name, shaper_name, 0, 0);
 
 	num_rcv_pkts = receive_pkts(odp_tm_systems[0], rcv_pktin,
 				    pkt_cnt + 4, 64 * 1000);
@@ -2777,6 +2854,8 @@ static int test_sched_queue_priority(const char *shaper_name,
 
 	CU_ASSERT(pkts_in_order == pkt_cnt);
 
+	/* Disable shaper in case it is still enabled */
+	set_shaper(node_name, shaper_name, 0, 0);
 	flush_leftover_pkts(odp_tm_systems[0], rcv_pktin);
 	CU_ASSERT(odp_tm_is_idle(odp_tm_systems[0]));
 	return 0;
@@ -2864,8 +2943,13 @@ static int test_sched_node_priority(const char *shaper_name,
 
 	busy_wait(100 * ODP_TIME_MSEC_IN_NS);
 
-	/* Disable the shaper, so as to get the pkts out quicker. */
-	set_shaper(node_name, shaper_name, 0, 0);
+	/* Disable the shaper, so as to get the pkts out quicker.
+	 * We cannot do this if dynamic shaper update is not supported. Without
+	 * dynamic update support set_shaper() can cause packet drops due to
+	 * start/stop.
+	 */
+	if (dynamic_shaper_update)
+		set_shaper(node_name, shaper_name, 0, 0);
 
 	num_rcv_pkts = receive_pkts(odp_tm_systems[0], rcv_pktin,
 				    pkts_sent, 64 * 1000);
@@ -2877,6 +2961,8 @@ static int test_sched_node_priority(const char *shaper_name,
 						 0, false, false);
 	CU_ASSERT(pkts_in_order == total_pkt_cnt);
 
+	/* Disable shaper in case it is still enabled */
+	set_shaper(node_name, shaper_name, 0, 0);
 	flush_leftover_pkts(odp_tm_systems[0], rcv_pktin);
 	CU_ASSERT(odp_tm_is_idle(odp_tm_systems[0]));
 	return 0;
@@ -2957,8 +3043,13 @@ static int test_sched_wfq(const char         *sched_base_name,
 
 	busy_wait(1000000);   /* wait 1 millisecond */
 
-	/* Disable the shaper, so as to get the pkts out quicker. */
-	set_shaper(node_name, shaper_name, 0, 0);
+	/* Disable the shaper, so as to get the pkts out quicker.
+	 * We cannot do this if dynamic shaper update is not supported. Without
+	 * dynamic update support set_shaper() can cause packet drops due to
+	 * start/stop.
+	 */
+	if (dynamic_shaper_update)
+		set_shaper(node_name, shaper_name, 0, 0);
 
 	num_rcv_pkts = receive_pkts(odp_tm_systems[0], rcv_pktin,
 				    pkt_cnt + 4, 64 * 1000);
@@ -2970,6 +3061,8 @@ static int test_sched_wfq(const char         *sched_base_name,
 		CU_ASSERT(rcv_rate_stats(&rcv_stats[fanin], pkt_class) == 0);
 	}
 
+	/* Disable shaper in case it is still enabled */
+	set_shaper(node_name, shaper_name, 0, 0);
 	flush_leftover_pkts(odp_tm_systems[0], rcv_pktin);
 	CU_ASSERT(odp_tm_is_idle(odp_tm_systems[0]));
 	return 0;
@@ -2982,6 +3075,13 @@ static int set_queue_thresholds(odp_tm_queue_t             tm_queue,
 	odp_tm_threshold_t threshold_profile;
 	int ret;
 
+	if (!dynamic_threshold_update) {
+		/* Stop TM system before update when dynamic update is not
+		 * supported.
+		 */
+		CU_ASSERT_FATAL(odp_tm_stop(odp_tm_systems[0]) == 0);
+	}
+
 	/* First see if a threshold profile already exists with this name, in
 	 * which case we use that profile, else create a new one. */
 	threshold_profile = odp_tm_thresholds_lookup(threshold_name);
@@ -2989,17 +3089,25 @@ static int set_queue_thresholds(odp_tm_queue_t             tm_queue,
 		ret = odp_tm_thresholds_params_update(threshold_profile,
 						      threshold_params);
 		if (ret)
-			return ret;
+			goto exit;
 	} else {
 		threshold_profile = odp_tm_threshold_create(threshold_name,
 							    threshold_params);
-		if (threshold_profile == ODP_TM_INVALID)
-			return -1;
+		if (threshold_profile == ODP_TM_INVALID) {
+			ret = -1;
+			goto exit;
+		}
 		threshold_profiles[num_threshold_profiles] = threshold_profile;
 		num_threshold_profiles++;
 	}
 
-	return odp_tm_queue_threshold_config(tm_queue, threshold_profile);
+	ret = odp_tm_queue_threshold_config(tm_queue, threshold_profile);
+exit:
+	if (!dynamic_threshold_update) {
+		/* Start TM system, post update */
+		CU_ASSERT_FATAL(odp_tm_start(odp_tm_systems[0]) == 0);
+	}
+	return ret;
 }
 
 static int test_threshold(const char *threshold_name,
@@ -3096,6 +3204,7 @@ static int set_queue_wred(odp_tm_queue_t   tm_queue,
 {
 	odp_tm_wred_params_t wred_params;
 	odp_tm_wred_t        wred_profile;
+	int rc;
 
 	odp_tm_wred_params_init(&wred_params);
 	if (use_dual_slope) {
@@ -3112,6 +3221,13 @@ static int set_queue_wred(odp_tm_queue_t   tm_queue,
 
 	wred_params.enable_wred       = true;
 	wred_params.use_byte_fullness = use_byte_fullness;
+
+	if (!dynamic_wred_update) {
+		/* Stop TM system before update when dynamic update is not
+		 * supported.
+		 */
+		CU_ASSERT_FATAL(odp_tm_stop(odp_tm_systems[0]) == 0);
+	}
 
 	/* First see if a wred profile already exists with this name, in
 	 * which case we use that profile, else create a new one. */
@@ -3131,7 +3247,14 @@ static int set_queue_wred(odp_tm_queue_t   tm_queue,
 		}
 	}
 
-	return odp_tm_queue_wred_config(tm_queue, pkt_color, wred_profile);
+	rc = odp_tm_queue_wred_config(tm_queue, pkt_color, wred_profile);
+
+	if (!dynamic_wred_update) {
+		/* Start TM system, post update */
+		CU_ASSERT_FATAL(odp_tm_start(odp_tm_systems[0]) == 0);
+	}
+	return rc;
+
 }
 
 static int test_byte_wred(const char      *wred_name,
@@ -3196,8 +3319,14 @@ static int test_byte_wred(const char      *wred_name,
 
 	pkts_sent = send_pkts(tm_queue, num_test_pkts);
 
-	/* Disable the shaper, so as to get the pkts out quicker. */
-	set_shaper(node_name, shaper_name, 0, 0);
+	/* Disable the shaper, so as to get the pkts out quicker.
+	 * We cannot do this if dynamic shaper update is not supported. Without
+	 * dynamic update support set_shaper() can cause packet drops due to
+	 * start/stop.
+	 */
+	if (dynamic_shaper_update)
+		set_shaper(node_name, shaper_name, 0, 0);
+
 	num_rcv_pkts = receive_pkts(odp_tm_systems[0], rcv_pktin,
 				    num_fill_pkts + pkts_sent, 64 * 1000);
 
@@ -3207,6 +3336,8 @@ static int test_byte_wred(const char      *wred_name,
 	if (wred_pkt_cnts == NULL)
 		return -1;
 
+	/* Disable shaper in case it is still enabled */
+	set_shaper(node_name, shaper_name, 0, 0);
 	flush_leftover_pkts(odp_tm_systems[0], rcv_pktin);
 	CU_ASSERT(odp_tm_is_idle(odp_tm_systems[0]));
 
@@ -3281,8 +3412,14 @@ static int test_pkt_wred(const char      *wred_name,
 
 	pkts_sent = send_pkts(tm_queue, num_test_pkts);
 
-	/* Disable the shaper, so as to get the pkts out quicker. */
-	set_shaper(node_name, shaper_name, 0, 0);
+	/* Disable the shaper, so as to get the pkts out quicker.
+	 * We cannot do this if dynamic shaper update is not supported. Without
+	 * dynamic update support set_shaper() can cause packet drops due to
+	 * start/stop.
+	 */
+	if (dynamic_shaper_update)
+		set_shaper(node_name, shaper_name, 0, 0);
+
 	ret = receive_pkts(odp_tm_systems[0], rcv_pktin,
 			   num_fill_pkts + pkts_sent, 64 * 1000);
 	if (ret < 0)
@@ -3296,6 +3433,8 @@ static int test_pkt_wred(const char      *wred_name,
 	if (wred_pkt_cnts == NULL)
 		return -1;
 
+	/* Disable shaper in case it is still enabled */
+	set_shaper(node_name, shaper_name, 0, 0);
 	flush_leftover_pkts(odp_tm_systems[0], rcv_pktin);
 	CU_ASSERT(odp_tm_is_idle(odp_tm_systems[0]));
 


### PR DESCRIPTION
Depends on series in order:
1. https://github.com/OpenDataPlane/odp/pull/1234
2. https://github.com/OpenDataPlane/odp/pull/1235

commit 358c96f4d80dc71f30b71270bf3525c936525aa7
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 19:36:31 2020 +0530

    validation: tm: use tm start and stop API
    
    Add tm start API after creating a TM system and TM stop API before
    destroying it.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 3f46857434bb0922b1cc4dd80d01accdd7586642
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 19:23:55 2020 +0530

    example: tm: use TM start and stop
    
    Use TM start to start the TM system after creation and
    TM stop to stop it before destroying TM queues.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit d12ca8902200c5779f3b264e016b6167573fb9f5
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 19:22:14 2020 +0530

    linux-gen: tm: add implementation of TM start/stop
    
    Add implementation of TM start or stop API. Since linux generic platform
    does not have any setup and cleanup constraints, the TM start/stop
    are a no-op.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit cae6e0c352188dd456caba7790ceb2fa3d5a75e7
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 19:21:28 2020 +0530

    api: tm: add interface to start and stop a TM system
    
    Some platforms needs to know when a TM system needs to
    start or stop in order to safely setup or cleanup TM system
    and drain pkts in it. Hence this patch adds support for
    TM start/stop API.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

