### PR TITLE
[PATCH v2] api: std: rename std_clib module to std

### DIFF
--- a/doc/implementers-guide/implementers-guide.adoc
+++ b/doc/implementers-guide/implementers-guide.adoc
@@ -327,7 +327,7 @@ TESTS = validation/api/pktio/pktio_run.sh \
 	$(ALL_API_VALIDATION)/queue/queue_main$(EXEEXT) \
 	$(ALL_API_VALIDATION)/random/random_main$(EXEEXT) \
 	$(ALL_API_VALIDATION)/scheduler/scheduler_main$(EXEEXT) \
-	$(ALL_API_VALIDATION)/std_clib/std_clib_main$(EXEEXT) \
+	$(ALL_API_VALIDATION)/std/std_main$(EXEEXT) \
 	$(ALL_API_VALIDATION)/thread/thread_main$(EXEEXT) \
 	$(ALL_API_VALIDATION)/time/time_main$(EXEEXT) \
 	$(ALL_API_VALIDATION)/timer/timer_main$(EXEEXT) \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -49,7 +49,7 @@ odpapiinclude_HEADERS = \
 	odp/api/spinlock.h \
 	odp/api/spinlock_recursive.h \
 	odp/api/stash.h \
-	odp/api/std_clib.h \
+	odp/api/std.h \
 	odp/api/std_types.h \
 	odp/api/support.h \
 	odp/api/sync.h \
@@ -104,7 +104,7 @@ odpapispecinclude_HEADERS = \
 		  odp/api/spec/spinlock.h \
 		  odp/api/spec/spinlock_recursive.h \
 		  odp/api/spec/stash.h \
-		  odp/api/spec/std_clib.h \
+		  odp/api/spec/std.h \
 		  odp/api/spec/std_types.h \
 		  odp/api/spec/support.h \
 		  odp/api/spec/sync.h \
@@ -155,7 +155,7 @@ odpapiabidefaultinclude_HEADERS = \
 	odp/api/abi-default/spinlock.h \
 	odp/api/abi-default/spinlock_recursive.h \
 	odp/api/abi-default/stash.h \
-	odp/api/abi-default/std_clib.h \
+	odp/api/abi-default/std.h \
 	odp/api/abi-default/std_types.h \
 	odp/api/abi-default/sync.h \
 	odp/api/abi-default/thread.h \
@@ -203,7 +203,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm32-linux/odp/api/abi/spinlock.h \
 	odp/arch/arm32-linux/odp/api/abi/spinlock_recursive.h \
 	odp/arch/arm32-linux/odp/api/abi/stash.h \
-	odp/arch/arm32-linux/odp/api/abi/std_clib.h \
+	odp/arch/arm32-linux/odp/api/abi/std.h \
 	odp/arch/arm32-linux/odp/api/abi/std_types.h \
 	odp/arch/arm32-linux/odp/api/abi/sync.h \
 	odp/arch/arm32-linux/odp/api/abi/thread.h \
@@ -247,7 +247,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm64-linux/odp/api/abi/spinlock.h \
 	odp/arch/arm64-linux/odp/api/abi/spinlock_recursive.h \
 	odp/arch/arm64-linux/odp/api/abi/stash.h \
-	odp/arch/arm64-linux/odp/api/abi/std_clib.h \
+	odp/arch/arm64-linux/odp/api/abi/std.h \
 	odp/arch/arm64-linux/odp/api/abi/std_types.h \
 	odp/arch/arm64-linux/odp/api/abi/sync.h \
 	odp/arch/arm64-linux/odp/api/abi/thread.h \
@@ -291,7 +291,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/default-linux/odp/api/abi/spinlock.h \
 	odp/arch/default-linux/odp/api/abi/spinlock_recursive.h \
 	odp/arch/default-linux/odp/api/abi/stash.h \
-	odp/arch/default-linux/odp/api/abi/std_clib.h \
+	odp/arch/default-linux/odp/api/abi/std.h \
 	odp/arch/default-linux/odp/api/abi/std_types.h \
 	odp/arch/default-linux/odp/api/abi/sync.h \
 	odp/arch/default-linux/odp/api/abi/thread.h \
@@ -335,7 +335,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/mips64-linux/odp/api/abi/spinlock.h \
 	odp/arch/mips64-linux/odp/api/abi/spinlock_recursive.h \
 	odp/arch/mips64-linux/odp/api/abi/stash.h \
-	odp/arch/mips64-linux/odp/api/abi/std_clib.h \
+	odp/arch/mips64-linux/odp/api/abi/std.h \
 	odp/arch/mips64-linux/odp/api/abi/std_types.h \
 	odp/arch/mips64-linux/odp/api/abi/sync.h \
 	odp/arch/mips64-linux/odp/api/abi/thread.h \
@@ -379,7 +379,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/power64-linux/odp/api/abi/spinlock.h \
 	odp/arch/power64-linux/odp/api/abi/spinlock_recursive.h \
 	odp/arch/power64-linux/odp/api/abi/stash.h \
-	odp/arch/power64-linux/odp/api/abi/std_clib.h \
+	odp/arch/power64-linux/odp/api/abi/std.h \
 	odp/arch/power64-linux/odp/api/abi/std_types.h \
 	odp/arch/power64-linux/odp/api/abi/sync.h \
 	odp/arch/power64-linux/odp/api/abi/thread.h \
@@ -423,7 +423,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_32-linux/odp/api/abi/spinlock.h \
 	odp/arch/x86_32-linux/odp/api/abi/spinlock_recursive.h \
 	odp/arch/x86_32-linux/odp/api/abi/stash.h \
-	odp/arch/x86_32-linux/odp/api/abi/std_clib.h \
+	odp/arch/x86_32-linux/odp/api/abi/std.h \
 	odp/arch/x86_32-linux/odp/api/abi/std_types.h \
 	odp/arch/x86_32-linux/odp/api/abi/sync.h \
 	odp/arch/x86_32-linux/odp/api/abi/thread.h \
@@ -467,7 +467,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_64-linux/odp/api/abi/spinlock.h \
 	odp/arch/x86_64-linux/odp/api/abi/spinlock_recursive.h \
 	odp/arch/x86_64-linux/odp/api/abi/stash.h \
-	odp/arch/x86_64-linux/odp/api/abi/std_clib.h \
+	odp/arch/x86_64-linux/odp/api/abi/std.h \
 	odp/arch/x86_64-linux/odp/api/abi/std_types.h \
 	odp/arch/x86_64-linux/odp/api/abi/sync.h \
 	odp/arch/x86_64-linux/odp/api/abi/thread.h \

--- a/include/odp/api/abi-default/std.h
+++ b/include/odp/api/abi-default/std.h
@@ -4,17 +4,14 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#ifndef ODP_API_STD_CLIB_H_
-#define ODP_API_STD_CLIB_H_
+#ifndef ODP_ABI_STD_H_
+#define ODP_ABI_STD_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <odp/api/abi/std_types.h>
-#include <odp/api/abi/std_clib.h>
-
-#include <odp/api/spec/std_clib.h>
+/* Empty header required due to the inline functions */
 
 #ifdef __cplusplus
 }

--- a/include/odp/api/abi-default/std_types.h
+++ b/include/odp/api/abi-default/std_types.h
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-/**
- * @file
- *
- * Standard C language types and definitions for ODP.
- */
-
 #ifndef ODP_ABI_STD_TYPES_H_
 #define ODP_ABI_STD_TYPES_H_
 
@@ -26,7 +20,7 @@ extern "C" {
 /* true and false for odp_bool_t */
 #include <stdbool.h>
 
-/** @addtogroup odp_system ODP SYSTEM
+/** @addtogroup odp_std
  *  @{
  */
 

--- a/include/odp/api/spec/std.h
+++ b/include/odp/api/spec/std.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -7,23 +8,24 @@
 /**
  * @file
  *
- * ODP version of often used C library calls
+ * ODP standard types and optimized C library functions
  */
 
-#ifndef ODP_API_SPEC_STD_CLIB_H_
-#define ODP_API_SPEC_STD_CLIB_H_
+#ifndef ODP_API_SPEC_STD_H_
+#define ODP_API_SPEC_STD_H_
 #include <odp/visibility_begin.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#include <odp/api/std_types.h>
+
 /**
- * @defgroup odp_std_clib ODP STD CLIB
- * Performance optimized versions of selected C library functions.
+ * @defgroup odp_std ODP STD
+ * Standard types and performance optimized versions of selected C library
+ * functions.
  *
- * @details
- * ODP version of often used C library calls
  * @{
  */
 
@@ -73,6 +75,18 @@ void *odp_memset(void *ptr, int value, size_t num);
  *            block 'ptr1' is greater than block 'ptr2'
  */
 int odp_memcmp(const void *ptr1, const void *ptr2, size_t num);
+
+/**
+ * Convert fractional number (u64) to double
+ *
+ * Converts value of the unsigned 64 bit fractional number to a double-precision
+ * floating-point value.
+ *
+ * @param fract  Pointer to a fractional number
+ *
+ * @return Value of the fractional number as double
+ */
+double odp_fract_u64_to_dbl(const odp_fract_u64_t *fract);
 
 /**
  * @}

--- a/include/odp/api/spec/std_types.h
+++ b/include/odp/api/spec/std_types.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-/** @addtogroup odp_system ODP SYSTEM
+/** @addtogroup odp_std ODP STD
  *  @{
  */
 
@@ -94,18 +94,6 @@ typedef struct odp_fract_u64_t {
 		uint64_t denom;
 
 } odp_fract_u64_t;
-
-/**
- * Convert fractional number (u64) to double
- *
- * Converts value of the unsigned 64 bit fractional number to a double-precision
- * floating-point value.
- *
- * @param fract  Pointer to a fractional number
- *
- * @return Value of the fractional number as double
- */
-double odp_fract_u64_to_dbl(const odp_fract_u64_t *fract);
 
 /**
  * @}

--- a/include/odp/api/std.h
+++ b/include/odp/api/std.h
@@ -4,21 +4,17 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-/**
- * @file
- *
- * ODP barrier
- */
-
-#ifndef ODP_API_ABI_STD_CLIB_H_
-#define ODP_API_ABI_STD_CLIB_H_
+#ifndef ODP_API_STD_H_
+#define ODP_API_STD_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define _ODP_INLINE static inline
-#include <odp/api/plat/std_clib_inlines.h>
+#include <odp/api/abi/std_types.h>
+#include <odp/api/abi/std.h>
+
+#include <odp/api/spec/std.h>
 
 #ifdef __cplusplus
 }

--- a/include/odp/arch/arm32-linux/odp/api/abi/std.h
+++ b/include/odp/arch/arm32-linux/odp/api/abi/std.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/api/abi-default/std_clib.h>
+#include <odp/api/abi-default/std.h>

--- a/include/odp/arch/arm64-linux/odp/api/abi/std.h
+++ b/include/odp/arch/arm64-linux/odp/api/abi/std.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/api/abi-default/std_clib.h>
+#include <odp/api/abi-default/std.h>

--- a/include/odp/arch/default-linux/odp/api/abi/std.h
+++ b/include/odp/arch/default-linux/odp/api/abi/std.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/api/abi-default/std_clib.h>
+#include <odp/api/abi-default/std.h>

--- a/include/odp/arch/mips64-linux/odp/api/abi/std.h
+++ b/include/odp/arch/mips64-linux/odp/api/abi/std.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/api/abi-default/std_clib.h>
+#include <odp/api/abi-default/std.h>

--- a/include/odp/arch/power64-linux/odp/api/abi/std.h
+++ b/include/odp/arch/power64-linux/odp/api/abi/std.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/api/abi-default/std_clib.h>
+#include <odp/api/abi-default/std.h>

--- a/include/odp/arch/x86_32-linux/odp/api/abi/std.h
+++ b/include/odp/arch/x86_32-linux/odp/api/abi/std.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/api/abi-default/std_clib.h>
+#include <odp/api/abi-default/std.h>

--- a/include/odp/arch/x86_64-linux/odp/api/abi/std.h
+++ b/include/odp/arch/x86_64-linux/odp/api/abi/std.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/api/abi-default/std_clib.h>
+#include <odp/api/abi-default/std.h>

--- a/include/odp_api.h
+++ b/include/odp_api.h
@@ -59,7 +59,7 @@ extern "C" {
 #include <odp/api/traffic_mngr.h>
 #include <odp/api/spinlock_recursive.h>
 #include <odp/api/rwlock_recursive.h>
-#include <odp/api/std_clib.h>
+#include <odp/api/std.h>
 #include <odp/api/support.h>
 #include <odp/api/ipsec.h>
 #include <odp/api/stash.h>

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -43,7 +43,7 @@ odpapiplatinclude_HEADERS = \
 		  include/odp/api/plat/pool_inline_types.h \
 		  include/odp/api/plat/queue_inlines.h \
 		  include/odp/api/plat/queue_inline_types.h \
-		  include/odp/api/plat/std_clib_inlines.h \
+		  include/odp/api/plat/std_inlines.h \
 		  include/odp/api/plat/strong_types.h \
 		  include/odp/api/plat/sync_inlines.h \
 		  include/odp/api/plat/thread_inlines.h \
@@ -81,7 +81,7 @@ odpapiabiarchinclude_HEADERS += \
 		  include-abi/odp/api/abi/spinlock.h \
 		  include-abi/odp/api/abi/spinlock_recursive.h \
 		  include-abi/odp/api/abi/stash.h \
-		  include-abi/odp/api/abi/std_clib.h \
+		  include-abi/odp/api/abi/std.h \
 		  include-abi/odp/api/abi/std_types.h \
 		  include-abi/odp/api/abi/sync.h \
 		  include-abi/odp/api/abi/thread.h \
@@ -176,7 +176,6 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_errno.c \
 			   odp_event.c \
 			   odp_fdserver.c \
-			   odp_fractional.c \
 			   odp_hash_crc_gen.c \
 			   odp_impl.c \
 			   odp_init.c \
@@ -214,6 +213,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_spinlock.c \
 			   odp_spinlock_recursive.c \
 			   odp_stash.c \
+			   odp_std.c \
 			   odp_system_info.c \
 			   odp_pcapng.c \
 			   odp_thread.c \
@@ -260,7 +260,7 @@ __LIB__libodp_linux_la_SOURCES += \
 			   odp_packet_flags_api.c \
 			   odp_pktio_api.c \
 			   odp_queue_api.c \
-			   odp_std_clib_api.c \
+			   odp_std_api.c \
 			   odp_sync_api.c \
 			   odp_thread_api.c \
 			   odp_ticketlock_api.c \

--- a/platform/linux-generic/include-abi/odp/api/abi/std.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/std.h
@@ -10,12 +10,15 @@
  * ODP barrier
  */
 
-#ifndef ODP_ABI_STD_CLIB_H_
-#define ODP_ABI_STD_CLIB_H_
+#ifndef ODP_API_ABI_STD_H_
+#define ODP_API_ABI_STD_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define _ODP_INLINE static inline
+#include <odp/api/plat/std_inlines.h>
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp/api/plat/std_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/std_inlines.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#ifndef ODP_PLAT_STD_CLIB_INLINE_H_
-#define ODP_PLAT_STD_CLIB_INLINE_H_
+#ifndef ODP_PLAT_STD_INLINE_H_
+#define ODP_PLAT_STD_INLINE_H_
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/odp_std.c
+++ b/platform/linux-generic/odp_std.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/api/std_types.h>
+#include <odp/api/std.h>
 
 double odp_fract_u64_to_dbl(const odp_fract_u64_t *fract)
 {

--- a/platform/linux-generic/odp_std_api.c
+++ b/platform/linux-generic/odp_std_api.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/api/std_clib.h>
+#include <odp/api/std.h>
 
 /* Include non-inlined versions of API functions */
 #define _ODP_NO_INLINE
-#include <odp/api/plat/std_clib_inlines.h>
+#include <odp/api/plat/std_inlines.h>

--- a/test/m4/configure.m4
+++ b/test/m4/configure.m4
@@ -40,7 +40,7 @@ AC_CONFIG_FILES([test/common/Makefile
 		 test/validation/api/scheduler/Makefile
 		 test/validation/api/shmem/Makefile
 		 test/validation/api/stash/Makefile
-		 test/validation/api/std_clib/Makefile
+		 test/validation/api/std/Makefile
 		 test/validation/api/system/Makefile
 		 test/validation/api/thread/Makefile
 		 test/validation/api/time/Makefile

--- a/test/validation/api/Makefile.am
+++ b/test/validation/api/Makefile.am
@@ -19,7 +19,7 @@ ODP_MODULES = atomic \
 	      random \
 	      scheduler \
 	      stash \
-	      std_clib \
+	      std \
 	      thread \
 	      time \
 	      timer \
@@ -64,7 +64,7 @@ TESTS = \
 	scheduler/scheduler_main$(EXEEXT) \
 	scheduler/scheduler_no_predef_groups$(EXEEXT) \
 	stash/stash_main$(EXEEXT) \
-	std_clib/std_clib_main$(EXEEXT) \
+	std/std_main$(EXEEXT) \
 	thread/thread_main$(EXEEXT) \
 	time/time_main$(EXEEXT) \
 	timer/timer_main$(EXEEXT) \

--- a/test/validation/api/std/.gitignore
+++ b/test/validation/api/std/.gitignore
@@ -1,0 +1,1 @@
+std_main

--- a/test/validation/api/std/Makefile.am
+++ b/test/validation/api/std/Makefile.am
@@ -1,0 +1,4 @@
+include ../Makefile.inc
+
+test_PROGRAMS = std_main
+std_main_SOURCES = std.c

--- a/test/validation/api/std/std.c
+++ b/test/validation/api/std/std.c
@@ -11,7 +11,7 @@
 
 #define PATTERN 0x5e
 
-static void std_clib_test_memcpy(void)
+static void std_test_memcpy(void)
 {
 	uint8_t src[] = {0, 1,  2,  3,  4,  5,  6,  7,
 			 8, 9, 10, 11, 12, 13, 14, 15};
@@ -27,7 +27,7 @@ static void std_clib_test_memcpy(void)
 	CU_ASSERT(ret == 0);
 }
 
-static void std_clib_test_memset(void)
+static void std_test_memset(void)
 {
 	uint8_t data[] = {0, 1,  2,  3,  4,  5,  6,  7,
 			  8, 9, 10, 11, 12, 13, 14, 15};
@@ -43,7 +43,7 @@ static void std_clib_test_memset(void)
 	CU_ASSERT(ret == 0);
 }
 
-static void std_clib_test_memcmp(void)
+static void std_test_memcmp(void)
 {
 	uint8_t data[]       = {1,  2,  3,  4,  5,  6,  7,  8,
 				9, 10, 11, 12, 13, 14, 15, 16};
@@ -80,15 +80,15 @@ static void std_clib_test_memcmp(void)
 	}
 }
 
-odp_testinfo_t std_clib_suite[] = {
-	ODP_TEST_INFO(std_clib_test_memcpy),
-	ODP_TEST_INFO(std_clib_test_memset),
-	ODP_TEST_INFO(std_clib_test_memcmp),
+odp_testinfo_t std_suite[] = {
+	ODP_TEST_INFO(std_test_memcpy),
+	ODP_TEST_INFO(std_test_memset),
+	ODP_TEST_INFO(std_test_memcmp),
 	ODP_TEST_INFO_NULL,
 };
 
-odp_suiteinfo_t std_clib_suites[] = {
-	{"Std C library", NULL, NULL, std_clib_suite},
+odp_suiteinfo_t std_suites[] = {
+	{"Std", NULL, NULL, std_suite},
 	ODP_SUITE_INFO_NULL
 };
 
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 	if (odp_cunit_parse_options(argc, argv))
 		return -1;
 
-	ret = odp_cunit_register(std_clib_suites);
+	ret = odp_cunit_register(std_suites);
 
 	if (ret == 0)
 		ret = odp_cunit_run();

--- a/test/validation/api/std_clib/.gitignore
+++ b/test/validation/api/std_clib/.gitignore
@@ -1,1 +1,0 @@
-std_clib_main

--- a/test/validation/api/std_clib/Makefile.am
+++ b/test/validation/api/std_clib/Makefile.am
@@ -1,4 +1,0 @@
-include ../Makefile.inc
-
-test_PROGRAMS = std_clib_main
-std_clib_main_SOURCES = std_clib.c


### PR DESCRIPTION
Move all generic ODP functions and data types to a common std module. Type
definitions have been moved inside std_types.h header to enable easier
function inlining.