### PR TITLE
[PATCH v1] github_ci: fix typo in coverity docker image path

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -21,5 +21,5 @@ jobs:
                -e COVERITY_TOKEN="${{ secrets.COVERITY_TOKEN }}"
                -e COVERITY_EMAIL="${COVERITY_EMAIL}"
                -e COVERITY_PROJECT="${COVERITY_PROJECT}"
-               ${CONTAINER_NAMESPACE}:odp-ci-${OS}-${ARCH}-coverity-linux-generic
+               ${CONTAINER_NAMESPACE}/odp-ci-${OS}-${ARCH}-coverity-linux-generic
                /odp/scripts/ci/coverity.sh


### PR DESCRIPTION
Downloading the Coverity image failed due to a typo in the image path.

Signed-off-by: Matias Elo <matias.elo@nokia.com>