### PR TITLE
[PATCH v3] api: ipsec: provide original ESP/AH packet length in IPsec packet result

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -1532,6 +1532,17 @@ typedef struct odp_ipsec_packet_result_t {
 		uint32_t len;
 	} outer_hdr;
 
+	/** Total IP length of the original ESP or AH packet before IPsec
+	 *  decapsulation. This is valid only for inbound inline and async
+	 *  processed packets. Zero value means that the length information
+	 *  is not available.
+	 *
+	 *  If the result packet was reassembled from multiple IPsec
+	 *  protected packets, this is the sum of the lengths of all the
+	 *  involved IPsec packets.
+	 */
+	uint32_t orig_ip_len;
+
 } odp_ipsec_packet_result_t;
 
 /**

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -757,7 +757,8 @@ static ipsec_sa_t *ipsec_in_single(odp_packet_t pkt,
 				   odp_ipsec_sa_t sa,
 				   odp_packet_t *pkt_out,
 				   odp_bool_t enqueue_op,
-				   odp_ipsec_op_status_t *status)
+				   odp_ipsec_op_status_t *status,
+				   uint32_t *orig_ip_len)
 {
 	ipsec_state_t state;
 	ipsec_sa_t *ipsec_sa = NULL;
@@ -793,6 +794,7 @@ static ipsec_sa_t *ipsec_in_single(odp_packet_t pkt,
 		status->error.alg = 1;
 		goto exit;
 	}
+	*orig_ip_len = state.ip_tot_len;
 
 	/* Check IP header for IPSec protocols and look it up */
 	if (_ODP_IPPROTO_ESP == state.ip_next_hdr ||
@@ -1742,6 +1744,7 @@ int odp_ipsec_in(const odp_packet_t pkt_in[], int num_in,
 		odp_ipsec_op_status_t status;
 		odp_ipsec_sa_t sa;
 		ipsec_sa_t *ipsec_sa;
+		uint32_t dummy; /* orig_ip_len not valid in sync operations */
 		odp_ipsec_packet_result_t *result;
 
 		memset(&status, 0, sizeof(status));
@@ -1753,7 +1756,7 @@ int odp_ipsec_in(const odp_packet_t pkt_in[], int num_in,
 			ODP_ASSERT(ODP_IPSEC_SA_INVALID != sa);
 		}
 
-		ipsec_sa = ipsec_in_single(pkt, sa, &pkt, false, &status);
+		ipsec_sa = ipsec_in_single(pkt, sa, &pkt, false, &status, &dummy);
 
 		packet_subtype_set(pkt, ODP_EVENT_PACKET_IPSEC);
 		result = ipsec_pkt_result(pkt);
@@ -1853,6 +1856,7 @@ int odp_ipsec_in_enq(const odp_packet_t pkt_in[], int num_in,
 		odp_ipsec_op_status_t status;
 		odp_ipsec_sa_t sa;
 		ipsec_sa_t *ipsec_sa;
+		uint32_t orig_ip_len = 0;
 		odp_ipsec_packet_result_t *result;
 		odp_queue_t queue;
 
@@ -1865,12 +1869,13 @@ int odp_ipsec_in_enq(const odp_packet_t pkt_in[], int num_in,
 			ODP_ASSERT(ODP_IPSEC_SA_INVALID != sa);
 		}
 
-		ipsec_sa = ipsec_in_single(pkt, sa, &pkt, true, &status);
+		ipsec_sa = ipsec_in_single(pkt, sa, &pkt, true, &status, &orig_ip_len);
 
 		packet_subtype_set(pkt, ODP_EVENT_PACKET_IPSEC);
 		result = ipsec_pkt_result(pkt);
 		memset(result, 0, sizeof(*result));
 		result->status = status;
+		result->orig_ip_len = orig_ip_len;
 		if (NULL != ipsec_sa) {
 			result->sa = ipsec_sa->ipsec_sa_hdl;
 			queue = ipsec_sa->queue;
@@ -1957,6 +1962,7 @@ int _odp_ipsec_try_inline(odp_packet_t *pkt)
 {
 	odp_ipsec_op_status_t status;
 	ipsec_sa_t *ipsec_sa;
+	uint32_t orig_ip_len = 0;
 	odp_ipsec_packet_result_t *result;
 	odp_packet_hdr_t *pkt_hdr;
 
@@ -1966,7 +1972,7 @@ int _odp_ipsec_try_inline(odp_packet_t *pkt)
 	memset(&status, 0, sizeof(status));
 
 	ipsec_sa = ipsec_in_single(*pkt, ODP_IPSEC_SA_INVALID, pkt, false,
-				   &status);
+				   &status, &orig_ip_len);
 	/*
 	 * Route packet back in case of lookup failure or early error before
 	 * lookup
@@ -1978,6 +1984,7 @@ int _odp_ipsec_try_inline(odp_packet_t *pkt)
 	result = ipsec_pkt_result(*pkt);
 	memset(result, 0, sizeof(*result));
 	result->status = status;
+	result->orig_ip_len = orig_ip_len;
 	result->sa = ipsec_sa->ipsec_sa_hdl;
 	result->flag.inline_mode = 1;
 

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -878,6 +878,11 @@ static void verify_in(const ipsec_test_part *part,
 			if (ODP_IPSEC_SA_INVALID != sa)
 				CU_ASSERT_EQUAL(IPSEC_SA_CTX,
 						odp_ipsec_sa_context(sa));
+			if (suite_context.inbound_op_mode != ODP_IPSEC_OP_MODE_SYNC) {
+				uint32_t len = part->pkt_in->len - part->pkt_in->l3_offset;
+
+				CU_ASSERT(result.orig_ip_len == len);
+			}
 		}
 		ipsec_check_packet(part->out[i].pkt_res,
 				   pkto[i],


### PR DESCRIPTION
Provide the original ESP/AH packet length before inbound IPsec processing
in odp_ipsec_packet_result_t. An application may use it for statistics
purposes.

This can be useful since post-IPsec reassemly offload makes it difficult
to deduce the original octet count that went into the creation of the
result packet. Even without reassembly offload, possible extra padding
cannot be deduced from the result packet.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>