### PR TITLE
[PATCH v11] api: tm: add node stats capability and query API 

### DIFF
--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2015-2018 Linaro Limited
  * Copyright (c) 2021-2022 Nokia
- * Copyright (c) 2022 Marvell
+ * Copyright (c) 2022-2025 Marvell
  */
 
 #ifndef ODP_API_SPEC_TRAFFIC_MNGR_H_
@@ -234,6 +234,51 @@ typedef struct odp_tm_queue_stats_capability_t {
 	};
 } odp_tm_queue_stats_capability_t;
 
+/** TM node specific statistics counters */
+typedef struct odp_tm_node_stats_t {
+	/** Number of discarded packets. */
+	uint64_t discards;
+
+	/** Number of octets in discarded packets. */
+	uint64_t discard_octets;
+
+	/** Number of successfully processed packets. */
+	uint64_t packets;
+
+	/** Number of octets in successfully processed packets. */
+	uint64_t octets;
+} odp_tm_node_stats_t;
+
+/**
+ * TM node statistics capabilities
+ */
+typedef struct odp_tm_node_stats_capability_t {
+	/** Supported counters */
+	union {
+		/** Statistics counters in a bit field struct */
+		struct {
+			/** See odp_tm_node_stats_t::discards */
+			uint64_t discards       : 1;
+
+			/** See odp_tm_node_stats_t::discard_octets */
+			uint64_t discard_octets : 1;
+
+			/** See odp_tm_node_stats_t::packets */
+			uint64_t packets        : 1;
+
+			/** See odp_tm_node_stats_t::octets */
+			uint64_t octets         : 1;
+
+		} counter;
+
+		/** All bits of the bit field structure
+		 *
+		 *  This field can be used to set/clear all flags, or
+		 *  for bitwise operations over the entire structure. */
+		uint64_t all_counters;
+	};
+} odp_tm_node_stats_capability_t;
+
 /** Per Level Capabilities
  *
  * The odp_tm_level_capabilities_t record is used to describe the capabilities
@@ -357,6 +402,8 @@ typedef struct {
 
 	} tm_node_threshold;
 
+	/** Node statistics counter capabilities */
+	odp_tm_node_stats_capability_t node_stats;
 } odp_tm_level_capabilities_t;
 
 /** The tm_pkt_prio_mode_t enumeration type is used to indicate different
@@ -2143,6 +2190,23 @@ typedef struct {
  */
 int odp_tm_node_fanin_info(odp_tm_node_t             tm_node,
 			   odp_tm_node_fanin_info_t *info);
+
+/** Get statistics for a TM node
+ *
+ * Read statistics counters associated with the given TM node. Counters not
+ * supported by the node are set to zero by the implementation.
+ *
+ * Depending on the implementation, certain statistics counters may be updated
+ * only on specific nodes in the TM node tree (e.g. by the final node in the
+ * tree even if the packet was marked to be dropped by an earlier node).
+ *
+ * @param      tm_node TM node handle
+ * @param[out] stats   Statistics structure for output
+ *
+ * @retval  0 on success
+ * @retval <0 on failure
+ */
+int odp_tm_node_stats(odp_tm_node_t tm_node, odp_tm_node_stats_t *stats);
 
 /** The odp_tm_queue_info_t record type  is used to return various bits of
  * information about a given tm_queue via the odp_tm_queue_info() function.

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2015 EZchip Semiconductor Ltd.
  * Copyright (c) 2015-2018 Linaro Limited
- * Copyright (c) 2022 Marvell
+ * Copyright (c) 2022-2025 Marvell
  * Copyright (c) 2022 Nokia
  */
 
@@ -4782,6 +4782,14 @@ int odp_tm_node_fanin_info(odp_tm_node_t             tm_node,
 	sched_params        = next_shaper_obj->sched_params;
 	if (sched_params != NULL)
 		info->sched_profile = sched_params->sched_profile;
+
+	return 0;
+}
+
+int odp_tm_node_stats(odp_tm_node_t tm_node, odp_tm_node_stats_t *stats)
+{
+	(void)tm_node;
+	memset(stats, 0, sizeof(odp_tm_node_stats_t));
 
 	return 0;
 }


### PR DESCRIPTION

api: tm: add node stats capability and query API

Add capability to advertise capability of nodes at a given level
to provide statistics.

Also add a new API to query for packet sent count in green, yellow
and red color and packet drop count stats, along with corresponding
octet count statistics. TM node stats query will return only platform
supported statistics.

Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>


linux-gen: tm: add node stats API stub

Add node stats API stub.

Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

