### PR TITLE
[PATCH v3] github_ci: update gh pages build workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Documentation:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
     - name: Deploy
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      uses: crazy-max/ghaction-github-pages@v2.2.0
+      uses: crazy-max/ghaction-github-pages@v2
       with:
         allow_empty_commit: false
         build_dir: ./doc/gh-pages


### PR DESCRIPTION
Use Ubuntu 20.04 to build documentation and bump ghaction-github-pages
version to v2.5.0.

Signed-off-by: Matias Elo <matias.elo@nokia.com>