### PR TITLE
[PATCH v3] api: ipsec: include success bytes in stats

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -937,6 +937,15 @@ typedef struct odp_ipsec_stats_t {
 
 	/** Number of packets with hard lifetime(packets) expired */
 	uint64_t hard_exp_pkts_err;
+
+	/** Total bytes of packet data processed by IPsec SA in success cases
+	 *
+	 * The range of packet bytes included in the success_bytes count is
+	 * implementation defined but includes at least the bytes input for
+	 * encryption or bytes output after decryption in ESP or the bytes
+	 * authenticated in AH.
+	 */
+	uint64_t success_bytes;
 } odp_ipsec_stats_t;
 
 /**

--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -196,11 +196,12 @@ struct ipsec_sa_s {
 		odp_atomic_u64_t hard_exp_pkts_err;
 
 		/*
-		 * Track error packets after lifetime check is done.
+		 * Track error packets and bytes after lifetime check is done.
 		 * Required since, the stats tracking lifetime is being
 		 * used for SA success packets stats.
 		 */
 		odp_atomic_u64_t post_lifetime_err_pkts;
+		odp_atomic_u64_t post_lifetime_err_bytes;
 	} stats;
 
 	odp_ipsec_sa_param_t param;
@@ -302,10 +303,11 @@ uint16_t _odp_ipsec_sa_alloc_ipv4_id(ipsec_sa_t *ipsec_sa);
 int _odp_ipsec_try_inline(odp_packet_t *pkt);
 
 /**
- * Get number of packets successfully processed by the SA
+ * Populate number of packets and bytes of data successfully processed by the SA
+ * in the odp_ipsec_stats_t structure passed.
  *
  */
-uint64_t _odp_ipsec_sa_stats_pkts(ipsec_sa_t *sa);
+void _odp_ipsec_sa_stats_pkts(ipsec_sa_t *sa, odp_ipsec_stats_t *stats);
 
 /**
  * @}

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -908,8 +908,11 @@ static ipsec_sa_t *ipsec_in_single(odp_packet_t pkt,
 	goto exit;
 
 post_lifetime_err_cnt_update:
-	if (ipsec_config->stats_en)
+	if (ipsec_config->stats_en) {
 		odp_atomic_inc_u64(&ipsec_sa->stats.post_lifetime_err_pkts);
+		odp_atomic_add_u64(&ipsec_sa->stats.post_lifetime_err_bytes,
+				   state.stats_length);
+	}
 
 exit:
 	*pkt_out = pkt;
@@ -1652,8 +1655,11 @@ static ipsec_sa_t *ipsec_out_single(odp_packet_t pkt,
 	goto exit;
 
 post_lifetime_err_cnt_update:
-	if (ipsec_config->stats_en)
+	if (ipsec_config->stats_en) {
 		odp_atomic_inc_u64(&ipsec_sa->stats.post_lifetime_err_pkts);
+		odp_atomic_add_u64(&ipsec_sa->stats.post_lifetime_err_bytes,
+				   state.stats_length);
+	}
 
 exit:
 	*pkt_out = pkt;
@@ -2110,7 +2116,7 @@ int odp_ipsec_stats(odp_ipsec_sa_t sa, odp_ipsec_stats_t *stats)
 	ipsec_sa = _odp_ipsec_sa_entry_from_hdl(sa);
 	ODP_ASSERT(NULL != ipsec_sa);
 
-	stats->success = _odp_ipsec_sa_stats_pkts(ipsec_sa);
+	_odp_ipsec_sa_stats_pkts(ipsec_sa, stats);
 	stats->proto_err = odp_atomic_load_u64(&ipsec_sa->stats.proto_err);
 	stats->auth_err = odp_atomic_load_u64(&ipsec_sa->stats.auth_err);
 	stats->antireplay_err = odp_atomic_load_u64(&ipsec_sa->stats.antireplay_err);

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -68,7 +68,7 @@ typedef struct sa_thread_local_s {
 	 * Bytes that can be processed in this thread before looking at
 	 * the SA-global byte counter and checking hard and soft limits.
 	 */
-	uint32_t byte_quota;
+	odp_atomic_u32_t byte_quota;
 	/*
 	 * Life time status when this thread last checked the global
 	 * counter(s).
@@ -130,7 +130,7 @@ static void init_sa_thread_local(ipsec_sa_t *sa)
 	for (n = 0; n < thread_count_max; n++) {
 		sa_tl = &ipsec_sa_tbl->per_thread[n].sa[sa->ipsec_sa_idx];
 		odp_atomic_init_u32(&sa_tl->packet_quota, 0);
-		sa_tl->byte_quota = 0;
+		odp_atomic_init_u32(&sa_tl->byte_quota, 0);
 		sa_tl->lifetime_status.all = 0;
 	}
 }
@@ -492,6 +492,7 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 	odp_atomic_init_u64(&ipsec_sa->stats.hard_exp_bytes_err, 0);
 	odp_atomic_init_u64(&ipsec_sa->stats.hard_exp_pkts_err, 0);
 	odp_atomic_init_u64(&ipsec_sa->stats.post_lifetime_err_pkts, 0);
+	odp_atomic_init_u64(&ipsec_sa->stats.post_lifetime_err_bytes, 0);
 
 	/* Copy application provided parameter values. */
 	ipsec_sa->param = *param;
@@ -835,6 +836,7 @@ int _odp_ipsec_sa_lifetime_update(ipsec_sa_t *ipsec_sa, uint32_t len,
 {
 	sa_thread_local_t *sa_tl = ipsec_sa_thread_local(ipsec_sa);
 	uint64_t packets, bytes;
+	uint32_t tl_byte_quota;
 	uint32_t tl_pkt_quota;
 
 	tl_pkt_quota = odp_atomic_load_u32(&sa_tl->packet_quota);
@@ -855,11 +857,12 @@ int _odp_ipsec_sa_lifetime_update(ipsec_sa_t *ipsec_sa, uint32_t len,
 	tl_pkt_quota--;
 	odp_atomic_store_u32(&sa_tl->packet_quota, tl_pkt_quota);
 
-	if (odp_unlikely(sa_tl->byte_quota < len)) {
+	tl_byte_quota = odp_atomic_load_u32(&sa_tl->byte_quota);
+	if (odp_unlikely(tl_byte_quota < len)) {
 		bytes = odp_atomic_fetch_add_u64(&ipsec_sa->hot.bytes,
 						 len + SA_LIFE_BYTES_PREALLOC);
 		bytes += len + SA_LIFE_BYTES_PREALLOC;
-		sa_tl->byte_quota += len + SA_LIFE_BYTES_PREALLOC;
+		tl_byte_quota += len + SA_LIFE_BYTES_PREALLOC;
 
 		if (ipsec_sa->soft_limit_bytes > 0 &&
 		    bytes >= ipsec_sa->soft_limit_bytes)
@@ -869,7 +872,9 @@ int _odp_ipsec_sa_lifetime_update(ipsec_sa_t *ipsec_sa, uint32_t len,
 		    bytes >= ipsec_sa->hard_limit_bytes)
 			sa_tl->lifetime_status.error.hard_exp_bytes = 1;
 	}
-	sa_tl->byte_quota -= len;
+	tl_byte_quota -= len;
+	odp_atomic_store_u32(&sa_tl->byte_quota, tl_byte_quota);
+
 
 	status->all |= sa_tl->lifetime_status.all;
 
@@ -973,9 +978,10 @@ uint16_t _odp_ipsec_sa_alloc_ipv4_id(ipsec_sa_t *ipsec_sa)
 	return tl->next_ipv4_id++;
 }
 
-uint64_t _odp_ipsec_sa_stats_pkts(ipsec_sa_t *sa)
+void _odp_ipsec_sa_stats_pkts(ipsec_sa_t *sa, odp_ipsec_stats_t *stats)
 {
 	int thread_count_max = odp_thread_count_max();
+	uint64_t tl_byte_quota = 0;
 	uint64_t tl_pkt_quota = 0;
 	sa_thread_local_t *sa_tl;
 	int n;
@@ -994,11 +1000,20 @@ uint64_t _odp_ipsec_sa_stats_pkts(ipsec_sa_t *sa)
 	for (n = 0; n < thread_count_max; n++) {
 		sa_tl = &ipsec_sa_tbl->per_thread[n].sa[sa->ipsec_sa_idx];
 		tl_pkt_quota += odp_atomic_load_u32(&sa_tl->packet_quota);
+		tl_byte_quota += odp_atomic_load_u32(&sa_tl->byte_quota);
 	}
 
-	return odp_atomic_load_u64(&sa->hot.packets)
+	stats->success =
+		odp_atomic_load_u64(&sa->hot.packets)
 	       - odp_atomic_load_u64(&sa->stats.post_lifetime_err_pkts)
 	       - tl_pkt_quota;
+
+	stats->success_bytes =
+		odp_atomic_load_u64(&sa->hot.bytes)
+	       - odp_atomic_load_u64(&sa->stats.post_lifetime_err_bytes)
+	       - tl_byte_quota;
+
+	return;
 }
 
 static void ipsec_out_sa_info(ipsec_sa_t *ipsec_sa, odp_ipsec_sa_info_t *sa_info)

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -361,17 +361,19 @@ static void test_ipsec_stats_zero_assert(odp_ipsec_stats_t *stats)
 	CU_ASSERT_EQUAL(stats->mtu_err, 0);
 	CU_ASSERT_EQUAL(stats->hard_exp_bytes_err, 0);
 	CU_ASSERT_EQUAL(stats->hard_exp_pkts_err, 0);
+	CU_ASSERT_EQUAL(stats->success_bytes, 0);
 }
 
 static void test_ipsec_stats_test_assert(odp_ipsec_stats_t *stats,
-					 enum ipsec_test_stats test)
+					 enum ipsec_test_stats test,
+					 uint64_t succ_bytes)
 {
 	if (test == IPSEC_TEST_STATS_SUCCESS) {
-		/* Braces needed by CU macro */
 		CU_ASSERT_EQUAL(stats->success, 1);
+		CU_ASSERT(stats->success_bytes >= succ_bytes);
 	} else {
-		/* Braces needed by CU macro */
 		CU_ASSERT_EQUAL(stats->success, 0);
+		CU_ASSERT_EQUAL(stats->success_bytes, 0);
 	}
 
 	if (test == IPSEC_TEST_STATS_PROTO_ERR) {
@@ -608,20 +610,36 @@ static void test_out_in_common(const ipsec_test_flags *flags,
 
 	ipsec_check_out_in_one(&test_out, &test_in, sa_out, sa_in, flags);
 
-	if (flags->stats == IPSEC_TEST_STATS_SUCCESS) {
-		CU_ASSERT_EQUAL(odp_ipsec_stats(sa_in, &stats), 0);
-		test_ipsec_stats_test_assert(&stats, flags->stats);
-	}
-
 	if (flags->stats != IPSEC_TEST_STATS_NONE) {
+		uint64_t succ_bytes = 0;
+
+		/* Minimum bytes to be counted for stats.success_bytes */
+		if (!flags->ah) {
+			succ_bytes = test_out.pkt_in[0].len -
+				     test_out.pkt_in[0].l4_offset;
+
+			if (flags->tunnel)
+				succ_bytes += test_out.pkt_in[0].l4_offset -
+					      test_out.pkt_in[0].l3_offset;
+		} else {
+			succ_bytes = test_out.pkt_in[0].len -
+				     test_out.pkt_in[0].l3_offset;
+
+			if (flags->tunnel)
+				succ_bytes += (flags->tunnel_is_v6 ?
+					       ODPH_IPV6HDR_LEN :
+					       ODPH_IPV4HDR_LEN);
+		}
+
 		/* All stats tests have outbound operation success and inbound
 		 * varying.
 		 */
 		CU_ASSERT_EQUAL(odp_ipsec_stats(sa_out, &stats), 0);
-		test_ipsec_stats_test_assert(&stats, IPSEC_TEST_STATS_SUCCESS);
+		test_ipsec_stats_test_assert(&stats, IPSEC_TEST_STATS_SUCCESS,
+					     succ_bytes);
 
 		CU_ASSERT_EQUAL(odp_ipsec_stats(sa_in, &stats), 0);
-		test_ipsec_stats_test_assert(&stats, flags->stats);
+		test_ipsec_stats_test_assert(&stats, flags->stats, succ_bytes);
 	}
 
 	ipsec_sa_destroy(sa_out);


### PR DESCRIPTION
Update IPsec stats with "success bytes" representing total bytes of data processed in success cases.