### PR TITLE
[PATCH v2] validation: ipsec: fix check function for ah tests

### DIFF
--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -217,20 +217,17 @@ int ipsec_check_esp_aes_gcm_256(void)
 
 int ipsec_check_ah_aes_gmac_128(void)
 {
-	return  ipsec_check_esp(ODP_CIPHER_ALG_NULL, 0,
-				ODP_AUTH_ALG_AES_GMAC, 128);
+	return  ipsec_check_ah(ODP_AUTH_ALG_AES_GMAC, 128);
 }
 
 int ipsec_check_ah_aes_gmac_192(void)
 {
-	return  ipsec_check_esp(ODP_CIPHER_ALG_NULL, 0,
-				ODP_AUTH_ALG_AES_GMAC, 192);
+	return  ipsec_check_ah(ODP_AUTH_ALG_AES_GMAC, 192);
 }
 
 int ipsec_check_ah_aes_gmac_256(void)
 {
-	return  ipsec_check_esp(ODP_CIPHER_ALG_NULL, 0,
-				ODP_AUTH_ALG_AES_GMAC, 256);
+	return  ipsec_check_ah(ODP_AUTH_ALG_AES_GMAC, 256);
 }
 
 int ipsec_check_esp_null_aes_gmac_128(void)


### PR DESCRIPTION
For some AH tests, esp check function is used which does not check the
AH capability. Use the ah check function which checks for AH capability.

Signed-off-by: Vidya Sagar Velumuri <vvelumuri@marvell.com>
Signed-off-by: Aakash Sasidharan <asasidharan@marvell.com>