### PR TITLE
[PATCH v6] helper: cli: don't create the server thread

### DIFF
--- a/helper/include/odp/helper/cli.h
+++ b/helper/include/odp/helper/cli.h
@@ -68,7 +68,10 @@ void odph_cli_param_init(odph_cli_param_t *param);
  * Initialize CLI helper
  *
  * This function initializes the CLI helper. It must be called before
- * odph_cli_register_command() and odph_cli_start().
+ * odph_cli_register_command() and odph_cli_run().
+ *
+ * In process mode (ODPH_PROC_MODE), this function must be called before
+ * creating the thread which calls odph_cli_run().
  *
  * @param instance ODP instance
  * @param param CLI server parameters to use
@@ -89,7 +92,7 @@ int odph_cli_init(odp_instance_t instance, const odph_cli_param_t *param);
  * the case they were registered in, but they may be invoked using any case.
  *
  * This function should be called after odph_cli_init() and before
- * odph_cli_start().
+ * odph_cli_run().
  *
  * @param name Command name (case-insensitive)
  * @param func Command function
@@ -102,26 +105,26 @@ int odph_cli_register_command(const char *name, odph_cli_user_cmd_func_t func,
 			      const char *help);
 
 /**
- * Start CLI server
+ * Run CLI server
  *
- * Upon successful return from this function, the CLI server will be
- * accepting client connections. This function spawns a new thread of
- * type ODP_THREAD_CONTROL using odp_cpumask_default_control().
+ * When executing this function, the CLI is accepting client connections and
+ * running commands from a client, if one is connected.
  *
  * This function should be called after odph_cli_init() and after any
- * odph_cli_register_command() calls.
+ * odph_cli_register_command() calls. After calling this function,
+ * odph_cli_stop() must be called before calling this function again.
+ *
+ * Returns only on a fatal error, or after odph_cli_stop() is called.
  *
  * @retval 0 Success
  * @retval <0 Failure
  */
-int odph_cli_start(void);
+int odph_cli_run(void);
 
 /**
  * Stop CLI server
  *
- * Stop accepting new client connections and disconnect currently
- * connected client. This function terminates the control thread
- * created in odph_cli_start().
+ * Stop accepting new client connections and disconnect any connected client.
  *
  * @retval 0 Success
  * @retval <0 Failure


### PR DESCRIPTION
Add odph_cli_run() and remove odph_cli_start().

Don't create a thread in the CLI helper. Instead, the caller may
create a thread and call odph_cli_run() to run the CLI.

v2:
- Update implementation.

v3:
- Helper API: Minor rewording of odph_cli_run() and odph_cli_stop() descriptions.
- odph_cli_stop(): Wait for server to exit.
- Fix cli_server() error handling.
- Some renaming (SP_*) and cleanup.

v4:
- Helper API: In process mode, odph_cli_init() must be called before creating the thread.
- Fix odph_cli_stop() in process mode.

v5:
- Rebase on PR #1355.
- Use odph_thread_param_init() and odph_thread_common_param_init().
- Add review and cc tags.

v6:
- Rebase on master.
