### PR TITLE
[PATCH v2] ci: update apt packages

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -16,7 +16,9 @@ jobs:
         fetch-depth: 0
 
     - name: Install dependencies
-      run: sudo apt install codespell
+      run: |
+        sudo apt update
+        sudo apt install codespell
 
     - name: Check pull request
       if: github.event_name == 'pull_request'
@@ -43,6 +45,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt update
         sudo apt install doxygen asciidoctor libconfig-dev libssl-dev mscgen cmake graphviz
         sudo gem install asciidoctor
     - name: Build

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,6 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
+        sudo apt update
         sudo apt install doxygen asciidoctor libconfig-dev libssl-dev mscgen cmake graphviz
         sudo gem install asciidoctor
     - name: Build


### PR DESCRIPTION
Run 'apt update' before installing new packages. Fixes CI failures where
packages were not found due to outdated information.

Signed-off-by: Matias Elo <matias.elo@nokia.com>