### PR TITLE
[PATCH v5] Ipsec example padding fix

### DIFF
--- a/example/ipsec_api/Makefile.am
+++ b/example/ipsec_api/Makefile.am
@@ -8,7 +8,9 @@ TESTS = \
 	odp_ipsec_api_run_ah_out.sh \
 	odp_ipsec_api_run_ah_tun_in.sh \
 	odp_ipsec_api_run_ah_tun_out.sh \
+	odp_ipsec_api_run_esp_in.sh \
 	odp_ipsec_api_run_esp_out.sh \
+	odp_ipsec_api_run_esp_tun_in.sh \
 	odp_ipsec_api_run_esp_tun_out.sh \
 	odp_ipsec_api_run_simple.sh
 endif

--- a/example/ipsec_api/odp_ipsec.c
+++ b/example/ipsec_api/odp_ipsec.c
@@ -640,11 +640,20 @@ pkt_disposition_e do_ipsec_in_classify(odp_packet_t *ppkt)
 		return PKT_POSTED;
 	} else {
 		int out = 1;
+		odp_ipsec_packet_result_t result;
 
 		rc = odp_ipsec_in(ppkt, 1, ppkt, &out, &in_param);
 		if (rc <= 0)
 			return PKT_DROP;
 
+		if (odp_ipsec_result(&result, *ppkt) < 0) {
+			ODPH_DBG("odp_ipsec_result() failed\n");
+			return PKT_DROP;
+		}
+		if (result.status.error.all != 0) {
+			ODPH_DBG("Error in inbound IPsec processing\n");
+			return PKT_DROP;
+		}
 		return PKT_CONTINUE;
 	}
 }
@@ -704,11 +713,20 @@ pkt_disposition_e do_ipsec_out_classify(odp_packet_t *ppkt, pkt_ctx_t *ctx)
 		return PKT_POSTED;
 	} else {
 		int out = 1;
+		odp_ipsec_packet_result_t result;
 
 		rc = odp_ipsec_out(ppkt, 1, ppkt, &out, &out_param);
 		if (rc <= 0)
 			return PKT_DROP;
 
+		if (odp_ipsec_result(&result, *ppkt) < 0) {
+			ODPH_DBG("odp_ipsec_result() failed\n");
+			return PKT_DROP;
+		}
+		if (result.status.error.all != 0) {
+			ODPH_DBG("Error in outbound IPsec processing\n");
+			return PKT_DROP;
+		}
 		return PKT_CONTINUE;
 	}
 }

--- a/example/ipsec_crypto/odp_ipsec_stream.c
+++ b/example/ipsec_crypto/odp_ipsec_stream.c
@@ -322,8 +322,8 @@ odp_packet_t create_ipv4_packet(stream_db_entry_t *stream,
 
 		encrypt_len = ESP_ENCODE_LEN(payload_len + sizeof(*esp_t),
 					     entry->esp.block_len);
-		memset(data, 0, encrypt_len - payload_len);
-		data += encrypt_len - payload_len;
+		for (int n = 0; n < encrypt_len - payload_len; n++)
+			*data++ = n + 1;
 
 		esp_t = (odph_esptrl_t *)(data) - 1;
 		esp_t->pad_len = encrypt_len - payload_len - sizeof(*esp_t);

--- a/example/ipsec_crypto/odp_ipsec_stream.c
+++ b/example/ipsec_crypto/odp_ipsec_stream.c
@@ -272,6 +272,10 @@ odp_packet_t create_ipv4_packet(stream_db_entry_t *stream,
 		inner_ip = (odph_ipv4hdr_t *)data;
 		memset((char *)inner_ip, 0, sizeof(*inner_ip));
 		inner_ip->ver_ihl = 0x45;
+		inner_ip->tot_len = odp_cpu_to_be_16(sizeof(odph_ipv4hdr_t) +
+						     sizeof(odph_icmphdr_t) +
+						     sizeof(stream_pkt_hdr_t) +
+						     stream->length);
 		inner_ip->proto = ODPH_IPPROTO_ICMPV4;
 		inner_ip->id = odp_cpu_to_be_16(stream->id);
 		inner_ip->ttl = 64;


### PR DESCRIPTION
    example: ipsec: fix content of ESP padding bytes

    Fix ESP padding so that it is filled with an increasing counter value
    as specified by the ESP RFC. Incorrect (zeroed) padding caused the ESP
    packets to be rejected by the IPsec offload of the linux-gen ODP.

    Fixes: https://github.com/OpenDataPlane/odp/issues/1167