### PR TITLE
[PATCH v1] linux-gen: pktio: update LSO capabilities

### DIFF
--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -39,8 +39,12 @@ extern "C" {
 
 #define PKTIO_MAX_QUEUES 64
 #define PKTIO_LSO_PROFILES 16
+/* Assume at least Ethernet header per each segment */
+#define PKTIO_LSO_MIN_PAYLOAD_OFFSET 14
 #define PKTIO_LSO_MAX_PAYLOAD_OFFSET 128
-#define PKTIO_LSO_MAX_SEGMENTS 8
+/* Allow 64 kB packet to be split into about 1kB segments */
+#define PKTIO_LSO_MAX_SEGMENTS 64
+
 ODP_STATIC_ASSERT(PKTIO_LSO_PROFILES < UINT8_MAX, "PKTIO_LSO_PROFILES_ERROR");
 
 #define PKTIO_NAME_LEN 256

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1812,7 +1812,7 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 		capa->lso.max_profiles_per_pktio = PKTIO_LSO_PROFILES;
 		capa->lso.max_packet_segments    = PKT_MAX_SEGS;
 		capa->lso.max_segments           = PKTIO_LSO_MAX_SEGMENTS;
-		capa->lso.max_payload_len        = mtu - PKTIO_LSO_MAX_PAYLOAD_OFFSET;
+		capa->lso.max_payload_len        = mtu - PKTIO_LSO_MIN_PAYLOAD_OFFSET;
 		capa->lso.max_payload_offset     = PKTIO_LSO_MAX_PAYLOAD_OFFSET;
 		capa->lso.max_num_custom         = ODP_LSO_MAX_CUSTOM;
 		capa->lso.proto.ipv4             = 1;
@@ -2831,6 +2831,12 @@ static int pktout_send_lso(odp_pktout_queue_t queue, odp_packet_t packet,
 	if (left_over_len) {
 		left_over = 1;
 		num_pkt++;
+	}
+
+	if (num_pkt > PKTIO_LSO_MAX_SEGMENTS) {
+		ODP_ERR("Too many LSO segments %i. Maximum is %i\n", num_pkt,
+			PKTIO_LSO_MAX_SEGMENTS);
+		return -1;
 	}
 
 	/* Alloc packets */


### PR DESCRIPTION
Increase max_segments capability to 64 segments. Increase max_payload_len capability to be closer to MTU.