### PR TITLE
[PATCH v3] Fix parsing of segmented packets

### DIFF
--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1922,6 +1922,16 @@ static inline uint16_t parse_eth(packet_parser_t *prs, const uint8_t **parseptr,
 		*parseptr += sizeof(_odp_vlanhdr_t);
 	}
 
+	/*
+	 * The packet was too short for what we parsed. We just give up
+	 * entirely without trying to parse what fits in the packet.
+	 */
+	if (odp_unlikely(*offset > frame_len)) {
+		input_flags.all = 0;
+		input_flags.l2  = 1;
+		ethtype = 0;
+	}
+
 error:
 	prs->input_flags.all |= input_flags.all;
 

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1955,6 +1955,7 @@ static inline uint8_t parse_ipv4(packet_parser_t *prs, const uint8_t **parseptr,
 
 	if (odp_unlikely(ihl < _ODP_IPV4HDR_IHL_MIN ||
 			 ver != 4 ||
+			 sizeof(*ipv4) > frame_len - *offset ||
 			 (l3_len > frame_len - *offset))) {
 		prs->flags.ip_err = 1;
 		return 0;
@@ -2013,8 +2014,9 @@ static inline uint8_t parse_ipv6(packet_parser_t *prs, const uint8_t **parseptr,
 			  _ODP_IPV6HDR_LEN;
 
 	/* Basic sanity checks on IPv6 header */
-	if ((odp_be_to_cpu_32(ipv6->ver_tc_flow) >> 28) != 6 ||
-	    l3_len > frame_len - *offset) {
+	if (odp_unlikely((odp_be_to_cpu_32(ipv6->ver_tc_flow) >> 28) != 6 ||
+			 sizeof(*ipv6) > frame_len - *offset ||
+			 l3_len > frame_len - *offset)) {
 		prs->flags.ip_err = 1;
 		return 0;
 	}

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1864,7 +1864,7 @@ static inline uint16_t parse_eth(packet_parser_t *prs, const uint8_t **parseptr,
 	eth = (const _odp_ethhdr_t *)*parseptr;
 
 	/* Detect jumbo frames */
-	if (odp_unlikely(frame_len > _ODP_ETH_LEN_MAX))
+	if (odp_unlikely(frame_len - *offset > _ODP_ETH_LEN_MAX))
 		input_flags.jumbo = 1;
 
 	/* Handle Ethernet broadcast/multicast addresses */

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -11,6 +11,7 @@
 #include <odp/api/plat/packet_inlines.h>
 #include <odp_packet_internal.h>
 #include <odp_debug_internal.h>
+#include <odp_macros_internal.h>
 #include <odp_chksum_internal.h>
 #include <odp_errno_define.h>
 #include <odp/api/hints.h>
@@ -1847,7 +1848,15 @@ static uint32_t packet_sum_crc32c(odp_packet_hdr_t *pkt_hdr,
 	return sum;
 }
 
-/** Parser helper function for Ethernet packets */
+/*
+ * In the worst case we look at the Ethernet header, 8 bytes of LLC/SNAP
+ * header and two VLAN tags in the same packet.
+ */
+#define PARSE_ETH_BYTES (sizeof(_odp_ethhdr_t) + 8 + 2 * sizeof(_odp_vlanhdr_t))
+/** Parser helper function for Ethernet packets
+ *
+ *  Requires up to PARSE_ETH_BYTES bytes of contiguous packet data.
+ */
 static inline uint16_t parse_eth(packet_parser_t *prs, const uint8_t **parseptr,
 				 uint32_t *offset, uint32_t frame_len)
 {
@@ -1938,8 +1947,11 @@ error:
 	return ethtype;
 }
 
+#define PARSE_IPV4_BYTES (0xfU * 4) /* max IPv4 header length with options */
 /**
  * Parser helper function for IPv4
+ *
+ * Requires up to PARSE_IPV4_BYTES bytes of contiguous packet data.
  */
 static inline uint8_t parse_ipv4(packet_parser_t *prs, const uint8_t **parseptr,
 				 uint32_t *offset, uint32_t frame_len,
@@ -1998,8 +2010,15 @@ static inline uint8_t parse_ipv4(packet_parser_t *prs, const uint8_t **parseptr,
 	return ipv4->proto;
 }
 
+/*
+ * Peeks 2 bytes beyond IPv6 base header without length check if there
+ * are extension headers.
+ */
+#define PARSE_IPV6_BYTES (sizeof(_odp_ipv6hdr_t) + 2)
 /**
  * Parser helper function for IPv6
+ *
+ * Requires at least PARSE_IPV6_BYTES bytes of contiguous packet data.
  */
 static inline uint8_t parse_ipv6(packet_parser_t *prs, const uint8_t **parseptr,
 				 uint32_t *offset, uint32_t frame_len,
@@ -2068,8 +2087,11 @@ static inline uint8_t parse_ipv6(packet_parser_t *prs, const uint8_t **parseptr,
 	return ipv6->next_hdr;
 }
 
+#define PARSE_TCP_BYTES (sizeof(_odp_tcphdr_t))
 /**
  * Parser helper function for TCP
+ *
+ * Requires PARSE_TCP_BYTES bytes of contiguous packet data.
  */
 static inline void parse_tcp(packet_parser_t *prs, const uint8_t **parseptr,
 			     uint16_t tcp_len,
@@ -2095,8 +2117,15 @@ static inline void parse_tcp(packet_parser_t *prs, const uint8_t **parseptr,
 	*parseptr += len;
 }
 
+/*
+ * In the worst case we look at the UDP header and 4 bytes of the UDP
+ * payload (the non-ESP marker to distinguish IKE packets from ESP packets).
+ */
+#define PARSE_UDP_BYTES (sizeof(_odp_udphdr_t) + 4)
 /**
  * Parser helper function for UDP
+ *
+ * Requires PARSE_UDP_BYTES bytes of contiguous packet data.
  */
 static inline void parse_udp(packet_parser_t *prs, const uint8_t **parseptr,
 			     odp_proto_chksums_t chksums,
@@ -2141,8 +2170,11 @@ static inline void parse_udp(packet_parser_t *prs, const uint8_t **parseptr,
 	*parseptr += sizeof(_odp_udphdr_t);
 }
 
+#define PARSE_SCTP_BYTES (sizeof(_odp_sctphdr_t))
 /**
  * Parser helper function for SCTP
+ *
+ * Requires PARSE_SCTP_BYTES bytes of contiguous packet data.
  */
 static inline void parse_sctp(packet_parser_t *prs, const uint8_t **parseptr,
 			      uint16_t sctp_len,
@@ -2169,6 +2201,10 @@ static inline void parse_sctp(packet_parser_t *prs, const uint8_t **parseptr,
 	*parseptr += sizeof(_odp_sctphdr_t);
 }
 
+#define MAX3(a, b, c) (MAX(MAX((a), (b)), (c)))
+#define PARSE_L3_L4_BYTES (MAX(PARSE_IPV4_BYTES, PARSE_IPV6_BYTES) + \
+			   MAX3(PARSE_TCP_BYTES, PARSE_UDP_BYTES, PARSE_SCTP_BYTES))
+/* Requires up to PARSE_L3_L4_BYTES bytes of contiguous packet data. */
 static inline
 int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 			      uint32_t offset,
@@ -2607,6 +2643,8 @@ int odp_packet_parse(odp_packet_t pkt, uint32_t offset,
 	int ret;
 	uint16_t ethtype;
 	uint64_t l4_part_sum = 0;
+	const uint32_t min_seglen = PARSE_ETH_BYTES + PARSE_L3_L4_BYTES;
+	uint8_t buf[min_seglen];
 
 	if (proto == ODP_PROTO_NONE || layer == ODP_PROTO_LAYER_NONE)
 		return -1;
@@ -2615,6 +2653,20 @@ int odp_packet_parse(odp_packet_t pkt, uint32_t offset,
 
 	if (data == NULL)
 		return -1;
+
+	/*
+	 * We must not have a packet segment boundary within the parsed
+	 * packet data range. Copy enough data to a temporary buffer for
+	 * parsing if necessary.
+	 */
+	if (odp_unlikely(pkt_hdr->seg_count > 1) &&
+	    odp_unlikely(seg_len < min_seglen)) {
+		seg_len = min_seglen;
+		if (seg_len > packet_len - offset)
+			seg_len = packet_len - offset;
+		odp_packet_copy_to_mem(pkt, offset, seg_len, buf);
+		data = buf;
+	}
 
 	/* Reset parser flags, keep other flags */
 	packet_parse_reset(pkt_hdr, 0);

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -172,9 +172,16 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 				pkt_hdr = packet_hdr(new_pkt);
 			}
 		} else {
-			_odp_packet_parse_layer(pkt_hdr,
-						pktio_entry->s.config.parser.layer,
-						pktio_entry->s.in_chksums);
+			odp_packet_parse_param_t param;
+
+			/*
+			 * Use odp_packet_parse() which can handle segmented
+			 * packets.
+			 */
+			param.proto = ODP_PROTO_ETH;
+			param.last_layer = pktio_entry->s.config.parser.layer;
+			param.chksums = pktio_entry->s.in_chksums;
+			odp_packet_parse(packet_handle(pkt_hdr), 0, &param);
 		}
 
 		packet_set_ts(pkt_hdr, ts);


### PR DESCRIPTION
Various fixes for packet parsing, mostly for segmented packets that get parsed when requested through odp_packet_parse() or after going through loop.
