### PR TITLE
[PATCH v2] api: increment ODP API version to 1.30.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,40 @@
+== OpenDataPlane (1.30.1.0)
+=== API
+==== Packet IO
+* Modified `odp_pktio_stats_t.in_octets/out_octets` definitions to not include
+CRC (4 bytes)
+* Added `odp_pktio_stats_capability_t` struct to `odp_pktio_capability_t` to
+inform about supported statistics counters
+* Added new statistics counters and related capabilities for
+received/transmitted multicast and broadcast Ethernet packets (`in_mcast_pkts`,
+`in_bcast_pkts`, `out_mcast_pkts`, `out_bcast_pkts`)
+* Added new pktio input/output queue specific statistics counters
+(`odp_pktin_queue_stats_t` and `odp_pktout_queue_stats_t`) and related
+functions and capabilities
+* Added new functions for reading and printing ODP implementation specific
+custom packet IO statistics counters: `odp_pktio_extra_stat_info()`,
+`odp_pktio_extra_stats()`, `odp_pktio_extra_stats_print()`
+* Specified that the default value of `odp_pktio_config_t.enable_loop` option is
+false
+
+==== IPsec
+* Specified that the default values of the IPsec specific reassembly enables
+are false
+
+==== Scheduler
+* Added `odp_schedule_print()` function for printing debug information about
+scheduler status into the ODP log
+
+==== Standard Types
+* Added `odp_fract_u64_t` type which can be used to define fractional numbers
+accurately
+* Added `odp_fract_u64_to_dbl()` function for converting `odp_fract_u64_t`
+fractional numbers into doubles
+
+==== Timer
+* Added timer tick info as part of `odp_timer_pool_info_t`. This enables timer
+implementation to specify tick frequency and duration very accurately.
+
 == OpenDataPlane (1.30.0.0)
 === API
 ==== IPsec

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.5])
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [30])
-m4_define([odpapi_minor_version], [0])
+m4_define([odpapi_minor_version], [1])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])


### PR DESCRIPTION
Increment API version number to reflect the following changes:

Backward compatible:
- packet_io: added odp_pktio_stats_capability_t struct to
  odp_pktio_capability_t to inform about supported statistics counters
- packet_io: added new statistics counters and related capabilities for
  received/transmitted multicast and broadcast Ethernet packets
  (in_mcast_pkts, in_bcast_pkts, out_mcast_pkts, out_bcast_pkts)
- packet_io: added new pktio input/output queue specific statistics
  counters and related functions and capabilities
- packet_io: added new functions for reading and printing ODP
  implementation specific custom packet IO statistics counters:
  odp_pktio_extra_stat_info() , odp_pktio_extra_stats(),
  odp_pktio_extra_stats_print()
- packet_io: specified that loopback mode is disabled by default
- packet_io: modified odp_pktio_stats_t.in_octets/out_octets definitions to
  not include CRC (4 bytes)
- ipsec: specified default values for reassembly enables
- scheduler: added odp_schedule_print() function for printing debug
  information about scheduler status into the ODP log
- std_types: added odp_fract_u64_t type which can be used to define
  fractional numbers accurately
- std_types: added odp_fract_u64_to_dbl() function for converting
  odp_fract_u64_t fractional numbers into doubles
- timer: added timer tick info as part of odp_timer_pool_info_t. This
  enables timer implementation to specify tick frequency and duration very
  accurately.

Signed-off-by: Matias Elo <matias.elo@nokia.com>