### PR TITLE
[PATCH v3] linux-gen: shm: fix unlink in _odp_ishm_cleanup_files()

### DIFF
--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -1645,7 +1645,7 @@ int _odp_ishm_cleanup_files(const char *dirpath)
 				return -1;
 			}
 			snprintf(fullpath, PATH_MAX, "%s/%s",
-				 dirpath, e->d_name);
+				 userdir, e->d_name);
 			ODP_DBG("deleting obsolete file: %s\n", fullpath);
 			if (unlink(fullpath))
 				ODP_ERR("unlink failed for %s: %s\n",

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -1621,11 +1621,12 @@ int _odp_ishm_cleanup_files(const char *dirpath)
 	char userdir[PATH_MAX];
 	char prefix[PATH_MAX];
 	char *fullpath;
-	int d_len = strlen(dirpath);
+	int d_len;
 	int p_len;
 	int f_len;
 
 	snprintf(userdir, PATH_MAX, "%s/%s", dirpath, odp_global_ro.uid);
+	d_len = strlen(userdir);
 
 	dir = opendir(userdir);
 	if (!dir) {


### PR DESCRIPTION
In _odp_ishm_cleanup_files(), when previous shm files still remain, unlink failed
due to wrong path given. Use correct path, which includes the instance uid.

Signed-off-by: Christian Hong <hongguochun@hotmail.com>