### PR TITLE
[PATCH v2] validation: ipsec: update orig IP len to cover reassembly cases

### DIFF
--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -949,7 +949,12 @@ static void verify_in(const ipsec_test_part *part,
 				CU_ASSERT_EQUAL(IPSEC_SA_CTX,
 						odp_ipsec_sa_context(sa));
 			if (suite_context.inbound_op_mode != ODP_IPSEC_OP_MODE_SYNC) {
-				uint32_t len = part->pkt_in->len - part->pkt_in->l3_offset;
+				uint32_t len;
+
+				if (part->out[i].orig_ip_len)
+					len = part->out[i].orig_ip_len;
+				else
+					len = part->pkt_in->len - part->pkt_in->l3_offset;
 
 				CU_ASSERT(result.orig_ip_len == 0 ||
 					  result.orig_ip_len == len);

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -96,6 +96,11 @@ typedef struct {
 		odp_proto_l3_type_t l3_type;
 		odp_proto_l4_type_t l4_type;
 		uint32_t seq_num;
+		/*
+		 * Expected original IP length. Non zero only when expected len
+		 * differs from that of input test packet (pkt_in).
+		 */
+		uint32_t orig_ip_len;
 	} out[MAX_FRAGS];
 } ipsec_test_part;
 


### PR DESCRIPTION
In case of successful reassembly tests, the original IP length
would be the aggregate of IP lengths of all individual fragments. Update
the test framework to have a field 'orig_ip_len' to be able to cover
cases when expected len differs from that of the input test packet
available with 'ipsec_test_part'.

Signed-off-by: Anoob Joseph <anoobj@marvell.com>