### PR TITLE
[PATCH v5] api: shm: introduce flags capability and ODP_SHM_NO_HP flag

### DIFF
--- a/doc/users-guide/users-guide.adoc
+++ b/doc/users-guide/users-guide.adoc
@@ -940,15 +940,6 @@ to other ODP instances running on the same OS.
 Other ODP instances willing to see this exported memory should use the
 `odp_shm_import()` ODP function.
 
-==== ODP_SHM_SW_ONLY
-This flag tells ODP that the shared memory will be used by the ODP application
-software only: no HW (such as DMA, or other accelerator) will ever
-try to access the memory. No other ODP call will be involved on this memory
-(as ODP calls could implicitly involve HW, depending on the ODP
-implementation), except for `odp_shm_lookup()` and `odp_shm_free()`.
-ODP implementations may use this flag as a hint for performance optimization,
-or may as well ignore this flag.
-
 ==== ODP_SHM_SINGLE_VA
 This flag is used to guarantee the uniqueness of the address at which
 the shared memory is mapped: without this flag, a given memory block may be

--- a/helper/cli.c
+++ b/helper/cli.c
@@ -85,7 +85,7 @@ int odph_cli_init(const odph_cli_param_t *param)
 	int shm_size = sizeof(cli_shm_t) +
 		param->max_user_commands * sizeof(user_cmd_t);
 	odp_shm_t shm_hdl =
-		odp_shm_reserve(shm_name, shm_size, 64, ODP_SHM_SW_ONLY);
+		odp_shm_reserve(shm_name, shm_size, 64, 0);
 
 	if (shm_hdl != ODP_SHM_INVALID)
 		shm = (cli_shm_t *)odp_shm_addr(shm_hdl);

--- a/helper/cuckootable.c
+++ b/helper/cuckootable.c
@@ -236,9 +236,8 @@ odph_cuckoo_table_create(
 	bucket_num = align32pow2(capacity) / HASH_BUCKET_ENTRIES;
 	bucket_size = bucket_num * sizeof(struct cuckoo_table_bucket);
 
-	shm_tbl = odp_shm_reserve(
-				name, impl_size + bucket_size,
-				ODP_CACHE_LINE_SIZE, ODP_SHM_SW_ONLY);
+	shm_tbl = odp_shm_reserve(name, impl_size + bucket_size,
+				  ODP_CACHE_LINE_SIZE, 0);
 
 	if (shm_tbl == ODP_SHM_INVALID) {
 		ODPH_DBG(

--- a/helper/hashtable.c
+++ b/helper/hashtable.c
@@ -81,7 +81,7 @@ odph_table_t odph_hash_table_create(const char *name, uint32_t capacity,
 		ODPH_DBG("name already exist\n");
 		return NULL;
 	}
-	shmem = odp_shm_reserve(name, capacity << 20, 64, ODP_SHM_SW_ONLY);
+	shmem = odp_shm_reserve(name, capacity << 20, 64, 0);
 	if (shmem == ODP_SHM_INVALID) {
 		ODPH_DBG("shm reserve fail\n");
 		return NULL;

--- a/helper/iplookuptable.c
+++ b/helper/iplookuptable.c
@@ -513,9 +513,7 @@ odph_table_t odph_iplookup_table_create(const char *name,
 	impl_size = sizeof(odph_iplookup_table_impl);
 	l1_size = ENTRY_SIZE * ENTRY_NUM_L1;
 
-	shm_tbl = odp_shm_reserve(
-				name, impl_size + l1_size,
-				ODP_CACHE_LINE_SIZE, ODP_SHM_SW_ONLY);
+	shm_tbl = odp_shm_reserve(name, impl_size + l1_size, ODP_CACHE_LINE_SIZE, 0);
 
 	if (shm_tbl == ODP_SHM_INVALID) {
 		ODPH_DBG(

--- a/helper/lineartable.c
+++ b/helper/lineartable.c
@@ -61,7 +61,7 @@ odph_table_t odph_linear_table_create(const char *name, uint32_t capacity,
 	}
 
 	/* alloc memory from shm */
-	shmem = odp_shm_reserve(name, capacity << 20, 64, ODP_SHM_SW_ONLY);
+	shmem = odp_shm_reserve(name, capacity << 20, 64, 0);
 	if (shmem == ODP_SHM_INVALID) {
 		ODPH_DBG("shm reserve fail\n");
 		return NULL;

--- a/include/odp/api/spec/shared_memory.h
+++ b/include/odp/api/spec/shared_memory.h
@@ -97,6 +97,15 @@ extern "C" {
 #define ODP_SHM_HW_ACCESS	0x20
 
 /**
+ * Don't use huge pages
+ *
+ * When set, this flag guarantees that the memory reserved by odp_shm_reserve()
+ * is not allocated from huge pages. This flag must not be combined with
+ * ODP_SHM_HP.
+ */
+#define ODP_SHM_NO_HP		0x40
+
+/**
  * Shared memory block info
  */
 typedef struct odp_shm_info_t {

--- a/include/odp/api/spec/shared_memory.h
+++ b/include/odp/api/spec/shared_memory.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2019, Nokia
- * Copyright (c) 2013-2018, Linaro Limited
+/* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2019-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -92,8 +92,7 @@ extern "C" {
  * When set, this flag guarantees that the reserved memory is accessible
  * by both CPUs and HW accelerators of the device. This may require e.g. that
  * the odp_shm_reserve() call configures the memory to be accessible through
- * an Input-Output Memory Management Unit (IOMMU). The reserve call will return
- * failure if such configuration is not supported.
+ * an Input-Output Memory Management Unit (IOMMU).
  */
 #define ODP_SHM_HW_ACCESS	0x20
 
@@ -138,6 +137,14 @@ typedef struct odp_shm_capability_t {
 	 * The value of zero means that alignment is limited only by the
 	 * available memory size. */
 	uint64_t max_align;
+
+	/** Supported shared memory flags
+	 *
+	 * A bit mask of supported ODP_SHM_* flags. Depending on the
+	 * implementation some flag combinations may not be supported. In this
+	 * case odp_shm_reserve() will fail.
+	 */
+	uint32_t flags;
 
 } odp_shm_capability_t;
 

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -1071,7 +1071,8 @@ int _odp_ishm_reserve(const char *name, uint64_t size, int fd,
 
 	/* Get system page sizes: page_hp_size is 0 if no huge page available*/
 	page_sz      = odp_sys_page_size();
-	page_hp_size = odp_sys_huge_page_size();
+	/* Use normal pages if ODP_SHM_NO_HP was used */
+	page_hp_size = (user_flags & ODP_SHM_NO_HP) ? 0 : odp_sys_huge_page_size();
 
 	/* grab a new entry: */
 	for (new_index = 0; new_index < ISHM_MAX_NB_BLOCKS; new_index++) {

--- a/platform/linux-generic/odp_shared_memory.c
+++ b/platform/linux-generic/odp_shared_memory.c
@@ -18,7 +18,7 @@
 
 /* Supported ODP_SHM_* flags */
 #define SUPPORTED_SHM_FLAGS (ODP_SHM_SW_ONLY | ODP_SHM_PROC | ODP_SHM_SINGLE_VA | ODP_SHM_EXPORT | \
-			     ODP_SHM_HP)
+			     ODP_SHM_HP | ODP_SHM_NO_HP)
 
 static inline uint32_t from_handle(odp_shm_t shm)
 {

--- a/platform/linux-generic/odp_shared_memory.c
+++ b/platform/linux-generic/odp_shared_memory.c
@@ -1,11 +1,12 @@
-/* Copyright (c) 2019, Nokia
- * Copyright (c) 2013-2018, Linaro Limited
+/* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2019-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
 #include <odp_config_internal.h>
+#include <odp_debug_internal.h>
 #include <odp/api/debug.h>
 #include <odp/api/std_types.h>
 #include <odp/api/shared_memory.h>
@@ -14,6 +15,10 @@
 #include <odp_init_internal.h>
 #include <odp_global_data.h>
 #include <string.h>
+
+/* Supported ODP_SHM_* flags */
+#define SUPPORTED_SHM_FLAGS (ODP_SHM_SW_ONLY | ODP_SHM_PROC | ODP_SHM_SINGLE_VA | ODP_SHM_EXPORT | \
+			     ODP_SHM_HP)
 
 static inline uint32_t from_handle(odp_shm_t shm)
 {
@@ -47,6 +52,7 @@ int odp_shm_capability(odp_shm_capability_t *capa)
 	capa->max_blocks = CONFIG_SHM_BLOCKS;
 	capa->max_size = odp_global_ro.shm_max_size;
 	capa->max_align = 0;
+	capa->flags = SUPPORTED_SHM_FLAGS;
 
 	return 0;
 }
@@ -56,6 +62,12 @@ odp_shm_t odp_shm_reserve(const char *name, uint64_t size, uint64_t align,
 {
 	int block_index;
 	uint32_t flgs = 0; /* internal ishm flags */
+	uint32_t supported_flgs = SUPPORTED_SHM_FLAGS;
+
+	if (flags & ~supported_flgs) {
+		ODP_ERR("Unsupported SHM flag\n");
+		return ODP_SHM_INVALID;
+	}
 
 	flgs = get_ishm_flags(flags);
 

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -285,7 +285,7 @@ static odp_timer_pool_t timer_pool_new(const char *name,
 	size_t sz0, sz1, sz2;
 	uint64_t tp_size;
 	uint64_t res_ns, nsec_per_scan;
-	uint32_t flags = ODP_SHM_SW_ONLY;
+	uint32_t flags = 0;
 
 	if (odp_global_ro.shm_single_va)
 		flags |= ODP_SHM_SINGLE_VA;

--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -752,8 +752,7 @@ static int atomic_init(odp_instance_t *inst)
 	}
 
 	global_shm = odp_shm_reserve(GLOBAL_SHM_NAME,
-				     sizeof(global_shared_mem_t), 64,
-				     ODP_SHM_SW_ONLY);
+				     sizeof(global_shared_mem_t), 64, 0);
 	if (ODP_SHM_INVALID == global_shm) {
 		fprintf(stderr, "Unable reserve memory for global_shm\n");
 		return -1;

--- a/test/validation/api/barrier/barrier.c
+++ b/test/validation/api/barrier/barrier.c
@@ -349,8 +349,7 @@ static int barrier_init(odp_instance_t *inst)
 	}
 
 	global_shm = odp_shm_reserve(GLOBAL_SHM_NAME,
-				     sizeof(global_shared_mem_t), 64,
-				     ODP_SHM_SW_ONLY);
+				     sizeof(global_shared_mem_t), 64, 0);
 	if (ODP_SHM_INVALID == global_shm) {
 		fprintf(stderr, "Unable reserve memory for global_shm\n");
 		return -1;

--- a/test/validation/api/lock/lock.c
+++ b/test/validation/api/lock/lock.c
@@ -1183,8 +1183,7 @@ static int lock_init(odp_instance_t *inst)
 	}
 
 	global_shm = odp_shm_reserve(GLOBAL_SHM_NAME,
-				     sizeof(global_shared_mem_t), 64,
-				     ODP_SHM_SW_ONLY);
+				     sizeof(global_shared_mem_t), 64, 0);
 	if (ODP_SHM_INVALID == global_shm) {
 		fprintf(stderr, "Unable reserve memory for global_shm\n");
 		return -1;

--- a/test/validation/api/shmem/shmem.c
+++ b/test/validation/api/shmem/shmem.c
@@ -297,6 +297,26 @@ static void shmem_test_flag_hp(void)
 	CU_ASSERT(odp_shm_free(shm) == 0);
 }
 
+/*
+ * Test reserving memory from normal pages
+ */
+static void shmem_test_flag_no_hp(void)
+{
+	odp_shm_t shm;
+	odp_shm_info_t info;
+
+	shm = odp_shm_reserve(MEM_NAME, sizeof(shared_test_data_t), 0,
+			      ODP_SHM_NO_HP);
+	CU_ASSERT_FATAL(shm != ODP_SHM_INVALID);
+
+	/* Make sure that the memory is reserved from normal pages */
+	CU_ASSERT_FATAL(odp_shm_info(shm, &info) == 0);
+
+	CU_ASSERT(info.page_size == odp_sys_page_size());
+
+	CU_ASSERT(odp_shm_free(shm) == 0);
+}
+
 static void shmem_test_flag_proc(void)
 {
 	odp_shm_t shm;
@@ -971,6 +991,7 @@ odp_testinfo_t shmem_suite[] = {
 	ODP_TEST_INFO(shmem_test_capability),
 	ODP_TEST_INFO(shmem_test_reserve),
 	ODP_TEST_INFO(shmem_test_flag_hp),
+	ODP_TEST_INFO(shmem_test_flag_no_hp),
 	ODP_TEST_INFO(shmem_test_flag_proc),
 	ODP_TEST_INFO(shmem_test_flag_export),
 	ODP_TEST_INFO(shmem_test_flag_hw_access),

--- a/test/validation/api/shmem/shmem.c
+++ b/test/validation/api/shmem/shmem.c
@@ -1,5 +1,5 @@
-/* Copyright (c) 2019, Nokia
- * Copyright (c) 2014-2018, Linaro Limited
+/* Copyright (c) 2014-2018, Linaro Limited
+ * Copyright (c) 2019-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -210,6 +210,35 @@ static void shmem_test_multi_thread(void)
 	odp_shm_print(shm);
 
 	CU_ASSERT(0 == odp_shm_free(shm));
+}
+
+static void shmem_test_capability(void)
+{
+	odp_shm_capability_t capa;
+
+	CU_ASSERT_FATAL(odp_shm_capability(&capa) == 0);
+
+	CU_ASSERT(capa.max_blocks);
+
+	printf("\nSHM capability\n--------------\n");
+
+	printf("  max_blocks: %u\n", capa.max_blocks);
+	printf("  max_size:   %" PRIu64 "\n", capa.max_size);
+	printf("  max_align:  %" PRIu64 "\n", capa.max_align);
+	printf("  flags:      ");
+	if (capa.flags & ODP_SHM_PROC)
+		printf("ODP_SHM_PROC ");
+	if (capa.flags & ODP_SHM_SINGLE_VA)
+		printf("ODP_SHM_SINGLE_VA ");
+	if (capa.flags & ODP_SHM_EXPORT)
+		printf("ODP_SHM_EXPORT ");
+	if (capa.flags & ODP_SHM_HP)
+		printf("ODP_SHM_HP ");
+	if (capa.flags & ODP_SHM_HW_ACCESS)
+		printf("ODP_SHM_HW_ACCESS ");
+	if (capa.flags & ODP_SHM_NO_HP)
+		printf("ODP_SHM_NO_HP ");
+	printf("\n\n");
 }
 
 static void shmem_test_reserve(void)
@@ -939,6 +968,7 @@ static void shmem_test_stress(void)
 }
 
 odp_testinfo_t shmem_suite[] = {
+	ODP_TEST_INFO(shmem_test_capability),
 	ODP_TEST_INFO(shmem_test_reserve),
 	ODP_TEST_INFO(shmem_test_flag_hp),
 	ODP_TEST_INFO(shmem_test_flag_proc),

--- a/test/validation/api/thread/thread.c
+++ b/test/validation/api/thread/thread.c
@@ -44,7 +44,7 @@ static int thread_global_init(odp_instance_t *inst)
 
 	global_shm = odp_shm_reserve(GLOBAL_SHM_NAME,
 				     sizeof(global_shared_mem_t),
-				     ODP_CACHE_LINE_SIZE, ODP_SHM_SW_ONLY);
+				     ODP_CACHE_LINE_SIZE, 0);
 	if (global_shm == ODP_SHM_INVALID) {
 		fprintf(stderr, "Unable reserve memory for global_shm\n");
 		return -1;

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -112,7 +112,7 @@ static int timer_global_init(odp_instance_t *inst)
 
 	global_shm = odp_shm_reserve(GLOBAL_SHM_NAME,
 				     sizeof(global_shared_mem_t),
-				     ODP_CACHE_LINE_SIZE, ODP_SHM_SW_ONLY);
+				     ODP_CACHE_LINE_SIZE, 0);
 	if (global_shm == ODP_SHM_INVALID) {
 		fprintf(stderr, "Unable reserve memory for global_shm\n");
 		return -1;


### PR DESCRIPTION
V2:
- Removed `odp_shm_addr_pa()` API
- `ODP_SHM_NO_HP` documentation clarification
- State that some flag combinations may not be supported

V3:
- Rebase