### PR TITLE
[PATCH v2] linux-gen: dpdk: add configuration option for multicast frame reception

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.16"
+config_file_version = "0.1.17"
 
 # System options
 system: {
@@ -118,6 +118,9 @@ pktio_dpdk: {
 
 	# Store RX RSS hash result as ODP flow hash
 	set_flow_hash = 0
+
+	# Enable reception of Ethernet frames sent to any multicast group
+	multicast_en = 1
 
 	# Driver specific options (use PMD names from DPDK)
 	net_ixgbe: {

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -3,7 +3,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [16])
+m4_define([_odp_config_version_minor], [17])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.16"
+config_file_version = "0.1.17"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/packet_align.conf
+++ b/platform/linux-generic/test/packet_align.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.16"
+config_file_version = "0.1.17"
 
 pool: {
 	pkt: {

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.16"
+config_file_version = "0.1.17"
 
 # Shared memory options
 shm: {

--- a/platform/linux-generic/test/sched-basic.conf
+++ b/platform/linux-generic/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.16"
+config_file_version = "0.1.17"
 
 sched_basic: {
 	# Test scheduler with an odd spread value


### PR DESCRIPTION
Add configuration option 'pktio_dpdk.multicast_en' for DPDK pktio to
enable/disable reception of all multicast frames.

Fixes: https://github.com/OpenDataPlane/odp/issues/1326

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reported-by: Bogdan Pricope <bogdan.pricope.2013@gmail.com>