### PR TITLE
[PATCH v4] api: ipsec: add ICV length in SA configuration parameters

### DIFF
--- a/helper/include/odp/helper/ipsec.h
+++ b/helper/include/odp/helper/ipsec.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -74,9 +75,9 @@ ODP_STATIC_ASSERT(sizeof(odph_ahhdr_t) == ODPH_AHHDR_LEN,
  * Check IPSEC algorithm support
  *
  * Based on the capabilities exposed by the ODP implementation, check whether
- * the specified IPSEC algorithm configuration is supported by the
- * implementation. The caller provides the IPSEC capability structure as an
- * argument to the helper function.
+ * the specified IPSEC algorithm configuration with the default ICV length
+ * is supported by the implementation. The caller provides the IPSEC
+ * capability structure as an argument to the helper function.
  *
  * @param      capa            IPSEC capability structure
  * @param      cipher_alg      Cipher algorithm
@@ -92,6 +93,18 @@ int odph_ipsec_alg_check(odp_ipsec_capability_t capa,
 			 uint32_t cipher_key_len,
 			 odp_auth_alg_t auth_alg,
 			 uint32_t auth_key_len);
+
+/**
+ * Return the default ICV length of an algorithm
+ *
+ * IPsec API specifies default ICV length for each authentication and
+ * combined mode algorithm. This function returns the default ICV length.
+ *
+ * @param      auth_alg   Authentication algorithm
+ *
+ * @return                The default ICV length in bytes
+ */
+uint32_t odph_ipsec_auth_icv_len_default(odp_auth_alg_t auth_alg);
 
 /**
  * @}

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2016-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -392,6 +393,8 @@ typedef struct odp_ipsec_auth_capability_t {
 	/** Key length in bytes */
 	uint32_t key_len;
 
+	/** ICV length in bytes */
+	uint32_t icv_len;
 } odp_ipsec_auth_capability_t;
 
 /**
@@ -542,6 +545,37 @@ typedef struct odp_ipsec_crypto_param_t {
 	 *  - ODP_AUTH_ALG_AES_GMAC: 4 bytes of salt
 	 */
 	odp_crypto_key_t auth_key_extra;
+
+	/**
+	 * Length of integrity check value (ICV) in bytes.
+	 *
+	 * Some algorithms support multiple ICV lengths when used with IPsec.
+	 * This field can be used to select a non-default ICV length.
+	 *
+	 * Zero value indicates that the default ICV length shall be used.
+	 * The default length depends on the selected algorithm as follows:
+	 *
+	 * Algorithm                       Default length     Other lengths
+	 * ----------------------------------------------------------------
+	 * ODP_AUTH_ALG_NULL               0
+	 * ODP_AUTH_ALG_MD5_HMAC           12
+	 * ODP_AUTH_ALG_SHA1_HMAC          12
+	 * ODP_AUTH_ALG_SHA256_HMAC        16
+	 * ODP_AUTH_ALG_SHA384_HMAC        24
+	 * ODP_AUTH_ALG_SHA512_HMAC        32
+	 * ODP_AUTH_ALG_AES_GCM            16                 8, 12
+	 * ODP_AUTH_ALG_AES_GMAC           16
+	 * ODP_AUTH_ALG_AES_CCM            16                 8, 12
+	 * ODP_AUTH_ALG_AES_CMAC           12
+	 * ODP_AUTH_ALG_AES_XCBC_MAC       12
+	 * ODP_AUTH_ALG_CHACHA20_POLY1305  16
+	 *
+	 * The requested ICV length must be supported for the selected
+	 * algorithm as indicated by odp_ipsec_auth_capability().
+	 *
+	 * The default value is 0.
+	 */
+	uint32_t icv_len;
 
 } odp_ipsec_crypto_param_t;
 
@@ -1065,11 +1099,9 @@ int odp_ipsec_cipher_capability(odp_cipher_alg_t cipher,
  * Query supported IPSEC authentication algorithm capabilities
  *
  * Outputs all supported configuration options for the algorithm. Output is
- * sorted (from the smallest to the largest) first by digest length, then by key
+ * sorted (from the smallest to the largest) first by ICV length, then by key
  * length. Use this information to select key lengths, etc authentication
- * algorithm options for SA creation (odp_ipsec_crypto_param_t). Application
- * must ignore values for AAD length capabilities as those are not relevant for
- * IPSEC API (fixed in IPSEC RFCs).
+ * algorithm options for SA creation (odp_ipsec_crypto_param_t).
  *
  * @param      auth         Authentication algorithm
  * @param[out] capa         Array of capability structures for output

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -244,8 +244,10 @@ int odp_ipsec_auth_capability(odp_auth_alg_t auth,
 				continue;
 		}
 
-		if (out < num)
+		if (out < num) {
 			capa[out].key_len = crypto_capa[i].key_len;
+			capa[out].icv_len = crypto_capa[i].digest_len;
+		}
 		out++;
 	}
 

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -631,6 +631,10 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 	crypto_param.auth_digest_len =
 		_odp_ipsec_auth_digest_len(crypto_param.auth_alg);
 
+	if (param->crypto.icv_len != 0 &&
+	    param->crypto.icv_len != crypto_param.auth_digest_len)
+		goto error;
+
 	if ((uint32_t)-1 == crypto_param.cipher_iv.length ||
 	    (uint32_t)-1 == crypto_param.auth_digest_len)
 		goto error;

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -1584,6 +1584,7 @@ static void ipsec_test_default_values(void)
 	CU_ASSERT(sa_param.proto == ODP_IPSEC_ESP);
 	CU_ASSERT(sa_param.crypto.cipher_alg == ODP_CIPHER_ALG_NULL);
 	CU_ASSERT(sa_param.crypto.auth_alg == ODP_AUTH_ALG_NULL);
+	CU_ASSERT(sa_param.crypto.icv_len == 0);
 	CU_ASSERT(sa_param.opt.esn == 0);
 	CU_ASSERT(sa_param.opt.udp_encap == 0);
 	CU_ASSERT(sa_param.opt.copy_dscp == 0);


### PR DESCRIPTION
AES-GCM and AES-CCM, as used with IPsec, support more than one ICV length but the current API supports only single, unspecified ICV length for each algorithm.

This PR clarifies what the default ICV lenght is and makes it possible to configure non-default ICV lengths.

Minimal linux-gen implemenation (no new ICV lenghts added) and minimal API validation tests are included.

v2: fixed doxygen comment