### PR TITLE
[PATCH v2] linux-gen: pktio: fix DPDK 18.11 build

### DIFF
--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -1737,10 +1737,19 @@ static int dpdk_open(odp_pktio_t id ODP_UNUSED,
 
 	promisc_mode_check(pkt_dpdk);
 
+#if RTE_VERSION < RTE_VERSION_NUM(19, 11, 0, 0)
+	ret = 0;
+	if (pkt_dpdk->opt.multicast_en)
+		rte_eth_allmulticast_enable(pkt_dpdk->port_id);
+	else
+		rte_eth_allmulticast_disable(pkt_dpdk->port_id);
+#else
 	if (pkt_dpdk->opt.multicast_en)
 		ret = rte_eth_allmulticast_enable(pkt_dpdk->port_id);
 	else
 		ret = rte_eth_allmulticast_disable(pkt_dpdk->port_id);
+#endif
+
 	/* Not supported by all PMDs, so ignore the return value */
 	if (ret)
 		ODP_DBG("Configuring multicast reception not supported by the PMD\n");


### PR DESCRIPTION
Fix build for DPDK versions earlier than 19.11, which changed
rte_eth_allmulticast_enable() prototype (added return value).

This fix has been tested with DPDK v18.11.
