### PR TITLE
[PATCH v7] validation: ipsec: reduce code duplication in reassembly test cases

### DIFF
--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -16,6 +16,8 @@
 					      ((c) << 8) | \
 					      ((d) << 0))
 
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
 /* test arrays: */
 extern odp_testinfo_t ipsec_in_suite[];
 extern odp_testinfo_t ipsec_out_suite[];

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -119,8 +119,6 @@ static struct cipher_auth_comb_param cipher_auth_comb[] = {
 	},
 };
 
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
-
 static void test_out_ipv4_ah_sha256(void)
 {
 	odp_ipsec_sa_param_t param;


### PR DESCRIPTION
This PR depends on PR 992 (api: reassembly) and adds one commit on top of it. The commit reduces code duplication and makes reassembly test case code simpler as suggested in the review of PR 992. @anoobj please review.

v2: Rebased on top of latest master that now includes PR 992 commits.