### PR TITLE
[PATCH v2] api: ipsec: allow losing completion events if destination queue is full

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -1786,6 +1786,10 @@ int odp_ipsec_out(const odp_packet_t pkt_in[], int num_in,
  * Logically, packet processing (e.g. sequence number check) happens in the
  * output order as defined above.
  *
+ * If a result packet event cannot be enqueued (e.g. the destination queue
+ * is full), then the output packet is dropped and no event for the consumed
+ * input packet is delivered to the appliation.
+ *
  * The function may be used also in inline processing mode, e.g. for IPSEC
  * packets for which inline processing is not possible. Packets for the same SA
  * may be processed simultaneously in both modes (initiated by this function
@@ -1835,8 +1839,12 @@ int odp_ipsec_in_enq(const odp_packet_t pkt[], int num,
  * (e.g. using locks) that the operation is not called simultaneously from
  * multiple threads for the same SA(s).
  *
- * Logically, packet processing (e.g. sequence number assignment) happens in the
- * output order as defined above.
+ * Logically, packet processing (e.g. sequence number assignment) happens in
+ * the output order as defined above.
+ *
+ * If a result packet event cannot be enqueued (e.g. the destination queue
+ * is full), then the output packet is dropped and no event for the consumed
+ * input packet is delivered to the appliation.
  *
  * The function may be used also in inline processing mode, e.g. for IPSEC
  * packets for which inline processing is not possible.


### PR DESCRIPTION
The first patch changes API so that packet completion events can be lost if the destination queue is full. The patch does not change whether SA disable completion events can be lost (the API is not explicit about it but the spirit is that those events cannot be lost, although in current linux-gen it can happen).

The second patch fixes existing bugs related to enqueue failures.
