### PR TITLE
[PATCH v2] example: ipfragreass: fix packet length adjustment during reassembly

### DIFF
--- a/example/ipfragreass/odp_ipfragreass_reassemble.c
+++ b/example/ipfragreass/odp_ipfragreass_reassemble.c
@@ -303,11 +303,17 @@ static int send_packet(struct packet *tail, odp_queue_t out)
 	 */
 	while (current && equal_flow(current, &result)) {
 		struct packet new_result = *current;
-		int concat_success;
+		int concat_success, trunc_success;
 
 		current = prev_packet(new_result);
 		header = odp_packet_data(result.handle);
-		odp_packet_pull_head(result.handle, ipv4hdr_ihl(*header));
+		trunc_success = odp_packet_trunc_head(&result.handle, ipv4hdr_ihl(*header),
+						      NULL, NULL);
+		if (trunc_success < 0) {
+			fprintf(stderr, "ERROR: odp_packet_trunc_head\n");
+			return -1;
+		}
+
 		concat_success = odp_packet_concat(&new_result.handle,
 						   result.handle);
 		if (concat_success < 0) {


### PR DESCRIPTION
At the time of fragmentation, packet length is increased using
odp_packet_extend_head() to make room for header in the fragments.

So during re-assembly, odp_packet_trunc_head() needs to be used
instead of odp_packet_pull_head() to strip off the header to
handle possible packet segmentation that may happen inside
odp_packet_extend_head().

Signed-off-by: Ashwin Sekhar T K <asekhar@marvell.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>
