### PR TITLE
[PATCH v2] linux-gen: crypto: fix error handling in odp_crypto_operation()

### DIFF
--- a/platform/linux-generic/odp_crypto_null.c
+++ b/platform/linux-generic/odp_crypto_null.c
@@ -276,12 +276,18 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 	packet_param.auth_range = param->auth_range;
 
 	rc = odp_crypto_op(&param->pkt, &out_pkt, &packet_param, 1);
-	if (rc < 0)
-		return rc;
+	if (rc <= 0)
+		return -1;
 
 	rc = odp_crypto_result(&packet_result, out_pkt);
-	if (rc < 0)
-		return rc;
+	if (rc < 0) {
+		/*
+		 * We cannot fail since odp_crypto_op() has already processed
+		 * the packet. Let's indicate error in the result instead.
+		 */
+		packet_hdr(out_pkt)->p.flags.crypto_err = 1;
+		packet_result.ok = false;
+	}
 
 	/* Indicate to caller operation was sync */
 	*posted = 0;

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -2461,12 +2461,18 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 	packet_param.auth_range = param->auth_range;
 
 	rc = odp_crypto_op(&param->pkt, &out_pkt, &packet_param, 1);
-	if (rc < 0)
-		return rc;
+	if (rc <= 0)
+		return -1;
 
 	rc = odp_crypto_result(&packet_result, out_pkt);
-	if (rc < 0)
-		return rc;
+	if (rc < 0) {
+		/*
+		 * We cannot fail since odp_crypto_op() has already processed
+		 * the packet. Let's indicate error in the result instead.
+		 */
+		packet_hdr(out_pkt)->p.flags.crypto_err = 1;
+		packet_result.ok = false;
+	}
 
 	/* Indicate to caller operation was sync */
 	*posted = 0;


### PR DESCRIPTION
odp_crypto_operation() calls odp_crypto_op() but incorrectly interprets
zero return value as success when it actually means that zero packets
were successfully processed. Consequently the result structure gets filled
with data that was not set by the failed odp_crypto_op(), input packet may
leak and output packet may not exists or contain incorrect data.

Fix the problem by returning an error if odp_crypto_op() returns zero.

Also, do not return a failure when odp_crypto_result() fails. At that
point odp_crypto_op() has already done the processing, including freeing
or overwriting the input packet. Indicate failure through the result
structure instead. Currently odp_crypto_result() never fails, but it may
not stay that way (and this piece of code seems to get reused elsewhere).

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>