### PR TITLE
[PATCH v10] api: pktio: add statistics capabilities and new counters

### DIFF
--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -908,6 +908,9 @@ typedef struct odp_pktio_capability_t {
 	/** Packet input reassembly capability */
 	odp_reass_capability_t reassembly;
 
+	/** Statistics counters capabilities */
+	odp_pktio_stats_capability_t stats;
+
 } odp_pktio_capability_t;
 
 /**

--- a/include/odp/api/spec/packet_io_stats.h
+++ b/include/odp/api/spec/packet_io_stats.h
@@ -87,6 +87,57 @@ typedef struct odp_pktio_stats_t {
 } odp_pktio_stats_t;
 
 /**
+ * Packet IO statistics capabilities
+ */
+typedef struct odp_pktio_stats_capability_t {
+	/** Interface level capabilities */
+	struct {
+		/** Supported counters */
+		union {
+			/** Statistics counters in a bit field structure */
+			struct {
+				/** @see odp_pktio_stats_t::in_octets */
+				uint64_t in_octets          : 1;
+
+				/** @see odp_pktio_stats_t::in_packets */
+				uint64_t in_packets         : 1;
+
+				/** @see odp_pktio_stats_t::in_ucast_pkts */
+				uint64_t in_ucast_pkts      : 1;
+
+				/** @see odp_pktio_stats_t::in_discards */
+				uint64_t in_discards        : 1;
+
+				/** @see odp_pktio_stats_t::in_errors */
+				uint64_t in_errors          : 1;
+
+				/** @see odp_pktio_stats_t::out_octets */
+				uint64_t out_octets         : 1;
+
+				/** @see odp_pktio_stats_t::out_packets */
+				uint64_t out_packets        : 1;
+
+				/** @see odp_pktio_stats_t::out_ucast_pkts */
+				uint64_t out_ucast_pkts     : 1;
+
+				/** @see odp_pktio_stats_t::out_discards */
+				uint64_t out_discards       : 1;
+
+				/** @see odp_pktio_stats_t::out_errors */
+				uint64_t out_errors         : 1;
+			} counter;
+
+			/** All bits of the bit field structure
+			 *
+			 *  This field can be used to set/clear all flags, or
+			 *  for bitwise operations over the entire structure. */
+			uint64_t all_counters;
+		};
+	} pktio;
+
+} odp_pktio_stats_capability_t;
+
+/**
  * Get statistics for pktio handle
  *
  * Counters not supported by the interface are set to zero.

--- a/include/odp/api/spec/packet_io_stats.h
+++ b/include/odp/api/spec/packet_io_stats.h
@@ -35,7 +35,7 @@ extern "C" {
  */
 typedef struct odp_pktio_stats_t {
 	/** Number of octets in successfully received packets. In case of
-	 *  Ethernet, packet size includes MAC header and FCS. */
+	 *  Ethernet, packet size includes MAC header. */
 	uint64_t in_octets;
 
 	/** Number of successfully received packets. */
@@ -68,7 +68,7 @@ typedef struct odp_pktio_stats_t {
 	uint64_t ODP_DEPRECATE(in_unknown_protos);
 
 	/** Number of octets in successfully transmitted packets. In case of
-	 *  Ethernet, packet size includes MAC header and FCS. */
+	 *  Ethernet, packet size includes MAC header. */
 	uint64_t out_octets;
 
 	/** Number of successfully transmitted packets. */

--- a/include/odp/api/spec/packet_io_stats.h
+++ b/include/odp/api/spec/packet_io_stats.h
@@ -20,6 +20,7 @@ extern "C" {
 #endif
 
 #include <odp/api/deprecated.h>
+#include <odp/api/queue.h>
 
 /** @addtogroup odp_packet_io
  *  @{
@@ -103,6 +104,48 @@ typedef struct odp_pktio_stats_t {
 } odp_pktio_stats_t;
 
 /**
+ * Packet IO input queue specific statistics counters
+ *
+ * Statistics counters for an individual packet input queue. Refer to packet IO
+ * level statistics odp_pktio_stats_t for counter definitions.
+ */
+typedef struct odp_pktin_queue_stats_t {
+	/** @see odp_pktio_stats_t::in_octets */
+	uint64_t octets;
+
+	/** @see odp_pktio_stats_t::in_packets */
+	uint64_t packets;
+
+	/** @see odp_pktio_stats_t::in_discards */
+	uint64_t discards;
+
+	/** @see odp_pktio_stats_t::in_errors */
+	uint64_t errors;
+
+} odp_pktin_queue_stats_t;
+
+/**
+ * Packet IO output queue specific statistics counters
+ *
+ * Statistics counters for an individual packet output queue. Refer to packet IO
+ * level statistics odp_pktio_stats_t for counter definitions.
+ */
+typedef struct odp_pktout_queue_stats_t {
+	/** @see odp_pktio_stats_t::out_octets */
+	uint64_t octets;
+
+	/** @see odp_pktio_stats_t::out_packets */
+	uint64_t packets;
+
+	/** @see odp_pktio_stats_t::out_discards */
+	uint64_t discards;
+
+	/** @see odp_pktio_stats_t::out_errors */
+	uint64_t errors;
+
+} odp_pktout_queue_stats_t;
+
+/**
  * Packet IO statistics capabilities
  */
 typedef struct odp_pktio_stats_capability_t {
@@ -163,6 +206,60 @@ typedef struct odp_pktio_stats_capability_t {
 		};
 	} pktio;
 
+	/** Input queue level capabilities */
+	struct {
+		/** Supported counters */
+		union {
+			/** Statistics counters in a bit field structure */
+			struct {
+				/** @see odp_pktin_queue_stats_t::octets */
+				uint64_t octets             : 1;
+
+				/** @see odp_pktin_queue_stats_t::packets */
+				uint64_t packets            : 1;
+
+				/** @see odp_pktin_queue_stats_t::discards */
+				uint64_t discards           : 1;
+
+				/** @see odp_pktin_queue_stats_t::errors */
+				uint64_t errors             : 1;
+			} counter;
+
+			/** All bits of the bit field structure
+			 *
+			 *  This field can be used to set/clear all flags, or
+			 *  for bitwise operations over the entire structure. */
+			uint64_t all_counters;
+		};
+	} pktin_queue;
+
+	/** Output queue level capabilities */
+	struct {
+		/** Supported counters */
+		union {
+			/** Statistics counters in a bit field structure */
+			struct {
+				/** @see odp_pktout_queue_stats_t::octets */
+				uint64_t octets             : 1;
+
+				/** @see odp_pktout_queue_stats_t::packets */
+				uint64_t packets            : 1;
+
+				/** @see odp_pktout_queue_stats_t::discards */
+				uint64_t discards           : 1;
+
+				/** @see odp_pktout_queue_stats_t::errors */
+				uint64_t errors             : 1;
+			} counter;
+
+			/** All bits of the bit field structure
+			 *
+			 *  This field can be used to set/clear all flags, or
+			 *  for bitwise operations over the entire structure. */
+			uint64_t all_counters;
+		};
+	} pktout_queue;
+
 } odp_pktio_stats_capability_t;
 
 /**
@@ -179,9 +276,75 @@ typedef struct odp_pktio_stats_capability_t {
 int odp_pktio_stats(odp_pktio_t pktio, odp_pktio_stats_t *stats);
 
 /**
+ * Get statistics for direct packet input queue
+ *
+ * Packet input queue handles can be requested with odp_pktin_queue(). Counters
+ * not supported by the interface are set to zero.
+ *
+ * @param       queue	 Packet input queue handle
+ * @param[out]  stats	 Output buffer for counters
+ *
+ * @retval  0 on success
+ * @retval <0 on failure
+ */
+int odp_pktin_queue_stats(odp_pktin_queue_t queue,
+			  odp_pktin_queue_stats_t *stats);
+
+/**
+ * Get statistics for packet input event queue
+ *
+ * The queue must be a packet input event queue. Event queue handles can be
+ * requested with odp_pktin_event_queue(). Counters not supported by the
+ * interface are set to zero.
+ *
+ * @param       pktio	 Packet IO handle
+ * @param       queue	 Packet input event queue handle
+ * @param[out]  stats	 Output buffer for counters
+ *
+ * @retval  0 on success
+ * @retval <0 on failure
+ */
+int odp_pktin_event_queue_stats(odp_pktio_t pktio, odp_queue_t queue,
+				odp_pktin_queue_stats_t *stats);
+
+/**
+ * Get statistics for direct packet output queue
+ *
+ * Packet output queue handles can be requested with odp_pktout_queue().
+ * Counters not supported by the interface are set to zero.
+ *
+ * @param       queue	 Packet output queue handle
+ * @param[out]  stats	 Output buffer for counters
+ *
+ * @retval  0 on success
+ * @retval <0 on failure
+ */
+int odp_pktout_queue_stats(odp_pktout_queue_t queue,
+			   odp_pktout_queue_stats_t *stats);
+
+/**
+ * Get statistics for packet output event queue
+ *
+ * The queue must be a packet output event queue. Event queue handles can be
+ * requested with odp_pktout_event_queue(). Counters not supported by the
+ * interface are set to zero.
+ *
+ * @param       pktio	 Packet IO handle
+ * @param       queue	 Packet output event queue handle
+ * @param[out]  stats	 Output buffer for counters
+ *
+ * @retval  0 on success
+ * @retval <0 on failure
+ */
+int odp_pktout_event_queue_stats(odp_pktio_t pktio, odp_queue_t queue,
+				 odp_pktout_queue_stats_t *stats);
+
+/**
  * Reset statistics for pktio handle
  *
- * Reset all statistics counters to zero.
+ * Reset all interface level statistics counters (odp_pktio_stats_t) to zero.
+ * It's implementation defined if other packet IO related statistics are
+ * affected.
  *
  * @param       pktio	 Packet IO handle
  *

--- a/include/odp/api/spec/packet_io_stats.h
+++ b/include/odp/api/spec/packet_io_stats.h
@@ -45,6 +45,14 @@ typedef struct odp_pktio_stats_t {
 	 *  destination MAC address. */
 	uint64_t in_ucast_pkts;
 
+	/** Number of successfully received Ethernet packets with a multicast
+	 *  destination MAC address. */
+	uint64_t in_mcast_pkts;
+
+	/** Number of successfully received Ethernet packets with a broadcast
+	 *  destination MAC address. */
+	uint64_t in_bcast_pkts;
+
 	/** Number of inbound packets which were discarded due to a lack of free
 	 *  resources (e.g. buffers) or other reasons than packet errors. */
 	uint64_t in_discards;
@@ -78,6 +86,14 @@ typedef struct odp_pktio_stats_t {
 	 *  destination MAC address. */
 	uint64_t out_ucast_pkts;
 
+	/** Number of successfully transmitted Ethernet packets with a multicast
+	 *  destination MAC address. */
+	uint64_t out_mcast_pkts;
+
+	/** Number of successfully transmitted Ethernet packets with a broadcast
+	 *  destination MAC address. */
+	uint64_t out_bcast_pkts;
+
 	/** Number of outbound packets which were discarded due to a lack of
 	 *  free resources (e.g. buffers) or other reasons than errors. */
 	uint64_t out_discards;
@@ -105,6 +121,12 @@ typedef struct odp_pktio_stats_capability_t {
 				/** @see odp_pktio_stats_t::in_ucast_pkts */
 				uint64_t in_ucast_pkts      : 1;
 
+				/** @see odp_pktio_stats_t::in_mcast_pkts */
+				uint64_t in_mcast_pkts      : 1;
+
+				/** @see odp_pktio_stats_t::in_bcast_pkts */
+				uint64_t in_bcast_pkts      : 1;
+
 				/** @see odp_pktio_stats_t::in_discards */
 				uint64_t in_discards        : 1;
 
@@ -119,6 +141,12 @@ typedef struct odp_pktio_stats_capability_t {
 
 				/** @see odp_pktio_stats_t::out_ucast_pkts */
 				uint64_t out_ucast_pkts     : 1;
+
+				/** @see odp_pktio_stats_t::out_mcast_pkts */
+				uint64_t out_mcast_pkts     : 1;
+
+				/** @see odp_pktio_stats_t::out_bcast_pkts */
+				uint64_t out_bcast_pkts     : 1;
 
 				/** @see odp_pktio_stats_t::out_discards */
 				uint64_t out_discards       : 1;

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2020, Nokia
+ * Copyright (c) 2019-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -196,6 +196,10 @@ typedef struct pktio_if_ops {
 	int (*stop)(pktio_entry_t *pktio_entry);
 	int (*stats)(pktio_entry_t *pktio_entry, odp_pktio_stats_t *stats);
 	int (*stats_reset)(pktio_entry_t *pktio_entry);
+	int (*pktin_queue_stats)(pktio_entry_t *pktio_entry, uint32_t index,
+				 odp_pktin_queue_stats_t *pktin_stats);
+	int (*pktout_queue_stats)(pktio_entry_t *pktio_entry, uint32_t index,
+				  odp_pktout_queue_stats_t *pktout_stats);
 	uint64_t (*pktio_ts_res)(pktio_entry_t *pktio_entry);
 	odp_time_t (*pktio_ts_from_ns)(pktio_entry_t *pktio_entry, uint64_t ns);
 	odp_time_t (*pktio_time)(pktio_entry_t *pktio_entry, odp_time_t *global_ts);

--- a/platform/linux-generic/include/odp_packet_io_stats.h
+++ b/platform/linux-generic/include/odp_packet_io_stats.h
@@ -22,6 +22,9 @@ int _odp_sock_stats_fd(pktio_entry_t *pktio_entry,
 		       int fd);
 int _odp_sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd);
 
+void _odp_sock_stats_capa(pktio_entry_t *pktio_entry,
+			  odp_pktio_capability_t *capa);
+
 pktio_stats_type_t _odp_sock_stats_type_fd(pktio_entry_t *pktio_entry, int fd);
 
 #ifdef __cplusplus

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -1799,6 +1799,17 @@ static int dpdk_setup_eth_tx(pktio_entry_t *pktio_entry,
 		}
 	}
 
+	/* Set per queue statistics mappings. Not supported by all PMDs, so
+	 * ignore the return value. */
+	for (i = 0; i < pktio_entry->s.num_out_queue && i < RTE_ETHDEV_QUEUE_STAT_CNTRS; i++) {
+		ret = rte_eth_dev_set_tx_queue_stats_mapping(port_id, i, i);
+		if (ret) {
+			ODP_DBG("Mapping per TX queue statistics not supported: %d\n", ret);
+			break;
+		}
+	}
+	ODP_DBG("Mapped %" PRIu32 "/%d TX counters\n", i, RTE_ETHDEV_QUEUE_STAT_CNTRS);
+
 	return 0;
 }
 
@@ -1826,6 +1837,17 @@ static int dpdk_setup_eth_rx(const pktio_entry_t *pktio_entry,
 			return -1;
 		}
 	}
+
+	/* Set per queue statistics mappings. Not supported by all PMDs, so
+	 * ignore the return value. */
+	for (i = 0; i < pktio_entry->s.num_in_queue && i < RTE_ETHDEV_QUEUE_STAT_CNTRS; i++) {
+		ret = rte_eth_dev_set_rx_queue_stats_mapping(port_id, i, i);
+		if (ret) {
+			ODP_DBG("Mapping per RX queue statistics not supported: %d\n", ret);
+			break;
+		}
+	}
+	ODP_DBG("Mapped %" PRIu32 "/%d RX counters\n", i, RTE_ETHDEV_QUEUE_STAT_CNTRS);
 
 	return 0;
 }

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -1613,6 +1613,14 @@ static int dpdk_init_capability(pktio_entry_t *pktio_entry,
 		capa->config.pktout.bit.tcp_chksum;
 	capa->config.pktout.bit.ts_ena = 1;
 
+	capa->stats.pktio.counter.in_octets = 1;
+	capa->stats.pktio.counter.in_packets = 1;
+	capa->stats.pktio.counter.in_discards = 1;
+	capa->stats.pktio.counter.in_errors = 1;
+	capa->stats.pktio.counter.out_octets = 1;
+	capa->stats.pktio.counter.out_packets = 1;
+	capa->stats.pktio.counter.out_errors = 1;
+
 	return 0;
 }
 

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -463,7 +463,11 @@ static int loopback_init_capability(pktio_entry_t *pktio_entry)
 	capa->stats.pktio.counter.in_errors = 1;
 	capa->stats.pktio.counter.out_octets = 1;
 	capa->stats.pktio.counter.out_packets = 1;
-
+	capa->stats.pktin_queue.counter.octets = 1;
+	capa->stats.pktin_queue.counter.packets = 1;
+	capa->stats.pktin_queue.counter.errors = 1;
+	capa->stats.pktout_queue.counter.octets = 1;
+	capa->stats.pktout_queue.counter.packets = 1;
 	return 0;
 }
 
@@ -499,6 +503,27 @@ static int loopback_stats_reset(pktio_entry_t *pktio_entry ODP_UNUSED)
 	return 0;
 }
 
+static int loopback_pktin_stats(pktio_entry_t *pktio_entry,
+				uint32_t index ODP_UNUSED,
+				odp_pktin_queue_stats_t *pktin_stats)
+{
+	memset(pktin_stats, 0, sizeof(odp_pktin_queue_stats_t));
+	pktin_stats->octets = pktio_entry->s.stats.in_octets;
+	pktin_stats->packets = pktio_entry->s.stats.in_packets;
+	pktin_stats->errors = pktio_entry->s.stats.in_errors;
+	return 0;
+}
+
+static int loopback_pktout_stats(pktio_entry_t *pktio_entry,
+				 uint32_t index ODP_UNUSED,
+				 odp_pktout_queue_stats_t *pktout_stats)
+{
+	memset(pktout_stats, 0, sizeof(odp_pktout_queue_stats_t));
+	pktout_stats->octets = pktio_entry->s.stats.out_octets;
+	pktout_stats->packets = pktio_entry->s.stats.out_packets;
+	return 0;
+}
+
 static int loop_init_global(void)
 {
 	ODP_PRINT("PKTIO: initialized loop interface.\n");
@@ -517,6 +542,8 @@ const pktio_if_ops_t _odp_loopback_pktio_ops = {
 	.stop = NULL,
 	.stats = loopback_stats,
 	.stats_reset = loopback_stats_reset,
+	.pktin_queue_stats = loopback_pktin_stats,
+	.pktout_queue_stats = loopback_pktout_stats,
 	.recv = loopback_recv,
 	.send = loopback_send,
 	.maxlen_get = loopback_mtu_get,

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -458,6 +458,12 @@ static int loopback_init_capability(pktio_entry_t *pktio_entry)
 	capa->config.pktout.bit.sctp_chksum_ena =
 		capa->config.pktout.bit.sctp_chksum;
 
+	capa->stats.pktio.counter.in_octets = 1;
+	capa->stats.pktio.counter.in_packets = 1;
+	capa->stats.pktio.counter.in_errors = 1;
+	capa->stats.pktio.counter.out_octets = 1;
+	capa->stats.pktio.counter.out_packets = 1;
+
 	return 0;
 }
 

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -637,6 +637,7 @@ static int netmap_open(odp_pktio_t id ODP_UNUSED, pktio_entry_t *pktio_entry,
 		pktio_entry->s.stats_type = STATS_UNSUPPORTED;
 	} else {
 		pktio_entry->s.stats_type = STATS_ETHTOOL;
+		_odp_sock_stats_capa(pktio_entry, &pktio_entry->s.capa);
 	}
 
 	(void)netmap_stats_reset(pktio_entry);

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -431,6 +431,11 @@ static int pcapif_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 
 	capa->config.pktout.bit.ts_ena = 1;
 
+	capa->stats.pktio.counter.in_octets = 1;
+	capa->stats.pktio.counter.in_packets = 1;
+	capa->stats.pktio.counter.out_octets = 1;
+	capa->stats.pktio.counter.out_packets = 1;
+
 	return 0;
 }
 

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -526,7 +526,7 @@ static int sock_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *inf
 	return _odp_link_info_fd(pkt_priv(pktio_entry)->sockfd, pktio_entry->s.name, info);
 }
 
-static int sock_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
+static int sock_capability(pktio_entry_t *pktio_entry,
 			   odp_pktio_capability_t *capa)
 {
 	pkt_sock_t *pkt_sock = pkt_priv(pktio_entry);
@@ -549,6 +549,9 @@ static int sock_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 	capa->config.pktin.bit.ts_ptp = 1;
 
 	capa->config.pktout.bit.ts_ena = 1;
+
+	/* Fill statistics capabilities */
+	_odp_sock_stats_capa(pktio_entry, capa);
 
 	return 0;
 }

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -841,7 +841,7 @@ static int sock_mmap_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t
 	return _odp_link_info_fd(pkt_priv(pktio_entry)->sockfd, pktio_entry->s.name, info);
 }
 
-static int sock_mmap_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
+static int sock_mmap_capability(pktio_entry_t *pktio_entry,
 				odp_pktio_capability_t *capa)
 {
 	pkt_sock_mmap_t *const pkt_sock = pkt_priv(pktio_entry);
@@ -864,6 +864,9 @@ static int sock_mmap_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 	capa->config.pktin.bit.ts_ptp = 1;
 
 	capa->config.pktout.bit.ts_ena = 1;
+
+	/* Fill statistics capabilities */
+	_odp_sock_stats_capa(pktio_entry, capa);
 
 	return 0;
 }

--- a/platform/linux-generic/pktio/stats/ethtool_stats.c
+++ b/platform/linux-generic/pktio/stats/ethtool_stats.c
@@ -134,6 +134,14 @@ static int ethtool_stats(int fd, struct ifreq *ifr, odp_pktio_stats_t *stats)
 		} else if (!strcmp(cnt, "rx_ucast_packets")) {
 			stats->in_ucast_pkts = val;
 			cnts++;
+		} else if (!strcmp(cnt, "rx_broadcast") ||
+			   !strcmp(cnt, "rx_bcast_packets")) {
+			stats->in_bcast_pkts = val;
+			cnts++;
+		} else if (!strcmp(cnt, "rx_multicast") ||
+			   !strcmp(cnt, "rx_mcast_packets")) {
+			stats->in_mcast_pkts = val;
+			cnts++;
 		} else if (!strcmp(cnt, "rx_discards")) {
 			stats->in_discards = val;
 			cnts++;
@@ -148,6 +156,14 @@ static int ethtool_stats(int fd, struct ifreq *ifr, odp_pktio_stats_t *stats)
 			cnts++;
 		} else if (!strcmp(cnt, "tx_ucast_packets")) {
 			stats->out_ucast_pkts = val;
+			cnts++;
+		} else if (!strcmp(cnt, "tx_broadcast") ||
+			   !strcmp(cnt, "tx_bcast_packets")) {
+			stats->out_bcast_pkts = val;
+			cnts++;
+		} else if (!strcmp(cnt, "tx_multicast") ||
+			   !strcmp(cnt, "tx_mcast_packets")) {
+			stats->out_mcast_pkts = val;
 			cnts++;
 		} else if (!strcmp(cnt, "tx_discards")) {
 			stats->out_discards = val;
@@ -164,7 +180,7 @@ static int ethtool_stats(int fd, struct ifreq *ifr, odp_pktio_stats_t *stats)
 	/* Ethtool strings came from kernel driver. Name of that
 	 * strings is not universal. Current function needs to be updated
 	 * if your driver has different names for counters */
-	if (cnts < 8)
+	if (cnts < 14)
 		return -1;
 
 	return 0;

--- a/platform/linux-generic/pktio/stats/packet_io_stats.c
+++ b/platform/linux-generic/pktio/stats/packet_io_stats.c
@@ -108,3 +108,40 @@ pktio_stats_type_t _odp_sock_stats_type_fd(pktio_entry_t *pktio_entry, int fd)
 
 	return STATS_UNSUPPORTED;
 }
+
+void _odp_sock_stats_capa(pktio_entry_t *pktio_entry,
+			  odp_pktio_capability_t *capa)
+{
+	capa->stats.pktio.all_counters = 0;
+	capa->stats.pktin_queue.all_counters = 0;
+	capa->stats.pktout_queue.all_counters = 0;
+
+	if (pktio_entry->s.stats_type == STATS_SYSFS) {
+		capa->stats.pktio.counter.in_octets = 1;
+		capa->stats.pktio.counter.in_packets = 1;
+		capa->stats.pktio.counter.in_ucast_pkts = 1;
+		capa->stats.pktio.counter.in_mcast_pkts = 1;
+		capa->stats.pktio.counter.in_discards = 1;
+		capa->stats.pktio.counter.in_errors = 1;
+		capa->stats.pktio.counter.out_octets = 1;
+		capa->stats.pktio.counter.out_packets = 1;
+		capa->stats.pktio.counter.out_ucast_pkts = 1;
+		capa->stats.pktio.counter.out_discards = 1;
+		capa->stats.pktio.counter.out_errors = 1;
+	} else if (pktio_entry->s.stats_type == STATS_ETHTOOL) {
+		capa->stats.pktio.counter.in_octets = 1;
+		capa->stats.pktio.counter.in_packets = 1;
+		capa->stats.pktio.counter.in_ucast_pkts = 1;
+		capa->stats.pktio.counter.in_bcast_pkts = 1;
+		capa->stats.pktio.counter.in_mcast_pkts = 1;
+		capa->stats.pktio.counter.in_discards = 1;
+		capa->stats.pktio.counter.in_errors = 1;
+		capa->stats.pktio.counter.out_octets = 1;
+		capa->stats.pktio.counter.out_packets = 1;
+		capa->stats.pktio.counter.out_ucast_pkts = 1;
+		capa->stats.pktio.counter.out_bcast_pkts = 1;
+		capa->stats.pktio.counter.out_mcast_pkts = 1;
+		capa->stats.pktio.counter.out_discards = 1;
+		capa->stats.pktio.counter.out_errors = 1;
+	}
+}

--- a/platform/linux-generic/pktio/stats/packet_io_stats.c
+++ b/platform/linux-generic/pktio/stats/packet_io_stats.c
@@ -66,6 +66,10 @@ int _odp_sock_stats_fd(pktio_entry_t *pktio_entry,
 				pktio_entry->s.stats.in_packets;
 	stats->in_ucast_pkts = cur_stats.in_ucast_pkts -
 				pktio_entry->s.stats.in_ucast_pkts;
+	stats->in_bcast_pkts = cur_stats.in_bcast_pkts -
+				pktio_entry->s.stats.in_bcast_pkts;
+	stats->in_mcast_pkts = cur_stats.in_mcast_pkts -
+				pktio_entry->s.stats.in_mcast_pkts;
 	stats->in_discards = cur_stats.in_discards -
 				pktio_entry->s.stats.in_discards;
 	stats->in_errors = cur_stats.in_errors -
@@ -80,6 +84,10 @@ int _odp_sock_stats_fd(pktio_entry_t *pktio_entry,
 				pktio_entry->s.stats.out_packets;
 	stats->out_ucast_pkts = cur_stats.out_ucast_pkts -
 				pktio_entry->s.stats.out_ucast_pkts;
+	stats->out_bcast_pkts = cur_stats.out_bcast_pkts -
+				pktio_entry->s.stats.out_bcast_pkts;
+	stats->out_mcast_pkts = cur_stats.out_mcast_pkts -
+				pktio_entry->s.stats.out_mcast_pkts;
 	stats->out_discards = cur_stats.out_discards -
 				pktio_entry->s.stats.out_discards;
 	stats->out_errors = cur_stats.out_errors -

--- a/platform/linux-generic/pktio/stats/sysfs_stats.c
+++ b/platform/linux-generic/pktio/stats/sysfs_stats.c
@@ -57,6 +57,9 @@ int _odp_sysfs_stats(pktio_entry_t *pktio_entry,
 	sprintf(fname, "/sys/class/net/%s/statistics/rx_packets", dev);
 	ret -= sysfs_get_val(fname, &stats->in_ucast_pkts);
 
+	sprintf(fname, "/sys/class/net/%s/statistics/multicast", dev);
+	ret -= sysfs_get_val(fname, &stats->in_mcast_pkts);
+
 	sprintf(fname, "/sys/class/net/%s/statistics/rx_droppped", dev);
 	ret -= sysfs_get_val(fname, &stats->in_discards);
 


### PR DESCRIPTION
- Add capabilities for statistics counters
- Add statistics counter for broadcast and multicast packets
- Add input/output queue specific statistics counters

V2:
- Added new `odp_pktio_queue_t` union for passing queue handles to `odp_pktin_queue_stats()` and `odp_pktout_queue_stats()` functions instead of using queue indices 

V3:
- Added reference implementation and validation tests

V4:
- Added separate functions for direct and event packet input/output queues

V5:
- Extend `odp_pktio_stats_reset()` documentation to state that resetting other than interface level statistics is implementation defined