### PR TITLE
[PATCH v12] api: tm: add spec to express shaper burst limits

### DIFF
--- a/example/traffic_mgmt/odp_traffic_mgmt.c
+++ b/example/traffic_mgmt/odp_traffic_mgmt.c
@@ -107,7 +107,7 @@ static profile_params_set_t COS0_PROFILE_PARAMS = {
 	.shaper_params = {
 		.commit_rate = 1 * MBPS, .commit_burst      = 100000,
 		.peak_rate   = 4 * MBPS, .peak_burst        = 200000,
-		.dual_rate  = FALSE,     .shaper_len_adjust = 20
+		.dual_rate  = TRUE,      .shaper_len_adjust = 20
 	},
 
 	.threshold_params = {
@@ -149,7 +149,7 @@ static profile_params_set_t COS1_PROFILE_PARAMS = {
 	.shaper_params = {
 		.commit_rate = 500  * KBPS, .commit_burst      = 50000,
 		.peak_rate   = 1500 * KBPS, .peak_burst        = 150000,
-		.dual_rate  = FALSE,        .shaper_len_adjust = 20
+		.dual_rate  = TRUE,         .shaper_len_adjust = 20
 	},
 
 	.threshold_params = {
@@ -191,7 +191,7 @@ static profile_params_set_t COS2_PROFILE_PARAMS = {
 	.shaper_params = {
 		.commit_rate = 200 * KBPS, .commit_burst      = 20000,
 		.peak_rate   = 400 * KBPS, .peak_burst        = 40000,
-		.dual_rate  = FALSE,       .shaper_len_adjust = 20
+		.dual_rate  = TRUE,        .shaper_len_adjust = 20
 	},
 
 	.threshold_params = {
@@ -304,7 +304,6 @@ clamp_rate(uint64_t rate)
 {
 	uint64_t val = MIN(MAX(rate, tm_shaper_min_rate), tm_shaper_max_rate);
 
-	/* PIR can be zero just with CIR valid and vice versa */
 	if (!rate)
 		return 0;
 

--- a/include/odp/api/abi-default/traffic_mngr.h
+++ b/include/odp/api/abi-default/traffic_mngr.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2022, Marvell
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -74,20 +75,6 @@ extern "C" {
  * *TBD* Does this need to be as large as ODP_TM_MAX_TM_QUEUES? *TBD*
  */
 #define ODP_TM_MAX_TM_NODE_FANIN  (4 * 1024)
-
-/** The ODP_TM_MIN_SHAPER_BW constant is the smallest amount of bandwidth that
- * can a shaper's peak or commit rate can be set to.  It is in units of
- * 1000 bytes/second so that it and the ODP_TM_MAX_SHAPER_BW can both fit in
- * 32 bits.
- */
-#define ODP_TM_MIN_SHAPER_BW  1
-
-/** The ODP_TM_MAX_SHAPER_BW constant is the largest amound of bandwidth that
- * any shaper's peak or commit rate can be set to.  It is in units of
- * 1000 bytes/second so that it and the ODP_TM_MIN_SHAPER_BW can both fit in
- * 32 bits.
- */
-#define ODP_TM_MAX_SHAPER_BW  12500000
 
 /** The ODP_NUM_SHAPER_COLORS constant just counts the number of enumeration
  * values defined in the odp_tm_shaper_color_t type.

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -1,5 +1,6 @@
 /* Copyright (c) 2015-2018, Linaro Limited
  * Copyright (c) 2021, Nokia
+ * Copyright (c) 2022, Marvell
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -277,6 +278,54 @@ typedef struct {
 	 * below is true, in which case it specifies the largest value
 	 * of the weights allowed at this level. */
 	uint32_t max_weight;
+
+	/** Minimum allowed value for odp_tm_shaper_params_t::commit_burst and
+	 * odp_tm_shaper_params_t::peak_burst when
+	 * odp_tm_shaper_params_t::packet_mode is true.
+	 */
+	uint32_t min_burst_packets;
+
+	/** Maximum allowed value fand odp_tm_shaper_params_t::commit_burst and
+	 * odp_tm_shaper_params_t::peak_burst when
+	 * odp_tm_shaper_params_t::packet_mode is true.
+	 */
+	uint32_t max_burst_packets;
+
+	/** Minimum allowed value for odp_tm_shaper_params_t::commit_rate and
+	 * odp_tm_shaper_params_t::peak_rate when
+	 * odp_tm_shaper_params_t::packet_mode is true.
+	 */
+	uint64_t min_rate_packets;
+
+	/** Maximum allowed value for odp_tm_shaper_params_t::commit_rate and
+	 * odp_tm_shaper_params_t::peak_rate when
+	 * odp_tm_shaper_params_t::packet_mode is true.
+	 */
+	uint64_t max_rate_packets;
+
+	/** Minimum allowed value for odp_tm_shaper_params_t::commit_burst and
+	 * odp_tm_shaper_params_t::peak_burst when
+	 * odp_tm_shaper_params_t::packet_mode is false.
+	 */
+	uint32_t min_burst;
+
+	/** Maximum allowed value for odp_tm_shaper_params_t::commit_burst and
+	 * odp_tm_shaper_params_t::peak_burst when
+	 * odp_tm_shaper_params_t::packet_mode is false.
+	 */
+	uint32_t max_burst;
+
+	/** Minimum allowed value for odp_tm_shaper_params_t::commit_rate and
+	 * odp_tm_shaper_params_t::peak_rate when
+	 * odp_tm_shaper_params_t::packet_mode is false.
+	 */
+	uint64_t min_rate;
+
+	/** Maximum allowed value for odp_tm_shaper_params_t::commit_rate and
+	 * odp_tm_shaper_params_t::peak_rate when
+	 * odp_tm_shaper_params_t::packet_mode is false.
+	 */
+	uint64_t max_rate;
 
 	/** tm_node_shaper_supported indicates that the tm_nodes at this level
 	 * all support TM shaping, */

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -1063,6 +1063,7 @@ typedef struct {
 	/** The peak information rate for this shaper profile.  The units for
 	 * this integer is in bits per second when packet_mode is
 	 * not TRUE while in packets per second when packet mode is TRUE.
+	 * This field is ignored when dual_rate is FALSE.
 	 */
 	union {
 		/**< @deprecated Use peak_rate instead */
@@ -1079,7 +1080,9 @@ typedef struct {
 	/** The peak burst tolerance for this shaper profile.  The units for
 	 * this field in bits when packet_mode is not TRUE and packets
 	 * when packet_mode is TRUE. This value sets an upper limit for the
-	 * size of the peakCnt. */
+	 * size of the peakCnt.
+	 * This field is ignored when dual_rate is FALSE.
+	 */
 	uint32_t peak_burst;
 
 	/** The shaper_len_adjust is a value between -128 and 127 which is

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -98,18 +98,6 @@ extern "C" {
  */
 
 /**
- * @def ODP_TM_MIN_SHAPER_BW
- * The lowest amount of bandwidth that any shaper's peak or commit rate can
- * be set to. It is in units of 1000 bytes/second.
- */
-
-/**
- * @def ODP_TM_MAX_SHAPER_BW
- * The largest amount of bandwidth that any shaper's peak or commit rate can
- * be set to. It is in units of 1000 bytes/second.
- */
-
-/**
  * @def ODP_NUM_SHAPER_COLORS
  * The number of enumeration values defined in the odp_tm_shaper_color_t type.
  */

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -1,6 +1,7 @@
 /* Copyright 2015 EZchip Semiconductor Ltd. All Rights Reserved.
  *
  * Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2022, Marvell
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -48,6 +49,10 @@ static const pkt_desc_t EMPTY_PKT_DESC = { .word = 0 };
 
 #define MAX_PRIORITIES ODP_TM_MAX_PRIORITIES
 #define NUM_SHAPER_COLORS ODP_NUM_SHAPER_COLORS
+
+/* Shaper BW limits in bits/sec */
+#define TM_MIN_SHAPER_BW  8000ULL
+#define TM_MAX_SHAPER_BW  (100ULL * 1000ULL * 1000ULL * 1000ULL)
 
 static const tm_prop_t basic_prop_tbl[MAX_PRIORITIES][NUM_SHAPER_COLORS] = {
 	[0] = {
@@ -2590,6 +2595,10 @@ static int tm_capabilities(odp_tm_capabilities_t capabilities[],
 		per_level_cap->max_priority       = ODP_TM_MAX_PRIORITIES - 1;
 		per_level_cap->min_weight         = ODP_TM_MIN_SCHED_WEIGHT;
 		per_level_cap->max_weight         = ODP_TM_MAX_SCHED_WEIGHT;
+		per_level_cap->min_burst          = 0;
+		per_level_cap->max_burst          = UINT32_MAX;
+		per_level_cap->min_rate           = TM_MIN_SHAPER_BW;
+		per_level_cap->max_rate           = TM_MAX_SHAPER_BW;
 
 		per_level_cap->tm_node_shaper_supported     = true;
 		per_level_cap->tm_node_wred_supported       = true;
@@ -2712,6 +2721,10 @@ static void tm_system_capabilities_set(odp_tm_capabilities_t *cap_ptr,
 		per_level_cap->max_priority       = max_priority;
 		per_level_cap->min_weight         = min_weight;
 		per_level_cap->max_weight         = max_weight;
+		per_level_cap->min_burst          = 0;
+		per_level_cap->max_burst          = UINT32_MAX;
+		per_level_cap->min_rate           = TM_MIN_SHAPER_BW;
+		per_level_cap->max_rate           = TM_MAX_SHAPER_BW;
 
 		per_level_cap->tm_node_shaper_supported     = shaper_supported;
 		per_level_cap->tm_node_wred_supported       = wred_supported;

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -2412,7 +2412,7 @@ static void check_shaper_profile(char *shaper_name, uint32_t shaper_idx)
 			      clamp_burst(shaper_idx * MIN_PEAK_BURST)));
 
 	CU_ASSERT(shaper_params.shaper_len_adjust == SHAPER_LEN_ADJ);
-	CU_ASSERT(shaper_params.dual_rate         == 0);
+	CU_ASSERT(shaper_params.dual_rate         == true);
 }
 
 static void traffic_mngr_test_shaper_profile(void)
@@ -2424,7 +2424,7 @@ static void traffic_mngr_test_shaper_profile(void)
 
 	odp_tm_shaper_params_init(&shaper_params);
 	shaper_params.shaper_len_adjust = SHAPER_LEN_ADJ;
-	shaper_params.dual_rate         = 0;
+	shaper_params.dual_rate         = true;
 
 	for (idx = 1; idx <= NUM_SHAPER_TEST_PROFILES; idx++) {
 		snprintf(shaper_name, sizeof(shaper_name),


### PR DESCRIPTION
commit d2988a3b6bde68dc7bc863ecf3edf15f1291351a
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Jul 14 20:18:06 2021 +0530

    abi: tm: provide shaper burst limits
    
    Provide shaper min burst and max burst limits.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit b44421e0bd4e8fd05dac955fa333c71985a84fbb
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Jul 14 20:17:52 2021 +0530

    api: tm: add spec to express shaper burst limits
    
    Add macro's that needs to be defined by platform to express
    shaper rate burst min and max in bytes. This is similar to existing
    shaper rate bandwidth min and max macros.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

