### PR TITLE
[PATCH v5] api: tm: add unordered enqueue and multi-packet enqueue

### DIFF
--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -1518,6 +1518,12 @@ typedef struct {
 	 * have the same single strict priority level and this level must be
 	 * in the range 0..max_priority. */
 	uint8_t priority;
+
+	/** Maintain original packet order of the source queue when enqueuing
+	 * packets to this queue while holding ordered or atomic queue
+	 * synchronization context. Default value of this flag is true.
+	 */
+	odp_bool_t ordered_enqueue;
 } odp_tm_queue_params_t;
 
 /** odp_tm_queue_params_init() must be called to initialize any
@@ -1718,6 +1724,22 @@ int odp_tm_queue_disconnect(odp_tm_queue_t tm_queue);
  *                  more common failure reasons is WRED drop.
  */
 int odp_tm_enq(odp_tm_queue_t tm_queue, odp_packet_t pkt);
+
+/** The odp_tm_enq_multi() function is used to add packets to a given TM system.
+ * This function enqueues multiple packets but is otherwise similar to
+ * odp_tm_enq(). Packets dropped by WRED or other queue management action do not
+ * cause this function to return a failure. Such packets get consumed just like
+ * the packets that are not dropped.
+ *
+ * @param tm_queue  Specifies the tm_queue (and indirectly the TM system).
+ * @param packets   Array of packets to enqueue.
+ * @param num       Number of packets to send.
+ *
+ * @retval >0  on success indicating number of packets consumed
+ * @retval <=0 on failure.
+ */
+int odp_tm_enq_multi(odp_tm_queue_t tm_queue, const odp_packet_t packets[],
+		     int num);
 
 /** The odp_tm_enq_with_cnt() function behaves identically to odp_tm_enq(),
  * except that it also returns (an approximation to?) the current tm_queue

--- a/platform/linux-generic/include/odp_traffic_mngr_internal.h
+++ b/platform/linux-generic/include/odp_traffic_mngr_internal.h
@@ -286,6 +286,7 @@ struct tm_queue_obj_s {
 	uint8_t blocked_cnt;
 	tm_status_t status;
 	odp_queue_t queue;
+	odp_bool_t ordered_enqueue;
 };
 
 struct tm_node_obj_s {


### PR DESCRIPTION
commit 07d45a29fdfcf90b9b3be2c1eaf00d7f81d54834
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Tue Jul 6 23:41:45 2021 +0530

    validation: tm: set ordered enqueue and use enq multi API
    
    Set new field ordered_enqueue in tm_queue_params and also use
    odp_tm_enq_multi() API in scheduler test as burst Tx function.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit f2a318af9c78c955c18acbf331d9c05f0a3f46ce
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Tue Jun 29 16:50:42 2021 +0530

    linux-gen: tm: support unordered enqueue and enq multi
    
    Add support for unordered enqueue and enq multi API.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 6c9fbeca05726e3646d2f4fccb1d5cef297ab799
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Sat Nov 7 16:32:37 2020 +0530

    api: tm: add unordered enqueue and multi-packet enqueue
    
    For Tx, Packet IO, with TM disabled has Direct mode for enqueueing packets
    and Queue mode for enqueueing packet or packet vector events with ordering
    maintained. For Packet IO with TM enabled, there is only single mode
    which is equivalent to Queue mode for enqueuing packets with ordering
    maintained.
    
    For benefit of disabling ordering when not needed such as a case of
    Direct mode, this patch adds per TM queue parameter to be provided at
    TM queue create time indicating whether order needs to be preserved or
    not.
    
    This patch also adds TM enqueue multi API equivalent to odp_tm_enq()
    but allowing multiple packets to be enqueued in single API call
    inline with pktout enqueue or send API's in non-TM mode.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>


This was reviewed and originally part of pull request https://github.com/OpenDataPlane/odp/pull/1237
