### PR TITLE
[PATCH v2] 1.29.0.0 release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,21 +1,47 @@
+== OpenDataPlane (1.29.0.0)
+=== API
+==== Packet IO
+* Modified statistics counters (`odp_pktio_stats_t`) definitions
+* Deprecated statistics counter `odp_pktio_stats_t.in_unknown_protos`
+* New `odp_pktio_stats_t.in_packets` and `odp_pktio_stats_t.out_packets`
+statistics counters
+* New APIs for packet input inline IP reassembly offload
+
+==== Packet
+* New `odp_packet_reass_status()` function added for checking packet reassembly
+status
+* New `odp_packet_reass_partial_state()` function added for reading packet
+partial reassembly state
+
+==== IPsec
+* New APIs for inline IP reassembly offload
+
+==== Init
+* New `odp_log_thread_fn_set()` function added for setting a thread specific log
+function
+
+=== Implementation
+* ABI compatibility default value has been changed to disabled. User can enable
+ABI compatibility with `--enable-abi-compat` configure option.
+
 == OpenDataPlane (1.28.0.0)
 === API
 ==== Crypto
 * New crypto capabilities for defining if a queue type (scheduled/plain) can be
 used as a crypto completion event destination
 
-=== Event
+==== Event
 * New packet TX completion event type and related functions
 
-=== Packet
+==== Packet
 * New packet APIs for requesting packet TX completion events
-* New packet APIS for requesting packet TX drop based on packet age
+* New packet APIs for requesting packet TX drop based on packet age
 
-=== Classifier
+==== Classifier
 * New `odp_cls_print_all()` function for printing implementation specific
 debug information about all classifier rules
 
-=== System
+==== System
 * New enumerations for ARMv8.7-A, ARMv9.0-A, ARMv9.1-A, and ARMv9.2-A ISA
 versions
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ([2.5])
 # ODP API version
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
-m4_define([odpapi_major_version], [28])
+m4_define([odpapi_major_version], [29])
 m4_define([odpapi_minor_version], [0])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],


### PR DESCRIPTION
Increment API version number to reflect the following changes:

Backward incompatible:
- Modified packet IO statistics counters (odp_pktio_stats_t) definitions
- Deprecated packet IO statistics field odp_pktio_stats_t.in_unknown_protos

Backward compatible:
- New APIs for inline fragmentation reassembly offload for packet input and
  IPsec
- New odp_log_thread_fn_set() function for setting a thread specific log
  function
- New packet IO statistics counters
  odp_pktio_stats_t.in_packets/out_packets
