### PR TITLE
[PATCH v2] api: ipsec, pktio: specify more default values for init functions

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -203,11 +203,13 @@ typedef struct odp_ipsec_inbound_config_t {
 	odp_reass_config_t reassembly;
 
 	/** Attempt reassembly after inbound IPsec processing in
-	 *  odp_ipsec_in_enq().
+	 *  odp_ipsec_in_enq(). Default value is false.
 	 */
 	odp_bool_t reass_async;
 
-	/** Attempt reassembly after inline inbound IPsec processing. */
+	/** Attempt reassembly after inline inbound IPsec processing.
+	 *  Default value is false.
+	 **/
 	odp_bool_t reass_inline;
 
 } odp_ipsec_inbound_config_t;
@@ -879,6 +881,8 @@ typedef struct odp_ipsec_sa_param_t {
 			 *  Reassembly may be enabled for an SA only if
 			 *  reassembly was enabled in the global IPsec
 			 *  configuration.
+			 *
+			 *  Default value is false.
 			 *
 			 *  @see odp_ipsec_config()
 			 *

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -585,7 +585,10 @@ typedef struct odp_pktio_config_t {
 	 * In this mode the packets sent out through the interface is
 	 * looped back to input of the same interface. Supporting loopback mode
 	 * is an optional feature per interface and should be queried in the
-	 * interface capability before enabling the same. */
+	 * interface capability before enabling the same.
+	 *
+	 * Default value is false.
+	 */
 	odp_bool_t enable_loop;
 
 	/** Inbound IPSEC inlined with packet input

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -261,6 +261,7 @@ void odp_ipsec_config_init(odp_ipsec_config_t *config)
 	config->inbound.default_queue = ODP_QUEUE_INVALID;
 	config->inbound.lookup.min_spi = 0;
 	config->inbound.lookup.max_spi = UINT32_MAX;
+	config->inbound.reassembly.max_num_frags = 2;
 	config->stats_en = false;
 }
 

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1534,6 +1534,7 @@ void odp_pktio_config_init(odp_pktio_config_t *config)
 	memset(config, 0, sizeof(odp_pktio_config_t));
 
 	config->parser.layer = ODP_PROTO_LAYER_ALL;
+	config->reassembly.max_num_frags = 2;
 }
 
 int odp_pktio_info(odp_pktio_t hdl, odp_pktio_info_t *info)

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -1570,6 +1570,12 @@ static void ipsec_test_default_values(void)
 	CU_ASSERT(config.inbound.retain_outer == ODP_PROTO_LAYER_NONE);
 	CU_ASSERT(config.inbound.parse_level == ODP_PROTO_LAYER_NONE);
 	CU_ASSERT(config.inbound.chksums.all_chksum == 0);
+	CU_ASSERT(!config.inbound.reassembly.en_ipv4);
+	CU_ASSERT(!config.inbound.reassembly.en_ipv6);
+	CU_ASSERT(config.inbound.reassembly.max_wait_time == 0);
+	CU_ASSERT(config.inbound.reassembly.max_num_frags == 2);
+	CU_ASSERT(!config.inbound.reass_async);
+	CU_ASSERT(!config.inbound.reass_inline);
 	CU_ASSERT(config.outbound.all_chksum == 0);
 	CU_ASSERT(!config.stats_en);
 
@@ -1592,6 +1598,7 @@ static void ipsec_test_default_values(void)
 	CU_ASSERT(sa_param.inbound.lookup_mode == ODP_IPSEC_LOOKUP_DISABLED);
 	CU_ASSERT(sa_param.inbound.antireplay_ws == 0);
 	CU_ASSERT(sa_param.inbound.pipeline == ODP_IPSEC_PIPELINE_NONE);
+	CU_ASSERT(!sa_param.inbound.reassembly_en);
 	CU_ASSERT(sa_param.outbound.tunnel.type == ODP_IPSEC_TUNNEL_IPV4);
 	CU_ASSERT(sa_param.outbound.tunnel.ipv4.dscp == 0);
 	CU_ASSERT(sa_param.outbound.tunnel.ipv4.df == 0);

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1658,12 +1658,24 @@ static void pktio_test_pktio_config(void)
 	pktio = create_pktio(0, ODP_PKTIN_MODE_DIRECT, ODP_PKTOUT_MODE_DIRECT);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 
+	memset(&config, 0xff, sizeof(config));
 	odp_pktio_config_init(&config);
+
+	/* Check default values */
+	CU_ASSERT(config.pktin.all_bits == 0);
+	CU_ASSERT(config.pktout.all_bits == 0);
+	CU_ASSERT(config.parser.layer == ODP_PROTO_LAYER_ALL);
+	CU_ASSERT(!config.enable_loop);
+	CU_ASSERT(!config.inbound_ipsec);
+	CU_ASSERT(!config.outbound_ipsec);
+	CU_ASSERT(!config.enable_lso);
+	CU_ASSERT(!config.reassembly.en_ipv4);
+	CU_ASSERT(!config.reassembly.en_ipv6);
+	CU_ASSERT(config.reassembly.max_wait_time == 0);
+	CU_ASSERT(config.reassembly.max_num_frags == 2);
 
 	/* Indicate packet refs might be used */
 	config.pktout.bit.no_packet_refs = 0;
-
-	CU_ASSERT(config.parser.layer == ODP_PROTO_LAYER_ALL);
 
 	CU_ASSERT(odp_pktio_config(pktio, NULL) == 0);
 


### PR DESCRIPTION
This PR specifies more default values for init functions, improves validation testing of the defaults and fixes one bug in default value setting.

Contained patches (reverse order):

validation: pktio: check default values of odp_pktio_config_t
api: pktio: make loopback mode disabled by default
validation: ipsec: check reassembly related default values
api: ipsec: specify default values for reassembly enables
linux-gen: reass: fix the default value of max_num_frags
