### PR TITLE
[PATCH v2] linux-gen: dpdk: fix snap ethtype parsing

### DIFF
--- a/platform/linux-generic/pktio/dpdk_parse.c
+++ b/platform/linux-generic/pktio/dpdk_parse.c
@@ -94,7 +94,7 @@ static inline uint16_t dpdk_parse_eth(packet_parser_t *prs,
 			goto error;
 		}
 		ethtype = odp_be_to_cpu_16(*((const uint16_t *)(uintptr_t)
-					      (parseptr + 6)));
+					      (*parseptr + 6)));
 		*offset   += 8;
 		*parseptr += 8;
 	}


### PR DESCRIPTION
DPDK pktio SNAP ethtype parsing code was using incorrect pointer.

Signed-off-by: Matias Elo <matias.elo@nokia.com>