### PR TITLE
[PATCH v4] validation: packet: fix verification for trunc/extend tests

### DIFF
--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -929,13 +929,7 @@ static void _verify_headroom_shift(odp_packet_t *pkt,
 	CU_ASSERT_PTR_NOT_NULL(data);
 	if (extended) {
 		CU_ASSERT(rc >= 0);
-		if (shift >= 0) {
-			CU_ASSERT(odp_packet_seg_len(*pkt) == shift - room);
-		} else {
-			CU_ASSERT(odp_packet_headroom(*pkt) >=
-				  (uint32_t)abs(shift) - seg_data_len);
-		}
-		CU_ASSERT(odp_packet_head(*pkt) != head_orig);
+		CU_ASSERT(odp_packet_seg_len(*pkt) == seg_len);
 	} else {
 		CU_ASSERT(odp_packet_headroom(*pkt) == room - shift);
 		CU_ASSERT(odp_packet_seg_len(*pkt) == seg_data_len + shift);
@@ -1032,15 +1026,13 @@ static void _verify_tailroom_shift(odp_packet_t *pkt,
 	CU_ASSERT_PTR_NOT_NULL(tail);
 	if (extended) {
 		CU_ASSERT(rc >= 0);
-		CU_ASSERT(odp_packet_last_seg(*pkt) != seg);
-		seg = odp_packet_last_seg(*pkt);
-		if (shift > 0) {
-			CU_ASSERT(odp_packet_seg_data_len(*pkt, seg) ==
-				  shift - room);
+
+		if (shift >= 0) {
+			if (rc == 0)
+				CU_ASSERT(tail == tail_orig);
 		} else {
-			CU_ASSERT(odp_packet_tailroom(*pkt) >=
-				  (uint32_t)abs(shift) - seg_data_len);
-			CU_ASSERT(seg_len == odp_packet_tailroom(*pkt));
+			CU_ASSERT(odp_packet_tail(*pkt) == tail);
+			CU_ASSERT(odp_packet_tailroom(*pkt) == seg_len);
 		}
 	} else {
 		CU_ASSERT(odp_packet_seg_data_len(*pkt, seg) ==
@@ -1049,19 +1041,15 @@ static void _verify_tailroom_shift(odp_packet_t *pkt,
 		if (room == 0 || (room - shift) == 0)
 			return;
 		if (shift >= 0) {
-			CU_ASSERT(odp_packet_tail(*pkt) ==
-				  tail_orig + shift);
+			CU_ASSERT(odp_packet_tail(*pkt) == tail_orig + shift);
+			CU_ASSERT(tail == tail_orig);
 		} else {
+			CU_ASSERT(odp_packet_tail(*pkt) == tail);
 			CU_ASSERT(tail == tail_orig + shift);
 		}
 	}
 
 	CU_ASSERT(odp_packet_len(*pkt) == pkt_data_len + shift);
-	if (shift >= 0) {
-		CU_ASSERT(tail == tail_orig);
-	} else {
-		CU_ASSERT(odp_packet_tail(*pkt) == tail);
-	}
 }
 
 static void packet_test_tailroom(void)


### PR DESCRIPTION
In packet test cases for headroom/tailroom, extend head/tail
APIs are always called with extend length greater than
headroom/tailroom. Also trunc head/tail APIs are always
called with truncate length greater than or equal to segment
length.

In these cases, the spec allows the implementation to change
the layout of the packet completely if required. So properties
of the output packet like segment lengths, headroom, tailroom
etc. can be entirely different from those of the input packet
and should not be compared with each other.

Also, comparison of older pointers from input packet with new
pointers from output packet should be done only if the return
value of these APIs is 0 as otherwise the older pointers are to
be considered invalid.

Signed-off-by: Ashwin Sekhar T K <asekhar@marvell.com>
Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>
