### PR TITLE
[PATCH v3] linux-gen: fix print formats and enable compile-time checking

### DIFF
--- a/platform/linux-generic/include/odp_debug_internal.h
+++ b/platform/linux-generic/include/odp_debug_internal.h
@@ -33,8 +33,15 @@ extern "C" {
  * level 0 to N. */
 #define CONFIG_DEBUG_LEVEL 0
 
+ODP_PRINTF_FORMAT(1, 2)
+static inline void check_printf_format(const char *fmt, ...)
+{
+	(void)fmt;
+}
+
 #define _ODP_LOG_FN(level, fmt, ...) \
 	do { \
+		check_printf_format(fmt, ##__VA_ARGS__); \
 		if (_odp_this_thread && _odp_this_thread->log_fn) \
 			_odp_this_thread->log_fn(level, fmt, ##__VA_ARGS__); \
 		else \

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -36,6 +36,7 @@ extern "C" {
 #include <net/if.h>
 #include <linux/if_ether.h>
 #include <sys/select.h>
+#include <inttypes.h>
 
 #define PKTIO_MAX_QUEUES 64
 #define PKTIO_LSO_PROFILES 16
@@ -237,7 +238,7 @@ static inline pktio_entry_t *get_pktio_entry(odp_pktio_t pktio)
 		return NULL;
 
 	if (odp_unlikely(_odp_typeval(pktio) > ODP_CONFIG_PKTIO_ENTRIES)) {
-		ODP_DBG("pktio limit %d/%d exceed\n",
+		ODP_DBG("pktio limit %" PRIuPTR "/%d exceed\n",
 			_odp_typeval(pktio), ODP_CONFIG_PKTIO_ENTRIES);
 		return NULL;
 	}

--- a/platform/linux-generic/odp_comp.c
+++ b/platform/linux-generic/odp_comp.c
@@ -133,7 +133,7 @@ static void process_input(odp_packet_t pkt_out,
 	do {
 		out_data =
 		    odp_packet_offset(pkt_out, start, &out_len, &cur_seg);
-		ODP_DBG("out_data 0x%x seg_data_ptr 0x%x out_len %d seg 0x%x\n",
+		ODP_DBG("out_data %p seg_data_ptr %p out_len %d seg %p\n",
 			out_data, odp_packet_seg_data(pkt_out, cur_seg),
 			out_len, cur_seg);
 
@@ -258,7 +258,7 @@ static int deflate_comp(odp_packet_t pkt_in,
 					 read,
 					 &in_len,
 					 &in_seg);
-		ODP_DBG("data 0x%x in_len %d seg 0x%x len %d\n",
+		ODP_DBG("data %p in_len %d seg %p len %d\n",
 			data, in_len, in_seg, len);
 
 		if (in_len > len)

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -1995,7 +1995,7 @@ int _odp_ishm_status(const char *title)
 	}
 
 	ODP_PRINT("%s\n", title);
-	ODP_PRINT("    %-*s flag %-29s %-08s   %-08s %-3s %-3s %-3s file\n",
+	ODP_PRINT("    %-*s flag %-29s %-8s   %-8s %-3s %-3s %-3s file\n",
 		  max_name_len, "name", "range", "user_len", "unused",
 		  "seq", "ref", "fd");
 
@@ -2045,8 +2045,8 @@ int _odp_ishm_status(const char *title)
 			entry_fd = ishm_proctable->entry[proc_index].fd;
 		}
 
-		ODP_PRINT("%2i  %-*s %s%c  %p-%p %-08" PRIu64 "   "
-			  "%-08" PRIu64 " %-3" PRIu64 " %-3" PRIu64 " "
+		ODP_PRINT("%2i  %-*s %s%c  %p-%p %-8" PRIu64 "   "
+			  "%-8" PRIu64 " %-3" PRIu64 " %-3" PRIu64 " "
 			  "%-3d %s\n",
 			  i, max_name_len, ishm_tbl->block[i].name,
 			  flags, huge, start_addr, end_addr,
@@ -2059,7 +2059,7 @@ int _odp_ishm_status(const char *title)
 					  ishm_tbl->block[i].filename :
 					  "(none)");
 	}
-	ODP_PRINT("TOTAL: %58s%-08" PRIu64 " %2s%-08" PRIu64 "\n",
+	ODP_PRINT("TOTAL: %58s%-8" PRIu64 " %2s%-8" PRIu64 "\n",
 		  "", len_total,
 		  "", lost_total);
 	ODP_PRINT("%65s(%" PRIu64 "MB) %4s(%" PRIu64 "MB)\n",
@@ -2072,15 +2072,15 @@ int _odp_ishm_status(const char *title)
 	     fragmnt; fragmnt = fragmnt->next) {
 		if (fragmnt->block_index >= 0) {
 			nb_allocated_frgments++;
-			ODP_PRINT("  %08p - %08p: ALLOCATED by block:%d\n",
-				  (uintptr_t)fragmnt->start,
-				  (uintptr_t)fragmnt->start + fragmnt->len - 1,
+			ODP_PRINT("  %8p - %8p: ALLOCATED by block:%d\n",
+				  fragmnt->start,
+				  (void *)((uintptr_t)fragmnt->start + fragmnt->len - 1),
 				  fragmnt->block_index);
 			consecutive_unallocated = 0;
 		} else {
-			ODP_PRINT("  %08p - %08p: NOT ALLOCATED\n",
-				  (uintptr_t)fragmnt->start,
-				  (uintptr_t)fragmnt->start + fragmnt->len - 1);
+			ODP_PRINT("  %8p - %8p: NOT ALLOCATED\n",
+				  fragmnt->start,
+				  (void *)((uintptr_t)fragmnt->start + fragmnt->len - 1));
 			if (consecutive_unallocated++)
 				ODP_ERR("defragmentation error\n");
 		}

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -377,7 +377,7 @@ static const char *driver_name(odp_pktio_t hdl)
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL) {
-		ODP_ERR("pktio entry %d does not exist\n", hdl);
+		ODP_ERR("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return "bad handle";
 	}
 
@@ -1253,7 +1253,7 @@ static inline uint32_t pktio_maxlen(odp_pktio_t hdl)
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", hdl);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return 0;
 	}
 
@@ -1296,7 +1296,7 @@ int odp_pktio_maxlen_set(odp_pktio_t hdl, uint32_t maxlen_input,
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL) {
-		ODP_ERR("Pktio entry %d does not exist\n", hdl);
+		ODP_ERR("Pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return -1;
 	}
 
@@ -1360,7 +1360,7 @@ int odp_pktio_promisc_mode_set(odp_pktio_t hdl, odp_bool_t enable)
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", hdl);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return -1;
 	}
 
@@ -1390,7 +1390,7 @@ int odp_pktio_promisc_mode(odp_pktio_t hdl)
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", hdl);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return -1;
 	}
 
@@ -1421,7 +1421,7 @@ int odp_pktio_mac_addr(odp_pktio_t hdl, void *mac_addr, int addr_size)
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", hdl);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return -1;
 	}
 
@@ -1456,7 +1456,7 @@ int odp_pktio_mac_addr_set(odp_pktio_t hdl, const void *mac_addr, int addr_size)
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", hdl);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return -1;
 	}
 
@@ -1487,7 +1487,7 @@ odp_pktio_link_status_t odp_pktio_link_status(odp_pktio_t hdl)
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", hdl);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return ODP_PKTIO_LINK_STATUS_UNKNOWN;
 	}
 
@@ -1543,7 +1543,7 @@ int odp_pktio_info(odp_pktio_t hdl, odp_pktio_info_t *info)
 	entry = get_pktio_entry(hdl);
 
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", hdl);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return -1;
 	}
 
@@ -1563,7 +1563,7 @@ int odp_pktio_link_info(odp_pktio_t hdl, odp_pktio_link_info_t *info)
 	entry = get_pktio_entry(hdl);
 
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", hdl);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return -1;
 	}
 
@@ -1579,7 +1579,7 @@ uint64_t odp_pktio_ts_res(odp_pktio_t hdl)
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL) {
-		ODP_ERR("pktio entry %d does not exist\n", hdl);
+		ODP_ERR("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return 0;
 	}
 
@@ -1596,7 +1596,7 @@ odp_time_t odp_pktio_ts_from_ns(odp_pktio_t hdl, uint64_t ns)
 	entry = get_pktio_entry(hdl);
 
 	if (entry == NULL) {
-		ODP_ERR("pktio entry %d does not exist\n", hdl);
+		ODP_ERR("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return ODP_TIME_NULL;
 	}
 
@@ -1613,7 +1613,7 @@ odp_time_t odp_pktio_time(odp_pktio_t hdl, odp_time_t *global_ts)
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL) {
-		ODP_ERR("pktio entry %d does not exist\n", hdl);
+		ODP_ERR("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return ODP_TIME_NULL;
 	}
 
@@ -1652,7 +1652,7 @@ void odp_pktio_print(odp_pktio_t hdl)
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", hdl);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return;
 	}
 
@@ -1781,7 +1781,7 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 
 	entry = get_pktio_entry(pktio);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", pktio);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)pktio);
 		return -1;
 	}
 
@@ -1850,7 +1850,7 @@ int odp_pktio_stats(odp_pktio_t pktio,
 
 	entry = get_pktio_entry(pktio);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", pktio);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)pktio);
 		return -1;
 	}
 
@@ -1880,7 +1880,7 @@ int odp_pktio_stats_reset(odp_pktio_t pktio)
 
 	entry = get_pktio_entry(pktio);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", pktio);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)pktio);
 		return -1;
 	}
 
@@ -1920,7 +1920,7 @@ int odp_pktin_queue_config(odp_pktio_t pktio,
 
 	entry = get_pktio_entry(pktio);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", pktio);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)pktio);
 		return -1;
 	}
 
@@ -2083,7 +2083,7 @@ int odp_pktout_queue_config(odp_pktio_t pktio,
 
 	entry = get_pktio_entry(pktio);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", pktio);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)pktio);
 		return -1;
 	}
 
@@ -2189,7 +2189,7 @@ int odp_pktin_event_queue(odp_pktio_t pktio, odp_queue_t queues[], int num)
 
 	entry = get_pktio_entry(pktio);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", pktio);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)pktio);
 		return -1;
 	}
 
@@ -2229,7 +2229,7 @@ int odp_pktin_queue(odp_pktio_t pktio, odp_pktin_queue_t queues[], int num)
 
 	entry = get_pktio_entry(pktio);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", pktio);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)pktio);
 		return -1;
 	}
 
@@ -2268,7 +2268,7 @@ int odp_pktout_event_queue(odp_pktio_t pktio, odp_queue_t queues[], int num)
 
 	entry = get_pktio_entry(pktio);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", pktio);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)pktio);
 		return -1;
 	}
 
@@ -2299,7 +2299,7 @@ int odp_pktout_queue(odp_pktio_t pktio, odp_pktout_queue_t queues[], int num)
 
 	entry = get_pktio_entry(pktio);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", pktio);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)pktio);
 		return -1;
 	}
 
@@ -2336,7 +2336,7 @@ int odp_pktin_recv(odp_pktin_queue_t queue, odp_packet_t packets[], int num)
 
 	entry = get_pktio_entry(pktio);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", pktio);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)pktio);
 		return -1;
 	}
 
@@ -2365,7 +2365,7 @@ int odp_pktin_recv_tmo(odp_pktin_queue_t queue, odp_packet_t packets[], int num,
 
 	entry = get_pktio_entry(queue.pktio);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", queue.pktio);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)queue.pktio);
 		return -1;
 	}
 
@@ -2520,7 +2520,7 @@ int odp_pktout_send(odp_pktout_queue_t queue, const odp_packet_t packets[],
 
 	entry = get_pktio_entry(pktio);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", pktio);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)pktio);
 		return -1;
 	}
 
@@ -2546,7 +2546,7 @@ int odp_pktout_ts_read(odp_pktio_t hdl, odp_time_t *ts)
 
 	entry = get_pktio_entry(hdl);
 	if (odp_unlikely(entry == NULL)) {
-		ODP_ERR("pktio entry %d does not exist\n", hdl);
+		ODP_ERR("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)hdl);
 		return -1;
 	}
 

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -180,7 +180,7 @@ static int queue_init_global(void)
 	queue_capa(&capa, 0);
 
 	ODP_DBG("... done.\n");
-	ODP_DBG("  queue_entry_t size %u\n", sizeof(queue_entry_t));
+	ODP_DBG("  queue_entry_t size %zu\n", sizeof(queue_entry_t));
 	ODP_DBG("  max num queues     %u\n", capa.max_queues);
 	ODP_DBG("  max queue size     %u\n", capa.plain.max_size);
 	ODP_DBG("  max num lockfree   %u\n", capa.plain.lockfree.max_num);
@@ -740,7 +740,7 @@ static void queue_print(odp_queue_t handle)
 		if (!odp_pktio_info(queue->s.pktout.pktio, &pktio_info))
 			ODP_PRINT("  pktout          %s\n", pktio_info.name);
 	}
-	ODP_PRINT("  timers          %" PRIu32 "\n",
+	ODP_PRINT("  timers          %" PRIu64 "\n",
 		  odp_atomic_load_u64(&queue->s.num_timers));
 	ODP_PRINT("  status          %s\n",
 		  queue->s.status == QUEUE_STATUS_READY ? "ready" :

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -1000,7 +1000,7 @@ static void queue_print(odp_queue_t handle)
 		if (!odp_pktio_info(queue->s.pktout.pktio, &pktio_info))
 			ODP_PRINT("  pktout          %s\n", pktio_info.name);
 	}
-	ODP_PRINT("  timers          %" PRIu32 "\n",
+	ODP_PRINT("  timers          %" PRIu64 "\n",
 		  odp_atomic_load_u64(&queue->s.num_timers));
 	ODP_PRINT("  param.size      %" PRIu32 "\n", queue->s.param.size);
 	ODP_PRINT("\n");

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -91,7 +91,7 @@ static uint64_t default_huge_page_size(void)
 
 	while (fgets(str, sizeof(str), file) != NULL) {
 		if (sscanf(str, "Hugepagesize:   %8lu kB", &sz) == 1) {
-			ODP_DBG("defaut hp size is %" PRIu64 " kB\n", sz);
+			ODP_DBG("defaut hp size is %lu kB\n", sz);
 			fclose(file);
 			return (uint64_t)sz * 1024;
 		}

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -244,7 +244,7 @@ static inline timer_pool_t *handle_to_tp(odp_timer_t hdl)
 		if (odp_likely(tp != NULL))
 			return timer_global->timer_pool[tp_idx];
 	}
-	ODP_ABORT("Invalid timer handle %#x\n", hdl);
+	ODP_ABORT("Invalid timer handle %p\n", hdl);
 }
 
 static inline uint32_t handle_to_idx(odp_timer_t hdl,
@@ -255,7 +255,7 @@ static inline uint32_t handle_to_idx(odp_timer_t hdl,
 	__builtin_prefetch(&tp->tick_buf[idx], 0, 0);
 	if (odp_likely(idx < odp_atomic_load_u32(&tp->high_wm)))
 		return idx;
-	ODP_ABORT("Invalid timer handle %#x\n", hdl);
+	ODP_ABORT("Invalid timer handle %p\n", hdl);
 }
 
 static inline odp_timer_t tp_idx_to_handle(timer_pool_t *tp,

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -4685,10 +4685,10 @@ void odp_tm_stats_print(odp_tm_t odp_tm)
 
 	ODP_PRINT("odp_tm_stats_print - tm_system=0x%" PRIX64 " tm_idx=%u\n",
 		  odp_tm, tm_system->tm_idx);
-	ODP_PRINT("  input_work_queue size=%u current cnt=%u peak cnt=%u\n",
-		  INPUT_WORK_RING_SIZE, input_work_queue->queue_cnt,
+	ODP_PRINT("  input_work_queue size=%u current cnt=%" PRIu64 " peak cnt=%" PRIu32 "\n",
+		  INPUT_WORK_RING_SIZE, odp_atomic_load_u64(&input_work_queue->queue_cnt),
 		  input_work_queue->peak_cnt);
-	ODP_PRINT("  input_work_queue enqueues=%" PRIu64 " dequeues=% " PRIu64
+	ODP_PRINT("  input_work_queue enqueues=%" PRIu64 " dequeues=%" PRIu64
 		  " fail_cnt=%" PRIu64 "\n", input_work_queue->total_enqueues,
 		  input_work_queue->total_dequeues,
 		  input_work_queue->enqueue_fail_cnt);

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -1286,7 +1286,7 @@ static int dpdk_pktio_init(void)
 	masklen = odp_cpumask_to_str(&mask, mask_str, ODP_CPUMASK_STR_SIZE);
 
 	if (masklen < 0) {
-		ODP_ERR("CPU mask error: d\n", masklen);
+		ODP_ERR("CPU mask error: %" PRId32 "\n", masklen);
 		return -1;
 	}
 

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -322,7 +322,7 @@ static int _ipc_init_master(pktio_entry_t *pktio_entry,
 	pinfo = pktio_ipc->pinfo;
 	pool_name = _ipc_odp_buffer_pool_shm_name(pool_hdl);
 	if (strlen(pool_name) > ODP_POOL_NAME_LEN) {
-		ODP_ERR("pid %d ipc pool name %s is too big %d\n",
+		ODP_ERR("pid %d ipc pool name %s is too big %zu\n",
 			getpid(), pool_name, strlen(pool_name));
 		goto free_s_prod;
 	}
@@ -742,7 +742,7 @@ static int ipc_pktio_recv_lockless(pktio_entry_t *pktio_entry,
 	ring_ptr_enq_multi(r_p, ring_mask, ipcbufs_p, pkts);
 
 	for (i = 0; i < pkts; i++) {
-		IPC_ODP_DBG("%d/%d send to be free packet offset %x\n",
+		IPC_ODP_DBG("%d/%d send to be free packet offset %" PRIuPTR "\n",
 			    i, pkts, offsets[i]);
 	}
 
@@ -820,7 +820,7 @@ static int ipc_pktio_send_lockless(pktio_entry_t *pktio_entry,
 
 		/* compile all function code even if ipc disabled with config */
 		IPC_ODP_DBG("%d/%d send packet %" PRIu64 ", pool %" PRIu64 ","
-			    "phdr = %p, offset %x, sendoff %x, addr %p iaddr "
+			    "phdr = %p, offset %td, sendoff %" PRIxPTR ", addr %p iaddr "
 			    "%p\n", i, num,
 			    odp_packet_to_u64(pkt), odp_pool_to_u64(pool_hdl),
 			    pkt_hdr, (uint8_t *)pkt_hdr->seg_data -

--- a/platform/linux-generic/pktio/pktio_common.c
+++ b/platform/linux-generic/pktio/pktio_common.c
@@ -7,6 +7,7 @@
 
 #include <odp_packet_io_internal.h>
 #include <errno.h>
+#include <inttypes.h>
 
 static int sock_recv_mq_tmo_select(pktio_entry_t * const *entry,
 				   const int index[],
@@ -71,8 +72,8 @@ int _odp_sock_recv_mq_tmo_try_int_driven(const struct odp_pktin_queue_t queues[]
 		entry[i] = get_pktio_entry(queues[i].pktio);
 		index[i] = queues[i].index;
 		if (entry[i] == NULL) {
-			ODP_DBG("pktio entry %d does not exist\n",
-				queues[i].pktio);
+			ODP_DBG("pktio entry %" PRIuPTR " does not exist\n",
+				(uintptr_t)queues[i].pktio);
 			*trial_successful = 0;
 			return -1;
 		}


### PR DESCRIPTION
```
linux-gen: fix print formats
    
    Fix mismatches between print formats and parameters in ODP_PRINT(),
    ODP_DBG(), etc. calls.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

linux-gen: debug: check print formats and parameters
    
    Format strings and parameters in ODP_LOG(), ODP_PRINT(), etc. calls
    have not been cross-checked during compilation for some time due to
    commit b776ca47c0d8 ("linux-generic: debug: use global fn ptr for
    logging fn"). Enable this checking.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
