### PR TITLE
[PATCH v2] api: ipsec: support associating inline SA to a pktio

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -306,6 +306,14 @@ typedef struct odp_ipsec_capability_t {
 	 */
 	odp_support_t op_mode_inline_out;
 
+	/**
+	 * Global or Non PKTIO specific Inline SA support. When supported,
+	 * an Inline SA need not be associated with a particular PKTIO. When
+	 * false, IPSEC SA params for Inline SA should provide PKTIO handle
+	 * to which that SA needs to be associated with.
+	 */
+	odp_support_t global_inline_sa;
+
 	/** IP Authenticated Header (ODP_IPSEC_AH) support */
 	odp_support_t proto_ah;
 
@@ -847,6 +855,16 @@ typedef struct odp_ipsec_sa_param_t {
 	 *  context data bytes to prefetch. Default value is zero (no hint).
 	 */
 	uint32_t context_len;
+
+	/** PKTIO Handle
+	 *
+	 *  PKTIO Handle to which this SA will be associated with for Inline
+	 *  processing. Default value is ODP_PKTIO_INVALID that indicates
+	 *  it is not associated to any specific PKTIO.
+	 *
+	 *  @see odp_ipsec_capability_t::global_inline_sa
+	 */
+	odp_pktio_t pktio;
 
 	/** IPSEC SA direction dependent parameters */
 	struct {

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -155,6 +155,8 @@ int odp_ipsec_capability(odp_ipsec_capability_t *capa)
 	capa->op_mode_inline_in = ODP_SUPPORT_PREFERRED;
 	capa->op_mode_inline_out = ODP_SUPPORT_PREFERRED;
 
+	capa->global_inline_sa = ODP_SUPPORT_YES;
+
 	capa->proto_ah = ODP_SUPPORT_YES;
 
 	capa->max_num_sa = _odp_ipsec_max_num_sa();

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -368,6 +368,7 @@ void odp_ipsec_sa_param_init(odp_ipsec_sa_param_t *param)
 	param->dest_queue = ODP_QUEUE_INVALID;
 	param->outbound.tunnel.ipv4.ttl = 255;
 	param->outbound.tunnel.ipv6.hlimit = 255;
+	param->pktio = ODP_PKTIO_INVALID;
 }
 
 /* Return IV length required for the cipher for IPsec use */

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -343,6 +343,16 @@ void ipsec_sa_param_fill(odp_ipsec_sa_param_t *param,
 	param->lifetime.hard_limit.bytes = 1000 * 1000;
 	param->lifetime.soft_limit.packets = 9000 * 1000;
 	param->lifetime.hard_limit.packets = 10000 * 1000;
+
+	if (suite_context.global_inline_sa)
+		return;
+
+	/* For platforms that don't support global inline SA's, we need to
+	 * associate an inline SA to a pktio.
+	 */
+	if ((in && suite_context.inbound_op_mode == ODP_IPSEC_OP_MODE_INLINE) ||
+	    (!in && suite_context.outbound_op_mode == ODP_IPSEC_OP_MODE_INLINE))
+		param->pktio = suite_context.pktio;
 }
 
 void ipsec_sa_destroy(odp_ipsec_sa_t sa)
@@ -1232,6 +1242,11 @@ int ipsec_config(odp_instance_t ODP_UNUSED inst)
 			suite_context.reass_ipv6 = false;
 		}
 	}
+
+	if (capa.global_inline_sa == ODP_SUPPORT_YES)
+		suite_context.global_inline_sa = true;
+	else
+		suite_context.global_inline_sa = false;
 
 	if (ODP_IPSEC_OK != odp_ipsec_config(&ipsec_config))
 		return -1;

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -41,6 +41,7 @@ struct suite_context_s {
 	odp_pool_t pool;
 	odp_queue_t queue;
 	odp_pktio_t pktio;
+	odp_bool_t global_inline_sa;
 };
 
 extern struct suite_context_s suite_context;


### PR DESCRIPTION
commit 5f4a585f32481122276036b34a9aac225a74a124
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Tue Sep 21 16:35:50 2021 +0530

    api: ipsec: support associating inline SA to a pktio
    
    Not all HW platforms support having a global Inline IPsec SA
    which can work synchronuously across all PKTIO's. Hence add
    a capability in odp_ipsec_capability_t to mention if a platform
    supports global Inline IPsec SA or not.
    
    If a platform doesn't support Global Inline IPsec SA, then PKTIO
    handle should be set in odp_ipsec_sa_param_t in order to enable it
    for inline processing on that PKTIO.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 0bcaf3ccb820e9f13028a36e6149f3602b2bb17e
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Tue Sep 21 16:44:50 2021 +0530

    linux-gen: ipsec: express support for global inline ipsec SA
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 82dd75e1fb20f4f10bc6ea35dfc6d47a2704b508
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Tue Sep 21 17:09:54 2021 +0530

    validation: ipsec: provide pktio handle to inline SA
    
    Provide PKTIO handle to inline SA's in Inline tests
    when platform doesn't support a global inline SA.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

