### PR TITLE
[PATCH v3] linux-gen: detect cpu cache line size during configure

### DIFF
--- a/include/odp/autoheader_external.h.in
+++ b/include/odp/autoheader_external.h.in
@@ -8,4 +8,7 @@
 /* Define to 1 to display debug information */
 #undef ODP_DEBUG_PRINT
 
+/* Define cache line size */
+#undef _ODP_CACHE_LINE_SIZE
+
 #endif

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/cpu.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/cpu.h
@@ -11,7 +11,11 @@
 extern "C" {
 #endif
 
-#define ODP_CACHE_LINE_SIZE 64
+#include <odp/autoheader_external.h>
+
+#ifndef ODP_CACHE_LINE_SIZE
+	#define ODP_CACHE_LINE_SIZE _ODP_CACHE_LINE_SIZE
+#endif
 
 static inline void odp_cpu_pause(void)
 {

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -6,6 +6,7 @@ ODP_ATOMIC
 
 ODP_PTHREAD
 ODP_TIMER
+m4_include([platform/linux-generic/m4/odp_cpu.m4])
 m4_include([platform/linux-generic/m4/odp_pcap.m4])
 m4_include([platform/linux-generic/m4/odp_scheduler.m4])
 

--- a/platform/linux-generic/m4/odp_cpu.m4
+++ b/platform/linux-generic/m4/odp_cpu.m4
@@ -1,0 +1,35 @@
+##########################################################################
+# Set ODP_CACHE_LINE_SIZE define
+##########################################################################
+# Currently used only for aarch64
+if test "${ARCH_DIR}" = "aarch64"; then
+	cache_line_size=64
+	# Use default cache size if cross-compiling
+	if test $build = $host; then
+		cpu_implementer=""
+		cpu_part=""
+
+		AC_PROG_GREP
+		AC_PROG_SED
+		while read line; do
+			if echo $line | $GREP -q "CPU implementer"; then
+				cpu_implementer=`echo $line | $SED 's/.*\:\s*//'`
+			fi
+			if echo $line | $GREP -q "CPU part"; then
+				cpu_part=`echo $line | $SED 's/.*\:\s*//'`
+			fi
+		done < /proc/cpuinfo
+
+		# Cavium
+		if test "$cpu_implementer" == "0x43"; then
+			# ThunderX2 (0x0af) 64B, others 128B
+			if test "$cpu_part" == "0x0af"; then
+				cache_line_size=64;
+			else
+				cache_line_size=128;
+			fi
+		fi
+	fi
+	AC_DEFINE_UNQUOTED([_ODP_CACHE_LINE_SIZE], [$cache_line_size],
+			   [Define cache line size])
+fi

--- a/test/validation/api/system/system.c
+++ b/test/validation/api/system/system.c
@@ -20,6 +20,9 @@
 /* 10 usec wait time assumes >100kHz resolution on CPU cycles counter */
 #define WAIT_TIME (10 * ODP_TIME_USEC_IN_NS)
 
+/* Check if value is power of two */
+#define IS_POW2(x) ((((x) - 1) & (x)) == 0)
+
 static void test_version_api_str(void)
 {
 	int char_ok = 0;
@@ -248,7 +251,11 @@ static void system_test_odp_sys_cache_line_size(void)
 
 	cache_size = odp_sys_cache_line_size();
 	CU_ASSERT(0 < cache_size);
-	CU_ASSERT(ODP_CACHE_LINE_SIZE == cache_size);
+	CU_ASSERT(0 < ODP_CACHE_LINE_SIZE);
+	CU_ASSERT(IS_POW2(cache_size));
+	CU_ASSERT(IS_POW2(ODP_CACHE_LINE_SIZE));
+	if (ODP_CACHE_LINE_SIZE != cache_size)
+		printf("WARNING: ODP_CACHE_LINE_SIZE and odp_sys_cache_line_size() not matching\n");
 
 	CU_ASSERT(ODP_CACHE_LINE_ROUNDUP(0) == 0);
 	CU_ASSERT(ODP_CACHE_LINE_ROUNDUP(1) == ODP_CACHE_LINE_SIZE);


### PR DESCRIPTION
Detect CPU cache line size automatically on aarch64 systems when abi-compatibility is disabled. Automatic cache line size detection is disabled when cross-compiling.

V2:
- Validation test fix