### PR TITLE
[PATCH v3] api: tm: increase sched weight parameter size

### DIFF
--- a/include/odp/api/abi-default/traffic_mngr.h
+++ b/include/odp/api/abi-default/traffic_mngr.h
@@ -46,13 +46,13 @@ extern "C" {
 /**
  * The smallest SCHED weight is 1 (i.e. 0 is not a legal WFQ/WRR value).
  */
-#define ODP_TM_MIN_SCHED_WEIGHT  1
+#define ODP_TM_MIN_SCHED_WEIGHT  1U
 
 /** The ODP_TM_MAX_SCHED_WEIGHT constant is the largest weight any TM system
  * can support (at least from a configuration standpoint).  A given TM system
  * could have a smaller value.
  */
-#define ODP_TM_MAX_SCHED_WEIGHT  255
+#define ODP_TM_MAX_SCHED_WEIGHT  255U
 
 /** The ODP_TM_MAX_TM_QUEUES constant is the largest number of tm_queues
  * that can be handled by any one TM system.

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -213,12 +213,12 @@ typedef struct {
 	/** min_weight only has significance when the weights_supported field
 	 * below is true, in which case it specifies the smallest value
 	 * of the weights allowed at this level. */
-	uint8_t min_weight;
+	uint32_t min_weight;
 
 	/** max_weight only has significance when the weights_supported field
 	 * below is true, in which case it specifies the largest value
 	 * of the weights allowed at this level. */
-	uint8_t max_weight;
+	uint32_t max_weight;
 
 	/** tm_node_shaper_supported indicates that the tm_nodes at this level
 	 * all support TM shaping, */
@@ -411,12 +411,12 @@ typedef struct {
 	/** min_weight only has significance when the weights_supported field
 	 * below is true, in which case it specifies the smallest value
 	 * of the weights that will be used at this level. */
-	uint8_t min_weight;
+	uint32_t min_weight;
 
 	/** max_weight only has significance when the weights_supported field
 	 * below is true, in which case it specifies the largest value
 	 * of the weights that will be used at this level. */
-	uint8_t max_weight;
+	uint32_t max_weight;
 
 	/** tm_node_shaper_needed indicates that the tm_nodes at this level
 	 * are expected to do TM shaping, */
@@ -1004,11 +1004,11 @@ typedef struct {
 	/** In the case that sched_modes for a given strict priority level
 	 * indicates the use of weighted scheduling, this field supplies the
 	 * weighting factors.  The weights - when defined - are used such that
-	 * the (adjusted) frame lengths are divided by these 8-bit weights
+	 * the (adjusted) frame lengths are divided by these weights
 	 * (i.e. they are divisors and not multipliers).  Consequently a
 	 * weight of 0 (when sched_mode is ODP_TM_BYTE_BASED_WEIGHTS) is
 	 * illegal. */
-	uint8_t sched_weights[ODP_TM_MAX_PRIORITIES];
+	uint32_t sched_weights[ODP_TM_MAX_PRIORITIES];
 } odp_tm_sched_params_t;
 
 /** odp_tm_sched_params_init() must be called to initialize any

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2604,7 +2604,8 @@ static void tm_system_capabilities_set(odp_tm_capabilities_t *cap_ptr,
 	odp_bool_t                   dual_slope;
 	uint32_t                     num_levels, level_idx, max_nodes;
 	uint32_t                     max_queues, max_fanin;
-	uint8_t                      max_priority, min_weight, max_weight;
+	uint32_t                     min_weight, max_weight;
+	uint8_t                      max_priority;
 
 	num_levels = MAX(MIN(req_ptr->num_levels, ODP_TM_MAX_LEVELS), 1);
 	memset(cap_ptr, 0, sizeof(odp_tm_capabilities_t));


### PR DESCRIPTION
Increase sched weight parameter size to accommodate larger
sched weights. This is needed for platform that support
weights larger than 255.

Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>