### PR TITLE
[PATCH v4] api: time: add strict time stamp read functions

### DIFF
--- a/include/odp/api/spec/time.h
+++ b/include/odp/api/spec/time.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2020, Nokia
+ * Copyright (c) 2020-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -66,6 +66,35 @@ extern "C" {
 odp_time_t odp_time_local(void);
 
 /**
+ * Current local time in nanoseconds
+ *
+ * Like odp_time_local(), but the time stamp value is converted into nanoseconds.
+ *
+ * @return Local time stamp in nanoseconds
+ */
+uint64_t odp_time_local_ns(void);
+
+/**
+ * Current local time (strict)
+ *
+ * Like odp_time_local(), but reads the time stamp value more strictly in the program order.
+ * The function may decrease CPU performance around the call, as it may include additional
+ * barrier instructions or otherwise limit out-of-order execution.
+ *
+ * @return Local time stamp
+ */
+odp_time_t odp_time_local_strict(void);
+
+/**
+ * Current local time in nanoseconds (strict)
+ *
+ * Like odp_time_local_strict(), but the time stamp value is converted into nanoseconds.
+ *
+ * @return Local time stamp in nanoseconds
+ */
+uint64_t odp_time_local_strict_ns(void);
+
+/**
  * Current global time
  *
  * Returns current global time stamp value. The global time source provides high
@@ -78,15 +107,6 @@ odp_time_t odp_time_local(void);
 odp_time_t odp_time_global(void);
 
 /**
- * Current local time in nanoseconds
- *
- * Like odp_time_local(), but the time stamp value is converted into nanoseconds.
- *
- * @return Local time stamp in nanoseconds
- */
-uint64_t odp_time_local_ns(void);
-
-/**
  * Current global time in nanoseconds
  *
  * Like odp_time_global(), but the time stamp value is converted into nanoseconds.
@@ -94,6 +114,25 @@ uint64_t odp_time_local_ns(void);
  * @return Global time stamp in nanoseconds
  */
 uint64_t odp_time_global_ns(void);
+
+/**
+ * Current global time (strict)
+ *
+ * Like odp_time_global(), but reads the time stamp value more strictly (see
+ * odp_time_local_strict() documentation) in the program order.
+ *
+ * @return Global time stamp
+ */
+odp_time_t odp_time_global_strict(void);
+
+/**
+ * Current global time in nanoseconds (strict)
+ *
+ * Like odp_time_global_strict(), but the time stamp value is converted into nanoseconds.
+ *
+ * @return Global time stamp in nanoseconds
+ */
+uint64_t odp_time_global_strict_ns(void);
 
 /**
  * Time difference

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -293,7 +293,7 @@ __LIB__libodp_linux_la_SOURCES += arch/aarch64/odp_atomic.c \
 				  arch/default/odp_hash_crc32.c \
 				  arch/aarch64/odp_sysinfo_parse.c
 odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/cpu_inlines.h \
-				arch/default/odp/api/abi/cpu_time.h \
+				arch/aarch64/odp/api/abi/cpu_time.h \
 				arch/aarch64/odp/api/abi/hash_crc32.h
 if !ODP_ABI_COMPAT
 odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/cpu_time.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/cpu_time.h
@@ -1,0 +1,50 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_API_ABI_CPU_TIME_H_
+#define ODP_API_ABI_CPU_TIME_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+static inline uint64_t _odp_cpu_global_time(void)
+{
+	uint64_t cntvct;
+
+	__asm__ volatile("mrs %0, cntvct_el0" : "=r"(cntvct) : : "memory");
+
+	return cntvct;
+}
+
+static inline uint64_t _odp_cpu_global_time_strict(void)
+{
+	uint64_t cntvct;
+
+	__asm__ volatile("isb" ::: "memory");
+	__asm__ volatile("mrs %0, cntvct_el0" : "=r"(cntvct) : : "memory");
+
+	return cntvct;
+}
+
+static inline uint64_t _odp_cpu_global_time_freq(void)
+{
+	uint64_t cntfrq;
+
+	__asm__ volatile("mrs %0, cntfrq_el0" : "=r"(cntfrq) : : );
+
+	return cntfrq;
+}
+
+int _odp_cpu_has_global_time(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/arch/aarch64/odp_global_time.c
+++ b/platform/linux-generic/arch/aarch64/odp_global_time.c
@@ -4,32 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp_posix_extensions.h>
-
-#include <time.h>
-
-#include <odp_debug_internal.h>
 #include <odp/api/abi/cpu_time.h>
-
-#include <odp/visibility_begin.h>
-
-uint64_t _odp_cpu_global_time(void)
-{
-	uint64_t cntvct;
-
-	/*
-	 * To be consistent with other architectures, do not issue a
-	 * serializing instruction, e.g. ISB, before reading this
-	 * sys reg.
-	 */
-
-	/* Memory clobber to minimize optimization around load from sys reg. */
-	__asm__ volatile("mrs %0, cntvct_el0" : "=r"(cntvct) : : "memory");
-
-	return cntvct;
-}
-
-#include <odp/visibility_end.h>
 
 int _odp_cpu_has_global_time(void)
 {
@@ -47,13 +22,4 @@ int _odp_cpu_has_global_time(void)
 	 * 1MHz and 6GHz (1us and .1667ns period).
 	 */
 	return hz >= 1000000 && hz <= 6000000000;
-}
-
-uint64_t _odp_cpu_global_time_freq(void)
-{
-	uint64_t cntfrq;
-
-	__asm__ volatile("mrs %0, cntfrq_el0" : "=r"(cntfrq) : : );
-
-	return cntfrq;
 }

--- a/platform/linux-generic/arch/default/odp/api/abi/cpu_time.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/cpu_time.h
@@ -15,6 +15,7 @@ extern "C" {
 
 int _odp_cpu_has_global_time(void);
 uint64_t _odp_cpu_global_time(void);
+uint64_t _odp_cpu_global_time_strict(void);
 uint64_t _odp_cpu_global_time_freq(void);
 
 #ifdef __cplusplus

--- a/platform/linux-generic/arch/default/odp_global_time.c
+++ b/platform/linux-generic/arch/default/odp_global_time.c
@@ -13,6 +13,11 @@ uint64_t _odp_cpu_global_time(void)
 	return 0;
 }
 
+uint64_t _odp_cpu_global_time_strict(void)
+{
+	return 0;
+}
+
 #include <odp/visibility_end.h>
 
 int _odp_cpu_has_global_time(void)

--- a/platform/linux-generic/arch/x86/odp/api/abi/cpu_time.h
+++ b/platform/linux-generic/arch/x86/odp/api/abi/cpu_time.h
@@ -19,6 +19,12 @@ static inline uint64_t _odp_cpu_global_time(void)
 	return _odp_cpu_rdtsc();
 }
 
+static inline uint64_t _odp_cpu_global_time_strict(void)
+{
+	__atomic_thread_fence(__ATOMIC_SEQ_CST);
+	return _odp_cpu_rdtsc();
+}
+
 int _odp_cpu_has_global_time(void);
 uint64_t _odp_cpu_global_time_freq(void);
 

--- a/platform/linux-generic/include/odp/api/plat/time_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/time_inlines.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2020, Nokia
+ * Copyright (c) 2020-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -46,6 +46,18 @@ static inline odp_time_t _odp_time_cur(void)
 	return _odp_timespec_cur();
 }
 
+static inline odp_time_t _odp_time_cur_strict(void)
+{
+	if (_odp_time_glob.use_hw) {
+		odp_time_t time;
+
+		time.count = _odp_cpu_global_time_strict() - _odp_time_glob.hw_start;
+		return time;
+	}
+
+	return _odp_timespec_cur();
+}
+
 static inline uint64_t _odp_time_hw_to_ns(odp_time_t time)
 {
 	uint64_t nsec;
@@ -79,6 +91,12 @@ static inline uint64_t _odp_time_convert_to_ns(odp_time_t time)
 	#define odp_time_to_ns      __odp_time_to_ns
 	#define odp_time_local_ns   __odp_time_local_ns
 	#define odp_time_global_ns  __odp_time_global_ns
+
+	#define odp_time_local_strict      __odp_time_local_strict
+	#define odp_time_global_strict     __odp_time_global_strict
+	#define odp_time_local_strict_ns   __odp_time_local_strict_ns
+	#define odp_time_global_strict_ns  __odp_time_global_strict_ns
+
 	#define odp_time_cmp        __odp_time_cmp
 	#define odp_time_diff       __odp_time_diff
 	#define odp_time_sum        __odp_time_sum
@@ -97,9 +115,14 @@ _ODP_INLINE odp_time_t odp_time_global(void)
 	return _odp_time_cur();
 }
 
-_ODP_INLINE uint64_t odp_time_to_ns(odp_time_t time)
+_ODP_INLINE odp_time_t odp_time_local_strict(void)
 {
-	return _odp_time_convert_to_ns(time);
+	return _odp_time_cur_strict();
+}
+
+_ODP_INLINE odp_time_t odp_time_global_strict(void)
+{
+	return _odp_time_cur_strict();
 }
 
 _ODP_INLINE uint64_t odp_time_local_ns(void)
@@ -110,6 +133,21 @@ _ODP_INLINE uint64_t odp_time_local_ns(void)
 _ODP_INLINE uint64_t odp_time_global_ns(void)
 {
 	return _odp_time_convert_to_ns(_odp_time_cur());
+}
+
+_ODP_INLINE uint64_t odp_time_local_strict_ns(void)
+{
+	return _odp_time_convert_to_ns(_odp_time_cur_strict());
+}
+
+_ODP_INLINE uint64_t odp_time_global_strict_ns(void)
+{
+	return _odp_time_convert_to_ns(_odp_time_cur_strict());
+}
+
+_ODP_INLINE uint64_t odp_time_to_ns(odp_time_t time)
+{
+	return _odp_time_convert_to_ns(time);
 }
 
 _ODP_INLINE int odp_time_cmp(odp_time_t t2, odp_time_t t1)

--- a/test/validation/api/time/time.c
+++ b/test/validation/api/time/time.c
@@ -223,6 +223,16 @@ static void time_test_global_cmp(void)
 	time_test_cmp(odp_time_global, odp_time_global_from_ns);
 }
 
+static void time_test_local_strict_cmp(void)
+{
+	time_test_cmp(odp_time_local_strict, odp_time_local_from_ns);
+}
+
+static void time_test_global_strict_cmp(void)
+{
+	time_test_cmp(odp_time_global_strict, odp_time_global_from_ns);
+}
+
 /* check that a time difference gives a reasonable result */
 static void time_test_diff(time_cb time_cur,
 			   time_from_ns_cb time_from_ns,
@@ -318,6 +328,16 @@ static void time_test_global_diff(void)
 	time_test_diff(odp_time_global, odp_time_global_from_ns, global_res);
 }
 
+static void time_test_local_strict_diff(void)
+{
+	time_test_diff(odp_time_local_strict, odp_time_local_from_ns, local_res);
+}
+
+static void time_test_global_strict_diff(void)
+{
+	time_test_diff(odp_time_global_strict, odp_time_global_from_ns, global_res);
+}
+
 /* check that a time sum gives a reasonable result */
 static void time_test_sum(time_cb time_cur,
 			  time_from_ns_cb time_from_ns,
@@ -368,6 +388,16 @@ static void time_test_local_sum(void)
 static void time_test_global_sum(void)
 {
 	time_test_sum(odp_time_global, odp_time_global_from_ns, global_res);
+}
+
+static void time_test_local_strict_sum(void)
+{
+	time_test_sum(odp_time_local_strict, odp_time_local_from_ns, local_res);
+}
+
+static void time_test_global_strict_sum(void)
+{
+	time_test_sum(odp_time_global_strict, odp_time_global_from_ns, global_res);
 }
 
 static void time_test_wait_until(time_cb time_cur, time_from_ns_cb time_from_ns)
@@ -488,16 +518,6 @@ static void time_test_accuracy(time_cb time_cur, time_from_ns_cb time_from_ns)
 	CU_ASSERT(sec_t > sec_c * 0.95);
 }
 
-static void time_test_local_accuracy(void)
-{
-	time_test_accuracy(odp_time_local, odp_time_local_from_ns);
-}
-
-static void time_test_global_accuracy(void)
-{
-	time_test_accuracy(odp_time_global, odp_time_global_from_ns);
-}
-
 static void time_test_accuracy_nsec(time_nsec_cb time_nsec)
 {
 	uint64_t t1, t2, diff;
@@ -533,6 +553,26 @@ static void time_test_accuracy_nsec(time_nsec_cb time_nsec)
 	CU_ASSERT(sec_t > sec_c * 0.95);
 }
 
+static void time_test_local_accuracy(void)
+{
+	time_test_accuracy(odp_time_local, odp_time_local_from_ns);
+}
+
+static void time_test_global_accuracy(void)
+{
+	time_test_accuracy(odp_time_global, odp_time_global_from_ns);
+}
+
+static void time_test_local_strict_accuracy(void)
+{
+	time_test_accuracy(odp_time_local_strict, odp_time_local_from_ns);
+}
+
+static void time_test_global_strict_accuracy(void)
+{
+	time_test_accuracy(odp_time_global_strict, odp_time_global_from_ns);
+}
+
 static void time_test_local_accuracy_nsec(void)
 {
 	time_test_accuracy_nsec(odp_time_local_ns);
@@ -543,26 +583,46 @@ static void time_test_global_accuracy_nsec(void)
 	time_test_accuracy_nsec(odp_time_global_ns);
 }
 
+static void time_test_local_strict_accuracy_nsec(void)
+{
+	time_test_accuracy_nsec(odp_time_local_strict_ns);
+}
+
+static void time_test_global_strict_accuracy_nsec(void)
+{
+	time_test_accuracy_nsec(odp_time_global_strict_ns);
+}
+
 odp_testinfo_t time_suite_time[] = {
 	ODP_TEST_INFO(time_test_constants),
 	ODP_TEST_INFO(time_test_local_res),
 	ODP_TEST_INFO(time_test_local_conversion),
-	ODP_TEST_INFO(time_test_monotony),
 	ODP_TEST_INFO(time_test_local_cmp),
 	ODP_TEST_INFO(time_test_local_diff),
 	ODP_TEST_INFO(time_test_local_sum),
-	ODP_TEST_INFO(time_test_local_wait_until),
-	ODP_TEST_INFO(time_test_wait_ns),
-	ODP_TEST_INFO(time_test_local_accuracy),
 	ODP_TEST_INFO(time_test_global_res),
 	ODP_TEST_INFO(time_test_global_conversion),
 	ODP_TEST_INFO(time_test_global_cmp),
 	ODP_TEST_INFO(time_test_global_diff),
 	ODP_TEST_INFO(time_test_global_sum),
+	ODP_TEST_INFO(time_test_wait_ns),
+	ODP_TEST_INFO(time_test_monotony),
+	ODP_TEST_INFO(time_test_local_wait_until),
 	ODP_TEST_INFO(time_test_global_wait_until),
+	ODP_TEST_INFO(time_test_local_accuracy),
 	ODP_TEST_INFO(time_test_global_accuracy),
 	ODP_TEST_INFO(time_test_local_accuracy_nsec),
 	ODP_TEST_INFO(time_test_global_accuracy_nsec),
+	ODP_TEST_INFO(time_test_local_strict_diff),
+	ODP_TEST_INFO(time_test_local_strict_sum),
+	ODP_TEST_INFO(time_test_local_strict_cmp),
+	ODP_TEST_INFO(time_test_global_strict_diff),
+	ODP_TEST_INFO(time_test_global_strict_sum),
+	ODP_TEST_INFO(time_test_global_strict_cmp),
+	ODP_TEST_INFO(time_test_local_strict_accuracy),
+	ODP_TEST_INFO(time_test_global_strict_accuracy),
+	ODP_TEST_INFO(time_test_local_strict_accuracy_nsec),
+	ODP_TEST_INFO(time_test_global_strict_accuracy_nsec),
 	ODP_TEST_INFO_NULL
 };
 


### PR DESCRIPTION
I named these functions "strict" due to they maintain program order more strictly than the basic functions. Other terms like precise/exact/etc would likely promise too much about when a time stamp is actually taken. This flavor of calls use more barriers/etc instructions to maintain program order than the basic calls (and thus hurt performance more), but may not still be able to guarantee 100% program order (if ISA does not allow it, or if it is impractical).