### PR TITLE
[PATCH v3] api: packet: fix doxygen warnings

### DIFF
--- a/include/odp/api/abi-default/packet_types.h
+++ b/include/odp/api/abi-default/packet_types.h
@@ -79,6 +79,7 @@ typedef uint8_t odp_proto_l4_type_t;
 #define ODP_PROTO_L4_TYPE_SCTP      132
 #define ODP_PROTO_L4_TYPE_ROHC      142
 
+/** Packet Color */
 typedef enum {
 	ODP_PACKET_GREEN = 0,
 	ODP_PACKET_YELLOW = 1,
@@ -86,6 +87,7 @@ typedef enum {
 	ODP_PACKET_ALL_COLORS = 3,
 } odp_packet_color_t;
 
+/** Packet Checksum Status */
 typedef enum {
 	ODP_PACKET_CHKSUM_UNKNOWN = 0,
 	ODP_PACKET_CHKSUM_BAD,

--- a/include/odp/api/spec/packet_types.h
+++ b/include/odp/api/spec/packet_types.h
@@ -68,7 +68,7 @@ extern "C" {
  */
 
 /**
- * @enum odp_packet_color_t
+ * @typedef odp_packet_color_t
  * Color of packet for shaper/drop processing
  *
  * @var ODP_PACKET_GREEN
@@ -179,7 +179,7 @@ extern "C" {
  */
 
 /**
- * @enum odp_packet_chksum_status_t
+ * @typedef odp_packet_chksum_status_t
  * Checksum check status in packet
  *
  * @var ODP_PACKET_CHKSUM_UNKNOWN


### PR DESCRIPTION
Fix below doxygen warnings seen with Doxygen version 1.9.1.

 * include/odp/api/abi-default/packet_types.h:82:
   warning: Member odp_packet_color_t (enumeration) of group odp_packet is
   not documented.
 * include/odp/api/abi-default/packet_types.h:89:
   warning: Member odp_packet_chksum_status_t (enumeration) of group
   odp_packet is not documented.
 * include/odp/api/spec/packet_types.h:71:
   warning: Documentation for undefined enum 'odp_packet_color_t' found.
 * include/odp/api/spec/packet_types.h:182:
   warning: Documentation for undefined enum 'odp_packet_chksum_status_t'
   found.

Signed-off-by: Ashwin Sekhar T K <asekhar@marvell.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>
