### PR TITLE
[PATCH v12] api: ipsec: add destination queue capability

### DIFF
--- a/example/ipsec_api/odp_ipsec.c
+++ b/example/ipsec_api/odp_ipsec.c
@@ -921,6 +921,7 @@ main(int argc, char *argv[])
 	odp_shm_t shm;
 	odp_cpumask_t cpumask;
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
+	odp_ipsec_capability_t ipsec_capa;
 	odp_pool_param_t params;
 	odp_instance_t instance;
 	odp_init_t init_param;
@@ -961,6 +962,23 @@ main(int argc, char *argv[])
 	if (odp_init_local(instance, ODP_THREAD_CONTROL)) {
 		ODPH_ERR("Error: ODP local init failed.\n");
 		exit(EXIT_FAILURE);
+	}
+
+	if (odp_ipsec_capability(&ipsec_capa)) {
+		ODPH_ERR("Error: IPsec capability request failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (queue_create == polled_odp_queue_create) {
+		if (!ipsec_capa.queue_type_plain) {
+			ODPH_ERR("Error: Plain type dest queue not supported.\n");
+			exit(EXIT_FAILURE);
+		}
+	} else {
+		if (!ipsec_capa.queue_type_sched) {
+			ODPH_ERR("Error: scheduled type dest queue not supported.\n");
+			exit(EXIT_FAILURE);
+		}
 	}
 
 	/* Reserve memory for args from shared mem */

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -338,6 +338,28 @@ typedef struct odp_ipsec_capability_t {
 	 */
 	uint32_t max_cls_cos;
 
+	/**
+	 * Scheduled queue support
+	 *
+	 * 0: Scheduled queues are not supported either as IPsec SA destination
+	 *    queues or as IPsec default queue
+	 * 1: Scheduled queues are supported as both IPsec SA destination queues
+	 *    and IPsec default queue
+	 * @see odp_ipsec_sa_param_t
+	 */
+	odp_bool_t queue_type_sched;
+
+	/**
+	 * Plain queue support
+	 *
+	 * 0: Plain queues are not supported either as IPsec SA destination
+	 *    queues or as IPsec default queue
+	 * 1: Plain queues are supported as both IPsec SA destination queues and
+	 *    IPsec default queue
+	 * @see odp_ipsec_sa_param_t
+	 */
+	odp_bool_t queue_type_plain;
+
 	/** Maximum number of different destination queues. The same queue may
 	 *  be used for many SAs. */
 	uint32_t max_queues;

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -165,6 +165,9 @@ int odp_ipsec_capability(odp_ipsec_capability_t *capa)
 	if (rc < 0)
 		return rc;
 
+	capa->queue_type_plain = true;
+	capa->queue_type_sched = true;
+
 	rc = odp_queue_capability(&queue_capa);
 	if (rc < 0)
 		return rc;

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -1030,6 +1030,7 @@ int main(int argc, char *argv[])
 	odph_odpthread_t thr[num_workers];
 	odp_instance_t instance;
 	odp_init_t init_param;
+	odp_ipsec_capability_t ipsec_capa;
 	odp_pool_capability_t capa;
 	odp_ipsec_config_t config;
 	uint32_t max_seg_len;
@@ -1091,6 +1092,21 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	}
 	odp_pool_print(pool);
+
+	if (odp_ipsec_capability(&ipsec_capa) < 0) {
+		app_err("IPSEC capability call failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (cargs.schedule && !ipsec_capa.queue_type_sched) {
+		app_err("Scheduled type destination queue not supported.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (cargs.poll && !ipsec_capa.queue_type_plain) {
+		app_err("Plain type destination queue not supported.\n");
+		exit(EXIT_FAILURE);
+	}
 
 	odp_ipsec_config_init(&config);
 	config.max_num_sa = 2;

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -100,6 +100,14 @@ static int pktio_start(odp_pktio_t pktio, odp_bool_t in, odp_bool_t out)
 	return 1;
 }
 
+static odp_event_t recv_event(odp_queue_t queue)
+{
+	if (odp_queue_type(queue) == ODP_QUEUE_TYPE_PLAIN)
+		return odp_queue_deq(queue);
+	else
+		return odp_schedule(NULL, ODP_SCHED_NO_WAIT);
+}
+
 static void pktio_stop(odp_pktio_t pktio)
 {
 	odp_queue_t queue = ODP_QUEUE_INVALID;
@@ -110,7 +118,7 @@ static void pktio_stop(odp_pktio_t pktio)
 		fprintf(stderr, "IPsec pktio stop failed.\n");
 
 	while (1) {
-		odp_event_t ev = odp_queue_deq(queue);
+		odp_event_t ev = recv_event(queue);
 
 		if (ev != ODP_EVENT_INVALID)
 			odp_event_free(ev);
@@ -138,6 +146,17 @@ int ipsec_check(odp_bool_t ah,
 	    (ODP_IPSEC_OP_MODE_INLINE == suite_context.outbound_op_mode &&
 	     ODP_SUPPORT_NO == capa.op_mode_inline_out))
 		return ODP_TEST_INACTIVE;
+
+	if (!(ODP_IPSEC_OP_MODE_SYNC == suite_context.inbound_op_mode &&
+	      ODP_IPSEC_OP_MODE_SYNC == suite_context.outbound_op_mode) &&
+	    ODP_QUEUE_INVALID != suite_context.queue) {
+		if (suite_context.q_type == ODP_QUEUE_TYPE_PLAIN &&
+		    !capa.queue_type_plain)
+			return ODP_TEST_INACTIVE;
+		if (suite_context.q_type == ODP_QUEUE_TYPE_SCHED &&
+		    !capa.queue_type_sched)
+			return ODP_TEST_INACTIVE;
+	}
 
 	/* suite_context.pktio is set to ODP_PKTIO_INVALID in ipsec_suite_init()
 	 * if the pktio device doesn't support inline IPsec processing. */
@@ -357,7 +376,7 @@ void ipsec_sa_destroy(odp_ipsec_sa_t sa)
 
 	if (ODP_QUEUE_INVALID != suite_context.queue) {
 		do {
-			event = odp_queue_deq(suite_context.queue);
+			event = recv_event(suite_context.queue);
 		} while (event == ODP_EVENT_INVALID);
 
 		CU_ASSERT(odp_event_is_valid(event) == 1);
@@ -532,7 +551,7 @@ static odp_event_t recv_pkt_async_inbound(odp_ipsec_op_status_t status)
 		queue = suite_context.default_queue;
 
 	do {
-		event = odp_queue_deq(queue);
+		event = recv_event(queue);
 	} while (event == ODP_EVENT_INVALID);
 
 	return event;
@@ -554,7 +573,7 @@ static int recv_pkts_inline(const ipsec_test_part *part,
 		odp_event_t ev;
 		odp_event_subtype_t subtype;
 
-		ev = odp_queue_deq(queue);
+		ev = recv_event(queue);
 		if (ODP_EVENT_INVALID != ev) {
 			CU_ASSERT(odp_event_is_valid(ev) == 1);
 			CU_ASSERT_EQUAL(ODP_EVENT_PACKET,
@@ -569,7 +588,7 @@ static int recv_pkts_inline(const ipsec_test_part *part,
 			continue;
 		}
 
-		ev = odp_queue_deq(suite_context.queue);
+		ev = recv_event(suite_context.queue);
 		if (ODP_EVENT_INVALID != ev) {
 			odp_packet_t pkt;
 			int num_pkts = 0;
@@ -701,7 +720,7 @@ static int ipsec_send_out_one(const ipsec_test_part *part,
 			odp_event_subtype_t subtype;
 
 			do {
-				event = odp_queue_deq(suite_context.queue);
+				event = recv_event(suite_context.queue);
 			} while (event == ODP_EVENT_INVALID);
 
 			CU_ASSERT(odp_event_is_valid(event) == 1);
@@ -784,7 +803,7 @@ static int ipsec_send_out_one(const ipsec_test_part *part,
 			odp_event_t ev;
 			odp_event_subtype_t subtype;
 
-			ev = odp_queue_deq(queue);
+			ev = recv_event(queue);
 			if (ODP_EVENT_INVALID != ev) {
 				CU_ASSERT(odp_event_is_valid(ev) == 1);
 				CU_ASSERT_EQUAL(ODP_EVENT_PACKET,
@@ -799,7 +818,7 @@ static int ipsec_send_out_one(const ipsec_test_part *part,
 				continue;
 			}
 
-			ev = odp_queue_deq(suite_context.queue);
+			ev = recv_event(suite_context.queue);
 			if (ODP_EVENT_INVALID != ev) {
 				CU_ASSERT(odp_event_is_valid(ev) == 1);
 				CU_ASSERT_EQUAL(ODP_EVENT_PACKET,
@@ -1025,7 +1044,7 @@ void ipsec_check_out_one(const ipsec_test_part *part, odp_ipsec_sa_t sa)
 		odp_packet_free(pkto[i]);
 }
 
-int ipsec_suite_init(void)
+static int ipsec_suite_init(void)
 {
 	int rc = 0;
 
@@ -1053,10 +1072,15 @@ void ipsec_test_packet_from_pkt(ipsec_test_packet *test_pkt, odp_packet_t *pkt)
 	odp_packet_free(*pkt);
 }
 
-static int ipsec_suite_term(void)
+int ipsec_suite_term(void)
 {
 	if (suite_context.pktio != ODP_PKTIO_INVALID)
 		pktio_stop(suite_context.pktio);
+
+	if (ODP_QUEUE_INVALID != suite_context.queue) {
+		if (odp_queue_destroy(suite_context.queue))
+			fprintf(stderr, "IPsec destq destroy failed.\n");
+	}
 
 	if (odp_cunit_print_inactive())
 		return -1;
@@ -1074,20 +1098,80 @@ int ipsec_out_term(void)
 	return ipsec_suite_term();
 }
 
+static odp_queue_t sched_queue_create(const char *name)
+{
+	odp_queue_param_t qparam;
+
+	odp_queue_param_init(&qparam);
+	qparam.type = ODP_QUEUE_TYPE_SCHED;
+	qparam.sched.prio  = ODP_SCHED_PRIO_DEFAULT;
+	qparam.sched.sync  = ODP_SCHED_SYNC_PARALLEL;
+	qparam.sched.group = ODP_SCHED_GROUP_ALL;
+
+	return odp_queue_create(name, &qparam);
+}
+
+static odp_queue_t plain_queue_create(const char *name)
+{
+	return odp_queue_create(name, NULL);
+}
+
+int ipsec_suite_sync_init(void)
+{
+	suite_context.queue = ODP_QUEUE_INVALID;
+
+	 /* q_type doesn't matter when queue handle is invalid. */
+	suite_context.q_type = ODP_QUEUE_TYPE_PLAIN;
+
+	return ipsec_suite_init();
+}
+
+int ipsec_suite_plain_init(void)
+{
+	odp_queue_t dest_queue;
+
+	dest_queue = plain_queue_create("ipsec-out");
+	if (ODP_QUEUE_INVALID == dest_queue) {
+		fprintf(stderr, "IPsec destq creation failed.\n");
+		return -1;
+	}
+
+	suite_context.queue = dest_queue;
+	suite_context.q_type = ODP_QUEUE_TYPE_PLAIN;
+
+	return ipsec_suite_init();
+}
+
+int ipsec_suite_sched_init(void)
+{
+	odp_queue_t dest_queue;
+
+	dest_queue = sched_queue_create("ipsec-out");
+	if (ODP_QUEUE_INVALID == dest_queue) {
+		fprintf(stderr, "IPsec destq creation failed.\n");
+		return -1;
+	}
+
+	suite_context.queue = dest_queue;
+	suite_context.q_type = ODP_QUEUE_TYPE_SCHED;
+
+	return ipsec_suite_init();
+}
+
 int ipsec_init(odp_instance_t *inst, odp_ipsec_op_mode_t mode)
 {
 	odp_pool_param_t params;
 	odp_pool_t pool;
-	odp_queue_t out_queue;
 	odp_pool_capability_t pool_capa;
-	odp_queue_t default_queue;
 	odp_pktio_t pktio;
 	odp_init_t init_param;
 	odph_helper_options_t helper_options;
 
+	suite_context.reass_ipv4 = false;
+	suite_context.reass_ipv6 = false;
 	suite_context.pool = ODP_POOL_INVALID;
-	suite_context.queue = ODP_QUEUE_INVALID;
 	suite_context.pktio = ODP_PKTIO_INVALID;
+	suite_context.default_queue = ODP_QUEUE_INVALID;
 
 	if (odph_options(&helper_options)) {
 		fprintf(stderr, "error: odph_options() failed.\n");
@@ -1104,6 +1188,11 @@ int ipsec_init(odp_instance_t *inst, odp_ipsec_op_mode_t mode)
 
 	if (0 != odp_init_local(*inst, ODP_THREAD_CONTROL)) {
 		fprintf(stderr, "error: odp_init_local() failed.\n");
+		return -1;
+	}
+
+	if (odp_schedule_config(NULL)) {
+		fprintf(stderr, "odp_schedule_config() failed.\n");
 		return -1;
 	}
 
@@ -1135,20 +1224,6 @@ int ipsec_init(odp_instance_t *inst, odp_ipsec_op_mode_t mode)
 	if (ODP_POOL_INVALID == pool) {
 		fprintf(stderr, "Packet pool creation failed.\n");
 		return -1;
-	}
-	if (mode == ODP_IPSEC_OP_MODE_ASYNC ||
-	    mode == ODP_IPSEC_OP_MODE_INLINE) {
-		out_queue = odp_queue_create("ipsec-out", NULL);
-		if (ODP_QUEUE_INVALID == out_queue) {
-			fprintf(stderr, "IPsec outq creation failed.\n");
-			return -1;
-		}
-
-		default_queue = odp_queue_create("ipsec-default", NULL);
-		if (ODP_QUEUE_INVALID == default_queue) {
-			fprintf(stderr, "IPsec defaultq creation failed.\n");
-			return -1;
-		}
 	}
 
 	if (mode == ODP_IPSEC_OP_MODE_INLINE) {
@@ -1185,6 +1260,19 @@ int ipsec_config(odp_instance_t ODP_UNUSED inst)
 	    (ODP_IPSEC_OP_MODE_INLINE == suite_context.outbound_op_mode &&
 	     ODP_SUPPORT_NO == capa.op_mode_inline_out))
 		return 0;
+
+	if (suite_context.inbound_op_mode == ODP_IPSEC_OP_MODE_ASYNC ||
+	    suite_context.inbound_op_mode == ODP_IPSEC_OP_MODE_INLINE) {
+		if (capa.queue_type_plain)
+			suite_context.default_queue = plain_queue_create("ipsec-default");
+		else if (capa.queue_type_sched)
+			suite_context.default_queue = sched_queue_create("ipsec-default");
+
+		if (ODP_QUEUE_INVALID == suite_context.default_queue) {
+			fprintf(stderr, "IPsec defaultq creation failed.\n");
+			return -1;
+		}
+	}
 
 	reass_test_vectors_init();
 
@@ -1269,7 +1357,6 @@ int ipsec_config(odp_instance_t ODP_UNUSED inst)
 int ipsec_term(odp_instance_t inst)
 {
 	odp_pool_t pool = suite_context.pool;
-	odp_queue_t out_queue = suite_context.queue;
 	odp_queue_t default_queue = suite_context.default_queue;
 	/* suite_context.pktio is set to ODP_PKTIO_INVALID by ipsec_suite_init()
 	   if inline processing is not supported. */
@@ -1278,11 +1365,6 @@ int ipsec_term(odp_instance_t inst)
 	if (ODP_PKTIO_INVALID != pktio) {
 		if (odp_pktio_close(pktio))
 			fprintf(stderr, "IPsec pktio close failed.\n");
-	}
-
-	if (ODP_QUEUE_INVALID != out_queue) {
-		if (odp_queue_destroy(out_queue))
-			fprintf(stderr, "IPsec outq destroy failed.\n");
 	}
 
 	if (ODP_QUEUE_INVALID != default_queue) {

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -39,6 +39,7 @@ struct suite_context_s {
 	odp_ipsec_op_mode_t inbound_op_mode;
 	odp_ipsec_op_mode_t outbound_op_mode;
 	odp_pool_t pool;
+	odp_queue_t default_queue;
 	odp_queue_t queue;
 	odp_pktio_t pktio;
 };

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -29,7 +29,10 @@ int ipsec_config(odp_instance_t inst);
 int ipsec_in_inline_init(void);
 int ipsec_out_inline_init(void);
 
-int ipsec_suite_init(void);
+int ipsec_suite_sync_init(void);
+int ipsec_suite_plain_init(void);
+int ipsec_suite_sched_init(void);
+int ipsec_suite_term(void);
 int ipsec_in_term(void);
 int ipsec_out_term(void);
 
@@ -42,6 +45,7 @@ struct suite_context_s {
 	odp_queue_t default_queue;
 	odp_queue_t queue;
 	odp_pktio_t pktio;
+	odp_queue_type_t q_type;
 };
 
 extern struct suite_context_s suite_context;

--- a/test/validation/api/ipsec/ipsec_async.c
+++ b/test/validation/api/ipsec/ipsec_async.c
@@ -20,6 +20,9 @@ static int ipsec_async_init(odp_instance_t *inst)
 	suite_context.queue = odp_queue_lookup("ipsec-out");
 	if (suite_context.queue == ODP_QUEUE_INVALID)
 		return -1;
+	suite_context.default_queue = odp_queue_lookup("ipsec-default");
+	if (suite_context.default_queue == ODP_QUEUE_INVALID)
+		return -1;
 
 	suite_context.inbound_op_mode = ODP_IPSEC_OP_MODE_ASYNC;
 	suite_context.outbound_op_mode = ODP_IPSEC_OP_MODE_ASYNC;

--- a/test/validation/api/ipsec/ipsec_async.c
+++ b/test/validation/api/ipsec/ipsec_async.c
@@ -10,6 +10,9 @@ static int ipsec_async_init(odp_instance_t *inst)
 {
 	int rc;
 
+	suite_context.inbound_op_mode = ODP_IPSEC_OP_MODE_ASYNC;
+	suite_context.outbound_op_mode = ODP_IPSEC_OP_MODE_ASYNC;
+
 	rc = ipsec_init(inst, ODP_IPSEC_OP_MODE_ASYNC);
 	if (rc != 0)
 		return rc;
@@ -17,22 +20,19 @@ static int ipsec_async_init(odp_instance_t *inst)
 	suite_context.pool = odp_pool_lookup("packet_pool");
 	if (suite_context.pool == ODP_POOL_INVALID)
 		return -1;
-	suite_context.queue = odp_queue_lookup("ipsec-out");
-	if (suite_context.queue == ODP_QUEUE_INVALID)
-		return -1;
-	suite_context.default_queue = odp_queue_lookup("ipsec-default");
-	if (suite_context.default_queue == ODP_QUEUE_INVALID)
-		return -1;
-
-	suite_context.inbound_op_mode = ODP_IPSEC_OP_MODE_ASYNC;
-	suite_context.outbound_op_mode = ODP_IPSEC_OP_MODE_ASYNC;
 
 	return ipsec_config(*inst);
 }
 
 odp_suiteinfo_t ipsec_suites[] = {
-	{"IPsec-in", ipsec_suite_init, ipsec_in_term, ipsec_in_suite},
-	{"IPsec-out", ipsec_suite_init, ipsec_out_term, ipsec_out_suite},
+	{"IPsec-plain-in", ipsec_suite_plain_init, ipsec_suite_term,
+	 ipsec_in_suite},
+	{"IPsec-sched-in", ipsec_suite_sched_init, ipsec_suite_term,
+	 ipsec_in_suite},
+	{"IPsec-plain-out", ipsec_suite_plain_init, ipsec_suite_term,
+	 ipsec_out_suite},
+	{"IPsec-sched-out", ipsec_suite_sched_init, ipsec_suite_term,
+	 ipsec_out_suite},
 	ODP_SUITE_INFO_NULL,
 };
 

--- a/test/validation/api/ipsec/ipsec_inline_in.c
+++ b/test/validation/api/ipsec/ipsec_inline_in.c
@@ -20,6 +20,9 @@ static int ipsec_sync_init(odp_instance_t *inst)
 	suite_context.queue = odp_queue_lookup("ipsec-out");
 	if (suite_context.queue == ODP_QUEUE_INVALID)
 		return -1;
+	suite_context.default_queue = odp_queue_lookup("ipsec-default");
+	if (suite_context.default_queue == ODP_QUEUE_INVALID)
+		return -1;
 	suite_context.pktio = odp_pktio_lookup("loop");
 	if (suite_context.pktio == ODP_PKTIO_INVALID)
 		return -1;

--- a/test/validation/api/ipsec/ipsec_inline_in.c
+++ b/test/validation/api/ipsec/ipsec_inline_in.c
@@ -10,6 +10,9 @@ static int ipsec_sync_init(odp_instance_t *inst)
 {
 	int rc;
 
+	suite_context.inbound_op_mode = ODP_IPSEC_OP_MODE_INLINE;
+	suite_context.outbound_op_mode = ODP_IPSEC_OP_MODE_ASYNC;
+
 	rc = ipsec_init(inst, ODP_IPSEC_OP_MODE_INLINE);
 	if (rc != 0)
 		return rc;
@@ -17,24 +20,18 @@ static int ipsec_sync_init(odp_instance_t *inst)
 	suite_context.pool = odp_pool_lookup("packet_pool");
 	if (suite_context.pool == ODP_POOL_INVALID)
 		return -1;
-	suite_context.queue = odp_queue_lookup("ipsec-out");
-	if (suite_context.queue == ODP_QUEUE_INVALID)
-		return -1;
-	suite_context.default_queue = odp_queue_lookup("ipsec-default");
-	if (suite_context.default_queue == ODP_QUEUE_INVALID)
-		return -1;
 	suite_context.pktio = odp_pktio_lookup("loop");
 	if (suite_context.pktio == ODP_PKTIO_INVALID)
 		return -1;
-
-	suite_context.inbound_op_mode = ODP_IPSEC_OP_MODE_INLINE;
-	suite_context.outbound_op_mode = ODP_IPSEC_OP_MODE_ASYNC;
 
 	return ipsec_config(*inst);
 }
 
 odp_suiteinfo_t ipsec_suites[] = {
-	{"IPsec-in", ipsec_suite_init, ipsec_in_term, ipsec_in_suite},
+	{"IPsec-plain-in", ipsec_suite_plain_init, ipsec_suite_term,
+	 ipsec_in_suite},
+	{"IPsec-sched-in", ipsec_suite_sched_init, ipsec_suite_term,
+	 ipsec_in_suite},
 	ODP_SUITE_INFO_NULL,
 };
 

--- a/test/validation/api/ipsec/ipsec_inline_out.c
+++ b/test/validation/api/ipsec/ipsec_inline_out.c
@@ -20,6 +20,9 @@ static int ipsec_sync_init(odp_instance_t *inst)
 	suite_context.queue = odp_queue_lookup("ipsec-out");
 	if (suite_context.queue == ODP_QUEUE_INVALID)
 		return -1;
+	suite_context.default_queue = odp_queue_lookup("ipsec-default");
+	if (suite_context.default_queue == ODP_QUEUE_INVALID)
+		return -1;
 	suite_context.pktio = odp_pktio_lookup("loop");
 	if (suite_context.pktio == ODP_PKTIO_INVALID)
 		return -1;

--- a/test/validation/api/ipsec/ipsec_inline_out.c
+++ b/test/validation/api/ipsec/ipsec_inline_out.c
@@ -10,6 +10,9 @@ static int ipsec_sync_init(odp_instance_t *inst)
 {
 	int rc;
 
+	suite_context.inbound_op_mode = ODP_IPSEC_OP_MODE_ASYNC;
+	suite_context.outbound_op_mode = ODP_IPSEC_OP_MODE_INLINE;
+
 	rc = ipsec_init(inst, ODP_IPSEC_OP_MODE_INLINE);
 	if (rc != 0)
 		return rc;
@@ -17,24 +20,18 @@ static int ipsec_sync_init(odp_instance_t *inst)
 	suite_context.pool = odp_pool_lookup("packet_pool");
 	if (suite_context.pool == ODP_POOL_INVALID)
 		return -1;
-	suite_context.queue = odp_queue_lookup("ipsec-out");
-	if (suite_context.queue == ODP_QUEUE_INVALID)
-		return -1;
-	suite_context.default_queue = odp_queue_lookup("ipsec-default");
-	if (suite_context.default_queue == ODP_QUEUE_INVALID)
-		return -1;
 	suite_context.pktio = odp_pktio_lookup("loop");
 	if (suite_context.pktio == ODP_PKTIO_INVALID)
 		return -1;
-
-	suite_context.inbound_op_mode = ODP_IPSEC_OP_MODE_ASYNC;
-	suite_context.outbound_op_mode = ODP_IPSEC_OP_MODE_INLINE;
 
 	return ipsec_config(*inst);
 }
 
 odp_suiteinfo_t ipsec_suites[] = {
-	{"IPsec-out", ipsec_suite_init, ipsec_out_term, ipsec_out_suite},
+	{"IPsec-plain-out", ipsec_suite_plain_init, ipsec_suite_term,
+	 ipsec_out_suite},
+	{"IPsec-sched-out", ipsec_suite_sched_init, ipsec_suite_term,
+	 ipsec_out_suite},
 	ODP_SUITE_INFO_NULL,
 };
 

--- a/test/validation/api/ipsec/ipsec_sync.c
+++ b/test/validation/api/ipsec/ipsec_sync.c
@@ -10,6 +10,9 @@ static int ipsec_sync_init(odp_instance_t *inst)
 {
 	int rc;
 
+	suite_context.inbound_op_mode = ODP_IPSEC_OP_MODE_SYNC;
+	suite_context.outbound_op_mode = ODP_IPSEC_OP_MODE_SYNC;
+
 	rc = ipsec_init(inst, ODP_IPSEC_OP_MODE_SYNC);
 	if (rc != 0)
 		return rc;
@@ -18,15 +21,12 @@ static int ipsec_sync_init(odp_instance_t *inst)
 	if (suite_context.pool == ODP_POOL_INVALID)
 		return -1;
 
-	suite_context.inbound_op_mode = ODP_IPSEC_OP_MODE_SYNC;
-	suite_context.outbound_op_mode = ODP_IPSEC_OP_MODE_SYNC;
-
 	return ipsec_config(*inst);
 }
 
 odp_suiteinfo_t ipsec_suites[] = {
-	{"IPsec-in", ipsec_suite_init, ipsec_in_term, ipsec_in_suite},
-	{"IPsec-out", ipsec_suite_init, ipsec_out_term, ipsec_out_suite},
+	{"IPsec-in", ipsec_suite_sync_init, ipsec_in_term, ipsec_in_suite},
+	{"IPsec-out", ipsec_suite_sync_init, ipsec_out_term, ipsec_out_suite},
 	ODP_SUITE_INFO_NULL,
 };
 


### PR DESCRIPTION
In some ODP implementations, plain queues might be using software
primitives such as a simple ring and the ODP IPsec hardware
can enqueue completion events only into schedule queues.
Introducing capability queue_type_sched and queue_type_plain
which define the queue types that can be the destination of the
IPsec events.