### PR TITLE
[PATCH v2] helper: cli: add commands for new *_print_all() functions

### DIFF
--- a/helper/cli.c
+++ b/helper/cli.c
@@ -47,30 +47,6 @@ void odph_cli_param_init(odph_cli_param_t *param)
 	*param = param_default;
 }
 
-static int cmd_show_cpu(struct cli_def *cli, const char *command ODP_UNUSED,
-			char *argv[] ODP_UNUSED, int argc ODP_UNUSED)
-{
-	for (int c = 0; c < odp_cpu_count(); c++) {
-		cli_print(cli, "% 4d: %s %.03f / %.03f GHz", c,
-			  odp_cpu_model_str_id(c),
-			  (float)odp_cpu_hz_id(c) / 1000000000.0,
-			  (float)odp_cpu_hz_max_id(c) / 1000000000.0);
-	}
-
-	return CLI_OK;
-}
-
-static int cmd_show_version(struct cli_def *cli, const char *command ODP_UNUSED,
-			    char *argv[] ODP_UNUSED, int argc ODP_UNUSED)
-{
-	cli_print(cli, "ODP API version: %s", odp_version_api_str());
-	cli_print(cli, "ODP implementation name: %s", odp_version_impl_name());
-	cli_print(cli, "ODP implementation version: %s",
-		  odp_version_impl_str());
-
-	return CLI_OK;
-}
-
 /*
  * Check that number of given arguments matches required number of
  * arguments. Print error messages if this is not the case. Return 0
@@ -223,16 +199,6 @@ static struct cli_def *create_cli(void)
 	cli = cli_init();
 	cli_set_banner(cli, NULL);
 	cli_set_hostname(cli, "ODP");
-
-	c = cli_register_command(cli, NULL, "show", NULL,
-				 PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
-				 "Show information.");
-	cli_register_command(cli, c, "cpu", cmd_show_cpu,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
-			     "Show CPU information.");
-	cli_register_command(cli, c, "version", cmd_show_version,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
-			     "Show version information.");
 
 	c = cli_register_command(cli, NULL, "call", NULL,
 				 PRIVILEGE_UNPRIVILEGED, MODE_EXEC,

--- a/helper/cli.c
+++ b/helper/cli.c
@@ -67,6 +67,18 @@ static int check_num_args(struct cli_def *cli, int argc, int req_argc)
 	return 0;
 }
 
+static int cmd_call_odp_cls_print_all(struct cli_def *cli,
+				      const char *command ODP_UNUSED,
+				      char *argv[] ODP_UNUSED, int argc)
+{
+	if (check_num_args(cli, argc, 0))
+		return CLI_ERROR;
+
+	odp_cls_print_all();
+
+	return CLI_OK;
+}
+
 static int cmd_call_odp_ipsec_print(struct cli_def *cli,
 				    const char *command ODP_UNUSED,
 				    char *argv[] ODP_UNUSED, int argc)
@@ -203,6 +215,9 @@ static struct cli_def *create_cli(void)
 	c = cli_register_command(cli, NULL, "call", NULL,
 				 PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
 				 "Call ODP API function.");
+	cli_register_command(cli, c, "odp_cls_print_all",
+			     cmd_call_odp_cls_print_all,
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
 	cli_register_command(cli, c, "odp_ipsec_print",
 			     cmd_call_odp_ipsec_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);

--- a/helper/cli.c
+++ b/helper/cli.c
@@ -533,11 +533,16 @@ int odph_cli_start(const odp_instance_t instance,
 	return 0;
 
 error:
-	close(shm->sp[SP_READ]);
-	close(shm->sp[SP_WRITE]);
-	close(shm->listen_fd);
-	close(shm->cli_fd);
-	shm->run = 0;
+	if (shm->sp[SP_READ] >= 0)
+		close(shm->sp[SP_READ]);
+	if (shm->sp[SP_WRITE] >= 0)
+		close(shm->sp[SP_WRITE]);
+	if (shm->listen_fd >= 0)
+		close(shm->listen_fd);
+	if (shm->cli_fd >= 0)
+		close(shm->cli_fd);
+	if (odp_shm_free(shm_hdl))
+		ODPH_ERR("Error: odp_shm_free() failed\n");
 	return -1;
 }
 

--- a/helper/cli.c
+++ b/helper/cli.c
@@ -184,6 +184,18 @@ static int cmd_call_odp_queue_print(struct cli_def *cli,
 	return CLI_OK;
 }
 
+static int cmd_call_odp_queue_print_all(struct cli_def *cli,
+					const char *command ODP_UNUSED,
+					char *argv[] ODP_UNUSED, int argc)
+{
+	if (check_num_args(cli, argc, 0))
+		return CLI_ERROR;
+
+	odp_queue_print_all();
+
+	return CLI_OK;
+}
+
 static int cmd_call_odp_shm_print(struct cli_def *cli,
 				  const char *command ODP_UNUSED, char *argv[],
 				  int argc)
@@ -230,6 +242,9 @@ static struct cli_def *create_cli(void)
 	cli_register_command(cli, c, "odp_queue_print",
 			     cmd_call_odp_queue_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
+	cli_register_command(cli, c, "odp_queue_print_all",
+			     cmd_call_odp_queue_print_all,
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
 	cli_register_command(cli, c, "odp_shm_print_all",
 			     cmd_call_odp_shm_print_all,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);


### PR DESCRIPTION
```
helper: cli: fix odph_cli_start() error handling
    
    When encountering an error in odph_cli_start(), close only file
    descriptors that are open, and free shm.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

helper: cli: remove "show" commands
    
    "call odp_sys_info_print" command provides the same information as
    "show cpu" and "show version" commands. Remove the redundant "show"
    commands.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

helper: cli: add command "call odp_cls_print_all"
    
    Add a CLI command, which calls the new odp_cls_print_all() API
    function.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

helper: cli: add command "call odp_queue_print_all"
    
    Add a CLI command, which calls the new odp_queue_print_all() API
    function.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
v2:
- Add reviewed-by tags.
