### PR TITLE
[PATCH v2] validation: ipsec: allow orig_ip_len to be unavailable

### DIFF
--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -951,7 +951,8 @@ static void verify_in(const ipsec_test_part *part,
 			if (suite_context.inbound_op_mode != ODP_IPSEC_OP_MODE_SYNC) {
 				uint32_t len = part->pkt_in->len - part->pkt_in->l3_offset;
 
-				CU_ASSERT(result.orig_ip_len == len);
+				CU_ASSERT(result.orig_ip_len == 0 ||
+					  result.orig_ip_len == len);
 			}
 		}
 		ipsec_check_packet(part->out[i].pkt_res,


### PR DESCRIPTION
The API specifies that zero odp_ipsec_packet_result_t::orig_ip_len means
that the length is not available. Check orig_ip_len against the original
packet length only when it is available.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>