### PR TITLE
test: validation: ipsec: add antireplay tests for larger window sizes

### DIFF
--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -937,6 +937,73 @@ void ipsec_check_out_one(const ipsec_test_part *part, odp_ipsec_sa_t sa)
 		odp_packet_free(pkto[i]);
 }
 
+static void ipsec_pkt_proto_err_set(odp_packet_t pkt)
+{
+	uint32_t l3_off = odp_packet_l3_offset(pkt);
+	odph_ipv4hdr_t ip;
+
+	/* Simulate proto error by corrupting protocol field */
+
+	odp_packet_copy_to_mem(pkt, l3_off, sizeof(ip), &ip);
+
+	if (ip.proto == ODPH_IPPROTO_ESP)
+		ip.proto = ODPH_IPPROTO_AH;
+	else
+		ip.proto = ODPH_IPPROTO_ESP;
+
+	odp_packet_copy_from_mem(pkt, l3_off, sizeof(ip), &ip);
+}
+
+static void ipsec_pkt_auth_err_set(odp_packet_t pkt)
+{
+	uint32_t data, len;
+
+	/* Simulate auth error by corrupting ICV */
+
+	len = odp_packet_len(pkt);
+	odp_packet_copy_to_mem(pkt, len - sizeof(data), sizeof(data), &data);
+	data = ~data;
+	odp_packet_copy_from_mem(pkt, len - sizeof(data), sizeof(data), &data);
+}
+
+void ipsec_check_out_in_one(const ipsec_test_part *part_outbound,
+			    const ipsec_test_part *part_inbound,
+			    odp_ipsec_sa_t sa,
+			    odp_ipsec_sa_t sa_in,
+			    const ipsec_test_flags *flags)
+{
+	int num_out = part_outbound->num_pkt;
+	odp_packet_t pkto[num_out];
+	int i;
+
+	num_out = ipsec_check_out(part_outbound, sa, pkto);
+
+	for (i = 0; i < num_out; i++) {
+		ipsec_test_part part_in = *part_inbound;
+		ipsec_test_packet pkt_in;
+
+		CU_ASSERT_FATAL(odp_packet_len(pkto[i]) <=
+				sizeof(pkt_in.data));
+
+		if (flags && flags->stats == IPSEC_TEST_STATS_PROTO_ERR)
+			ipsec_pkt_proto_err_set(pkto[i]);
+
+		if (flags && flags->stats == IPSEC_TEST_STATS_AUTH_ERR)
+			ipsec_pkt_auth_err_set(pkto[i]);
+
+		pkt_in.len = odp_packet_len(pkto[i]);
+		pkt_in.l2_offset = odp_packet_l2_offset(pkto[i]);
+		pkt_in.l3_offset = odp_packet_l3_offset(pkto[i]);
+		pkt_in.l4_offset = odp_packet_l4_offset(pkto[i]);
+		odp_packet_copy_to_mem(pkto[i], 0,
+				       pkt_in.len,
+				       pkt_in.data);
+		part_in.pkt_in = &pkt_in;
+		ipsec_check_in_one(&part_in, sa_in);
+		odp_packet_free(pkto[i]);
+	}
+}
+
 int ipsec_suite_init(void)
 {
 	int rc = 0;

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -11,6 +11,11 @@
 
 #include <odp_cunit_common.h>
 
+#define IPV4ADDR(a, b, c, d) odp_cpu_to_be_32(((a) << 24) | \
+					      ((b) << 16) | \
+					      ((c) << 8) | \
+					      ((d) << 0))
+
 /* test arrays: */
 extern odp_testinfo_t ipsec_in_suite[];
 extern odp_testinfo_t ipsec_out_suite[];
@@ -81,6 +86,20 @@ typedef struct {
 	} out[1];
 } ipsec_test_part;
 
+/*
+ * Miscellaneous parameters for combined out+in tests
+ */
+typedef struct {
+	ipsec_test_part_flags_t part_flags;
+	odp_bool_t display_algo;
+	odp_bool_t ah;
+	odp_bool_t v6;
+	odp_bool_t tunnel;
+	odp_bool_t tunnel_is_v6;
+	odp_bool_t udp_encap;
+	enum ipsec_test_stats stats;
+} ipsec_test_flags;
+
 void ipsec_sa_param_fill(odp_ipsec_sa_param_t *param,
 			 odp_bool_t in,
 			 odp_bool_t ah,
@@ -100,6 +119,11 @@ int ipsec_check_out(const ipsec_test_part *part,
 		    odp_ipsec_sa_t sa,
 		    odp_packet_t *pkto);
 void ipsec_check_out_one(const ipsec_test_part *part, odp_ipsec_sa_t sa);
+void ipsec_check_out_in_one(const ipsec_test_part *part_outbound,
+			    const ipsec_test_part *part_inbound,
+			    odp_ipsec_sa_t sa,
+			    odp_ipsec_sa_t sa_in,
+			    const ipsec_test_flags *flags);
 int ipsec_test_sa_update_seq_num(odp_ipsec_sa_t sa, uint32_t seq_num);
 
 int ipsec_check(odp_bool_t ah,

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -11,20 +11,6 @@
 #include "ipsec.h"
 #include "test_vectors.h"
 
-/*
- * Miscellaneous parameters for combined out+in tests
- */
-typedef struct {
-	ipsec_test_part_flags_t part_flags;
-	odp_bool_t display_algo;
-	odp_bool_t ah;
-	odp_bool_t v6;
-	odp_bool_t tunnel;
-	odp_bool_t tunnel_is_v6;
-	odp_bool_t udp_encap;
-	enum ipsec_test_stats stats;
-} ipsec_test_flags;
-
 struct cipher_param {
 	const char *name;
 	odp_cipher_alg_t algo;
@@ -150,11 +136,6 @@ static void test_out_ipv4_ah_sha256(void)
 
 	ipsec_sa_destroy(sa);
 }
-
-#define IPV4ADDR(a, b, c, d) odp_cpu_to_be_32((a << 24) | \
-					      (b << 16) | \
-					      (c << 8) | \
-					      (d << 0))
 
 static void test_out_ipv4_ah_sha256_tun_ipv4(void)
 {
@@ -400,73 +381,6 @@ static void test_ipsec_stats_test_assert(odp_ipsec_stats_t *stats,
 	CU_ASSERT_EQUAL(stats->mtu_err, 0);
 	CU_ASSERT_EQUAL(stats->hard_exp_bytes_err, 0);
 	CU_ASSERT_EQUAL(stats->hard_exp_pkts_err, 0);
-}
-
-static void ipsec_pkt_proto_err_set(odp_packet_t pkt)
-{
-	uint32_t l3_off = odp_packet_l3_offset(pkt);
-	odph_ipv4hdr_t ip;
-
-	/* Simulate proto error by corrupting protocol field */
-
-	odp_packet_copy_to_mem(pkt, l3_off, sizeof(ip), &ip);
-
-	if (ip.proto == ODPH_IPPROTO_ESP)
-		ip.proto = ODPH_IPPROTO_AH;
-	else
-		ip.proto = ODPH_IPPROTO_ESP;
-
-	odp_packet_copy_from_mem(pkt, l3_off, sizeof(ip), &ip);
-}
-
-static void ipsec_pkt_auth_err_set(odp_packet_t pkt)
-{
-	uint32_t data, len;
-
-	/* Simulate auth error by corrupting ICV */
-
-	len = odp_packet_len(pkt);
-	odp_packet_copy_to_mem(pkt, len - sizeof(data), sizeof(data), &data);
-	data = ~data;
-	odp_packet_copy_from_mem(pkt, len - sizeof(data), sizeof(data), &data);
-}
-
-static void ipsec_check_out_in_one(const ipsec_test_part *part_outbound,
-				   const ipsec_test_part *part_inbound,
-				   odp_ipsec_sa_t sa,
-				   odp_ipsec_sa_t sa_in,
-				   const ipsec_test_flags *flags)
-{
-	int num_out = part_outbound->num_pkt;
-	odp_packet_t pkto[num_out];
-	int i;
-
-	num_out = ipsec_check_out(part_outbound, sa, pkto);
-
-	for (i = 0; i < num_out; i++) {
-		ipsec_test_part part_in = *part_inbound;
-		ipsec_test_packet pkt_in;
-
-		CU_ASSERT_FATAL(odp_packet_len(pkto[i]) <=
-				sizeof(pkt_in.data));
-
-		if (flags && flags->stats == IPSEC_TEST_STATS_PROTO_ERR)
-			ipsec_pkt_proto_err_set(pkto[i]);
-
-		if (flags && flags->stats == IPSEC_TEST_STATS_AUTH_ERR)
-			ipsec_pkt_auth_err_set(pkto[i]);
-
-		pkt_in.len = odp_packet_len(pkto[i]);
-		pkt_in.l2_offset = odp_packet_l2_offset(pkto[i]);
-		pkt_in.l3_offset = odp_packet_l3_offset(pkto[i]);
-		pkt_in.l4_offset = odp_packet_l4_offset(pkto[i]);
-		odp_packet_copy_to_mem(pkto[i], 0,
-				       pkt_in.len,
-				       pkt_in.data);
-		part_in.pkt_in = &pkt_in;
-		ipsec_check_in_one(&part_in, sa_in);
-		odp_packet_free(pkto[i]);
-	}
 }
 
 static void test_out_in_common(const ipsec_test_flags *flags,


### PR DESCRIPTION
A reference validation test for exercising more antireplay tests
required for validating the AR larger window sizes(PR#1261).

Signed-off-by: Mahipal Challa <mchalla@marvell.com>