### PR TITLE
[PATCH v11] linux-gen: atomic: emit STADD explicitly for __atomic_fetch_add operation

### DIFF
--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -108,6 +108,23 @@ jobs:
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
 
+  Run_CFLAGS:
+    if: ${{ github.repository == 'OpenDataPlane/odp' }}
+    runs-on: [self-hosted, ARM64]
+    strategy:
+      fail-fast: false
+      matrix:
+        cc: [gcc, clang]
+        cflags: ['-march=armv8.2-a -O2', '-march=armv8-a+lse -O2']
+    steps:
+      - uses: AutoModality/action-clean@v1.1.0
+      - uses: actions/checkout@v2
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}" -e ARCH="${ARCH}"
+               -e CXX=g++-10 -e CFLAGS="${{matrix.cflags}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
+      - name: Failure log
+        if: ${{ failure() }}
+        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+
 
   Run_OS:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -100,6 +100,18 @@ jobs:
         run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
 
+      - name: CFLAGS="-march=armv8.2-a"
+        env:
+          CONF: "CFLAGS=-march=armv8.2-a"
+        run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
+               -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
+
+      - name: CFLAGS="-march=armv8-a+lse"
+        env:
+          CONF: "CFLAGS=-march=armv8-a+lse"
+        run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
+               -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
+
       - name: Ubuntu 20.04
         env:
           CONF: "--enable-dpdk-shared"

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h
@@ -152,7 +152,60 @@ static inline int _odp_atomic_cas_acq_rel_u128(odp_atomic_u128_t *atom, odp_u128
 
 	return 0;
 }
-#else /* _ODP_LOCK_FREE_128BIT_ATOMICS */
+
+static inline void _odp_atomic_add_u32(odp_atomic_u32_t *atom, uint32_t val)
+{
+	__asm__ volatile("stadd   %w[val], %[atom]"
+			 : [atom] "+Q" (atom->v)
+			 : [val] "r" (val));
+}
+
+static inline void _odp_atomic_sub_u32(odp_atomic_u32_t *atom, uint32_t val)
+{
+	int32_t neg_val = -val;
+
+	__asm__ volatile("stadd   %w[neg_val], %[atom]"
+			 : [atom] "+Q" (atom->v)
+			 : [neg_val] "r" (neg_val));
+}
+
+static inline void _odp_atomic_inc_u32(odp_atomic_u32_t *atom)
+{
+	_odp_atomic_add_u32(atom, 1);
+}
+
+static inline void _odp_atomic_dec_u32(odp_atomic_u32_t *atom)
+{
+	_odp_atomic_sub_u32(atom, 1);
+}
+
+static inline void _odp_atomic_add_u64(odp_atomic_u64_t *atom, uint64_t val)
+{
+	__asm__ volatile("stadd   %[val], %[atom]"
+			 : [atom] "+Q" (atom->v)
+			 : [val] "r" (val));
+}
+
+static inline void _odp_atomic_sub_u64(odp_atomic_u64_t *atom, uint64_t val)
+{
+	int64_t neg_val = -val;
+
+	__asm__ volatile("stadd   %[neg_val], %[atom]"
+			 : [atom] "+Q" (atom->v)
+			 : [neg_val] "r" (neg_val));
+}
+
+static inline void _odp_atomic_inc_u64(odp_atomic_u64_t *atom)
+{
+	_odp_atomic_add_u64(atom, 1);
+}
+
+static inline void _odp_atomic_dec_u64(odp_atomic_u64_t *atom)
+{
+	_odp_atomic_sub_u64(atom, 1);
+}
+
+#else /* !_ODP_LOCK_FREE_128BIT_ATOMICS */
 
 /* Use generic implementation */
 #include <odp/api/abi/atomic_generic.h>

--- a/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
@@ -10,6 +10,46 @@
 
 #include <odp/api/atomic.h>
 
+static inline void _odp_atomic_add_u32(odp_atomic_u32_t *atom, uint32_t val)
+{
+	(void)__atomic_fetch_add(&atom->v, val, __ATOMIC_RELAXED);
+}
+
+static inline void _odp_atomic_sub_u32(odp_atomic_u32_t *atom, uint32_t val)
+{
+	(void)__atomic_fetch_sub(&atom->v, val, __ATOMIC_RELAXED);
+}
+
+static inline void _odp_atomic_inc_u32(odp_atomic_u32_t *atom)
+{
+	(void)__atomic_fetch_add(&atom->v, 1, __ATOMIC_RELAXED);
+}
+
+static inline void _odp_atomic_dec_u32(odp_atomic_u32_t *atom)
+{
+	(void)__atomic_fetch_sub(&atom->v, 1, __ATOMIC_RELAXED);
+}
+
+static inline void _odp_atomic_add_u64(odp_atomic_u64_t *atom, uint64_t val)
+{
+	(void)__atomic_fetch_add(&atom->v, val, __ATOMIC_RELAXED);
+}
+
+static inline void _odp_atomic_sub_u64(odp_atomic_u64_t *atom, uint64_t val)
+{
+	(void)__atomic_fetch_sub(&atom->v, val, __ATOMIC_RELAXED);
+}
+
+static inline void _odp_atomic_inc_u64(odp_atomic_u64_t *atom)
+{
+	(void)__atomic_fetch_add(&atom->v, 1, __ATOMIC_RELAXED);
+}
+
+static inline void _odp_atomic_dec_u64(odp_atomic_u64_t *atom)
+{
+	(void)__atomic_fetch_sub(&atom->v, 1, __ATOMIC_RELAXED);
+}
+
 #ifdef __SIZEOF_INT128__
 
 static inline void _odp_atomic_init_u128(odp_atomic_u128_t *atom, odp_u128_t val)

--- a/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
@@ -100,7 +100,7 @@ _ODP_INLINE uint32_t odp_atomic_fetch_add_u32(odp_atomic_u32_t *atom,
 
 _ODP_INLINE void odp_atomic_add_u32(odp_atomic_u32_t *atom, uint32_t val)
 {
-	(void)__atomic_fetch_add(&atom->v, val, __ATOMIC_RELAXED);
+	_odp_atomic_add_u32(atom, val);
 }
 
 _ODP_INLINE uint32_t odp_atomic_fetch_sub_u32(odp_atomic_u32_t *atom,
@@ -111,7 +111,7 @@ _ODP_INLINE uint32_t odp_atomic_fetch_sub_u32(odp_atomic_u32_t *atom,
 
 _ODP_INLINE void odp_atomic_sub_u32(odp_atomic_u32_t *atom, uint32_t val)
 {
-	(void)__atomic_fetch_sub(&atom->v, val, __ATOMIC_RELAXED);
+	_odp_atomic_sub_u32(atom, val);
 }
 
 _ODP_INLINE uint32_t odp_atomic_fetch_inc_u32(odp_atomic_u32_t *atom)
@@ -121,7 +121,7 @@ _ODP_INLINE uint32_t odp_atomic_fetch_inc_u32(odp_atomic_u32_t *atom)
 
 _ODP_INLINE void odp_atomic_inc_u32(odp_atomic_u32_t *atom)
 {
-	(void)__atomic_fetch_add(&atom->v, 1, __ATOMIC_RELAXED);
+	_odp_atomic_inc_u32(atom);
 }
 
 _ODP_INLINE uint32_t odp_atomic_fetch_dec_u32(odp_atomic_u32_t *atom)
@@ -131,7 +131,7 @@ _ODP_INLINE uint32_t odp_atomic_fetch_dec_u32(odp_atomic_u32_t *atom)
 
 _ODP_INLINE void odp_atomic_dec_u32(odp_atomic_u32_t *atom)
 {
-	(void)__atomic_fetch_sub(&atom->v, 1, __ATOMIC_RELAXED);
+	_odp_atomic_dec_u32(atom);
 }
 
 _ODP_INLINE int odp_atomic_cas_u32(odp_atomic_u32_t *atom, uint32_t *old_val,
@@ -350,7 +350,7 @@ _ODP_INLINE uint64_t odp_atomic_fetch_add_u64(odp_atomic_u64_t *atom,
 
 _ODP_INLINE void odp_atomic_add_u64(odp_atomic_u64_t *atom, uint64_t val)
 {
-	(void)__atomic_fetch_add(&atom->v, val, __ATOMIC_RELAXED);
+	_odp_atomic_add_u64(atom, val);
 }
 
 _ODP_INLINE uint64_t odp_atomic_fetch_sub_u64(odp_atomic_u64_t *atom,
@@ -361,7 +361,7 @@ _ODP_INLINE uint64_t odp_atomic_fetch_sub_u64(odp_atomic_u64_t *atom,
 
 _ODP_INLINE void odp_atomic_sub_u64(odp_atomic_u64_t *atom, uint64_t val)
 {
-	(void)__atomic_fetch_sub(&atom->v, val, __ATOMIC_RELAXED);
+	_odp_atomic_sub_u64(atom, val);
 }
 
 _ODP_INLINE uint64_t odp_atomic_fetch_inc_u64(odp_atomic_u64_t *atom)
@@ -371,7 +371,7 @@ _ODP_INLINE uint64_t odp_atomic_fetch_inc_u64(odp_atomic_u64_t *atom)
 
 _ODP_INLINE void odp_atomic_inc_u64(odp_atomic_u64_t *atom)
 {
-	(void)__atomic_fetch_add(&atom->v, 1, __ATOMIC_RELAXED);
+	_odp_atomic_inc_u64(atom);
 }
 
 _ODP_INLINE uint64_t odp_atomic_fetch_dec_u64(odp_atomic_u64_t *atom)
@@ -381,7 +381,7 @@ _ODP_INLINE uint64_t odp_atomic_fetch_dec_u64(odp_atomic_u64_t *atom)
 
 _ODP_INLINE void odp_atomic_dec_u64(odp_atomic_u64_t *atom)
 {
-	(void)__atomic_fetch_sub(&atom->v, 1, __ATOMIC_RELAXED);
+	_odp_atomic_dec_u64(atom);
 }
 
 _ODP_INLINE int odp_atomic_cas_u64(odp_atomic_u64_t *atom, uint64_t *old_val,


### PR DESCRIPTION
Following performance gains were observed for the atomic add/sub/inc/dec APIs in the atomic perf test:
```
         _______________________________________
        |   odp_atomic_add_u32   |     7-8%   |
        |   odp_atomic_sub_u32    |     7-8%   |
        |   odp_atomic_inc_u32     |     5-6%   |
        |   odp_atomic_dec_u32    |     4-5%   |
        |   odp_atomic_add_u64    |     4-5%   |
        |   odp_atomic_sub_u64    |     5-6%   |
        |   odp_atomic_inc_u64     |     5-6%   |
        |   odp_atomic_dec_u64    |     4-5%   |
        |___________________________|__________ |

```
For the pool performance test, no significant performance improvement was observed with this change.