### PR TITLE
[PATCH v5] api: packet: add odp_packet_reass_info() for reassembly details

### DIFF
--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -180,6 +180,20 @@ void odp_packet_to_event_multi(const odp_packet_t pkt[], odp_event_t ev[],
 			       int num);
 
 /**
+ * Get information about successful reassembly offload that has happened
+ *
+ * This function may be called only if the reassembly status of a packet
+ * is ODP_PACKET_REASS_COMPLETE.
+ *
+ * @param      pkt   Completely reassembled packet.
+ * @param[out] info  Pointer to the info structure to be filled
+ *
+ * @retval 0 on success
+ * @retval <0 on failure
+ */
+int odp_packet_reass_info(odp_packet_t pkt, odp_packet_reass_info_t *info);
+
+/**
  * Get partial reassembly state from a packet
  *
  * In case of incomplete reassembly, a packet carries information on

--- a/include/odp/api/spec/packet_types.h
+++ b/include/odp/api/spec/packet_types.h
@@ -286,6 +286,14 @@ typedef enum odp_packet_reass_status_t {
 } odp_packet_reass_status_t;
 
 /**
+ * Information about a completed reassembly
+ */
+typedef struct odp_packet_reass_info_t {
+	/** Number of fragments reassembled */
+	uint16_t num_frags;
+} odp_packet_reass_info_t;
+
+/**
  * Result from odp_packet_reass_partial_state()
  */
 typedef struct odp_packet_reass_partial_state_t {

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2942,6 +2942,13 @@ odp_packet_reass_status(odp_packet_t pkt)
 	return ODP_PACKET_REASS_NONE;
 }
 
+int odp_packet_reass_info(odp_packet_t pkt, odp_packet_reass_info_t *info)
+{
+	(void)pkt;
+	(void)info;
+	return -1;
+}
+
 int
 odp_packet_reass_partial_state(odp_packet_t pkt, odp_packet_t frags[],
 			       odp_packet_reass_partial_state_t *res)

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -520,8 +520,6 @@ static int send_pkts(const ipsec_test_part part[], int num_part)
 static int recv_pkts_inline(const ipsec_test_part *part,
 			    odp_packet_t *pkto)
 {
-	odp_packet_reass_partial_state_t reass_state;
-	odp_packet_reass_status_t reass_status;
 	odp_queue_t queue = ODP_QUEUE_INVALID;
 	int i;
 
@@ -551,6 +549,11 @@ static int recv_pkts_inline(const ipsec_test_part *part,
 		if (ODP_EVENT_INVALID != ev) {
 			odp_packet_t pkt;
 			int num_pkts = 0;
+			odp_packet_reass_status_t reass_status;
+			odp_packet_reass_info_t reass = {0};
+			odp_packet_reass_partial_state_t reass_state;
+			odp_packet_t frags[MAX_FRAGS];
+			int j;
 
 			CU_ASSERT(odp_event_is_valid(ev) == 1);
 			CU_ASSERT_EQUAL(ODP_EVENT_PACKET, odp_event_type(ev));
@@ -559,13 +562,18 @@ static int recv_pkts_inline(const ipsec_test_part *part,
 			CU_ASSERT(!part->out[i].status.error.sa_lookup);
 
 			reass_status = odp_packet_reass_status(pkt);
-			if (ODP_PACKET_REASS_INCOMPLETE != reass_status) {
+			CU_ASSERT(reass_status == part->out[i].reass_status);
+
+			switch (reass_status) {
+			case ODP_PACKET_REASS_COMPLETE:
+				CU_ASSERT(odp_packet_reass_info(pkt, &reass) == 0);
+				CU_ASSERT(part->out[i].num_frags == reass.num_frags);
+				/* FALLTHROUGH */
+			case ODP_PACKET_REASS_NONE:
 				pkto[i] = pkt;
 				num_pkts = 1;
-			} else {
-				odp_packet_t frags[MAX_FRAGS];
-				int j;
-
+				break;
+			case ODP_PACKET_REASS_INCOMPLETE:
 				CU_ASSERT(0 ==
 					  odp_packet_reass_partial_state(pkt, frags, &reass_state));
 				num_pkts = reass_state.num_frags;
@@ -573,6 +581,10 @@ static int recv_pkts_inline(const ipsec_test_part *part,
 				CU_ASSERT_FATAL(i + num_pkts <= part->num_pkt);
 				for (j = 0; j < num_pkts; j++)
 					pkto[i + j] = frags[j];
+				break;
+			default:
+				CU_FAIL("Unknown reassembly status");
+				break;
 			}
 
 			for (; num_pkts > 0; num_pkts--)

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -85,6 +85,8 @@ typedef struct {
 	int num_pkt;
 	struct {
 		odp_ipsec_op_status_t status;
+		odp_packet_reass_status_t reass_status;
+		uint16_t num_frags;
 		const ipsec_test_packet *pkt_res;
 		odp_proto_l3_type_t l3_type;
 		odp_proto_l4_type_t l4_type;

--- a/test/validation/api/ipsec/ipsec_test_in.c
+++ b/test/validation/api/ipsec/ipsec_test_in.c
@@ -1772,7 +1772,8 @@ static void test_multi_out_in(odp_ipsec_sa_t out_sa,
 			      uint8_t tunnel_ip_ver,
 			      int num_input_packets,
 			      ipsec_test_packet *input_packets[],
-			      ipsec_test_packet *result_packet)
+			      ipsec_test_packet *result_packet,
+			      odp_packet_reass_status_t reass_status)
 {
 	uint8_t ver_ihl = result_packet->data[result_packet->l3_offset];
 	odp_bool_t is_result_ipv6 = (ODPH_IPV4HDR_VER(ver_ihl) == ODPH_IPV6);
@@ -1800,6 +1801,8 @@ static void test_multi_out_in(odp_ipsec_sa_t out_sa,
 		if (i == num_input_packets - 1) {
 			part_prep_plain(&test_in, 1, is_result_ipv6, true);
 			test_in.out[0].pkt_res = result_packet;
+			test_in.out[0].reass_status = reass_status;
+			test_in.out[0].num_frags = num_input_packets;
 		}
 		ipsec_test_packet_from_pkt(&test_pkt, &pkt);
 		test_in.pkt_in = &test_pkt;
@@ -1820,7 +1823,8 @@ static void test_in_ipv4_esp_reass_success_two_frags(odp_ipsec_sa_t out_sa,
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV4,
 			  ARRAY_SIZE(input_packets),
 			  input_packets,
-			  result_packet);
+			  result_packet,
+			  ODP_PACKET_REASS_COMPLETE);
 }
 
 static void test_in_ipv4_esp_reass_success_four_frags(odp_ipsec_sa_t out_sa,
@@ -1837,7 +1841,8 @@ static void test_in_ipv4_esp_reass_success_four_frags(odp_ipsec_sa_t out_sa,
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV4,
 			  ARRAY_SIZE(input_packets),
 			  input_packets,
-			  result_packet);
+			  result_packet,
+			  ODP_PACKET_REASS_COMPLETE);
 }
 
 static void test_in_ipv4_esp_reass_success_two_frags_ooo(odp_ipsec_sa_t out_sa,
@@ -1852,7 +1857,8 @@ static void test_in_ipv4_esp_reass_success_two_frags_ooo(odp_ipsec_sa_t out_sa,
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV4,
 			  ARRAY_SIZE(input_packets),
 			  input_packets,
-			  result_packet);
+			  result_packet,
+			  ODP_PACKET_REASS_COMPLETE);
 }
 
 static void test_in_ipv4_esp_reass_success_four_frags_ooo(odp_ipsec_sa_t out_sa,
@@ -1869,7 +1875,8 @@ static void test_in_ipv4_esp_reass_success_four_frags_ooo(odp_ipsec_sa_t out_sa,
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV4,
 			  ARRAY_SIZE(input_packets),
 			  input_packets,
-			  result_packet);
+			  result_packet,
+			  ODP_PACKET_REASS_COMPLETE);
 }
 
 static void test_in_ipv4_esp_reass_incomp_missing(odp_ipsec_sa_t out_sa,
@@ -1883,7 +1890,8 @@ static void test_in_ipv4_esp_reass_incomp_missing(odp_ipsec_sa_t out_sa,
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV4,
 			  ARRAY_SIZE(input_packets),
 			  input_packets,
-			  result_packet);
+			  result_packet,
+			  ODP_PACKET_REASS_INCOMPLETE);
 }
 
 static void test_in_ipv4_esp_reass_success(void)
@@ -2001,7 +2009,8 @@ static void test_in_ipv6_esp_reass_success_two_frags(odp_ipsec_sa_t out_sa,
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV6,
 			  ARRAY_SIZE(input_packets),
 			  input_packets,
-			  result_packet);
+			  result_packet,
+			  ODP_PACKET_REASS_COMPLETE);
 }
 
 static void test_in_ipv6_esp_reass_success_four_frags(odp_ipsec_sa_t out_sa,
@@ -2018,7 +2027,8 @@ static void test_in_ipv6_esp_reass_success_four_frags(odp_ipsec_sa_t out_sa,
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV6,
 			  ARRAY_SIZE(input_packets),
 			  input_packets,
-			  result_packet);
+			  result_packet,
+			  ODP_PACKET_REASS_COMPLETE);
 }
 
 static void test_in_ipv6_esp_reass_success_two_frags_ooo(odp_ipsec_sa_t out_sa,
@@ -2033,7 +2043,8 @@ static void test_in_ipv6_esp_reass_success_two_frags_ooo(odp_ipsec_sa_t out_sa,
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV6,
 			  ARRAY_SIZE(input_packets),
 			  input_packets,
-			  result_packet);
+			  result_packet,
+			  ODP_PACKET_REASS_COMPLETE);
 }
 
 static void test_in_ipv6_esp_reass_success_four_frags_ooo(odp_ipsec_sa_t out_sa,
@@ -2050,7 +2061,8 @@ static void test_in_ipv6_esp_reass_success_four_frags_ooo(odp_ipsec_sa_t out_sa,
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV6,
 			  ARRAY_SIZE(input_packets),
 			  input_packets,
-			  result_packet);
+			  result_packet,
+			  ODP_PACKET_REASS_COMPLETE);
 }
 
 static void test_in_ipv6_esp_reass_incomp_missing(odp_ipsec_sa_t out_sa,
@@ -2064,7 +2076,8 @@ static void test_in_ipv6_esp_reass_incomp_missing(odp_ipsec_sa_t out_sa,
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV6,
 			  ARRAY_SIZE(input_packets),
 			  input_packets,
-			  result_packet);
+			  result_packet,
+			  ODP_PACKET_REASS_INCOMPLETE);
 }
 
 static void test_in_ipv6_esp_reass_success(void)


### PR DESCRIPTION
Intoroduce odp_packet_reass_info() that provides information on
a completed reassemly. The number of fragments that were reassembled
is useful for statistics and the IP length of the longest fragment
is useful for path MTU handling purposes if reassembly offload if used
for forwarded traffic.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>