### PR TITLE
[PATCH v8] api:tm: add missing capabilities and egress specific capability API

### DIFF
--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -647,6 +647,9 @@ void odp_tm_egress_init(odp_tm_egress_t *egress);
 
 /** Query All TM Capabilities
  *
+ * @deprecated Use odp_tm_egress_capabilities() instead that also additionally
+ * takes egress as input to provide capabilities specific to a given egress.
+ *
  * This function returns the set of TM capabilities that are common for all
  * egresses. The reason that this returns a SET of capabilities and not just
  * one, is because it is expected that many HW based implementations may have
@@ -672,8 +675,8 @@ void odp_tm_egress_init(odp_tm_egress_t *egress);
  *                               implementations supports. *NOTE* that this
  *                               number can be > capabilities_size!
  */
-int odp_tm_capabilities(odp_tm_capabilities_t capabilities[],
-			uint32_t              capabilities_size);
+int ODP_DEPRECATE(odp_tm_capabilities)(odp_tm_capabilities_t capabilities[],
+				       uint32_t              capabilities_size);
 
 /** Query TM Capabilities specific to an egress
  *

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2555,8 +2555,8 @@ void odp_tm_egress_init(odp_tm_egress_t *egress)
 	memset(egress, 0, sizeof(odp_tm_egress_t));
 }
 
-int odp_tm_capabilities(odp_tm_capabilities_t capabilities[],
-			uint32_t              capabilities_size)
+static int tm_capabilities(odp_tm_capabilities_t capabilities[],
+			   uint32_t              capabilities_size)
 {
 	odp_tm_level_capabilities_t *per_level_cap;
 	odp_tm_capabilities_t       *cap_ptr;
@@ -2616,6 +2616,12 @@ int odp_tm_capabilities(odp_tm_capabilities_t capabilities[],
 	return 1;
 }
 
+int ODP_DEPRECATE(odp_tm_capabilities)(odp_tm_capabilities_t capabilities[],
+				       uint32_t              capabilities_size)
+{
+	return tm_capabilities(capabilities, capabilities_size);
+}
+
 int odp_tm_egress_capabilities(odp_tm_capabilities_t *capabilities,
 			       const odp_tm_egress_t *egress)
 {
@@ -2636,7 +2642,7 @@ int odp_tm_egress_capabilities(odp_tm_capabilities_t *capabilities,
 			return 0;
 	}
 
-	ret = odp_tm_capabilities(capabilities, 1);
+	ret = tm_capabilities(capabilities, 1);
 	if (ret <= 0)
 		return -1;
 	return 0;

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -20,7 +20,6 @@
 
 #define TM_DEBUG                 0
 
-#define MAX_CAPABILITIES         16
 #define MAX_NUM_IFACES           2
 #define MAX_TM_SYSTEMS           3
 #define NUM_LEVELS               3
@@ -386,35 +385,29 @@ static odp_bool_t approx_eq64(uint64_t val, uint64_t correct)
 static int test_overall_capabilities(void)
 {
 	odp_tm_level_capabilities_t *per_level;
-	odp_tm_capabilities_t        capabilities_array[MAX_CAPABILITIES];
+	odp_tm_capabilities_t        capabilities_array[2];
 	odp_tm_capabilities_t       *cap_ptr;
+	odp_tm_egress_t              egress;
 	uint32_t                     num_records, idx, num_levels, level;
 	int                          rc;
 
-	rc = odp_tm_capabilities(capabilities_array, MAX_CAPABILITIES);
-	if (rc < 0) {
-		CU_ASSERT(rc < 0);
-		return -1;
-	}
+	odp_tm_egress_init(&egress);
+	egress.egress_kind = ODP_TM_EGRESS_PKT_IO;
+	egress.pktio = xmt_pktio;
 
-	/* Now test the return code (which did not indicate a failure code)
-	 * to make sure that there is at least ONE capabilities record
-	 * returned */
-	if (rc == 0) {
-		CU_ASSERT(rc != 0);
-		return -1;
-	}
+	rc = odp_tm_egress_capabilities(&capabilities_array[0], &egress);
+	CU_ASSERT_FATAL(rc == 0);
+	num_records = 1;
 
-	/* Now test the return code to see if there were more capabilities
-	 * records than the call above allowed for.  This is not an error,
-	 * just an interesting fact.
-	 */
-	num_records = MAX_CAPABILITIES;
-	if (MAX_CAPABILITIES < rc)
-		ODPH_DBG("There were more than %u capabilities (%u)\n",
-			 MAX_CAPABILITIES, rc);
-	else
-		num_records = rc;
+	/* Get capabilities for egress kind function. */
+	odp_tm_egress_init(&egress);
+	egress.egress_kind = ODP_TM_EGRESS_FN;
+	rc = odp_tm_egress_capabilities(&capabilities_array[1], &egress);
+	CU_ASSERT_FATAL(rc == 0);
+
+	/* Validate this record only if egress function is supported */
+	if (capabilities_array[1].max_tm_queues)
+		num_records++;
 
 	/* Loop through the returned capabilities (there MUST be at least one)
 	 * and do some basic checks to prove that it isn't just an empty
@@ -1649,12 +1642,50 @@ static uint32_t find_child_queues(uint8_t         tm_system_idx,
 	return num_queues;
 }
 
+static void
+set_reqs_based_on_capas(odp_tm_requirements_t *req)
+{
+	odp_packet_color_t color;
+	int j;
+
+	/* Use tm capabilities identified based on egress capabilities
+	 * to see what can be enabled.
+	 */
+	if (tm_capabilities.ecn_marking_supported)
+		req->ecn_marking_needed = true;
+	if (tm_capabilities.drop_prec_marking_supported)
+		req->drop_prec_marking_needed = true;
+	if (tm_capabilities.tm_queue_wred_supported)
+		req->tm_queue_wred_needed = true;
+	if (tm_capabilities.tm_queue_dual_slope_supported)
+		req->tm_queue_dual_slope_needed = true;
+	if (tm_capabilities.vlan_marking_supported)
+		req->vlan_marking_needed = true;
+	if (tm_capabilities.tm_queue_threshold)
+		req->tm_queue_threshold_needed = true;
+
+	for (j = 0; j < tm_capabilities.max_levels; j++) {
+		if (tm_capabilities.per_level[j].tm_node_threshold)
+			req->per_level[j].tm_node_threshold_needed = true;
+	}
+
+	/* Mark colors as needed if at least one of the marking
+	 * feature is needed.
+	 * */
+	if (req->ecn_marking_needed || req->drop_prec_marking_needed) {
+		for (color = 0; color < ODP_NUM_PACKET_COLORS; color++)
+			req->marking_colors_needed[color] = true;
+	}
+
+	if (tm_capabilities.tm_queue_shaper_supported)
+		req->tm_queue_shaper_needed = true;
+}
+
 static int create_tm_system(void)
 {
 	odp_tm_level_requirements_t *per_level;
 	odp_tm_requirements_t        requirements;
 	odp_tm_egress_t              egress;
-	odp_packet_color_t           color;
 	tm_node_desc_t              *root_node_desc;
 	uint32_t                     level, max_nodes[ODP_TM_MAX_LEVELS];
 	odp_tm_t                     odp_tm, found_odp_tm;
@@ -1664,16 +1695,10 @@ static int create_tm_system(void)
 	odp_tm_requirements_init(&requirements);
 	odp_tm_egress_init(&egress);
 
-	requirements.max_tm_queues              = NUM_TM_QUEUES + 1;
+	requirements.max_tm_queues              = NUM_TM_QUEUES;
 	requirements.num_levels                 = NUM_LEVELS;
-	requirements.tm_queue_shaper_needed     = true;
-	requirements.tm_queue_wred_needed       = true;
-	requirements.tm_queue_dual_slope_needed = true;
-	requirements.vlan_marking_needed        = false;
-	requirements.ecn_marking_needed         = true;
-	requirements.drop_prec_marking_needed   = true;
-	for (color = 0; color < ODP_NUM_PACKET_COLORS; color++)
-		requirements.marking_colors_needed[color] = true;
+
+	set_reqs_based_on_capas(&requirements);
 
 	/* Set the max_num_tm_nodes to be double the expected number of nodes
 	 * at that level */
@@ -1701,10 +1726,8 @@ static int create_tm_system(void)
 	snprintf(tm_name, sizeof(tm_name), "TM_system_%" PRIu32,
 		 num_odp_tm_systems);
 	odp_tm = odp_tm_create(tm_name, &requirements, &egress);
-	if (odp_tm == ODP_TM_INVALID) {
-		ODPH_ERR("odp_tm_create() failed\n");
-		return -1;
-	}
+	CU_ASSERT_FATAL(odp_tm != ODP_TM_INVALID);
+
 
 	odp_tm_systems[num_odp_tm_systems] = odp_tm;
 
@@ -2144,9 +2167,10 @@ static int destroy_tm_systems(void)
 
 static int traffic_mngr_suite_init(void)
 {
-	odp_tm_capabilities_t capabilities_array[MAX_CAPABILITIES];
+	odp_tm_capabilities_t egress_capa;
 	uint32_t payload_len, copy_len;
-	int ret, i;
+	odp_tm_egress_t egress;
+	int j, ret;
 
 	/* Initialize some global variables. */
 	num_pkts_made   = 0;
@@ -2195,26 +2219,49 @@ static int traffic_mngr_suite_init(void)
 	if (ret > 0)
 		goto skip_tests;
 
-	/* Fetch initial dynamic update capabilities, it will be updated
-	 * later after TM system is created.
-	 */
-	ret = odp_tm_capabilities(capabilities_array, MAX_CAPABILITIES);
-	if (ret <= 0)
-		return -1;
+	odp_tm_egress_init(&egress);
+	egress.egress_kind = ODP_TM_EGRESS_PKT_IO;
+	egress.pktio = xmt_pktio;
 
-	for (i = 0; i < ret; i++) {
-		if (!capabilities_array[i].dynamic_shaper_update)
-			dynamic_shaper_update = false;
-
-		if (!capabilities_array[i].dynamic_sched_update)
-			dynamic_sched_update = false;
-
-		if (!capabilities_array[i].dynamic_threshold_update)
-			dynamic_threshold_update = false;
-
-		if (!capabilities_array[i].dynamic_wred_update)
-			dynamic_wred_update = false;
+	/* Get TM capabilities */
+	ret = odp_tm_egress_capabilities(&egress_capa, &egress);
+	if (ret) {
+		ODPH_ERR("Failed to retrieve tm capabilities");
+		return ret;
 	}
+
+	/* Check for sufficient TM queues */
+	if (egress_capa.max_tm_queues < NUM_TM_QUEUES)
+		goto skip_tests;
+
+	/* Check for sufficient TM levels */
+	if (egress_capa.max_levels < NUM_LEVELS)
+		goto skip_tests;
+
+	for (j = 0; j < NUM_LEVELS; j++) {
+		/* Per node fanin */
+		if (egress_capa.per_level[j].max_fanin_per_node <
+		    FANIN_RATIO)
+			break;
+	}
+
+	if (j != NUM_LEVELS)
+		goto skip_tests;
+
+	/* Init tm capabilities with matching egress capa until tm is created */
+	tm_capabilities = egress_capa;
+
+	if (!tm_capabilities.dynamic_shaper_update)
+		dynamic_shaper_update = false;
+
+	if (!tm_capabilities.dynamic_sched_update)
+		dynamic_sched_update = false;
+
+	if (!tm_capabilities.dynamic_threshold_update)
+		dynamic_threshold_update = false;
+
+	if (!tm_capabilities.dynamic_wred_update)
+		dynamic_wred_update = false;
 
 	return 0;
 skip_tests:
@@ -4147,6 +4194,17 @@ static void traffic_mngr_test_scheduler(void)
 				 INCREASING_WEIGHTS) == 0);
 }
 
+static int traffic_mngr_check_thresholds(void)
+{
+	/* Check only for tm queue threshold support as
+	 * we only test queue threshold.
+	 */
+	if (!tm_capabilities.tm_queue_threshold)
+		return ODP_TEST_INACTIVE;
+
+	return ODP_TEST_ACTIVE;
+}
+
 static void traffic_mngr_test_thresholds(void)
 {
 	CU_ASSERT(test_threshold("thresh_A", "shaper_A", "node_1_2_1", 0,
@@ -4157,12 +4215,7 @@ static void traffic_mngr_test_thresholds(void)
 
 static int traffic_mngr_check_queue_stats(void)
 {
-	odp_tm_capabilities_t capa;
-
-	if (odp_tm_capabilities(&capa, 1) < 1)
-		return ODP_TEST_INACTIVE;
-
-	if (capa.queue_stats.all_counters == 0)
+	if (tm_capabilities.queue_stats.all_counters == 0)
 		return ODP_TEST_INACTIVE;
 
 	return ODP_TEST_ACTIVE;
@@ -4229,14 +4282,17 @@ static void traffic_mngr_test_queue_stats(void)
 	CU_ASSERT(odp_tm_is_idle(odp_tm_systems[0]));
 }
 
+static int traffic_mngr_check_wred(void)
+{
+	/* Check if wred is part of created odp_tm_t capabilities */
+	if (!tm_capabilities.tm_queue_wred_supported)
+		return ODP_TEST_INACTIVE;
+
+	return ODP_TEST_ACTIVE;
+}
+
 static void traffic_mngr_test_byte_wred(void)
 {
-	if (!tm_capabilities.tm_queue_wred_supported) {
-		ODPH_DBG("\nwas not run because tm_capabilities indicates"
-			 " no WRED support\n");
-		return;
-	}
-
 	CU_ASSERT(test_byte_wred("byte_wred_30G", "byte_bw_30G",
 				 "byte_thresh_30G", "node_1_3_1", 1,
 				 ODP_PACKET_GREEN, TM_PERCENT(30), true) == 0);
@@ -4255,12 +4311,6 @@ static void traffic_mngr_test_byte_wred(void)
 static void traffic_mngr_test_pkt_wred(void)
 {
 	int rc;
-
-	if (!tm_capabilities.tm_queue_wred_supported) {
-		ODPH_DBG("\ntest_pkt_wred was not run because tm_capabilities "
-			 "indicates no WRED support\n");
-		return;
-	}
 
 	rc = test_pkt_wred("pkt_wred_40G", "pkt_bw_40G",
 			   "pkt_thresh_40G", "node_1_3_2", 1,
@@ -4293,59 +4343,75 @@ static void traffic_mngr_test_pkt_wred(void)
 		CU_FAIL("70Y test failed\n");
 }
 
+static int traffic_mngr_check_query(void)
+{
+	uint32_t query_flags = (ODP_TM_QUERY_PKT_CNT | ODP_TM_QUERY_BYTE_CNT);
+
+	/* We need both pkt count and byte count query support */
+	if ((tm_capabilities.tm_queue_query_flags & query_flags) != query_flags)
+		return ODP_TEST_INACTIVE;
+
+	return ODP_TEST_ACTIVE;
+}
+
 static void traffic_mngr_test_query(void)
 {
 	CU_ASSERT(test_query_functions("query_shaper", "node_1_3_3", 3, 10)
 		  == 0);
 }
 
-static void traffic_mngr_test_marking(void)
+static int traffic_mngr_check_vlan_marking(void)
+{
+	if (!tm_capabilities.vlan_marking_supported)
+		return ODP_TEST_INACTIVE;
+	return ODP_TEST_ACTIVE;
+}
+
+static int traffic_mngr_check_ecn_marking(void)
+{
+	if (!tm_capabilities.ecn_marking_supported)
+		return ODP_TEST_INACTIVE;
+	return ODP_TEST_ACTIVE;
+}
+
+static int traffic_mngr_check_drop_prec_marking(void)
+{
+	if (!tm_capabilities.drop_prec_marking_supported)
+		return ODP_TEST_INACTIVE;
+	return ODP_TEST_ACTIVE;
+}
+
+static int traffic_mngr_check_ecn_drop_prec_marking(void)
+{
+	if (!tm_capabilities.ecn_marking_supported ||
+	    !tm_capabilities.drop_prec_marking_supported)
+		return ODP_TEST_INACTIVE;
+	return ODP_TEST_ACTIVE;
+}
+
+static void traffic_mngr_test_vlan_marking(void)
 {
 	odp_packet_color_t color;
-	odp_bool_t         test_ecn, test_drop_prec;
-	int                rc;
 
-	if (tm_capabilities.vlan_marking_supported) {
-		for (color = 0; color < ODP_NUM_PKT_COLORS; color++) {
-			rc = test_vlan_marking("node_1_3_1", color);
-			CU_ASSERT(rc == 0);
-		}
-	} else {
-		ODPH_DBG("\ntest_vlan_marking was not run because "
-			 "tm_capabilities indicates no vlan marking support\n");
+	for (color = 0; color < ODP_NUM_PKT_COLORS; color++) {
+		/* Tree is 3 level */
+		CU_ASSERT(test_vlan_marking("node_1_3_1", color) == 0);
 	}
+}
 
-	if (tm_capabilities.ecn_marking_supported) {
-		test_ecn       = true;
-		test_drop_prec = false;
+static void traffic_mngr_test_ecn_marking(void)
+{
+	CU_ASSERT(ip_marking_tests("node_1_3_2", true, false) == 0);
+}
 
-		rc = ip_marking_tests("node_1_3_2", test_ecn, test_drop_prec);
-		CU_ASSERT(rc == 0);
-	} else {
-		ODPH_DBG("\necn_marking tests were not run because "
-			 "tm_capabilities indicates no ecn marking support\n");
-	}
+static void traffic_mngr_test_drop_prec_marking(void)
+{
+	CU_ASSERT(ip_marking_tests("node_1_4_2", false, true) == 0);
+}
 
-	if (tm_capabilities.drop_prec_marking_supported) {
-		test_ecn       = false;
-		test_drop_prec = true;
-
-		rc = ip_marking_tests("node_1_4_2", test_ecn, test_drop_prec);
-		CU_ASSERT(rc == 0);
-	} else {
-		ODPH_DBG("\ndrop_prec marking tests were not run because "
-			 "tm_capabilities indicates no drop precedence "
-			 "marking support\n");
-	}
-
-	if (tm_capabilities.ecn_marking_supported &&
-	    tm_capabilities.drop_prec_marking_supported) {
-		test_ecn       = true;
-		test_drop_prec = true;
-
-		rc = ip_marking_tests("node_1_4_2", test_ecn, test_drop_prec);
-		CU_ASSERT(rc == 0);
-	}
+static void traffic_mngr_test_ecn_drop_prec_marking(void)
+{
+	CU_ASSERT(ip_marking_tests("node_1_4_2", true, true) == 0);
 }
 
 static void traffic_mngr_test_fanin_info(void)
@@ -4365,19 +4431,32 @@ odp_testinfo_t traffic_mngr_suite[] = {
 	ODP_TEST_INFO(traffic_mngr_test_tm_create),
 	ODP_TEST_INFO(traffic_mngr_test_shaper_profile),
 	ODP_TEST_INFO(traffic_mngr_test_sched_profile),
-	ODP_TEST_INFO(traffic_mngr_test_threshold_profile),
-	ODP_TEST_INFO(traffic_mngr_test_wred_profile),
+	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_threshold_profile,
+				  traffic_mngr_check_thresholds),
+	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_wred_profile,
+				  traffic_mngr_check_wred),
 	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_shaper,
 				  traffic_mngr_check_shaper),
 	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_scheduler,
 				  traffic_mngr_check_scheduler),
-	ODP_TEST_INFO(traffic_mngr_test_thresholds),
-	ODP_TEST_INFO(traffic_mngr_test_byte_wred),
-	ODP_TEST_INFO(traffic_mngr_test_pkt_wred),
-	ODP_TEST_INFO(traffic_mngr_test_query),
+	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_thresholds,
+				  traffic_mngr_check_thresholds),
+	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_byte_wred,
+				  traffic_mngr_check_wred),
+	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_pkt_wred,
+				  traffic_mngr_check_wred),
+	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_query,
+				  traffic_mngr_check_query),
 	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_queue_stats,
 				  traffic_mngr_check_queue_stats),
-	ODP_TEST_INFO(traffic_mngr_test_marking),
+	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_vlan_marking,
+				  traffic_mngr_check_vlan_marking),
+	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_ecn_marking,
+				  traffic_mngr_check_ecn_marking),
+	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_drop_prec_marking,
+				  traffic_mngr_check_drop_prec_marking),
+	ODP_TEST_INFO_CONDITIONAL(traffic_mngr_test_ecn_drop_prec_marking,
+				  traffic_mngr_check_ecn_drop_prec_marking),
 	ODP_TEST_INFO(traffic_mngr_test_fanin_info),
 	ODP_TEST_INFO(traffic_mngr_test_destroy),
 	ODP_TEST_INFO_NULL,


### PR DESCRIPTION
commit df6ce5a7a00d0fc61690fedba0001fa0139345f2
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Mon Jun 7 18:45:39 2021 +0530

    api: tm: deprecate tm capabilities API
    
    Deprecate odp_tm_capabilities() API as odp_tm_egress_capabilities()
    provides similar functionality with additional input of egress
    so that egress specific capabilities can be returned. Egress specific
    capabilities are more useful as each TM system should have an egress.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 06dda1fa4a53132a04813999f482015ec85b4b73
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Tue Jul 6 22:12:58 2021 +0530

    validation: tm: use egress capabability before running tests
    
    Use egress capabilities to identify if different features are
    supported before running the test for features like, threshold,
    pkt marking, wred etc. Also mark test as inactive if required
    number of levels, queues or nodes are not supported for a test suite.
    
    This patch also splits marking tests to subtests for better control
    and replaces odp_tm_capabilities() calls with odp_tm_egress_capabilities()
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 754052d51b64cfe2d9525decde492a7b305e6b75
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Tue Jun 29 15:50:38 2021 +0530

    linux-gen: tm: express new capa and support egress capa API
    
    Express new capabilities for queue/node query/threshold.
    Also implement egress capability API.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 3b08ed7b87e48b9e0872df86c477a33f2167a83d
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Nov 4 20:06:49 2020 +0530

    api: tm: add missing capabilities and egress specific capability API
    
    Not all platforms support TM node query, node threshold, queue query,
    and queue threshold features. Since they are missing from existing
    global and level capabilities, adding the same to express no support.
    
    Also, in some platforms capabilities are specific to a egress kind
    like a PKTIO. Since capabilities provide a way to application to know
    things like how many levels can be supported etc, prior to TM creation,
    add a capability get API to retrieve egress function specific capabilities
    records.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

This was originally part of https://github.com/OpenDataPlane/odp/pull/1237
