### PR TITLE
[PATCH v2] misc fixes

### DIFF
--- a/platform/linux-generic/odp_fdserver.c
+++ b/platform/linux-generic/odp_fdserver.c
@@ -246,10 +246,14 @@ static int get_socket(void)
 	int len;
 
 	/* construct the named socket path: */
-	snprintf(sockpath, FDSERVER_SOCKPATH_MAXLEN, FDSERVER_SOCK_FORMAT,
-		 odp_global_ro.shm_dir,
-		 odp_global_ro.uid,
-		 odp_global_ro.main_pid);
+	len = snprintf(sockpath, FDSERVER_SOCKPATH_MAXLEN, FDSERVER_SOCK_FORMAT,
+		       odp_global_ro.shm_dir, odp_global_ro.uid,
+		       odp_global_ro.main_pid);
+
+	if (len >= FDSERVER_SOCKPATH_MAXLEN || len >= (int)sizeof(remote.sun_path)) {
+		ODP_ERR("path too long\n");
+		return -1;
+	}
 
 	s_sock = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (s_sock == -1) {
@@ -561,7 +565,7 @@ int _odp_fdserver_init_global(void)
 	int sock;
 	struct sockaddr_un local;
 	pid_t server_pid;
-	int res;
+	int len, res;
 
 	snprintf(sockpath, FDSERVER_SOCKPATH_MAXLEN, FDSERVER_SOCKDIR_FORMAT,
 		 odp_global_ro.shm_dir,
@@ -570,10 +574,14 @@ int _odp_fdserver_init_global(void)
 	mkdir(sockpath, 0744);
 
 	/* construct the server named socket path: */
-	snprintf(sockpath, FDSERVER_SOCKPATH_MAXLEN, FDSERVER_SOCK_FORMAT,
-		 odp_global_ro.shm_dir,
-		 odp_global_ro.uid,
-		 odp_global_ro.main_pid);
+	len = snprintf(sockpath, FDSERVER_SOCKPATH_MAXLEN, FDSERVER_SOCK_FORMAT,
+		       odp_global_ro.shm_dir, odp_global_ro.uid,
+		       odp_global_ro.main_pid);
+
+	if (len >= FDSERVER_SOCKPATH_MAXLEN || len >= (int)sizeof(local.sun_path)) {
+		ODP_ERR("path too long\n");
+		return -1;
+	}
 
 	/* create UNIX domain socket: */
 	sock = socket(AF_UNIX, SOCK_STREAM, 0);

--- a/platform/linux-generic/odp_ishmpool.c
+++ b/platform/linux-generic/odp_ishmpool.c
@@ -280,7 +280,7 @@ static void *_odp_ishmbud_alloc(pool_t *bpool, uint64_t size)
 	uintptr_t nr;
 
 	/* if size is zero or too big reject: */
-	if ((!size) && (size > (1U << bpool->ctrl.order))) {
+	if ((!size) && (size > (1ULL << bpool->ctrl.order))) {
 		ODP_ERR("Invalid alloc size (0 or larger than whole pool)\n");
 		return NULL;
 	}

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -8,7 +8,7 @@ fi
 cd "$(dirname "$0")"/../..
 ./bootstrap
 ./configure \
-	CFLAGS="-O0 -coverage $CLFAGS" CXXFLAGS="-O0 -coverage $CXXFLAGS" LDFLAGS="--coverage $LDFLAGS" \
+	CFLAGS="-O0 -coverage $CFLAGS" CXXFLAGS="-O0 -coverage $CXXFLAGS" LDFLAGS="--coverage $LDFLAGS" \
 	--enable-debug=full --enable-helper-linux --enable-dpdk
 export CCACHE_DISABLE=1
 make -j $(nproc)


### PR DESCRIPTION
```
ci: fix misspelled CFLAGS in coverage.sh
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

linux-gen: fdserver: check unix socket path length
    
    Make sure that path length is within the sockaddr_un::sun_path limit
    when connecting unix sockets.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

linux-gen: shm: avoid potential integer overflow
    
    In _odp_ishmbud_alloc(), avoid integer overflow when calculating the
    maximum allocation size.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
