### PR TITLE
[PATCH v3] github_ci: run x86_64 tests with debug build too

### DIFF
--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -104,7 +104,7 @@ jobs:
       fail-fast: false
       matrix:
         cc: [gcc, clang]
-        conf: ['', '--disable-abi-compat', '--enable-deprecated', '--enable-dpdk-zero-copy --disable-static-applications', '--disable-host-optimization', '--disable-host-optimization --disable-abi-compat', '--without-openssl --without-pcap']
+        conf: ['', '--disable-abi-compat', '--enable-deprecated --enable-debug=full', '--enable-dpdk-zero-copy --disable-static-applications', '--disable-host-optimization', '--disable-host-optimization --disable-abi-compat', '--without-openssl --without-pcap']
     steps:
       - uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -241,7 +241,7 @@ jobs:
       fail-fast: false
       matrix:
         cc: [gcc, clang]
-        conf: ['', '--enable-abi-compat', '--enable-deprecated', '--enable-dpdk-zero-copy --disable-static-applications', '--disable-host-optimization', '--disable-host-optimization --enable-abi-compat', '--without-openssl --without-pcap']
+        conf: ['', '--enable-abi-compat', '--enable-deprecated --enable-debug=full', '--enable-dpdk-zero-copy --disable-static-applications', '--disable-host-optimization', '--disable-host-optimization --enable-abi-compat', '--without-openssl --without-pcap']
     steps:
       - uses: actions/checkout@v2
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}" -e ARCH="${ARCH}"


### PR DESCRIPTION
Run x86_64 tests with debug build too to catch issues that e.g. trigger
asserts in the ODP implementation. Add debug build flag in the existing
--enable-deprecated test configuration to avoid increasing the number
of test runs.

The coverage test does already use debug build, but this change makes
the debug build explicitly part of the common test run and makes
possible error reports hopefully more clear.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>