### PR TITLE
[PATCH v8] api: introduce per-thread log function

### DIFF
--- a/helper/test/linux/process.c
+++ b/helper/test/linux/process.c
@@ -82,9 +82,19 @@ int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 	if (ret == 0) {
 		/* Child process */
 		worker_fn(NULL);
+
+		if (odp_term_local() < 0) {
+			ODPH_ERR("Error: ODP local term failed.\n");
+			exit(EXIT_FAILURE);
+		}
 	} else {
 		/* Parent process */
 		odph_linux_process_wait_n(proc, num_workers);
+
+		if (odp_term_local()) {
+			ODPH_ERR("Error: ODP local term failed.\n");
+			exit(EXIT_FAILURE);
+		}
 
 		if (odp_term_global(instance)) {
 			ODPH_ERR("Error: ODP global term failed.\n");

--- a/include/odp/api/spec/init.h
+++ b/include/odp/api/spec/init.h
@@ -333,6 +333,20 @@ int odp_term_local(void);
 int odp_term_global(odp_instance_t instance);
 
 /**
+ * Set thread specific log function
+ *
+ * By default, all ODP log writes use the global log function, which may be set
+ * as part of odp_init_t. Using this operation, an alternative ODP log function
+ * may be set for the calling thread. When set, ODP uses the thread specific log
+ * function for all log writes originating from ODP API calls made by the
+ * calling thread. Setting the log function to NULL causes the calling thread to
+ * use the global log function.
+ *
+ * @param func Log function
+ */
+void odp_log_thread_fn_set(odp_log_func_t func);
+
+/**
  * @}
  */
 

--- a/include/odp/api/spec/init.h
+++ b/include/odp/api/spec/init.h
@@ -20,7 +20,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/hints.h>
 #include <odp/api/feature.h>
-#include <odp/api/thread.h>
+#include <odp/api/spec/thread_types.h>
 #include <odp/api/cpumask.h>
 
 /** @defgroup odp_initialization ODP INITIALIZATION

--- a/platform/linux-generic/include/odp/api/plat/thread_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/thread_inlines.h
@@ -7,6 +7,8 @@
 #ifndef ODP_PLAT_THREAD_INLINES_H_
 #define ODP_PLAT_THREAD_INLINES_H_
 
+#include <odp/api/init.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -17,6 +19,7 @@ typedef struct {
 	int thr;
 	int cpu;
 	odp_thread_type_t type;
+	odp_log_func_t log_fn;
 
 } _odp_thread_state_t;
 

--- a/platform/linux-generic/include/odp_debug_internal.h
+++ b/platform/linux-generic/include/odp_debug_internal.h
@@ -20,6 +20,7 @@
 #include <odp/autoheader_external.h>
 #include <odp/api/debug.h>
 #include <odp_global_data.h>
+#include <odp/api/plat/thread_inlines.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -31,6 +32,14 @@ extern "C" {
 /* Debug level configure option. Zero is the highest level. Value of N prints debug messages from
  * level 0 to N. */
 #define CONFIG_DEBUG_LEVEL 0
+
+#define _ODP_LOG_FN(level, fmt, ...) \
+	do { \
+		if (_odp_this_thread && _odp_this_thread->log_fn) \
+			_odp_this_thread->log_fn(level, fmt, ##__VA_ARGS__); \
+		else \
+			odp_global_ro.log_fn(level, fmt, ##__VA_ARGS__); \
+	} while (0)
 
 /**
  * Runtime assertion-macro - aborts if 'cond' is false.
@@ -45,7 +54,7 @@ extern "C" {
  * This macro is used to indicate when a given function is not implemented
  */
 #define ODP_UNIMPLEMENTED() \
-		odp_global_ro.log_fn(ODP_LOG_UNIMPLEMENTED, \
+		_ODP_LOG_FN(ODP_LOG_UNIMPLEMENTED, \
 			"%s:%d:The function %s() is not implemented\n", \
 			__FILE__, __LINE__, __func__)
 /*
@@ -72,7 +81,7 @@ extern "C" {
 #define ODP_DBG_RAW(level, fmt, ...) \
 	do { \
 		if (ODP_DEBUG_PRINT == 1 && CONFIG_DEBUG_LEVEL >= (level)) \
-			odp_global_ro.log_fn(ODP_LOG_DBG, fmt, ##__VA_ARGS__);\
+			_ODP_LOG_FN(ODP_LOG_DBG, fmt, ##__VA_ARGS__);\
 	} while (0)
 
 /**
@@ -95,7 +104,7 @@ extern "C" {
  * ODP LOG macro.
  */
 #define ODP_LOG(level, fmt, ...) \
-	odp_global_ro.log_fn(level, "%s:%d:%s():" fmt, __FILE__, \
+	_ODP_LOG_FN(level, "%s:%d:%s():" fmt, __FILE__, \
 	__LINE__, __func__, ##__VA_ARGS__)
 
 /**
@@ -103,7 +112,7 @@ extern "C" {
  * specifically for dumping internal data.
  */
 #define ODP_PRINT(fmt, ...) \
-	odp_global_ro.log_fn(ODP_LOG_PRINT, fmt, ##__VA_ARGS__)
+	_ODP_LOG_FN(ODP_LOG_PRINT, fmt, ##__VA_ARGS__)
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -12,6 +12,7 @@
 #include <odp_init_internal.h>
 #include <odp_schedule_if.h>
 #include <odp_libconfig_internal.h>
+#include <odp/api/plat/thread_inlines.h>
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -622,4 +623,9 @@ init_fail:
 int odp_term_local(void)
 {
 	return term_local(ALL_INIT);
+}
+
+void odp_log_thread_fn_set(odp_log_func_t func)
+{
+	_odp_this_thread->log_fn = func;
 }

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -531,7 +531,7 @@ static int term_local(enum init_stage stage)
 			rc = -1;
 		} else {
 			if (!rc)
-				rc = rc_thd;
+				rc = (rc_thd == 0) ? 0 : 1;
 		}
 		/* Fall through */
 

--- a/platform/linux-generic/odp_thread.c
+++ b/platform/linux-generic/odp_thread.c
@@ -88,7 +88,14 @@ int _odp_thread_init_global(void)
 
 int _odp_thread_term_global(void)
 {
-	int ret;
+	int ret, num;
+
+	odp_spinlock_lock(&thread_globals->lock);
+	num = thread_globals->num;
+	odp_spinlock_unlock(&thread_globals->lock);
+
+	if (num)
+		ODP_ERR("%u threads have not called odp_term_local().\n", num);
 
 	ret = odp_shm_free(odp_shm_lookup("_odp_thread_globals"));
 	if (ret < 0)

--- a/platform/linux-generic/odp_thread.c
+++ b/platform/linux-generic/odp_thread.c
@@ -231,6 +231,8 @@ int _odp_thread_term_local(void)
 	if (type == ODP_THREAD_CONTROL && group_control)
 		_odp_sched_fn->thr_rem(ODP_SCHED_GROUP_CONTROL, id);
 
+	_odp_this_thread = NULL;
+
 	odp_spinlock_lock(&thread_globals->lock);
 	num = free_id(id);
 	odp_spinlock_unlock(&thread_globals->lock);

--- a/test/validation/api/Makefile.am
+++ b/test/validation/api/Makefile.am
@@ -47,6 +47,7 @@ TESTS = \
 	init/init_defaults$(EXEEXT) \
 	init/init_abort$(EXEEXT) \
 	init/init_log$(EXEEXT) \
+	init/init_log_thread$(EXEEXT) \
 	init/init_num_thr$(EXEEXT) \
 	init/init_feature_enabled$(EXEEXT) \
 	init/init_feature_disabled$(EXEEXT) \

--- a/test/validation/api/init/.gitignore
+++ b/test/validation/api/init/.gitignore
@@ -1,6 +1,7 @@
 init_defaults
 init_abort
 init_log
+init_log_thread
 init_num_thr
 init_feature_enabled
 init_feature_disabled

--- a/test/validation/api/init/Makefile.am
+++ b/test/validation/api/init/Makefile.am
@@ -3,7 +3,7 @@ include ../Makefile.inc
 # Keep init test cases in separate binaries. Some implementations may not allow
 # the same application process to call odp_init_global() multiple times.
 test_PROGRAMS = init_defaults init_abort init_log init_num_thr \
-		init_feature_enabled init_feature_disabled
+		init_feature_enabled init_feature_disabled init_log_thread
 
 init_defaults_CPPFLAGS = -DINIT_TEST=0 $(AM_CPPFLAGS)
 init_abort_CPPFLAGS    = -DINIT_TEST=1 $(AM_CPPFLAGS)
@@ -11,6 +11,7 @@ init_log_CPPFLAGS      = -DINIT_TEST=2 $(AM_CPPFLAGS)
 init_num_thr_CPPFLAGS  = -DINIT_TEST=3 $(AM_CPPFLAGS)
 init_feature_enabled_CPPFLAGS = -DINIT_TEST=4 $(AM_CPPFLAGS)
 init_feature_disabled_CPPFLAGS = -DINIT_TEST=5 $(AM_CPPFLAGS)
+init_log_thread_CPPFLAGS = -DINIT_TEST=6 $(AM_CPPFLAGS)
 
 init_defaults_SOURCES = init_main.c
 init_abort_SOURCES = init_main.c
@@ -18,3 +19,4 @@ init_log_SOURCES = init_main.c
 init_num_thr_SOURCES = init_main.c
 init_feature_enabled_SOURCES = init_main.c
 init_feature_disabled_SOURCES = init_main.c
+init_log_thread_SOURCES = init_main.c


### PR DESCRIPTION
```
api: introduce per-thread log function
    
    The odp_log_thread_fn_set() API allows the caller to set a per-thread
    log function. This log function is called to do output when the thread
    calls other API functions.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

linux-gen: implement odp_thread_set_log_fn()
    
    Implement the odp_thread_set_log_fn() API function.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

helper: cli: direct prints to the CLI user instead of the log
    
    Use the odp_log_thread_fn_set() API to direct prints from API calls to
    the CLI user.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

validation: init: test thread-specific log function
    
    Test that a thread-specific log function is called if and only if it
    is set.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
This PR is alternative to PR #1242.

v3:
- Call _ODP_LOG_FN in debug_internal.h.
- Add validation test.
- Add reviewed-by tags.

v4:
- helper/cli.c: Remove _GNU_SOURCE, strdup() and *asprintf().
- api: Improve description of odp_log_thread_fn_set().
- test/validation/api/init/.gitignore: Add init_log_thread.
- Set _odp_this_thread to NULL in term_local.
- Use the term "thread specific" consistently (instead of "per thread").

v5:
- Add commit "helper: test: linux: process: add missing odp_term_local() calls"
- Add commit "linux-gen: init: fix odp_term_local() return value"

v6:
- Add commit "linux-gen: thread: in global termination, check number of active threads"

v7:
- odp_thread.c: ODP_DBG() -> ODP_ERR()

v8:
- Free cli_log_fn buffer when client disconnects.
- Call odp_log_thread_fn_set() right before and after cli_loop().
- Use "CLI client" instead of "CLI user".
