### PR TITLE
[PATCH v2] crypto: fix crypto and auth range offset in bit mode

### DIFF
--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -482,10 +482,13 @@ static void alg_test_execute(const alg_test_param_t *param)
 	auth_range.offset = param->header_len;
 	auth_range.length = ref->length;
 
-	if (param->bit_mode)
+	if (param->bit_mode) {
 		reflength = (ref->length + 7) / 8;
-	else
+		cipher_range.offset *= 8;
+		auth_range.offset *= 8;
+	} else {
 		reflength = ref->length;
+	}
 
 	for (iteration = NORMAL_TEST; iteration < MAX_TEST; iteration++) {
 		odp_packet_t pkt;


### PR DESCRIPTION
In bit mode the crypto and auth ranges are supposed to be given in bits,
not in bytes. Fix the linux-gen implementation that interpreted crypto and
auth offset in bytes in AES EEA2 and AES EIA2, respectively. Fix crypto
validation test to provide the offsets in bits as specified by the API.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>