### PR TITLE
[PATCH v6] api: pktio: add implementation specific extra statistics counters

### DIFF
--- a/include/odp/api/abi-default/packet_io.h
+++ b/include/odp/api/abi-default/packet_io.h
@@ -53,6 +53,8 @@ typedef struct odp_pktout_queue_t {
 
 #define ODP_PKTIN_NO_WAIT 0
 
+#define ODP_PKTIO_STATS_EXTRA_NAME_LEN 64
+
 /**
  * @}
  */

--- a/include/odp/api/spec/packet_io_stats.h
+++ b/include/odp/api/spec/packet_io_stats.h
@@ -27,6 +27,12 @@ extern "C" {
  */
 
 /**
+ * @def ODP_PKTIO_STATS_EXTRA_NAME_LEN
+ * Maximum packet IO extra statistics counter name length in chars including
+ * null char
+ */
+
+/**
  * Packet IO statistics counters
  *
  * In the counter definitions the term successfully refers to packets which were
@@ -263,6 +269,15 @@ typedef struct odp_pktio_stats_capability_t {
 } odp_pktio_stats_capability_t;
 
 /**
+ * Packet IO extra statistics counter information
+ */
+typedef struct odp_pktio_extra_stat_info_t {
+	/** Name of the counter */
+	char name[ODP_PKTIO_STATS_EXTRA_NAME_LEN];
+
+} odp_pktio_extra_stat_info_t;
+
+/**
  * Get statistics for pktio handle
  *
  * Counters not supported by the interface are set to zero.
@@ -352,6 +367,78 @@ int odp_pktout_event_queue_stats(odp_pktio_t pktio, odp_queue_t queue,
  * @retval <0 on failure
  */
 int odp_pktio_stats_reset(odp_pktio_t pktio);
+
+/**
+ * Get extra statistics counter information for a packet IO interface
+ *
+ * Returns the number of implementation specific packet IO extra statistics
+ * counters supported by the interface. Outputs up to 'num' extra statistics
+ * counter info structures when the 'info' array pointer is not NULL. If the
+ * return value is larger than 'num', there are more extra counters than the
+ * function was allowed to output. If the return value (N) is less than 'num',
+ * only info[0 ... N-1] have been written.
+ *
+ * The index of a counter in the 'info' array can be used to read the value of
+ * the individual counter with odp_pktio_extra_stat_counter(). The order of
+ * counters in the output array matches with odp_pktio_extra_stats().
+ *
+ * @param       pktio    Packet IO handle
+ * @param[out]  info     Array of extra statistics info structs for output
+ * @param       num      Maximum number of info structs to output
+ *
+ * @return Number of extra statistics
+ * @retval <0 on failure
+ */
+int odp_pktio_extra_stat_info(odp_pktio_t pktio,
+			      odp_pktio_extra_stat_info_t info[], int num);
+
+/**
+ * Get extra statistics for a packet IO interface
+ *
+ * Returns the number of implementation specific packet IO extra statistics
+ * counters supported by the interface. Outputs up to 'num' counters when the
+ * 'stats' array pointer is not NULL. If the return value is larger than 'num',
+ * there are more counters than the function was allowed to output. If the
+ * return value (N) is less than 'num', only stats[0 ... N-1] have been written.
+ *
+ * The index of a counter in the 'stats' array can be used to read the value of
+ * the individual counter with odp_pktio_extra_stat_counter(). The order of
+ * counters in the output array matches with odp_pktio_extra_stat_info().
+ *
+ * @param       pktio    Packet IO handle
+ * @param[out]  stats    Array of extra statistics for output
+ * @param       num      Maximum number of extra statistics to output
+ *
+ * @return Number of extra statistics
+ * @retval <0 on failure
+ */
+int odp_pktio_extra_stats(odp_pktio_t pktio, uint64_t stats[], int num);
+
+/**
+ * Get extra statistic counter value
+ *
+ * 'id' is the index of the particular counter in the output array of
+ * odp_pktio_extra_stat_info() or odp_pktio_extra_stats().
+ *
+ *
+ * @param       pktio    Packet IO handle
+ * @param       id       ID of the extra statistics counter
+ * @param[out]  stat     Pointer for statistic counter output
+ *
+ * @retval  0 on success
+ * @retval <0 on failure
+ */
+int odp_pktio_extra_stat_counter(odp_pktio_t pktio, uint32_t id,
+				 uint64_t *stat);
+
+/**
+ * Print extra statistics for a packet IO interface
+ *
+ * Print all packet IO device extra statistics to ODP log.
+ *
+ * @param       pktio    Packet IO handle
+ */
+void odp_pktio_extra_stats_print(odp_pktio_t pktio);
 
 /**
  * @}

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_io.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_io.h
@@ -50,6 +50,8 @@ typedef struct odp_pktout_queue_t {
 #define ODP_PKTIN_NO_WAIT 0
 #define ODP_PKTIN_WAIT    UINT64_MAX
 
+#define ODP_PKTIO_STATS_EXTRA_NAME_LEN 64
+
 /**
  * @}
  */

--- a/platform/linux-generic/include/odp_ethtool_stats.h
+++ b/platform/linux-generic/include/odp_ethtool_stats.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -18,6 +19,11 @@ extern "C" {
  * Get ethtool statistics of a packet socket
  */
 int _odp_ethtool_stats_get_fd(int fd, const char *name, odp_pktio_stats_t *stats);
+
+int _odp_ethtool_extra_stat_info(int fd, const char *name, odp_pktio_extra_stat_info_t info[],
+				 int num);
+int _odp_ethtool_extra_stats(int fd, const char *name, uint64_t stats[], int num);
+int _odp_ethtool_extra_stat_counter(int fd, const char *name, uint32_t id, uint64_t *stat);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -200,6 +200,10 @@ typedef struct pktio_if_ops {
 				 odp_pktin_queue_stats_t *pktin_stats);
 	int (*pktout_queue_stats)(pktio_entry_t *pktio_entry, uint32_t index,
 				  odp_pktout_queue_stats_t *pktout_stats);
+	int (*extra_stat_info)(pktio_entry_t *pktio_entry, odp_pktio_extra_stat_info_t info[],
+			       int num);
+	int (*extra_stats)(pktio_entry_t *pktio_entry, uint64_t stats[], int num);
+	int (*extra_stat_counter)(pktio_entry_t *pktio_entry, uint32_t id, uint64_t *stat);
 	uint64_t (*pktio_ts_res)(pktio_entry_t *pktio_entry);
 	odp_time_t (*pktio_ts_from_ns)(pktio_entry_t *pktio_entry, uint64_t ns);
 	odp_time_t (*pktio_time)(pktio_entry_t *pktio_entry, odp_time_t *global_ts);

--- a/platform/linux-generic/include/odp_packet_io_stats.h
+++ b/platform/linux-generic/include/odp_packet_io_stats.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -24,6 +25,14 @@ int _odp_sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd);
 
 void _odp_sock_stats_capa(pktio_entry_t *pktio_entry,
 			  odp_pktio_capability_t *capa);
+
+int _odp_sock_extra_stat_info(pktio_entry_t *pktio_entry,
+			      odp_pktio_extra_stat_info_t info[], int num,
+			      int fd);
+int _odp_sock_extra_stats(pktio_entry_t *pktio_entry, uint64_t stats[], int num,
+			  int fd);
+int _odp_sock_extra_stat_counter(pktio_entry_t *pktio_entry, uint32_t id,
+				 uint64_t *stat, int fd);
 
 pktio_stats_type_t _odp_sock_stats_type_fd(pktio_entry_t *pktio_entry, int fd);
 

--- a/platform/linux-generic/include/odp_sysfs_stats.h
+++ b/platform/linux-generic/include/odp_sysfs_stats.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -16,6 +17,13 @@ extern "C" {
 
 int _odp_sysfs_stats(pktio_entry_t *pktio_entry,
 		     odp_pktio_stats_t *stats);
+
+int _odp_sysfs_extra_stat_info(pktio_entry_t *pktio_entry,
+			       odp_pktio_extra_stat_info_t info[], int num);
+int _odp_sysfs_extra_stats(pktio_entry_t *pktio_entry, uint64_t stats[],
+			   int num);
+int _odp_sysfs_extra_stat_counter(pktio_entry_t *pktio_entry, uint32_t id,
+				  uint64_t *stat);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -315,6 +315,10 @@ static odp_pktio_t setup_pktio_entry(const char *name, odp_pool_t pool,
 		return ODP_PKTIO_INVALID;
 	}
 
+	snprintf(pktio_entry->s.name,
+		 sizeof(pktio_entry->s.name), "%s", if_name);
+	snprintf(pktio_entry->s.full_name,
+		 sizeof(pktio_entry->s.full_name), "%s", name);
 	pktio_entry->s.pool = pool;
 	memcpy(&pktio_entry->s.param, param, sizeof(odp_pktio_param_t));
 	pktio_entry->s.handle = hdl;
@@ -347,10 +351,6 @@ static odp_pktio_t setup_pktio_entry(const char *name, odp_pool_t pool,
 		return ODP_PKTIO_INVALID;
 	}
 
-	snprintf(pktio_entry->s.name,
-		 sizeof(pktio_entry->s.name), "%s", if_name);
-	snprintf(pktio_entry->s.full_name,
-		 sizeof(pktio_entry->s.full_name), "%s", name);
 	pktio_entry->s.state = PKTIO_STATE_OPENED;
 	pktio_entry->s.ops = _odp_pktio_if_ops[pktio_if];
 	unlock_entry(pktio_entry);

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -2242,7 +2242,85 @@ static int dpdk_stats(pktio_entry_t *pktio_entry, odp_pktio_stats_t *stats)
 
 static int dpdk_stats_reset(pktio_entry_t *pktio_entry)
 {
-	rte_eth_stats_reset(pkt_priv(pktio_entry)->port_id);
+	uint16_t port_id = pkt_priv(pktio_entry)->port_id;
+
+	(void)rte_eth_stats_reset(port_id);
+	(void)rte_eth_xstats_reset(port_id);
+	return 0;
+}
+
+static int dpdk_extra_stat_info(pktio_entry_t *pktio_entry,
+				odp_pktio_extra_stat_info_t info[], int num)
+{
+	uint16_t port_id = pkt_priv(pktio_entry)->port_id;
+	int num_stats, ret, i;
+
+	num_stats = rte_eth_xstats_get_names(port_id, NULL, 0);
+	if (num_stats < 0) {
+		ODP_ERR("rte_eth_xstats_get_names() failed: %d\n", num_stats);
+		return num_stats;
+	} else if (info == NULL || num == 0 || num_stats == 0) {
+		return num_stats;
+	}
+
+	struct rte_eth_xstat_name xstats_names[num_stats];
+
+	ret = rte_eth_xstats_get_names(port_id, xstats_names, num_stats);
+	if (ret < 0 || ret > num_stats) {
+		ODP_ERR("rte_eth_xstats_get_names() failed: %d\n", ret);
+		return -1;
+	}
+	num_stats = ret;
+
+	for (i = 0; i < num && i < num_stats; i++)
+		strncpy(info[i].name, xstats_names[i].name,
+			ODP_PKTIO_STATS_EXTRA_NAME_LEN - 1);
+
+	return num_stats;
+}
+
+static int dpdk_extra_stats(pktio_entry_t *pktio_entry,
+			    uint64_t stats[], int num)
+{
+	uint16_t port_id = pkt_priv(pktio_entry)->port_id;
+	int num_stats, ret, i;
+
+	num_stats = rte_eth_xstats_get(port_id, NULL, 0);
+	if (num_stats < 0) {
+		ODP_ERR("rte_eth_xstats_get() failed: %d\n", num_stats);
+		return num_stats;
+	} else if (stats == NULL || num == 0 || num_stats == 0) {
+		return num_stats;
+	}
+
+	struct rte_eth_xstat xstats[num_stats];
+
+	ret = rte_eth_xstats_get(port_id, xstats, num_stats);
+	if (ret < 0 || ret > num_stats) {
+		ODP_ERR("rte_eth_xstats_get() failed: %d\n", ret);
+		return -1;
+	}
+	num_stats = ret;
+
+	for (i = 0; i < num && i < num_stats; i++)
+		stats[i] = xstats[i].value;
+
+	return num_stats;
+}
+
+static int dpdk_extra_stat_counter(pktio_entry_t *pktio_entry, uint32_t id,
+				   uint64_t *stat)
+{
+	uint16_t port_id = pkt_priv(pktio_entry)->port_id;
+	uint64_t xstat_id = id;
+	int ret;
+
+	ret = rte_eth_xstats_get_by_id(port_id, &xstat_id, stat, 1);
+	if (ret != 1) {
+		ODP_ERR("rte_eth_xstats_get_by_id() failed: %d\n", ret);
+		return -1;
+	}
+
 	return 0;
 }
 
@@ -2312,6 +2390,9 @@ const pktio_if_ops_t _odp_dpdk_pktio_ops = {
 	.stats_reset = dpdk_stats_reset,
 	.pktin_queue_stats = dpdk_pktin_stats,
 	.pktout_queue_stats = dpdk_pktout_stats,
+	.extra_stat_info = dpdk_extra_stat_info,
+	.extra_stats = dpdk_extra_stats,
+	.extra_stat_counter = dpdk_extra_stat_counter,
 	.recv = dpdk_recv,
 	.send = dpdk_send,
 	.link_status = dpdk_link_status,

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -1250,6 +1250,27 @@ static int netmap_stats_reset(pktio_entry_t *pktio_entry)
 					pkt_priv(pktio_entry)->sockfd);
 }
 
+static int netmap_extra_stat_info(pktio_entry_t *pktio_entry,
+				  odp_pktio_extra_stat_info_t info[], int num)
+{
+	return _odp_sock_extra_stat_info(pktio_entry, info, num,
+					 pkt_priv(pktio_entry)->sockfd);
+}
+
+static int netmap_extra_stats(pktio_entry_t *pktio_entry, uint64_t stats[],
+			      int num)
+{
+	return _odp_sock_extra_stats(pktio_entry, stats, num,
+				     pkt_priv(pktio_entry)->sockfd);
+}
+
+static int netmap_extra_stat_counter(pktio_entry_t *pktio_entry, uint32_t id,
+				     uint64_t *stat)
+{
+	return _odp_sock_extra_stat_counter(pktio_entry, id, stat,
+					    pkt_priv(pktio_entry)->sockfd);
+}
+
 static void netmap_print(pktio_entry_t *pktio_entry)
 {
 	odp_pktin_hash_proto_t hash_proto;
@@ -1288,6 +1309,9 @@ const pktio_if_ops_t _odp_netmap_pktio_ops = {
 	.link_info = netmap_link_info,
 	.stats = netmap_stats,
 	.stats_reset = netmap_stats_reset,
+	.extra_stat_info = netmap_extra_stat_info,
+	.extra_stats = netmap_extra_stats,
+	.extra_stat_counter = netmap_extra_stat_counter,
 	.maxlen_get = netmap_mtu_get,
 	.maxlen_set = netmap_mtu_set,
 	.promisc_mode_set = netmap_promisc_mode_set,

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -578,6 +578,28 @@ static int sock_stats_reset(pktio_entry_t *pktio_entry)
 	return _odp_sock_stats_reset_fd(pktio_entry, pkt_priv(pktio_entry)->sockfd);
 }
 
+static int sock_extra_stat_info(pktio_entry_t *pktio_entry,
+				odp_pktio_extra_stat_info_t info[],
+				int num)
+{
+	return _odp_sock_extra_stat_info(pktio_entry, info, num,
+					 pkt_priv(pktio_entry)->sockfd);
+}
+
+static int sock_extra_stats(pktio_entry_t *pktio_entry, uint64_t stats[],
+			    int num)
+{
+	return _odp_sock_extra_stats(pktio_entry, stats, num,
+				     pkt_priv(pktio_entry)->sockfd);
+}
+
+static int sock_extra_stat_counter(pktio_entry_t *pktio_entry, uint32_t id,
+				   uint64_t *stat)
+{
+	return _odp_sock_extra_stat_counter(pktio_entry, id, stat,
+					    pkt_priv(pktio_entry)->sockfd);
+}
+
 static int sock_init_global(void)
 {
 	if (getenv("ODP_PKTIO_DISABLE_SOCKET_MMSG")) {
@@ -603,6 +625,9 @@ const pktio_if_ops_t _odp_sock_mmsg_pktio_ops = {
 	.stop = NULL,
 	.stats = sock_stats,
 	.stats_reset = sock_stats_reset,
+	.extra_stat_info = sock_extra_stat_info,
+	.extra_stats = sock_extra_stats,
+	.extra_stat_counter = sock_extra_stat_counter,
 	.recv = sock_mmsg_recv,
 	.recv_tmo = sock_recv_tmo,
 	.recv_mq_tmo = sock_recv_mq_tmo,

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -896,6 +896,28 @@ static int sock_mmap_stats_reset(pktio_entry_t *pktio_entry)
 					pkt_priv(pktio_entry)->sockfd);
 }
 
+static int sock_mmap_extra_stat_info(pktio_entry_t *pktio_entry,
+				     odp_pktio_extra_stat_info_t info[],
+				     int num)
+{
+	return _odp_sock_extra_stat_info(pktio_entry, info, num,
+					 pkt_priv(pktio_entry)->sockfd);
+}
+
+static int sock_mmap_extra_stats(pktio_entry_t *pktio_entry, uint64_t stats[],
+				 int num)
+{
+	return _odp_sock_extra_stats(pktio_entry, stats, num,
+				     pkt_priv(pktio_entry)->sockfd);
+}
+
+static int sock_mmap_extra_stat_counter(pktio_entry_t *pktio_entry, uint32_t id,
+					uint64_t *stat)
+{
+	return _odp_sock_extra_stat_counter(pktio_entry, id, stat,
+					    pkt_priv(pktio_entry)->sockfd);
+}
+
 static int sock_mmap_init_global(void)
 {
 	if (getenv("ODP_PKTIO_DISABLE_SOCKET_MMAP")) {
@@ -921,6 +943,9 @@ const pktio_if_ops_t _odp_sock_mmap_pktio_ops = {
 	.stop = NULL,
 	.stats = sock_mmap_stats,
 	.stats_reset = sock_mmap_stats_reset,
+	.extra_stat_info = sock_mmap_extra_stat_info,
+	.extra_stats = sock_mmap_extra_stats,
+	.extra_stat_counter = sock_mmap_extra_stat_counter,
 	.recv = sock_mmap_recv,
 	.recv_tmo = sock_mmap_recv_tmo,
 	.recv_mq_tmo = sock_mmap_recv_mq_tmo,

--- a/platform/linux-generic/pktio/stats/ethtool_stats.c
+++ b/platform/linux-generic/pktio/stats/ethtool_stats.c
@@ -125,13 +125,15 @@ static int ethtool_stats(int fd, struct ifreq *ifr, odp_pktio_stats_t *stats)
 		char *cnt = (char *)&strings->data[i * ETH_GSTRING_LEN];
 		uint64_t val = estats->data[i];
 
-		if (!strcmp(cnt, "rx_octets")) {
+		if (!strcmp(cnt, "rx_octets") ||
+		    !strcmp(cnt, "rx_bytes")) {
 			stats->in_octets = val;
 			cnts++;
 		} else if (!strcmp(cnt, "rx_packets")) {
 			stats->in_packets = val;
 			cnts++;
-		} else if (!strcmp(cnt, "rx_ucast_packets")) {
+		} else if (!strcmp(cnt, "rx_ucast_packets") ||
+			   !strcmp(cnt, "rx_unicast")) {
 			stats->in_ucast_pkts = val;
 			cnts++;
 		} else if (!strcmp(cnt, "rx_broadcast") ||
@@ -142,19 +144,22 @@ static int ethtool_stats(int fd, struct ifreq *ifr, odp_pktio_stats_t *stats)
 			   !strcmp(cnt, "rx_mcast_packets")) {
 			stats->in_mcast_pkts = val;
 			cnts++;
-		} else if (!strcmp(cnt, "rx_discards")) {
+		} else if (!strcmp(cnt, "rx_discards") ||
+			   !strcmp(cnt, "rx_dropped")) {
 			stats->in_discards = val;
 			cnts++;
 		} else if (!strcmp(cnt, "rx_errors")) {
 			stats->in_errors = val;
 			cnts++;
-		} else if (!strcmp(cnt, "tx_octets")) {
+		} else if (!strcmp(cnt, "tx_octets") ||
+			   !strcmp(cnt, "tx_bytes")) {
 			stats->out_octets = val;
 			cnts++;
 		} else if (!strcmp(cnt, "tx_packets")) {
 			stats->out_packets = val;
 			cnts++;
-		} else if (!strcmp(cnt, "tx_ucast_packets")) {
+		} else if (!strcmp(cnt, "tx_ucast_packets") ||
+			   !strcmp(cnt, "tx_unicast")) {
 			stats->out_ucast_pkts = val;
 			cnts++;
 		} else if (!strcmp(cnt, "tx_broadcast") ||
@@ -165,7 +170,8 @@ static int ethtool_stats(int fd, struct ifreq *ifr, odp_pktio_stats_t *stats)
 			   !strcmp(cnt, "tx_mcast_packets")) {
 			stats->out_mcast_pkts = val;
 			cnts++;
-		} else if (!strcmp(cnt, "tx_discards")) {
+		} else if (!strcmp(cnt, "tx_discards") ||
+			   !strcmp(cnt, "tx_dropped")) {
 			stats->out_discards = val;
 			cnts++;
 		} else if (!strcmp(cnt, "tx_errors")) {

--- a/platform/linux-generic/pktio/stats/packet_io_stats.c
+++ b/platform/linux-generic/pktio/stats/packet_io_stats.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -94,6 +95,53 @@ int _odp_sock_stats_fd(pktio_entry_t *pktio_entry,
 				pktio_entry->s.stats.out_errors;
 
 	return ret;
+}
+
+int _odp_sock_extra_stat_info(pktio_entry_t *pktio_entry,
+			      odp_pktio_extra_stat_info_t info[], int num,
+			      int fd)
+{
+	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED)
+		return 0;
+
+	if (pktio_entry->s.stats_type == STATS_ETHTOOL)
+		return _odp_ethtool_extra_stat_info(fd, pktio_entry->s.name,
+						    info, num);
+	else if (pktio_entry->s.stats_type == STATS_SYSFS)
+		return _odp_sysfs_extra_stat_info(pktio_entry, info, num);
+
+	return 0;
+}
+
+int _odp_sock_extra_stats(pktio_entry_t *pktio_entry, uint64_t stats[], int num,
+			  int fd)
+{
+	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED)
+		return 0;
+
+	if (pktio_entry->s.stats_type == STATS_ETHTOOL)
+		return _odp_ethtool_extra_stats(fd, pktio_entry->s.name,
+						stats, num);
+	else if (pktio_entry->s.stats_type == STATS_SYSFS)
+		return _odp_sysfs_extra_stats(pktio_entry, stats, num);
+
+	return 0;
+}
+
+int _odp_sock_extra_stat_counter(pktio_entry_t *pktio_entry, uint32_t id,
+				 uint64_t *stat, int fd)
+{
+	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED)
+		return -1;
+
+	if (pktio_entry->s.stats_type == STATS_ETHTOOL) {
+		return _odp_ethtool_extra_stat_counter(fd, pktio_entry->s.name,
+						       id, stat);
+	} else if (pktio_entry->s.stats_type == STATS_SYSFS) {
+		return _odp_sysfs_extra_stat_counter(pktio_entry, id, stat);
+	}
+
+	return 0;
 }
 
 pktio_stats_type_t _odp_sock_stats_type_fd(pktio_entry_t *pktio_entry, int fd)

--- a/platform/linux-generic/pktio/stats/sysfs_stats.c
+++ b/platform/linux-generic/pktio/stats/sysfs_stats.c
@@ -60,7 +60,7 @@ int _odp_sysfs_stats(pktio_entry_t *pktio_entry,
 	sprintf(fname, "/sys/class/net/%s/statistics/multicast", dev);
 	ret -= sysfs_get_val(fname, &stats->in_mcast_pkts);
 
-	sprintf(fname, "/sys/class/net/%s/statistics/rx_droppped", dev);
+	sprintf(fname, "/sys/class/net/%s/statistics/rx_dropped", dev);
 	ret -= sysfs_get_val(fname, &stats->in_discards);
 
 	sprintf(fname, "/sys/class/net/%s/statistics/rx_errors", dev);

--- a/platform/linux-generic/pktio/stats/sysfs_stats.c
+++ b/platform/linux-generic/pktio/stats/sysfs_stats.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -7,9 +8,13 @@
 #include <odp_api.h>
 #include <odp_sysfs_stats.h>
 #include <odp_errno_define.h>
+#include <dirent.h>
 #include <errno.h>
 #include <string.h>
 #include <inttypes.h>
+#include <linux/limits.h>
+
+#define SYSFS_DIR "/sys/class/net/%s/statistics"
 
 static int sysfs_get_val(const char *fname, uint64_t *val)
 {
@@ -80,6 +85,119 @@ int _odp_sysfs_stats(pktio_entry_t *pktio_entry,
 
 	sprintf(fname, "/sys/class/net/%s/statistics/tx_errors", dev);
 	ret -= sysfs_get_val(fname, &stats->out_errors);
+
+	return ret;
+}
+
+int _odp_sysfs_extra_stat_info(pktio_entry_t *pktio_entry,
+			       odp_pktio_extra_stat_info_t info[], int num)
+{
+	struct dirent *e;
+	DIR *dir;
+	char sysfs_dir[PATH_MAX];
+	int counters = 0;
+
+	snprintf(sysfs_dir, PATH_MAX, SYSFS_DIR, pktio_entry->s.name);
+	dir = opendir(sysfs_dir);
+	if (!dir) {
+		ODP_ERR("Failed to open sysfs dir: %s\n", sysfs_dir);
+		return -1;
+	}
+
+	while ((e = readdir(dir)) != NULL) {
+		/* Skip . and .. */
+		if (strncmp(e->d_name, ".", 1) == 0)
+			continue;
+
+		if (info && counters < num)
+			snprintf(info[counters].name,
+				 ODP_PKTIO_STATS_EXTRA_NAME_LEN, "%s",
+				 e->d_name);
+		counters++;
+	}
+	(void)closedir(dir);
+
+	return counters;
+}
+
+int _odp_sysfs_extra_stats(pktio_entry_t *pktio_entry, uint64_t stats[],
+			   int num)
+{
+	struct dirent *e;
+	DIR *dir;
+	char sysfs_dir[PATH_MAX];
+	char file_path[PATH_MAX];
+	int counters = 0;
+
+	snprintf(sysfs_dir, PATH_MAX, SYSFS_DIR, pktio_entry->s.name);
+	dir = opendir(sysfs_dir);
+	if (!dir) {
+		ODP_ERR("Failed to open dir: %s\n", sysfs_dir);
+		return -1;
+	}
+
+	while ((e = readdir(dir)) != NULL) {
+		uint64_t val;
+
+		/* Skip . and .. */
+		if (strncmp(e->d_name, ".", 1) == 0)
+			continue;
+
+		snprintf(file_path, PATH_MAX, "%s/%s", sysfs_dir, e->d_name);
+		if (sysfs_get_val(file_path, &val)) {
+			ODP_ERR("Failed to read file: %s/n", file_path);
+			counters = -1;
+			break;
+		}
+
+		if (stats && counters < num)
+			stats[counters] = val;
+
+		counters++;
+	}
+	(void)closedir(dir);
+
+	return counters;
+}
+
+int _odp_sysfs_extra_stat_counter(pktio_entry_t *pktio_entry, uint32_t id,
+				  uint64_t *stat)
+{
+	struct dirent *e;
+	DIR *dir;
+	char sysfs_dir[PATH_MAX];
+	char file_path[PATH_MAX];
+	uint32_t counters = 0;
+	int ret = -1;
+
+	snprintf(sysfs_dir, PATH_MAX, SYSFS_DIR, pktio_entry->s.name);
+	dir = opendir(sysfs_dir);
+	if (!dir) {
+		ODP_ERR("Failed to open dir: %s\n", sysfs_dir);
+		return -1;
+	}
+
+	while ((e = readdir(dir)) != NULL) {
+		/* Skip . and .. */
+		if (strncmp(e->d_name, ".", 1) == 0)
+			continue;
+
+		if (counters == id) {
+			uint64_t val;
+
+			snprintf(file_path, PATH_MAX, "%s/%s",
+				 sysfs_dir, e->d_name);
+			if (sysfs_get_val(file_path, &val)) {
+				ODP_ERR("Failed to read file: %s/n", file_path);
+			} else {
+				*stat = val;
+				ret = 0;
+			}
+			break;
+		}
+		counters++;
+	}
+	(void)closedir(dir);
 
 	return ret;
 }


### PR DESCRIPTION
Add new functions for reading ODP implementation specific custom packet IO
statistics counters.

Signed-off-by: Matias Elo <matias.elo@nokia.com>

V2:
- Removed mention of `odp_pktio_stats_reset()`. PR #1288 will extend `odp_pktio_stats_reset()` documentation.

V4:
- Added implementation and validation tests
- Added `odp_pktio_extra_stats_print()`function