### PR TITLE
[PATCH v1] linux-gen: pktio: fix print format

### DIFF
--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -2080,7 +2080,7 @@ int _odp_pktio_pktout_tm_config(odp_pktio_t pktio_hdl,
 
 	entry = get_pktio_entry(pktio_hdl);
 	if (entry == NULL) {
-		ODP_DBG("pktio entry %d does not exist\n", pktio_hdl);
+		ODP_DBG("pktio entry %" PRIuPTR " does not exist\n", (uintptr_t)pktio_hdl);
 		return -1;
 	}
 


### PR DESCRIPTION
Addition of_odp_pktio_pktout_tm_config() introduced a new print
format error, which breaks the build currently. Print format check
was merged after the new code (and bug) was merged.
