### PR TITLE
[PATCH v2] github_ci: abi compatibility is disabled by default

### DIFF
--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -19,12 +19,13 @@ jobs:
       fail-fast: false
       matrix:
         cc: [gcc, clang]
-        conf: ['', 'CFLAGS=-O3', 'CFLAGS=-O1', 'CFLAGS=-O0 --enable-debug=full', '--enable-lto', '--enable-lto --disable-abi-compat', '--enable-pcapng-support']
+        conf: ['', 'CFLAGS=-O3', 'CFLAGS=-O1', 'CFLAGS=-O0 --enable-debug=full', '--enable-lto',
+               '--enable-lto --enable-abi-compat', '--enable-pcapng-support']
         exclude:
           - cc: clang
             conf: '--enable-lto'
           - cc: clang
-            conf: '--enable-lto --disable-abi-compat'
+            conf: '--enable-lto --enable-abi-compat'
     steps:
       - uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v2
@@ -86,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        conf: ['--enable-user-guides', '--enable-user-guides --disable-abi-compat']
+        conf: ['--enable-user-guides', '--enable-user-guides --enable-abi-compat']
     steps:
       - uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v2
@@ -104,7 +105,10 @@ jobs:
       fail-fast: false
       matrix:
         cc: [gcc, clang]
-        conf: ['', '--disable-abi-compat', '--enable-deprecated --enable-debug=full', '--enable-dpdk-zero-copy --disable-static-applications', '--disable-host-optimization', '--disable-host-optimization --disable-abi-compat', '--without-openssl --without-pcap']
+        conf: ['', '--enable-abi-compat', '--enable-deprecated --enable-debug=full',
+               '--enable-dpdk-zero-copy --disable-static-applications',
+               '--disable-host-optimization', '--disable-host-optimization --enable-abi-compat',
+               '--without-openssl --without-pcap']
     steps:
       - uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v2


### PR DESCRIPTION
ABI compatibility default value has been changed to disabled, so modify the
arm64 test cases accordingly. Most of the test cases are now run with ABI
compatibility disabled, as this is more common with real word applications.

Signed-off-by: Matias Elo <matias.elo@nokia.com>