### PR TITLE
scripts: coverity: fix directory name

### DIFF
--- a/scripts/ci/coverity.sh
+++ b/scripts/ci/coverity.sh
@@ -7,9 +7,9 @@ cd "$(dirname "$0")"/../..
 
 make clean
 
-cov-build --dir coverity-build make -j $(nproc)
+cov-build --dir cov-int make -j $(nproc)
 
-tar czf odp-coverity.tgz coverity-build
+tar czvf odp-coverity.tgz cov-int
 
 curl --form token="${COVERITY_TOKEN}" \
   --form email="${COVERITY_EMAIL}" \


### PR DESCRIPTION
Coverity expects directory name to be cov-int.

Signed-off-by: Matias Elo <matias.elo@nokia.com>