### PR TITLE
[PATCH v3] validation: pktin event queue

### DIFF
--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -135,23 +135,29 @@ jobs:
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
 
-
-  Run_scheduler:
+  Run_scheduler_sp:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
     runs-on: [self-hosted, ARM64]
-    strategy:
-      fail-fast: false
-      matrix:
-        scheduler: ['sp', 'scalable']
     steps:
       - uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v2
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
-               -e CONF="${CONF}" -e ODP_SCHEDULER=${{matrix.scheduler}} $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
+               -e CONF="${CONF}" -e ODP_SCHEDULER=sp $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
       - name: Failure log
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
 
+  Run_scheduler_scalable:
+    if: ${{ github.repository == 'OpenDataPlane/odp' }}
+    runs-on: [self-hosted, ARM64]
+    steps:
+      - uses: AutoModality/action-clean@v1.1.0
+      - uses: actions/checkout@v2
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
+               -e CONF="${CONF}" -e ODP_SCHEDULER=scalable -e CI_SKIP=pktio_test_pktin_event_sched $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
+      - name: Failure log
+        if: ${{ failure() }}
+        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
 
   Run_inline_timer:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -262,16 +262,22 @@ jobs:
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
 
-  Run_scheduler:
+  Run_scheduler_sp:
     runs-on: ubuntu-18.04
-    strategy:
-      fail-fast: false
-      matrix:
-        scheduler: ['sp', 'scalable']
     steps:
       - uses: actions/checkout@v2
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
-               -e CONF="${CONF}" -e ODP_SCHEDULER=${{matrix.scheduler}} $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/check.sh
+               -e CONF="${CONF}" -e ODP_SCHEDULER=sp $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/check.sh
+      - name: Failure log
+        if: ${{ failure() }}
+        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+
+  Run_scheduler_scalable:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
+               -e CONF="${CONF}" -e ODP_SCHEDULER=scalable -e CI_SKIP=pktio_test_pktin_event_sched $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/check.sh
       - name: Failure log
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -25,7 +25,7 @@ ODP_SCHEDULER=basic    make check
 
 # Run only validation tests for scalable and sp schedulers
 pushd ./test/validation/api/
-ODP_SCHEDULER=scalable make check
+ODP_SCHEDULER=scalable CI_SKIP=pktio_test_pktin_event_sched make check
 ODP_SCHEDULER=sp       make check
 popd
 

--- a/test/common/odp_cunit_common.c
+++ b/test/common/odp_cunit_common.c
@@ -555,3 +555,17 @@ int odp_cunit_ret(int val)
 {
 	return allow_skip_result ? 0 : val;
 }
+
+int odp_cunit_ci_skip(const char *test_name)
+{
+	const char *ci_skip;
+	const char *found;
+
+	ci_skip = getenv("CI_SKIP");
+	if (ci_skip == NULL)
+		return 0;
+
+	found = strstr(ci_skip, test_name);
+
+	return found != NULL;
+}

--- a/test/common/odp_cunit_common.h
+++ b/test/common/odp_cunit_common.h
@@ -107,6 +107,9 @@ int odp_cunit_ret(int val);
 int odp_cunit_print_inactive(void);
 int odp_cunit_set_inactive(void);
 
+/* Check from CI_SKIP environment variable if the test case should be skipped by CI */
+int odp_cunit_ci_skip(const char *test_name);
+
 /*
  * Wrapper for CU_ASSERT_FATAL implementation to show the compiler that
  * the function does not return if the assertion fails. This reduces bogus


### PR DESCRIPTION
Add test where (in addition to packet input) application sends events into pktin event queue. Scalable scheduler needs bug fixes (or further development) to support this. CI is disabled to run checks on scalable until it is fixed. 