### PR TITLE
[PATCH v1] api: increment ODP API version to 1.30.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,47 @@
+== OpenDataPlane (1.30.0.0)
+=== API
+==== IPsec
+* New success bytes field in stats (`odp_ipsec_stats_t.success_bytes`)
+
+==== Packet IO
+* Specify explicitly that an application may enqueue to packet input side event
+queues, and cannot dequeue from output side event queues
+
+==== Time
+* Added time stamp read functions which read time stamp value more strictly
+in the program order: `odp_time_local_strict()`, `odp_time_local_strict_ns()`,
+`odp_time_global_strict()`, `odp_time_global_strict_ns()`
+
+==== Timer
+* Added new default clock source enumeration `ODP_CLOCK_DEFAULT`
+(=`ODP_CLOCK_SRC_0`) and support for multiple clock sources (`ODP_CLOCK_SRC_1`,
+`ODP_CLOCK_SRC_2`...). The old `ODP_CLOCK_CPU` and `ODP_CLOCK_EXT` enumerations
+will be deprecated in the future.
+* Renamed set operation return codes (`odp_timer_set_t`) to better document
+expiration time position to current time:
+`ODP_TIMER_TOOEARLY` -> `ODP_TIMER_TOO_NEAR`, `ODP_TIMER_TOOLATE` ->
+`ODP_TIMER_TOO_FAR`
+* Renamed set operation failure code (`odp_timer_set_t`) to cover all error
+cases: `ODP_TIMER_NOEVENT` -> `ODP_TIMER_FAIL`
+
+==== Traffic Manager
+* Added option to enable packet mode shaper (packets per second as opposed to
+bits per second)
+* Added new mandatory `odp_tm_start()` and `odp_tm_stop()` calls for starting and
+stopping traffic manager system
+* Added capabilities (`odp_tm_capabilities_t`) for supported dynamic
+configuration updates
+* Deprecated shaper commit information rate bps
+(`odp_tm_shaper_params_t.commit_bps`) and peak information rate bps
+(`odp_tm_shaper_params_t.peak_bps`) fields. `odp_tm_shaper_params_t.commit_rate`
+and `odp_tm_shaper_params_t.peak_rate` fields should be used instead.
+
+=== Helper (1.1.0)
+* Added new mandatory `odph_cli_init()` and `odph_cli_term()` functions for
+initializing and terminating the CLI helper
+* Added `odph_cli_register_command()` function for registering user defined CLI
+commands
+
 == OpenDataPlane (1.29.0.0)
 === API
 ==== Packet IO

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ([2.5])
 # ODP API version
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
-m4_define([odpapi_major_version], [29])
+m4_define([odpapi_major_version], [30])
 m4_define([odpapi_minor_version], [0])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],


### PR DESCRIPTION
Increment API version number to reflect the following changes:

Backward compatible:
- traffic manager: add option to enable packet mode shaper (packets per
  second as opposed to bits per second)
- packet io: specify explicitly that an application may enqueue to packet
  input side event queues, and cannot dequeue from output side event queues
- ipsec: include success bytes in stats (odp_ipsec_stats_t.success_bytes)
- time: added new time stamp read functions which read time stamp value
  more strictly in the program order: odp_time_local_strict(),
  odp_time_local_strict_ns(), odp_time_global_strict(),
  odp_time_global_strict_ns()
- timer: added new default clock source enumeration ODP_CLOCK_DEFAULT
  (=ODP_CLOCK_SRC_0) and support for multiple clock sources
  (ODP_CLOCK_SRC_1, ODP_CLOCK_SRC_2...). The old ODP_CLOCK_CPU and
  ODP_CLOCK_EXT enumerations will be deprecated in the future.
- timer: rename set operation return codes (odp_timer_set_t) to better
  document expiration time position to current time:
    ODP_TIMER_TOOEARLY -> ODP_TIMER_TOO_NEAR
    ODP_TIMER_TOOLATE  -> ODP_TIMER_TOO_FAR
- timer: rename set operation failure code (odp_timer_set_t) to cover all
  error cases: ODP_TIMER_NOEVENT -> ODP_TIMER_FAIL

Backward incompatible:
- traffic manager: add new mandatory odp_tm_start() and odp_tm_stop() calls
  for starting and stopping traffic manager system
- traffic manager: add capabilities (odp_tm_capabilities_t) for supported
  dynamic configuration updates
- traffic manager: deprecate shaper commit information rate bps
  (odp_tm_shaper_params_t.commit_bps) and peak information rate bps
  (odp_tm_shaper_params_t.peak_bps) fields.
  odp_tm_shaper_params_t.commit_rate and odp_tm_shaper_params_t.peak_rate
  fields should be used instead.

Helper library:
- cli: added new mandatory odph_cli_init() and odph_cli_term() functions
  for initializing and terminating the helper
- cli: added odph_cli_register_command() function for registering user
  defined commands

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reviewed-by: Petri Savolainen <petri.savolainen@nokia.com>