### PR TITLE
[PATCH v6] api: cls: add queue specific statistics counters

### DIFF
--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -128,8 +128,9 @@ typedef union odp_cls_pmr_terms_t {
  * threshold values. RED is enabled when 'red_enable' boolean is true and
  * the resource usage is equal to or greater than the minimum threshold value.
  * Resource usage could be defined either as the percentage of pool being full
- * or the number of packets/bytes occupied in the queue depening on the platform
- * capabilities.
+ * or the number of packets/bytes occupied in the queue depending on the
+ * platform capabilities.
+ *
  * When RED is enabled for a particular flow then further incoming packets are
  * assigned a drop probability based on the size of the pool/queue.
  *
@@ -196,7 +197,7 @@ typedef struct odp_cls_capability_t {
 	/** Maximum number of CoS supported */
 	unsigned int max_cos;
 
-	/** Maximun number of queue supported per CoS
+	/** Maximun number of queues supported per CoS
 	 * if the value is 1, then hashing is not supported*/
 	unsigned int max_hash_queues;
 
@@ -227,8 +228,8 @@ typedef struct odp_cls_capability_t {
  * class of service packet drop policies
  */
 typedef enum {
-	ODP_COS_DROP_POOL,    /**< Follow buffer pool drop policy */
-	ODP_COS_DROP_NEVER,    /**< Never drop, ignoring buffer pool policy */
+	ODP_COS_DROP_POOL,      /**< Follow buffer pool drop policy */
+	ODP_COS_DROP_NEVER,     /**< Never drop, ignoring buffer pool policy */
 } odp_cls_drop_t;
 
 /**
@@ -264,12 +265,12 @@ typedef struct odp_cls_cos_param {
 	 * and application need not configure any queue to the class of service.
 	 * When hashing is disabled application has to configure the queue to
 	 * the class of service.
-	 * Depening on the implementation this number might be rounded-off to
+	 * Depending on the implementation this number might be rounded-off to
 	 * nearest supported value (e.g power of 2)
 	 */
 	uint32_t num_queue;
 
-	/** Variant mapping for queue hash configurataion */
+	/** Variant mapping for queue hash configuration */
 	union {
 		/** Mapping used when num_queue = 1, hashing is disabled in
 		 * this case and application has to configure this queue and
@@ -339,8 +340,8 @@ int odp_cls_capability(odp_cls_capability_t *capability);
  * @retval ODP_COS_INVALID on failure.
  *
  * @note ODP_QUEUE_INVALID and ODP_POOL_INVALID are valid values for queue
- * and pool associated with a class of service and when any one of these values
- * are configured as INVALID then the packets assigned to the CoS gets dropped.
+ * and pool associated with a class of service. When either of these values
+ * is configured as INVALID packets assigned to the CoS get dropped.
  */
 odp_cos_t odp_cls_cos_create(const char *name,
 			     const odp_cls_cos_param_t *param);
@@ -351,7 +352,7 @@ odp_cos_t odp_cls_cos_create(const char *name,
  * based on the packet parameters and hash protocol field configured with the
  * class of service.
  *
- * @param cos          class of service
+ * @param cos          CoS handle
  * @param packet       Packet handle
  *
  * @retval Returns the queue handle on which this packet will be enqueued.
@@ -364,62 +365,61 @@ odp_queue_t odp_cls_hash_result(odp_cos_t cos, odp_packet_t packet);
 /**
  * Discard a class-of-service along with all its associated resources
  *
- * @param cos_id       class-of-service instance.
+ * @param cos          CoS handle
  *
  * @retval  0 on success
  * @retval <0 on failure
  */
-int odp_cos_destroy(odp_cos_t cos_id);
+int odp_cos_destroy(odp_cos_t cos);
 
 /**
  * Assign a queue for a class-of-service
  *
- * @param cos_id       class-of-service instance.
- * @param queue_id     Identifier of a queue where all packets of this specific
+ * @param cos          CoS handle
+ * @param queue        Handle of the queue where all packets of this specific
  *                     class of service will be enqueued.
  *
  * @retval  0 on success
  * @retval <0 on failure
  */
-int odp_cos_queue_set(odp_cos_t cos_id, odp_queue_t queue_id);
+int odp_cos_queue_set(odp_cos_t cos, odp_queue_t queue);
 
 /**
 * Get the queue associated with the specific class-of-service
 *
-* @param cos_id        class-of-service instance.
+* @param cos           CoS handle
 *
 * @retval Queue handle associated with the given class-of-service
 * @retval ODP_QUEUE_INVALID on failure
 */
-odp_queue_t odp_cos_queue(odp_cos_t cos_id);
+odp_queue_t odp_cos_queue(odp_cos_t cos);
 
 /**
  * Get the number of queues linked with the specific class-of-service
  *
- * @param cos_id       class-of-service instance.
+ * @param cos          CoS handle
  *
  * @return Number of queues linked with the class-of-service.
  */
-uint32_t odp_cls_cos_num_queue(odp_cos_t cos_id);
+uint32_t odp_cls_cos_num_queue(odp_cos_t cos);
 
 /**
  * Get the list of queue associated with the specific class-of-service
  *
- * @param      cos_id  class-of-service instance.
+ * @param      cos     CoS handle
  * @param[out] queue   Array of queue handles associated with
  *                     the class-of-service.
  * @param      num     Maximum number of queue handles to output.
  *
  * @return Number of queues linked with CoS
- * @retval on 0 failure
+ * @retval 0 on failure
  */
-uint32_t odp_cls_cos_queues(odp_cos_t cos_id, odp_queue_t queue[],
-			    uint32_t num);
+uint32_t odp_cls_cos_queues(odp_cos_t cos, odp_queue_t queue[], uint32_t num);
 
 /**
  * Assign packet drop policy for specific class-of-service
  *
- * @param cos_id       class-of-service instance.
+ * @param cos          CoS handle
  * @param drop_policy  Desired packet drop policy for this class.
  *
  * @retval  0 on success
@@ -427,16 +427,16 @@ uint32_t odp_cls_cos_queues(odp_cos_t cos_id, odp_queue_t queue[],
  *
  * @note Optional.
  */
-int odp_cos_drop_set(odp_cos_t cos_id, odp_cls_drop_t drop_policy);
+int odp_cos_drop_set(odp_cos_t cos, odp_cls_drop_t drop_policy);
 
 /**
 * Get the drop policy configured for a specific class-of-service instance.
 *
-* @param cos_id        class-of-service instance.
+* @param cos           CoS handle
 *
 * @retval Drop policy configured with the given class-of-service
 */
-odp_cls_drop_t odp_cos_drop(odp_cos_t cos_id);
+odp_cls_drop_t odp_cos_drop(odp_cos_t cos);
 
 /**
  * Request to override per-port class of service
@@ -608,7 +608,8 @@ typedef enum {
  * an exception to this (uint32_t in CPU endian).
  */
 typedef struct odp_pmr_param_t {
-	odp_cls_pmr_term_t  term;	/**< Packet Matching Rule term */
+	/** Packet Matching Rule term */
+	odp_cls_pmr_term_t  term;
 
 	/** True if the value is range and false if match */
 	odp_bool_t range_term;
@@ -700,6 +701,7 @@ void odp_cls_pmr_create_opt_init(odp_pmr_create_opt_t *opt);
  * This packet matching rule is applied on all packets arriving at the source
  * class of service and packets satisfying this PMR are sent to the destination
  * class of service.
+ *
  * A composite PMR rule is created when the number of terms in the match rule
  * is more than one. The composite rule is considered as matching only if
  * the packet satisfies all the terms in Packet Match Rule.
@@ -751,50 +753,53 @@ odp_pmr_t odp_cls_pmr_create_opt(const odp_pmr_create_opt_t *opt,
 				 odp_cos_t src_cos, odp_cos_t dst_cos);
 /**
  * Function to destroy a packet match rule
+ *
  * Destroying a PMR removes the link between the source and destination
  * class of service and this PMR will no longer be applied for packets arriving
- * at the source class of service. All the resource associated with the PMR
- * be release but the class of service will remain intact.
+ * at the source class of service. All the resources associated with the PMR
+ * will be released but the class of service will remain intact.
+ *
  * Depending on the implementation details, destroying a composite rule
  * may not guarantee the availability of hardware resources to create the
  * same or essentially similar rule.
  *
- * @param pmr_id       Identifier of the PMR to be destroyed
+ * @param pmr       Handle of the PMR to be destroyed
  *
  * @retval  0 on success
  * @retval <0 on failure
  */
-int odp_cls_pmr_destroy(odp_pmr_t pmr_id);
+int odp_cls_pmr_destroy(odp_pmr_t pmr);
 
 /**
-* Assigns a packet pool for a specific class of service.
+* Assigns a packet pool for a specific class of service
+*
 * All the packets belonging to the given class of service will
 * be allocated from the assigned packet pool.
 * The packet pool associated with class of service will supersede the
 * packet pool associated with the pktio interface.
 *
-* @param cos_id        class of service handle
-* @param pool_id       packet pool handle
+* @param cos        CoS handle
+* @param pool_id    Packet pool handle
 *
 * @retval  0 on success
 * @retval <0 on failure
 */
-int odp_cls_cos_pool_set(odp_cos_t cos_id, odp_pool_t pool_id);
+int odp_cls_cos_pool_set(odp_cos_t cos, odp_pool_t pool_id);
 
 /**
 * Get the pool associated with the given class of service
 *
-* @param cos_id        class of service handle
+* @param cos        CoS handle
 *
 * @retval pool handle of the associated pool
 * @retval ODP_POOL_INVALID if no associated pool found or in case of an error
 */
-odp_pool_t odp_cls_cos_pool(odp_cos_t cos_id);
+odp_pool_t odp_cls_cos_pool(odp_cos_t cos);
 
 /**
  * Get printable value for an odp_cos_t
  *
- * @param hdl          odp_cos_t handle to be printed
+ * @param cos       CoS handle to be printed
  *
  * @return uint64_t value that can be used to print/display this handle
  *
@@ -802,12 +807,12 @@ odp_pool_t odp_cls_cos_pool(odp_cos_t cos_id);
  * to enable applications to generate a printable value that represents
  * an odp_cos_t handle.
  */
-uint64_t odp_cos_to_u64(odp_cos_t hdl);
+uint64_t odp_cos_to_u64(odp_cos_t cos);
 
 /**
  * Get printable value for an odp_pmr_t
  *
- * @param hdl          odp_pmr_t handle to be printed
+ * @param pmr          odp_pmr_t handle to be printed
  *
  * @return uint64_t value that can be used to print/display this handle
  *
@@ -815,7 +820,7 @@ uint64_t odp_cos_to_u64(odp_cos_t hdl);
  * to enable applications to generate a printable value that represents
  * an odp_pmr_t handle.
  */
-uint64_t odp_pmr_to_u64(odp_pmr_t hdl);
+uint64_t odp_pmr_to_u64(odp_pmr_t pmr);
 
 /**
  * Print classifier info

--- a/platform/linux-generic/include/odp_classification_datamodel.h
+++ b/platform/linux-generic/include/odp_classification_datamodel.h
@@ -145,6 +145,10 @@ struct cos_s {
 	odp_queue_param_t queue_param;
 	char name[ODP_COS_NAME_LEN];	/* name */
 	uint8_t index;
+	struct {
+		odp_atomic_u64_t discards;
+		odp_atomic_u64_t packets;
+	} stats[CLS_COS_QUEUE_MAX];
 };
 
 typedef union cos_u {

--- a/platform/linux-generic/include/odp_classification_datamodel.h
+++ b/platform/linux-generic/include/odp_classification_datamodel.h
@@ -230,6 +230,17 @@ typedef struct pmr_tbl {
 	pmr_t pmr[CLS_PMR_MAX_ENTRY];
 } pmr_tbl_t;
 
+/**
+Classifier global data
+**/
+typedef struct cls_global_t {
+	cos_tbl_t cos_tbl;
+	pmr_tbl_t pmr_tbl;
+	_cls_queue_grp_tbl_t queue_grp_tbl;
+	odp_shm_t shm;
+
+} cls_global_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/include/odp_classification_internal.h
+++ b/platform/linux-generic/include/odp_classification_internal.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -25,7 +26,12 @@ extern "C" {
 #include <odp_packet_io_internal.h>
 #include <odp_classification_datamodel.h>
 
-cos_t *_odp_cos_entry_from_idx(uint32_t ndx);
+extern cls_global_t *_odp_cls_global;
+
+static inline cos_t *_odp_cos_entry_from_idx(uint32_t ndx)
+{
+	return &_odp_cls_global->cos_tbl.cos_entry[ndx];
+}
 
 /** Classification Internal function **/
 

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2019-2020, Nokia
+ * Copyright (c) 2019-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -42,15 +42,7 @@ static cos_tbl_t *cos_tbl;
 static pmr_tbl_t	*pmr_tbl;
 static _cls_queue_grp_tbl_t *queue_grp_tbl;
 
-typedef struct cls_global_t {
-	cos_tbl_t cos_tbl;
-	pmr_tbl_t pmr_tbl;
-	_cls_queue_grp_tbl_t queue_grp_tbl;
-	odp_shm_t shm;
-
-} cls_global_t;
-
-static cls_global_t *cls_global;
+cls_global_t *_odp_cls_global;
 
 static const rss_key default_rss = {
 	.u8 = {
@@ -61,11 +53,6 @@ static const rss_key default_rss = {
 	0x6a, 0x42, 0xb7, 0x3b, 0xbe, 0xac, 0x01, 0xfa,
 	}
 };
-
-cos_t *_odp_cos_entry_from_idx(uint32_t ndx)
-{
-	return &cos_tbl->cos_entry[ndx];
-}
 
 static inline uint32_t _odp_cos_to_ndx(odp_cos_t cos)
 {
@@ -109,13 +96,13 @@ int _odp_classification_init_global(void)
 	if (shm == ODP_SHM_INVALID)
 		return -1;
 
-	cls_global = odp_shm_addr(shm);
-	memset(cls_global, 0, sizeof(cls_global_t));
+	_odp_cls_global = odp_shm_addr(shm);
+	memset(_odp_cls_global, 0, sizeof(cls_global_t));
 
-	cls_global->shm = shm;
-	cos_tbl       = &cls_global->cos_tbl;
-	pmr_tbl       = &cls_global->pmr_tbl;
-	queue_grp_tbl = &cls_global->queue_grp_tbl;
+	_odp_cls_global->shm = shm;
+	cos_tbl       = &_odp_cls_global->cos_tbl;
+	pmr_tbl       = &_odp_cls_global->pmr_tbl;
+	queue_grp_tbl = &_odp_cls_global->queue_grp_tbl;
 
 	for (i = 0; i < CLS_COS_MAX_ENTRY; i++) {
 		/* init locks */
@@ -136,7 +123,7 @@ int _odp_classification_init_global(void)
 
 int _odp_classification_term_global(void)
 {
-	if (cls_global && odp_shm_free(cls_global->shm)) {
+	if (_odp_cls_global && odp_shm_free(_odp_cls_global->shm)) {
 		ODP_ERR("shm free failed\n");
 		return -1;
 	}


### PR DESCRIPTION
Add classifier queue specific statistics counters (odp_cls_queue_stats_t)
and matching capabilities (odp_cls_stats_capability_t). Statistics counters
can be reset with odp_cls_queue_stats_reset() function and read
with odp_cls_queue_stats().

V2:
- Clarified `odp_cls_queue_stats_reset()` and `odp_cls_queue_stats()` argument documentation

V3:
- Removed `odp_cls_queue_stats_reset()` and clarified `odp_cls_queue_stats()` documentation

V4:
- Added implementation and validation tests
- Removed FCS from `odp_cls_queue_stats_t.octets` specification (Sunil)