### PR TITLE
[PATCH v4] api: timer: add clock src enumerations

### DIFF
--- a/example/debug/odp_debug.c
+++ b/example/debug/odp_debug.c
@@ -375,7 +375,7 @@ static int timer_debug(void)
 		return -1;
 	}
 
-	if (odp_timer_capability(ODP_CLOCK_CPU, &timer_capa)) {
+	if (odp_timer_capability(ODP_CLOCK_DEFAULT, &timer_capa)) {
 		ODPH_ERR("Timer capa failed\n");
 		return -1;
 	}
@@ -385,7 +385,7 @@ static int timer_debug(void)
 
 	memset(&timer_res_capa, 0, sizeof(odp_timer_res_capability_t));
 	timer_res_capa.max_tmo = max_tmo;
-	if (odp_timer_res_capability(ODP_CLOCK_CPU, &timer_res_capa)) {
+	if (odp_timer_res_capability(ODP_CLOCK_DEFAULT, &timer_res_capa)) {
 		ODPH_ERR("Timer resolution capability failed\n");
 		return -1;
 	}
@@ -398,7 +398,7 @@ static int timer_debug(void)
 	timer_param.min_tmo = max_tmo / 10;
 	timer_param.max_tmo = max_tmo;
 	timer_param.num_timers = 10;
-	timer_param.clk_src = ODP_CLOCK_CPU;
+	timer_param.clk_src = ODP_CLOCK_DEFAULT;
 
 	timer_pool = odp_timer_pool_create("debug_timer", &timer_param);
 

--- a/example/sysinfo/odp_sysinfo.c
+++ b/example/sysinfo/odp_sysinfo.c
@@ -408,7 +408,7 @@ int main(void)
 		return -1;
 	}
 
-	if (odp_timer_capability(ODP_CLOCK_CPU, &timer_capa)) {
+	if (odp_timer_capability(ODP_CLOCK_DEFAULT, &timer_capa)) {
 		printf("timer capability failed\n");
 		return -1;
 	}

--- a/example/timer/odp_timer_accuracy.c
+++ b/example/timer/odp_timer_accuracy.c
@@ -106,8 +106,8 @@ static void print_usage(void)
 	       "  -e, --early_retry <num> When timer restart fails due to ODP_TIMER_TOOEARLY, retry this many times\n"
 	       "                          with expiration time incremented by the period. Default: 0\n"
 	       "  -s, --clk_src           Clock source select (default 0):\n"
-	       "                            0: ODP_CLOCK_CPU\n"
-	       "                            1: ODP_CLOCK_EXT\n"
+	       "                            0: ODP_CLOCK_DEFAULT\n"
+	       "                            1: ODP_CLOCK_SRC_1, ...\n"
 	       "  -i, --init              Set global init parameters. Default: init params not set.\n"
 	       "  -h, --help              Display help and exit.\n\n");
 }
@@ -144,7 +144,7 @@ static int parse_options(int argc, char *argv[], test_global_t *test_global)
 	test_global->opt.burst     = 1;
 	test_global->opt.burst_gap = 0;
 	test_global->opt.mode      = 0;
-	test_global->opt.clk_src   = 0;
+	test_global->opt.clk_src   = ODP_CLOCK_DEFAULT;
 	test_global->opt.init      = 0;
 	test_global->opt.output    = 0;
 	test_global->opt.early_retry = 0;
@@ -289,11 +289,7 @@ static int start_timers(test_global_t *test_global)
 	}
 
 	test_global->timeout_pool = pool;
-
-	if (test_global->opt.clk_src == 0)
-		clk_src = ODP_CLOCK_CPU;
-	else
-		clk_src = ODP_CLOCK_EXT;
+	clk_src = test_global->opt.clk_src;
 
 	if (odp_timer_capability(clk_src, &timer_capa)) {
 		printf("Timer capa failed\n");

--- a/example/timer/odp_timer_simple.c
+++ b/example/timer/odp_timer_simple.c
@@ -65,7 +65,7 @@ int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 	/*
 	 * Create pool of timeouts
 	 */
-	if (odp_timer_capability(ODP_CLOCK_CPU, &timer_capa)) {
+	if (odp_timer_capability(ODP_CLOCK_DEFAULT, &timer_capa)) {
 		ret += 1;
 		goto err_tp;
 	}
@@ -76,7 +76,7 @@ int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 	tparams.max_tmo = 1 * ODP_TIME_SEC_IN_NS;
 	tparams.num_timers = 1; /* One timer per worker */
 	tparams.priv = 0; /* Shared */
-	tparams.clk_src = ODP_CLOCK_CPU;
+	tparams.clk_src = ODP_CLOCK_DEFAULT;
 	timer_pool = odp_timer_pool_create("timer_pool", &tparams);
 	if (timer_pool == ODP_TIMER_POOL_INVALID) {
 		ret += 1;

--- a/example/timer/odp_timer_test.c
+++ b/example/timer/odp_timer_test.c
@@ -273,7 +273,7 @@ static int parse_args(int argc, char *argv[], test_args_t *args)
 	static const char *shortopts = "+c:r:m:x:p:t:h";
 
 	/* defaults */
-	if (odp_timer_capability(ODP_CLOCK_CPU, &timer_capa))
+	if (odp_timer_capability(ODP_CLOCK_DEFAULT, &timer_capa))
 		return -1;
 
 	args->cpu_count     = 1;
@@ -444,7 +444,7 @@ int main(int argc, char *argv[])
 	tparams.max_tmo = gbls->args.max_us * ODP_TIME_USEC_IN_NS;
 	tparams.num_timers = num_workers; /* One timer per worker */
 	tparams.priv = 0; /* Shared */
-	tparams.clk_src = ODP_CLOCK_CPU;
+	tparams.clk_src = ODP_CLOCK_DEFAULT;
 	gbls->tp = odp_timer_pool_create("timer_pool", &tparams);
 	if (gbls->tp == ODP_TIMER_POOL_INVALID) {
 		err = 1;

--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2020, Nokia
+ * Copyright (c) 2019-2021, Nokia
  *
  * All rights reserved.
  *
@@ -36,15 +36,46 @@ extern "C" {
  */
 
 /**
- * Clock sources for timers in timer pool.
+ * Clock sources for timer pools
+ *
+ * ODP_CLOCK_DEFAULT is the default clock source and it is supported always. It is implementation
+ * defined which other clock sources are supported. See from implementation documentation how the
+ * supported clock sources are mapped into these enumerations.
  */
 typedef enum {
-	/** Use CPU clock as clock source for timers */
-	ODP_CLOCK_CPU,
-	/** Use external clock as clock source for timers */
-	ODP_CLOCK_EXT
-	/* Platform dependent which other clock sources exist */
+	/** Clock source number 0 */
+	ODP_CLOCK_SRC_0,
+
+	/** Clock source number 1 */
+	ODP_CLOCK_SRC_1,
+
+	/** Clock source number 2 */
+	ODP_CLOCK_SRC_2,
+
+	/** Clock source number 3  */
+	ODP_CLOCK_SRC_3,
+
+	/** Clock source number 4  */
+	ODP_CLOCK_SRC_4,
+
+	/** Clock source number 5  */
+	ODP_CLOCK_SRC_5,
+
+	/** Number of clock source enumerations */
+	ODP_CLOCK_NUM_SRC
+
 } odp_timer_clk_src_t;
+
+/** The default clock source */
+#define ODP_CLOCK_DEFAULT ODP_CLOCK_SRC_0
+
+/** For backwards compatibility, ODP_CLOCK_CPU is synonym of ODP_CLOCK_DEFAULT.
+ *  This will be deprecated in the future. */
+#define ODP_CLOCK_CPU ODP_CLOCK_DEFAULT
+
+/** For backwards compatibility, ODP_CLOCK_EXT is synonym of ODP_CLOCK_SRC_1.
+ *  This will be deprecated in the future. */
+#define ODP_CLOCK_EXT ODP_CLOCK_SRC_1
 
 /**
  * @typedef odp_timer_t
@@ -240,18 +271,19 @@ typedef struct {
 } odp_timer_capability_t;
 
 /**
- * Query timer capabilities
+ * Query timer capabilities per clock source
  *
- * Outputs timer capabilities on success.
+ * Outputs timer capabilities on success. Returns -1 if the clock source
+ * is not supported.
  *
  * @param      clk_src  Clock source for timers
  * @param[out] capa     Pointer to capability structure for output
  *
- * @retval 0 on success
- * @retval <0 on failure
+ * @retval   0 on success
+ * @retval  -1 when the clock source is not supported
+ * @retval <-1 on other failures
  */
-int odp_timer_capability(odp_timer_clk_src_t clk_src,
-			 odp_timer_capability_t *capa);
+int odp_timer_capability(odp_timer_clk_src_t clk_src, odp_timer_capability_t *capa);
 
 /**
  * Timer resolution capability

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -399,7 +399,7 @@ static odp_timer_pool_t timer_pool_new(const char *name,
 	odp_ticketlock_unlock(&timer_global->lock);
 
 	if (!odp_global_rw->inline_timers) {
-		if (tp->param.clk_src == ODP_CLOCK_CPU)
+		if (tp->param.clk_src == ODP_CLOCK_DEFAULT)
 			itimer_init(tp);
 	} else {
 		/* Update the highest index for inline timer scan */
@@ -441,7 +441,7 @@ static void odp_timer_pool_del(timer_pool_t *tp)
 
 	if (!odp_global_rw->inline_timers) {
 		/* Stop POSIX itimer signals */
-		if (tp->param.clk_src == ODP_CLOCK_CPU)
+		if (tp->param.clk_src == ODP_CLOCK_DEFAULT)
 			itimer_fini(tp);
 
 		stop_timer_thread(tp);
@@ -1220,8 +1220,8 @@ static void itimer_fini(timer_pool_t *tp)
 int odp_timer_capability(odp_timer_clk_src_t clk_src,
 			 odp_timer_capability_t *capa)
 {
-	if (clk_src != ODP_CLOCK_CPU) {
-		ODP_ERR("Only CPU clock source supported\n");
+	if (clk_src != ODP_CLOCK_DEFAULT) {
+		ODP_ERR("Only ODP_CLOCK_DEFAULT supported. Requested %i.\n", clk_src);
 		return -1;
 	}
 
@@ -1248,8 +1248,8 @@ int odp_timer_capability(odp_timer_clk_src_t clk_src,
 int odp_timer_res_capability(odp_timer_clk_src_t clk_src,
 			     odp_timer_res_capability_t *res_capa)
 {
-	if (clk_src != ODP_CLOCK_CPU) {
-		ODP_ERR("Only CPU clock source supported\n");
+	if (clk_src != ODP_CLOCK_DEFAULT) {
+		ODP_ERR("Only ODP_CLOCK_DEFAULT supported. Requested %i.\n", clk_src);
 		return -1;
 	}
 

--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -1253,7 +1253,7 @@ static int create_timers(test_global_t *test_global)
 	if (test_global->opt.timeout_us == 0)
 		return 0;
 
-	if (odp_timer_capability(ODP_CLOCK_CPU, &timer_capa)) {
+	if (odp_timer_capability(ODP_CLOCK_DEFAULT, &timer_capa)) {
 		printf("Timer capa failed\n");
 		return -1;
 	}
@@ -1272,7 +1272,7 @@ static int create_timers(test_global_t *test_global)
 	timer_param.min_tmo    = timeout_ns;
 	timer_param.max_tmo    = timeout_ns;
 	timer_param.num_timers = num_timer;
-	timer_param.clk_src    = ODP_CLOCK_CPU;
+	timer_param.clk_src    = ODP_CLOCK_DEFAULT;
 
 	timer_pool = odp_timer_pool_create("sched_pktio_timer", &timer_param);
 

--- a/test/performance/odp_timer_perf.c
+++ b/test/performance/odp_timer_perf.c
@@ -307,14 +307,14 @@ static int create_timer_pools(test_global_t *global)
 			global->timer[i][j] = ODP_TIMER_INVALID;
 	}
 
-	if (odp_timer_capability(ODP_CLOCK_CPU, &timer_capa)) {
+	if (odp_timer_capability(ODP_CLOCK_DEFAULT, &timer_capa)) {
 		ODPH_ERR("Timer capability failed\n");
 		return -1;
 	}
 
 	memset(&timer_res_capa, 0, sizeof(odp_timer_res_capability_t));
 	timer_res_capa.res_ns = res_ns;
-	if (odp_timer_res_capability(ODP_CLOCK_CPU, &timer_res_capa)) {
+	if (odp_timer_res_capability(ODP_CLOCK_DEFAULT, &timer_res_capa)) {
 		ODPH_ERR("Timer resolution capability failed\n");
 		return -1;
 	}
@@ -352,7 +352,7 @@ static int create_timer_pools(test_global_t *global)
 	timer_pool_param.max_tmo    = max_tmo_ns;
 	timer_pool_param.num_timers = num_timer;
 	timer_pool_param.priv       = priv;
-	timer_pool_param.clk_src    = ODP_CLOCK_CPU;
+	timer_pool_param.clk_src    = ODP_CLOCK_DEFAULT;
 
 	odp_pool_param_init(&pool_param);
 	pool_param.type    = ODP_POOL_TIMEOUT;

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -125,7 +125,7 @@ static int timer_global_init(odp_instance_t *inst)
 	odp_schedule_config(NULL);
 
 	memset(&capa, 0, sizeof(capa));
-	if (odp_timer_capability(ODP_CLOCK_CPU, &capa)) {
+	if (odp_timer_capability(ODP_CLOCK_DEFAULT, &capa)) {
 		fprintf(stderr, "Timer capability failed\n");
 		return -1;
 	}
@@ -138,7 +138,7 @@ static int timer_global_init(odp_instance_t *inst)
 	memset(&res_capa, 0, sizeof(res_capa));
 	res_capa.res_ns = res_ns;
 
-	if (odp_timer_res_capability(ODP_CLOCK_CPU, &res_capa)) {
+	if (odp_timer_res_capability(ODP_CLOCK_DEFAULT, &res_capa)) {
 		fprintf(stderr, "Timer resolution capability failed\n");
 		return -1;
 	}
@@ -395,7 +395,7 @@ static void timer_pool_create_destroy(void)
 	int ret;
 
 	memset(&capa, 0, sizeof(capa));
-	ret = odp_timer_capability(ODP_CLOCK_CPU, &capa);
+	ret = odp_timer_capability(ODP_CLOCK_DEFAULT, &capa);
 	CU_ASSERT_FATAL(ret == 0);
 
 	odp_queue_param_init(&queue_param);
@@ -414,7 +414,7 @@ static void timer_pool_create_destroy(void)
 	tparam.max_tmo    = global_mem->param.max_tmo;
 	tparam.num_timers = 100;
 	tparam.priv       = 0;
-	tparam.clk_src    = ODP_CLOCK_CPU;
+	tparam.clk_src    = ODP_CLOCK_DEFAULT;
 
 	tp[0] = odp_timer_pool_create("timer_pool_a", &tparam);
 	CU_ASSERT(tp[0] != ODP_TIMER_POOL_INVALID);
@@ -480,7 +480,7 @@ static void timer_pool_max_res(void)
 	int ret, i;
 
 	memset(&capa, 0, sizeof(capa));
-	ret = odp_timer_capability(ODP_CLOCK_CPU, &capa);
+	ret = odp_timer_capability(ODP_CLOCK_DEFAULT, &capa);
 	CU_ASSERT_FATAL(ret == 0);
 
 	odp_pool_param_init(&pool_param);
@@ -517,7 +517,7 @@ static void timer_pool_max_res(void)
 		tp_param.max_tmo    = capa.max_res.max_tmo;
 		tp_param.num_timers = 100;
 		tp_param.priv       = 0;
-		tp_param.clk_src    = ODP_CLOCK_CPU;
+		tp_param.clk_src    = ODP_CLOCK_DEFAULT;
 
 		tp = odp_timer_pool_create("high_res_tp", &tp_param);
 		CU_ASSERT_FATAL(tp != ODP_TIMER_POOL_INVALID);
@@ -581,7 +581,7 @@ static void timer_test_event_type(odp_queue_type_t queue_type,
 	period_ns              = 2 * global_mem->param.min_tmo;
 	timer_param.max_tmo    = global_mem->param.max_tmo;
 	timer_param.num_timers = num;
-	timer_param.clk_src    = ODP_CLOCK_CPU;
+	timer_param.clk_src    = ODP_CLOCK_DEFAULT;
 
 	timer_pool = odp_timer_pool_create("timer_pool", &timer_param);
 	if (timer_pool == ODP_TIMER_POOL_INVALID)
@@ -776,7 +776,7 @@ static void timer_test_queue_type(odp_queue_type_t queue_type, int priv)
 	tparam.max_tmo    = global_mem->param.max_tmo;
 	tparam.num_timers = num + 1;
 	tparam.priv       = priv;
-	tparam.clk_src    = ODP_CLOCK_CPU;
+	tparam.clk_src    = ODP_CLOCK_DEFAULT;
 
 	ODPH_DBG("\nTimer pool parameters:\n");
 	ODPH_DBG("  res_ns  %" PRIu64 "\n", tparam.res_ns);
@@ -938,7 +938,7 @@ static void timer_test_cancel(void)
 	int ret;
 
 	memset(&capa, 0, sizeof(capa));
-	ret = odp_timer_capability(ODP_CLOCK_CPU, &capa);
+	ret = odp_timer_capability(ODP_CLOCK_DEFAULT, &capa);
 	CU_ASSERT_FATAL(ret == 0);
 
 	odp_pool_param_init(&params);
@@ -956,7 +956,7 @@ static void timer_test_cancel(void)
 	tparam.max_tmo    = global_mem->param.max_tmo;
 	tparam.num_timers = 1;
 	tparam.priv       = 0;
-	tparam.clk_src    = ODP_CLOCK_CPU;
+	tparam.clk_src    = ODP_CLOCK_DEFAULT;
 	tp = odp_timer_pool_create(NULL, &tparam);
 	if (tp == ODP_TIMER_POOL_INVALID)
 		CU_FAIL_FATAL("Timer pool create failed");
@@ -1044,7 +1044,7 @@ static void timer_test_tmo_limit(odp_queue_type_t queue_type,
 	odp_timer_t timer[num];
 
 	memset(&timer_capa, 0, sizeof(timer_capa));
-	ret = odp_timer_capability(ODP_CLOCK_CPU, &timer_capa);
+	ret = odp_timer_capability(ODP_CLOCK_DEFAULT, &timer_capa);
 	CU_ASSERT_FATAL(ret == 0);
 
 	if (max_res) {
@@ -1064,7 +1064,7 @@ static void timer_test_tmo_limit(odp_queue_type_t queue_type,
 	timer_param.min_tmo    = min_tmo;
 	timer_param.max_tmo    = max_tmo;
 	timer_param.num_timers = num;
-	timer_param.clk_src    = ODP_CLOCK_CPU;
+	timer_param.clk_src    = ODP_CLOCK_DEFAULT;
 
 	timer_pool = odp_timer_pool_create("timer_pool", &timer_param);
 	if (timer_pool == ODP_TIMER_POOL_INVALID)
@@ -1597,7 +1597,7 @@ static void timer_test_all(odp_queue_type_t queue_type)
 		num_workers = 1;
 
 	num_timers = num_workers * NTIMERS;
-	CU_ASSERT_FATAL(!odp_timer_capability(ODP_CLOCK_CPU, &timer_capa));
+	CU_ASSERT_FATAL(!odp_timer_capability(ODP_CLOCK_DEFAULT, &timer_capa));
 	if (timer_capa.max_timers && timer_capa.max_timers < num_timers)
 		num_timers = timer_capa.max_timers;
 
@@ -1630,7 +1630,7 @@ static void timer_test_all(odp_queue_type_t queue_type)
 	tparam.max_tmo = max_tmo;
 	tparam.num_timers = num_timers;
 	tparam.priv = 0;
-	tparam.clk_src = ODP_CLOCK_CPU;
+	tparam.clk_src = ODP_CLOCK_DEFAULT;
 	global_mem->tp = odp_timer_pool_create(NAME, &tparam);
 	if (global_mem->tp == ODP_TIMER_POOL_INVALID)
 		CU_FAIL_FATAL("Timer pool create failed");


### PR DESCRIPTION
I moved clock source enumeration patches into this PR from the tick info PR. I think it makes sense to add rename CPU to DEFAULT  clock source at the same time.