### PR TITLE
[PATCH v3] api: packet: move odp_packet_proto_stats_opt_t definition

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -38,6 +38,7 @@ odpapiinclude_HEADERS = \
 	odp/api/protocols.h \
 	odp/api/pool.h \
 	odp/api/proto_stats.h \
+	odp/api/proto_stats_types.h \
 	odp/api/queue.h \
 	odp/api/queue_types.h \
 	odp/api/random.h \
@@ -94,6 +95,7 @@ odpapispecinclude_HEADERS = \
 		  odp/api/spec/pool.h \
 		  odp/api/spec/pool_types.h \
 		  odp/api/spec/proto_stats.h \
+		  odp/api/spec/proto_stats_types.h \
 		  odp/api/spec/queue.h \
 		  odp/api/spec/queue_types.h \
 		  odp/api/spec/random.h \
@@ -147,6 +149,7 @@ odpapiabidefaultinclude_HEADERS = \
 	odp/api/abi-default/packet_flags.h \
 	odp/api/abi-default/packet_io.h \
 	odp/api/abi-default/proto_stats.h \
+	odp/api/abi-default/proto_stats_types.h \
 	odp/api/abi-default/pool.h \
 	odp/api/abi-default/queue.h \
 	odp/api/abi-default/queue_types.h \
@@ -197,6 +200,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm32-linux/odp/api/abi/packet_io.h \
 	odp/arch/arm32-linux/odp/api/abi/pool.h \
 	odp/arch/arm32-linux/odp/api/abi/proto_stats.h \
+	odp/arch/arm32-linux/odp/api/abi/proto_stats_types.h \
 	odp/arch/arm32-linux/odp/api/abi/queue.h \
 	odp/arch/arm32-linux/odp/api/abi/queue_types.h \
 	odp/arch/arm32-linux/odp/api/abi/rwlock.h \
@@ -242,6 +246,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm64-linux/odp/api/abi/packet_io.h \
 	odp/arch/arm64-linux/odp/api/abi/pool.h \
 	odp/arch/arm64-linux/odp/api/abi/proto_stats.h \
+	odp/arch/arm64-linux/odp/api/abi/proto_stats_types.h \
 	odp/arch/arm64-linux/odp/api/abi/queue.h \
 	odp/arch/arm64-linux/odp/api/abi/queue_types.h \
 	odp/arch/arm64-linux/odp/api/abi/rwlock.h \
@@ -287,6 +292,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/default-linux/odp/api/abi/packet_io.h \
 	odp/arch/default-linux/odp/api/abi/pool.h \
 	odp/arch/default-linux/odp/api/abi/proto_stats.h \
+	odp/arch/default-linux/odp/api/abi/proto_stats_types.h \
 	odp/arch/default-linux/odp/api/abi/queue.h \
 	odp/arch/default-linux/odp/api/abi/queue_types.h \
 	odp/arch/default-linux/odp/api/abi/rwlock.h \
@@ -332,6 +338,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/mips64-linux/odp/api/abi/packet_io.h \
 	odp/arch/mips64-linux/odp/api/abi/pool.h \
 	odp/arch/mips64-linux/odp/api/abi/proto_stats.h \
+	odp/arch/mips64-linux/odp/api/abi/proto_stats_types.h \
 	odp/arch/mips64-linux/odp/api/abi/queue.h \
 	odp/arch/mips64-linux/odp/api/abi/queue_types.h \
 	odp/arch/mips64-linux/odp/api/abi/rwlock.h \
@@ -377,6 +384,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/power64-linux/odp/api/abi/packet_io.h \
 	odp/arch/power64-linux/odp/api/abi/pool.h \
 	odp/arch/power64-linux/odp/api/abi/proto_stats.h \
+	odp/arch/power64-linux/odp/api/abi/proto_stats_types.h \
 	odp/arch/power64-linux/odp/api/abi/queue.h \
 	odp/arch/power64-linux/odp/api/abi/queue_types.h \
 	odp/arch/power64-linux/odp/api/abi/rwlock.h \
@@ -422,6 +430,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_32-linux/odp/api/abi/packet_io.h \
 	odp/arch/x86_32-linux/odp/api/abi/pool.h \
 	odp/arch/x86_32-linux/odp/api/abi/proto_stats.h \
+	odp/arch/x86_32-linux/odp/api/abi/proto_stats_types.h \
 	odp/arch/x86_32-linux/odp/api/abi/queue.h \
 	odp/arch/x86_32-linux/odp/api/abi/queue_types.h \
 	odp/arch/x86_32-linux/odp/api/abi/rwlock.h \
@@ -467,6 +476,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_64-linux/odp/api/abi/packet_io.h \
 	odp/arch/x86_64-linux/odp/api/abi/pool.h \
 	odp/arch/x86_64-linux/odp/api/abi/proto_stats.h \
+	odp/arch/x86_64-linux/odp/api/abi/proto_stats_types.h \
 	odp/arch/x86_64-linux/odp/api/abi/queue.h \
 	odp/arch/x86_64-linux/odp/api/abi/queue_types.h \
 	odp/arch/x86_64-linux/odp/api/abi/rwlock.h \

--- a/include/odp/api/abi-default/proto_stats.h
+++ b/include/odp/api/abi-default/proto_stats.h
@@ -1,11 +1,7 @@
-/* SPDX-License-Identifier: BSD-3-Clause
- * Copyright(C) 2021 Marvell.
- */
-
-/**
- * @file
+/* Copyright (c) 2021, Marvell
+ * All rights reserved.
  *
- * ODP Proto Stats
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef ODP_ABI_PROTO_STATS_H_
@@ -15,23 +11,7 @@
 extern "C" {
 #endif
 
-#include <odp/api/std_types.h>
-
-/** @internal Dummy type for strong typing */
-typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_proto_stats_t;
-
-/** @ingroup odp_proto_stats
- *  Operations on a proto stats object.
- *  @{
- */
-
-typedef _odp_abi_proto_stats_t *odp_proto_stats_t;
-
-#define ODP_PROTO_STATS_INVALID ((odp_proto_stats_t)0)
-
-/**
- * @}
- */
+/* Empty header required to enable API function inlining */
 
 #ifdef __cplusplus
 }

--- a/include/odp/api/abi-default/proto_stats_types.h
+++ b/include/odp/api/abi-default/proto_stats_types.h
@@ -1,0 +1,37 @@
+/* Copyright (c) 2021, Marvell
+ * Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef ODP_ABI_PROTO_STATS_TYPES_H_
+#define ODP_ABI_PROTO_STATS_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/** @internal Dummy type for strong typing */
+typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_proto_stats_t;
+
+/** @ingroup odp_proto_stats
+ *  Operations on a proto stats object.
+ *  @{
+ */
+
+typedef _odp_abi_proto_stats_t *odp_proto_stats_t;
+
+#define ODP_PROTO_STATS_INVALID ((odp_proto_stats_t)0)
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/api/proto_stats.h
+++ b/include/odp/api/proto_stats.h
@@ -1,5 +1,7 @@
-/* SPDX-License-Identifier: BSD-3-Clause
- * Copyright(C) 2021 Marvell.
+/* Copyright (c) 2021, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /**
@@ -17,6 +19,7 @@ extern "C" {
 
 #include <odp/api/std_types.h>
 #include <odp/api/abi/queue.h>
+#include <odp/api/abi/proto_stats_types.h>
 #include <odp/api/abi/proto_stats.h>
 
 #include <odp/api/spec/proto_stats.h>

--- a/include/odp/api/proto_stats_types.h
+++ b/include/odp/api/proto_stats_types.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP proto stats types
+ */
+
+#ifndef ODP_API_PROTO_STATS_TYPES_H_
+#define ODP_API_PROTO_STATS_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/abi/proto_stats_types.h>
+
+#include <odp/api/spec/proto_stats_types.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-#include <odp/api/proto_stats.h>
+#include <odp/api/proto_stats_types.h>
 #include <odp/api/time.h>
 #include <odp/api/packet_types.h>
 

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -2032,23 +2032,6 @@ int odp_packet_tx_compl_request(odp_packet_t pkt, const odp_packet_tx_compl_opt_
 int odp_packet_has_tx_compl_request(odp_packet_t pkt);
 
 /**
- * Packet proto stats options.
- */
-typedef struct odp_packet_proto_stats_opt_t {
-	/** Packet proto stats object handle
-	 *
-	 * Stats in the packet proto stats object will be updated.
-	 */
-	odp_proto_stats_t stat;
-
-	/** Octet counter 0 adjust */
-	int32_t oct_count0_adj;
-
-	/** Octet counter 1 adjust */
-	int32_t oct_count1_adj;
-} odp_packet_proto_stats_opt_t;
-
-/**
  * Request packet proto stats.
  *
  * The statistics enabled in the proto stats object are updated for the packet in

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -25,7 +25,6 @@ extern "C" {
 #include <odp/api/reassembly.h>
 #include <odp/api/time.h>
 #include <odp/api/packet.h>
-#include <odp/api/proto_stats.h>
 
 /** @defgroup odp_packet_io ODP PACKET IO
  *  Packet IO interfaces.

--- a/include/odp/api/spec/packet_types.h
+++ b/include/odp/api/spec/packet_types.h
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 
+#include <odp/api/proto_stats.h>
 #include <odp/api/queue_types.h>
 
 /** @addtogroup odp_packet
@@ -435,6 +436,23 @@ typedef struct odp_packet_tx_compl_opt_t {
 	odp_packet_tx_compl_mode_t mode;
 
 } odp_packet_tx_compl_opt_t;
+
+/**
+ * Packet proto stats options
+ */
+typedef struct odp_packet_proto_stats_opt_t {
+	/** Packet proto stats object handle
+	 *
+	 * Stats in the packet proto stats object will be updated.
+	 */
+	odp_proto_stats_t stat;
+
+	/** Octet counter 0 adjust */
+	int32_t oct_count0_adj;
+
+	/** Octet counter 1 adjust */
+	int32_t oct_count1_adj;
+} odp_packet_proto_stats_opt_t;
 
 /**
  * @}

--- a/include/odp/api/spec/packet_types.h
+++ b/include/odp/api/spec/packet_types.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-#include <odp/api/proto_stats.h>
+#include <odp/api/proto_stats_types.h>
 #include <odp/api/queue_types.h>
 
 /** @addtogroup odp_packet

--- a/include/odp/api/spec/proto_stats.h
+++ b/include/odp/api/spec/proto_stats.h
@@ -1,5 +1,7 @@
-/* SPDX-License-Identifier: BSD-3-Clause
- * Copyright(C) 2021 Marvell.
+/* Copyright (c) 2021, Marvell
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /**
@@ -16,77 +18,12 @@
 extern "C" {
 #endif
 
-/** @addtogroup odp_proto_stats
+#include <odp/api/proto_stats_types.h>
+
+/** @defgroup odp_proto_stats ODP PROTO STATS
+ *  Flow specific packet statistics.
  *  @{
  */
-
-/**
- * @def ODP_PROTO_STATS_INVALID
- * Invalid proto stats handle
- */
-
-/** ODP proto stats counters
- *
- * Statistics that can be enabled in proto stats object. For Tx stats counters,
- * Pktout config `odp_pktout_config_opt_t::bit::proto_stats_ena` needs to be
- * enabled.
- *
- * Tx packet and octet sent/drop statistics might include packets sent/dropped via
- * Traffic Manager or Tx packet Aging or due to any other Tx errors. It is
- * implementation specific as to what all Tx sent/drop events are accounted for.
- */
-typedef union odp_proto_stats_counters_t {
-	/** Option flags */
-	struct {
-		/** Tx packet sent count */
-		uint64_t tx_pkts : 1;
-
-		/** Tx packet drop count */
-		uint64_t tx_pkt_drops : 1;
-
-		/** Tx packet sent Octet counter 0 */
-		uint64_t tx_oct_count0 : 1;
-
-		/** Tx packet drop Octet counter 0 */
-		uint64_t tx_oct_count0_drops : 1;
-
-		/** Tx packet sent octet counter 1 */
-		uint64_t tx_oct_count1 : 1;
-
-		/** Tx packet drop octet counter 1 */
-		uint64_t tx_oct_count1_drops : 1;
-	} bit;
-
-	/** All bits of the bit field structure
-	 *
-	 * This field can be used to set/clear all flags, or bitwise
-	 * operations over the entire structure.
-	 */
-	uint64_t all_bits;
-} odp_proto_stats_counters_t;
-
-/** ODP proto stats params */
-typedef struct odp_proto_stats_param_t {
-	/** Stats counters to enable */
-	odp_proto_stats_counters_t counters;
-} odp_proto_stats_param_t;
-
-/**
- * Proto stats capabilities
- */
-typedef struct odp_proto_stats_capability_t {
-	/** Tx capabilities */
-	struct {
-		/** Stats counters supported */
-		odp_proto_stats_counters_t counters;
-
-		/** Packet adjust support for Octet counter 0 */
-		odp_bool_t oct_count0_adj;
-
-		/** Packet adjust support for Octet counter 1 */
-		odp_bool_t oct_count1_adj;
-	} tx;
-} odp_proto_stats_capability_t;
 
 /**
  * Initialize proto stats parameters
@@ -158,27 +95,6 @@ odp_proto_stats_t odp_proto_stats_lookup(const char *name);
  * @retval <0 on failure
  */
 int odp_proto_stats_destroy(odp_proto_stats_t stat);
-
-/** ODP proto stats counters */
-typedef struct odp_proto_stats_data_t {
-	/** Packet sent count */
-	uint64_t tx_pkts;
-
-	/** Packet drop count */
-	uint64_t tx_pkt_drops;
-
-	/** Packet sent Octet counter 0 */
-	uint64_t tx_oct_count0;
-
-	/** Packet drop Octet counter 0 */
-	uint64_t tx_oct_count0_drops;
-
-	/** Packet sent octet counter 1 */
-	uint64_t tx_oct_count1;
-
-	/** Packet drop octet counter 1 */
-	uint64_t tx_oct_count1_drops;
-} odp_proto_stats_data_t;
 
 /**
  * Get all proto stats counters

--- a/include/odp/api/spec/proto_stats_types.h
+++ b/include/odp/api/spec/proto_stats_types.h
@@ -1,0 +1,126 @@
+/* Copyright(C) 2021, Marvell
+ * Copyright(C) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP proto stats types
+ */
+
+#ifndef ODP_API_SPEC_PROTO_STATS_TYPES_H_
+#define ODP_API_SPEC_PROTO_STATS_TYPES_H_
+#include <odp/visibility_begin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/std_types.h>
+
+/** @addtogroup odp_proto_stats
+ *  @{
+ */
+
+/**
+ * @def ODP_PROTO_STATS_INVALID
+ * Invalid proto stats handle
+ */
+
+/** ODP proto stats counters
+ *
+ * Statistics that can be enabled in proto stats object. For Tx stats counters,
+ * Pktout config `odp_pktout_config_opt_t::bit::proto_stats_ena` needs to be
+ * enabled.
+ *
+ * Tx packet and octet sent/drop statistics might include packets sent/dropped via
+ * Traffic Manager or Tx packet Aging or due to any other Tx errors. It is
+ * implementation specific as to what all Tx sent/drop events are accounted for.
+ */
+typedef union odp_proto_stats_counters_t {
+	/** Option flags */
+	struct {
+		/** Tx packet sent count */
+		uint64_t tx_pkts : 1;
+
+		/** Tx packet drop count */
+		uint64_t tx_pkt_drops : 1;
+
+		/** Tx packet sent Octet counter 0 */
+		uint64_t tx_oct_count0 : 1;
+
+		/** Tx packet drop Octet counter 0 */
+		uint64_t tx_oct_count0_drops : 1;
+
+		/** Tx packet sent octet counter 1 */
+		uint64_t tx_oct_count1 : 1;
+
+		/** Tx packet drop octet counter 1 */
+		uint64_t tx_oct_count1_drops : 1;
+	} bit;
+
+	/** All bits of the bit field structure
+	 *
+	 * This field can be used to set/clear all flags, or bitwise
+	 * operations over the entire structure.
+	 */
+	uint64_t all_bits;
+} odp_proto_stats_counters_t;
+
+/** ODP proto stats params */
+typedef struct odp_proto_stats_param_t {
+	/** Stats counters to enable */
+	odp_proto_stats_counters_t counters;
+} odp_proto_stats_param_t;
+
+/**
+ * Proto stats capabilities
+ */
+typedef struct odp_proto_stats_capability_t {
+	/** Tx capabilities */
+	struct {
+		/** Stats counters supported */
+		odp_proto_stats_counters_t counters;
+
+		/** Packet adjust support for Octet counter 0 */
+		odp_bool_t oct_count0_adj;
+
+		/** Packet adjust support for Octet counter 1 */
+		odp_bool_t oct_count1_adj;
+	} tx;
+} odp_proto_stats_capability_t;
+
+/** ODP proto stats counters */
+typedef struct odp_proto_stats_data_t {
+	/** Packet sent count */
+	uint64_t tx_pkts;
+
+	/** Packet drop count */
+	uint64_t tx_pkt_drops;
+
+	/** Packet sent Octet counter 0 */
+	uint64_t tx_oct_count0;
+
+	/** Packet drop Octet counter 0 */
+	uint64_t tx_oct_count0_drops;
+
+	/** Packet sent octet counter 1 */
+	uint64_t tx_oct_count1;
+
+	/** Packet drop octet counter 1 */
+	uint64_t tx_oct_count1_drops;
+} odp_proto_stats_data_t;
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <odp/visibility_end.h>
+#endif

--- a/include/odp/arch/arm32-linux/odp/api/abi/proto_stats_types.h
+++ b/include/odp/arch/arm32-linux/odp/api/abi/proto_stats_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/proto_stats_types.h>

--- a/include/odp/arch/arm64-linux/odp/api/abi/proto_stats_types.h
+++ b/include/odp/arch/arm64-linux/odp/api/abi/proto_stats_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/proto_stats_types.h>

--- a/include/odp/arch/default-linux/odp/api/abi/proto_stats_types.h
+++ b/include/odp/arch/default-linux/odp/api/abi/proto_stats_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/proto_stats_types.h>

--- a/include/odp/arch/mips64-linux/odp/api/abi/proto_stats_types.h
+++ b/include/odp/arch/mips64-linux/odp/api/abi/proto_stats_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/proto_stats_types.h>

--- a/include/odp/arch/power64-linux/odp/api/abi/proto_stats_types.h
+++ b/include/odp/arch/power64-linux/odp/api/abi/proto_stats_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/proto_stats_types.h>

--- a/include/odp/arch/x86_32-linux/odp/api/abi/proto_stats_types.h
+++ b/include/odp/arch/x86_32-linux/odp/api/abi/proto_stats_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/proto_stats_types.h>

--- a/include/odp/arch/x86_64-linux/odp/api/abi/proto_stats_types.h
+++ b/include/odp/arch/x86_64-linux/odp/api/abi/proto_stats_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/proto_stats_types.h>

--- a/include/odp_api.h
+++ b/include/odp_api.h
@@ -49,6 +49,7 @@ extern "C" {
 #include <odp/api/packet.h>
 #include <odp/api/packet_flags.h>
 #include <odp/api/packet_io.h>
+#include <odp/api/proto_stats.h>
 #include <odp/api/crypto.h>
 #include <odp/api/classification.h>
 #include <odp/api/rwlock.h>

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -71,6 +71,7 @@ odpapiabiarchinclude_HEADERS += \
 		  include-abi/odp/api/abi/packet_flags.h \
 		  include-abi/odp/api/abi/packet_io.h \
 		  include-abi/odp/api/abi/proto_stats.h \
+		  include-abi/odp/api/abi/proto_stats_types.h \
 		  include-abi/odp/api/abi/pool.h \
 		  include-abi/odp/api/abi/queue.h \
 		  include-abi/odp/api/abi/queue_types.h \

--- a/platform/linux-generic/include-abi/odp/api/abi/proto_stats.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/proto_stats.h
@@ -1,5 +1,8 @@
-/* SPDX-License-Identifier: BSD-3-Clause
- * Copyright(C) 2021 Marvell.
+/* Copyright (c) 2021, Marvell
+ * Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /**
@@ -15,20 +18,7 @@
 extern "C" {
 #endif
 
-#include <odp/api/std_types.h>
-#include <odp/api/plat/strong_types.h>
-
-/** @ingroup odp_proto_stats
- *  @{
- */
-
-typedef ODP_HANDLE_T(odp_proto_stats_t);
-
-#define ODP_PROTO_STATS_INVALID _odp_cast_scalar(odp_proto_stats_t, 0)
-
-/**
- * @}
- */
+/* Placeholder for inlined functions for non-ABI compat mode */
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include-abi/odp/api/abi/proto_stats_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/proto_stats_types.h
@@ -1,0 +1,40 @@
+/* Copyright (c) 2021, Marvell
+ * Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP proto stats types
+ */
+
+#ifndef ODP_API_ABI_PROTO_STATS_TYPES_H_
+#define ODP_API_ABI_PROTO_STATS_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/std_types.h>
+#include <odp/api/plat/strong_types.h>
+
+/** @ingroup odp_proto_stats
+ *  @{
+ */
+
+typedef ODP_HANDLE_T(odp_proto_stats_t);
+
+#define ODP_PROTO_STATS_INVALID _odp_cast_scalar(odp_proto_stats_t, 0)
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Packet type definitions belong to packet_types.h header.

Signed-off-by: Matias Elo <matias.elo@nokia.com>


V2:
- Added separate header for proto_stats  type definitions