### PR TITLE
[PATCH v2] helper: ipsec: fix capability API usage

### DIFF
--- a/helper/ipsec.c
+++ b/helper/ipsec.c
@@ -108,7 +108,7 @@ int odph_ipsec_alg_check(odp_ipsec_capability_t capa,
 	}
 
 	/* Check whether requested cipher key length is supported */
-	max_capa = odp_crypto_cipher_capability(cipher_alg, NULL, 0);
+	max_capa = odp_ipsec_cipher_capability(cipher_alg, NULL, 0);
 	if (max_capa <= 0)
 		return -1;
 
@@ -134,7 +134,7 @@ int odph_ipsec_alg_check(odp_ipsec_capability_t capa,
 	}
 
 	/* Check whether requested auth key length is supported */
-	max_capa = odp_crypto_auth_capability(auth_alg, NULL, 0);
+	max_capa = odp_ipsec_auth_capability(auth_alg, NULL, 0);
 	if (max_capa <= 0)
 		return max_capa;
 


### PR DESCRIPTION
Currently, the alg check function uses odp_crypto_*_capability
API to get the number of capability entries for a specific algorithm.
This is incorrect. Replacing the use of crypto capability APIs with
the correct IPsec APIs.

Signed-off-by: Aakash Sasidharan <asasidharan@marvell.com>