### PR TITLE
[PATCH v9] api: tm: add support for non-global packet priority mode in TM system

### DIFF
--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -502,6 +502,16 @@ typedef struct {
 	 * odp_tm_requirements_t.
 	 */
 	odp_bool_t pkt_prio_modes[ODP_TM_PKT_PRIO_MODE_MAX];
+
+	/** Maximum number of schedulers supported by a TM node at any level.
+	 * A TM node contains a WFQ/WRR scheduler for each packet priority level
+	 * for which the node has more than one possible input. TM topology and
+	 * priority configuration must be made so that the resulting number of
+	 * WFQ/WRR schedulers does not exceed this capability in any TM node.
+	 *
+	 * The value can vary between 0 and ODP_TM_MAX_PRIORITIES.
+	 */
+	uint8_t max_schedulers_per_node;
 } odp_tm_capabilities_t;
 
 /** Per Level Requirements

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -312,6 +312,33 @@ typedef struct {
 	odp_bool_t tm_node_threshold;
 } odp_tm_level_capabilities_t;
 
+/** The tm_pkt_prio_mode_t enumeration type is used to indicate different
+ * modes a tm system supports with respect to assigning priority to a packet
+ * and propagating it across TM system. All the nodes in a TM system can
+ * function only on single mode specified at time of odp_tm_create().
+ */
+typedef enum odp_tm_pkt_prio_mode {
+	/** Indicates Packet priority preserve mode. In this mode, a packet gets
+	 * its priority based on a TM queue it gets enqueued to and then it
+	 * carries the same priority along with it as long as it is in the TM
+	 * system. At every TM node in the topology, that specific pkt is
+	 * scheduled as per that priority.
+	 */
+	ODP_TM_PKT_PRIO_MODE_PRESERVE,
+
+	/** Indicates Packet priority overwrite mode. In this mode, a packet
+	 * gets a new priority every time it passes through a TM queue or a
+	 * TM node. All the packets fed by a fan-in node will get the same
+	 * priority and that will be valid until overwritten again by another TM
+	 * node. This priority is part of the TM fan-in node parameters and is
+	 * fixed at node creation time.
+	 */
+	ODP_TM_PKT_PRIO_MODE_OVERWRITE,
+
+	/** Max enum of Packet priority mode */
+	ODP_TM_PKT_PRIO_MODE_MAX,
+} odp_tm_pkt_prio_mode_t;
+
 /** TM Capabilities Record.
  *
  * The odp_tm_capabilities_t record type is used to describe the feature set
@@ -468,6 +495,13 @@ typedef struct {
 	 * ODP_TM_QUERY_THRESHOLDS.
 	 */
 	uint32_t tm_queue_query_flags;
+
+	/** Indicates the packet priority modes supported by TM systems on a
+	 * platform. A platform can support multiple packet priority modes. The
+	 * actual mode a TM system runs with is defined by
+	 * odp_tm_requirements_t.
+	 */
+	odp_bool_t pkt_prio_modes[ODP_TM_PKT_PRIO_MODE_MAX];
 } odp_tm_capabilities_t;
 
 /** Per Level Requirements
@@ -587,6 +621,12 @@ typedef struct {
 	 * the application expects to use this color in conjunction with one or
 	 * more of the marking APIs. */
 	odp_bool_t marking_colors_needed[ODP_NUM_PACKET_COLORS];
+
+	/** Packet priority mode.
+	 * TM capabilities indicate which modes are supported.
+	 * The default value is ODP_TM_PKT_PRIO_MODE_PRESERVE.
+	 */
+	odp_tm_pkt_prio_mode_t pkt_prio_mode;
 
 	/** The per_level array specifies the TM system requirements that
 	 * can vary based upon the tm_node level. */
@@ -1473,6 +1513,22 @@ typedef struct {
 	 * greater levels may be connected to the fan-in of tm_node's with
 	 * numerically smaller levels. */
 	uint8_t level;
+
+	/** New strict priority level assigned to packets going through this
+	 * node when packet priority mode is ODP_TM_PKT_PRIO_MODE_OVERWRITE.
+	 * In other packet priority modes this field is ignored. The new
+	 * priority does not affect packet processing in this node but in
+	 * its destination node.
+	 *
+	 * The value must be in the range 0..ODP_TM_MAX_PRIORITIES-1.
+	 * Additionally, the total number of possible priorities seen by
+	 * the destination node must not exceed the max priority configured
+	 * for the destination node.
+	 *
+	 * @see odp_tm_pkt_prio_mode_t
+	 * @see odp_tm_level_requirements_t::max_priority
+	 */
+	uint8_t priority;
 } odp_tm_node_params_t;
 
 /** odp_tm_node_params_init() must be called to initialize any

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2548,6 +2548,8 @@ odp_bool_t odp_tm_is_idle(odp_tm_t odp_tm)
 void odp_tm_requirements_init(odp_tm_requirements_t *requirements)
 {
 	memset(requirements, 0, sizeof(odp_tm_requirements_t));
+
+	requirements->pkt_prio_mode = ODP_TM_PKT_PRIO_MODE_PRESERVE;
 }
 
 void odp_tm_egress_init(odp_tm_egress_t *egress)
@@ -2588,6 +2590,9 @@ static int tm_capabilities(odp_tm_capabilities_t capabilities[],
 	cap_ptr->dynamic_sched_update     = true;
 	cap_ptr->dynamic_wred_update      = true;
 	cap_ptr->dynamic_threshold_update = true;
+
+	/* We only support pkt priority mode preserve */
+	cap_ptr->pkt_prio_modes[ODP_TM_PKT_PRIO_MODE_PRESERVE] = true;
 
 	for (color = 0; color < ODP_NUM_PACKET_COLORS; color++)
 		cap_ptr->marking_colors_supported[color] = true;
@@ -2690,6 +2695,8 @@ static void tm_system_capabilities_set(odp_tm_capabilities_t *cap_ptr,
 	cap_ptr->dynamic_sched_update     = true;
 	cap_ptr->dynamic_wred_update      = true;
 	cap_ptr->dynamic_threshold_update = true;
+
+	cap_ptr->pkt_prio_modes[ODP_TM_PKT_PRIO_MODE_PRESERVE] = true;
 
 	for (color = 0; color < ODP_NUM_PACKET_COLORS; color++)
 		cap_ptr->marking_colors_supported[color] =
@@ -2998,6 +3005,11 @@ odp_tm_t odp_tm_create(const char            *name,
 		return ODP_TM_INVALID;
 	}
 
+	/* We only support global pkt priority mode */
+	if (requirements->pkt_prio_mode != ODP_TM_PKT_PRIO_MODE_PRESERVE) {
+		ODP_ERR("Unsupported Packet priority mode\n");
+		return ODP_TM_INVALID;
+	}
 	odp_ticketlock_lock(&tm_glb->create_lock);
 
 	/* If we are using pktio output (usual case) get the first associated

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2584,6 +2584,7 @@ static int tm_capabilities(odp_tm_capabilities_t capabilities[],
 	cap_ptr->tm_queue_query_flags          = (ODP_TM_QUERY_PKT_CNT |
 						  ODP_TM_QUERY_BYTE_CNT |
 						  ODP_TM_QUERY_THRESHOLDS);
+	cap_ptr->max_schedulers_per_node       = ODP_TM_MAX_PRIORITIES;
 
 	cap_ptr->dynamic_topology_update  = true;
 	cap_ptr->dynamic_shaper_update    = true;
@@ -2689,6 +2690,7 @@ static void tm_system_capabilities_set(odp_tm_capabilities_t *cap_ptr,
 	cap_ptr->tm_queue_query_flags          = (ODP_TM_QUERY_PKT_CNT |
 						  ODP_TM_QUERY_BYTE_CNT |
 						  ODP_TM_QUERY_THRESHOLDS);
+	cap_ptr->max_schedulers_per_node       = ODP_TM_MAX_PRIORITIES;
 
 	cap_ptr->dynamic_topology_update  = true;
 	cap_ptr->dynamic_shaper_update    = true;

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -2267,6 +2267,14 @@ static int traffic_mngr_suite_init(void)
 	if (j != NUM_LEVELS)
 		goto skip_tests;
 
+	if (egress_capa.pkt_prio_modes[ODP_TM_PKT_PRIO_MODE_PRESERVE] &&
+	    egress_capa.max_schedulers_per_node < NUM_QUEUES_PER_NODE)
+		goto skip_tests;
+
+	if (!egress_capa.pkt_prio_modes[ODP_TM_PKT_PRIO_MODE_PRESERVE] &&
+	    egress_capa.max_schedulers_per_node < 1)
+		goto skip_tests;
+
 	/* Init tm capabilities with matching egress capa until tm is created */
 	tm_capabilities = egress_capa;
 


### PR DESCRIPTION
**Depends on series in order:**
1. https://github.com/OpenDataPlane/odp/pull/1234
2. https://github.com/OpenDataPlane/odp/pull/1235
3. https://github.com/OpenDataPlane/odp/pull/1236

**Commits to be ignored for this pull request:**
* f7ee3dc validation: tm: use tm start and stop API - Nithin Dabilpuram, 5 months ago
* db7b267 validation: tm: use commit_rate and peak_rate in shaper params - Nithin Dabilpuram, 3 months ago
* c7bbc8d validation: traffic_mngr: use pktout mode as TM for Tx - Nithin Dabilpuram, 2 days ago


**Commits for review:**
commit 4625b916486048466c88beade7c8b85057cde432
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Tue Jul 6 22:19:04 2021 +0530

    validation: tm: add five level test case suite
    
    Current validation suite only validates 3 level TM systems.
    Refactor the test cases to use suite inited parameters instead
    of compile time and add suite init for 5 level TM system.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 831754cb21fcb5b8029f5d0e88254c8acea7dbf6
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Tue Jul 6 22:21:37 2021 +0530

    validation: tm: use pkt priority mode supported by platform
    
    Use pkt priority mode supported by a given platform for
    TM systems.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 28c3e865d793f9abfe142cb9452ed470983c915e
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Tue Jun 29 15:35:32 2021 +0530

    linux-gen: tm: express support pkt priority mode
    
    Linux generic only supports Packet Priority mode preserve.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit b869de28d3d13828d1bb1759bb55ce69d7892cb6
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 21:57:28 2020 +0530

    api: tm: support different packet priority modes
    
    Current TM spec associates a priority to a packet at TM queue and
    expects all the levels to honour that priority globally in the TM
    system. In some platforms, this is not supportable and a packet's
    priority gets overridden when it passes through a fan-in node, it
    is passing through. In other words, like assigning packet a
    priority based on the TM queue it is enqueued on, every node it
    is passing through overrides the packet priority with a fixed value.
    
    So this patch adds flexibility for platforms to expose pkt priority
    modes supported and also choose the mode per TM system among supported
    modes at time of odp_tm_create().
    
    This patch also adds "max_schedulers_per_node" capability that is
    expressed by a platform. This field expresses maximum number of schedulers
    available which can schedule among multiple equal priority fan-ins
    as some platforms have limitation on how many such schedulers can be
    configured.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

