### PR TITLE
[PATCH v4] api: increment ODP API version to 1.28.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,24 @@
+== OpenDataPlane (1.28.0.0)
+=== API
+==== Crypto
+* New crypto capabilities for defining if a queue type (scheduled/plain) can be
+used as a crypto completion event destination
+
+=== Event
+* New packet TX completion event type and related functions
+
+=== Packet
+* New packet APIs for requesting packet TX completion events
+* New packet APIS for requesting packet TX drop based on packet age
+
+=== Classifier
+* New `odp_cls_print_all()` function for printing implementation specific
+debug information about all classifier rules
+
+=== System
+* New enumerations for ARMv8.7-A, ARMv9.0-A, ARMv9.1-A, and ARMv9.2-A ISA
+versions
+
 == OpenDataPlane (1.24.0.0)
 === Summary of Changes
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ([2.5])
 # ODP API version
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
-m4_define([odpapi_major_version], [27])
+m4_define([odpapi_major_version], [28])
 m4_define([odpapi_minor_version], [0])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],


### PR DESCRIPTION
Increment API version number to reflect the following changes:

Backward-incompatible:
- New crypto capabilities for defining if a queue type (scheduled/plain)
  can be used as a crypto completion event destination

Backward-compatible:
- New TX completion event type and related functions
- New packet APIs for requesting packet TX completion events
- New packet APIS for requesting packet TX drop based on packet age
- New odp_cls_print_all() function for printing implementation specific
  debug information about all classifier rules
- New enumerations for ARMv8.7-A, ARMv9.0-A, ARMv9.1-A, and ARMv9.2-A ISA
  versions

Signed-off-by: Matias Elo <matias.elo@nokia.com>