### PR TITLE
[PATCH v8] linux-gen: ipsec: add anti-replay larger window sizes support.

### DIFF
--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -158,7 +158,7 @@ int odp_ipsec_capability(odp_ipsec_capability_t *capa)
 
 	capa->max_num_sa = _odp_ipsec_max_num_sa();
 
-	capa->max_antireplay_ws = IPSEC_ANTIREPLAY_WS;
+	capa->max_antireplay_ws = IPSEC_AR_WIN_SIZE_MAX;
 
 	rc = set_ipsec_crypto_capa(capa);
 	if (rc < 0)


### PR DESCRIPTION
Patch series adds support for larger anti-replay window sizes.
The maximum supported AR window size is limitted to 4096, where as
the minimum supported AR window size is remained the same 32.

Will send separate PR for performance related reference odp_ipsec application
changes.

Signed-off-by: Mahipal Challa <mchalla@marvell.com>