### PR TITLE
[PATCH v2] linux-gen: dpdk: fix invalid mbuf data offset

### DIFF
--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -288,7 +288,7 @@ static inline void mbuf_update(struct rte_mbuf *mbuf, odp_packet_hdr_t *pkt_hdr,
 	mbuf->refcnt = 1;
 	mbuf->ol_flags = 0;
 
-	if (odp_unlikely(pkt_hdr->buf_hdr.base_data != pkt_hdr->seg_data))
+	if (odp_unlikely(((uint8_t *)mbuf->buf_addr +  mbuf->data_off) != pkt_hdr->seg_data))
 		mbuf->data_off = mbuf_data_off(mbuf, pkt_hdr);
 }
 


### PR DESCRIPTION
Fix the check in mbuf_update() which detects if mbuf data offset needs to
be updated. The previous check didn't detect a scenario where data offset
was not at default value (caused by e.g. odp_packet_push_head()).

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reported-and-tested-by: Christian Hong <guochun.hgc@alibaba-inc.com>