### PR TITLE
[PATCH v4] test: performance: ipsec: Fix for ipsec schedule mode to work

### DIFF
--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -866,7 +866,12 @@ run_measure_one_config(ipsec_args_t *cargs,
 		odp_ipsec_status_t status;
 
 		while (1) {
-			odp_event_t event = odp_queue_deq(out_queue);
+			odp_event_t event;
+
+			if (cargs->poll)
+				event = odp_queue_deq(out_queue);
+			else
+				event = odp_schedule(NULL, ODP_SCHED_NO_WAIT);
 
 			if (event != ODP_EVENT_INVALID &&
 			    odp_event_type(event) == ODP_EVENT_IPSEC_STATUS &&


### PR DESCRIPTION
This fix enables the use of -s option for odp_ipsec performance test app

Signed-off-by: Vijay Ram Inavolu <vinavolu@marvell.com>