### PR TITLE
[PATCH v4] linux-gen: config: add string array lookup function

### DIFF
--- a/platform/linux-generic/include/odp_libconfig_internal.h
+++ b/platform/linux-generic/include/odp_libconfig_internal.h
@@ -22,6 +22,8 @@ int _odp_libconfig_term_global(void);
 
 int _odp_libconfig_lookup_int(const char *path, int *value);
 int _odp_libconfig_lookup_array(const char *path, int value[], int max_num);
+int _odp_libconfig_lookup_array_str(const char *path, char **value,
+				    int max_count, unsigned int max_str);
 
 int _odp_libconfig_lookup_ext_int(const char *base_path,
 				  const char *local_path,


### PR DESCRIPTION
adds new function to get the size of the string array and its
elements

Signed-off-by: Vijay Ram Inavolu <vinavolu@marvell.com>