### PR TITLE
[PATCH v2] ipsec: add support for AES-CMAC-96 auth algorithm

### DIFF
--- a/helper/ipsec.c
+++ b/helper/ipsec.c
@@ -98,6 +98,10 @@ int odph_ipsec_alg_check(odp_ipsec_capability_t capa,
 		if (!capa.auths.bit.aes_ccm)
 			return -1;
 		break;
+	case ODP_AUTH_ALG_AES_CMAC:
+		if (!capa.auths.bit.aes_cmac)
+			return -1;
+		break;
 	case ODP_AUTH_ALG_CHACHA20_POLY1305:
 		if (!capa.auths.bit.chacha20_poly1305)
 			return -1;

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -430,6 +430,8 @@ uint32_t _odp_ipsec_auth_digest_len(odp_auth_alg_t auth)
 		return 16;
 	case ODP_AUTH_ALG_AES_CCM:
 		return 16;
+	case ODP_AUTH_ALG_AES_CMAC:
+		return 12;
 	case ODP_AUTH_ALG_CHACHA20_POLY1305:
 		return 16;
 	default:

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -68,6 +68,7 @@ static struct auth_param auths[] = {
 	ALG(ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256, NULL),
 	ALG(ODP_AUTH_ALG_SHA384_HMAC, &key_5a_384, NULL),
 	ALG(ODP_AUTH_ALG_SHA512_HMAC, &key_5a_512, NULL),
+	ALG(ODP_AUTH_ALG_AES_CMAC, &key_5a_128, NULL),
 	ALG(ODP_AUTH_ALG_AES_XCBC_MAC, &key_5a_128, NULL)
 };
 


### PR DESCRIPTION
ODP IPsec API supports AES-CMAC-96 but the algorithm is missing from validation test and the capability checker in helper. This PR adds minimal IPsec validation test (the digest algorithm itself is already validated in crypto validation tests) and makes the helper aware of the algorithm.

This PR also adds AES-CMAC-96 support in linux-gen IPsec implementation. The change is a one-liner as the crypto subsystem supports the algorithm and the IPsec implementation just needs to enable its use.