### PR TITLE
[PATCH v2] validation: scheduler: add check for max_flow_id default value

### DIFF
--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -145,10 +145,13 @@ static void scheduler_test_init(void)
 
 	odp_schedule_config_init(&default_config);
 
+	CU_ASSERT(default_config.max_flow_id == 0);
+
 	CU_ASSERT(default_config.sched_group.all);
 	CU_ASSERT(default_config.sched_group.control);
 	CU_ASSERT(default_config.sched_group.worker);
 }
+
 static void scheduler_test_capa(void)
 {
 	odp_schedule_capability_t sched_capa;


### PR DESCRIPTION
The default value for odp_schedule_config_t.max_flow_id should be zero.

Signed-off-by: Matias Elo <matias.elo@nokia.com>