### PR TITLE
[PATCH v4] api: stash: add type specific put/get functions

### DIFF
--- a/include/odp/api/spec/stash.h
+++ b/include/odp/api/spec/stash.h
@@ -339,6 +339,23 @@ int32_t odp_stash_put_u32(odp_stash_t stash, const uint32_t u32[], int32_t num);
 int32_t odp_stash_put_u64(odp_stash_t stash, const uint64_t u64[], int32_t num);
 
 /**
+ * Put pointers into a stash
+ *
+ * Otherwise like odp_stash_put(), except that this function operates on
+ * pointers. The stash must have been created with 'obj_size' matching to the
+ * size of uintptr_t.
+ *
+ * @param stash  Stash handle
+ * @param ptr    Points to an array of pointers to be stored. The array must be
+ *               pointer size aligned in memory.
+ * @param num    Number of pointers to store
+ *
+ * @return Number of pointers actually stored (0 ... num)
+ * @retval <0 on failure
+ */
+int32_t odp_stash_put_ptr(odp_stash_t stash, const uintptr_t ptr[], int32_t num);
+
+/**
  * Get object handles from a stash
  *
  * Get previously stored object handles from the stash. Application specifies
@@ -387,6 +404,23 @@ int32_t odp_stash_get_u32(odp_stash_t stash, uint32_t u32[], int32_t num);
  * @retval <0 on failure
  */
 int32_t odp_stash_get_u64(odp_stash_t stash, uint64_t u64[], int32_t num);
+
+/**
+ * Get pointers from a stash
+ *
+ * Otherwise like odp_stash_get(), except that this function operates on
+ * pointers. The stash must have been created with 'obj_size' matching to the
+ * size of uintptr_t.
+ *
+ * @param      stash  Stash handle
+ * @param[out] ptr    Points to an array of pointers for output. The array must
+ *                    be pointer size aligned in memory.
+ * @param      num    Maximum number of pointers to get from the stash
+ *
+ * @return Number of pointers actually output (0 ... num) to 'ptr' array
+ * @retval <0 on failure
+ */
+int32_t odp_stash_get_ptr(odp_stash_t stash, uintptr_t ptr[], int32_t num);
 
 /**
  * Flush object handles from the thread local cache

--- a/include/odp/api/spec/stash.h
+++ b/include/odp/api/spec/stash.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020, Nokia
+/* Copyright (c) 2020-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -307,6 +307,22 @@ uint64_t odp_stash_to_u64(odp_stash_t stash);
 int32_t odp_stash_put(odp_stash_t stash, const void *obj, int32_t num);
 
 /**
+ * Put 64-bit integers into a stash
+ *
+ * Otherwise like odp_stash_put(), except that this function operates on 64-bit
+ * integers. The stash must have been created with 'obj_size' of 8.
+ *
+ * @param stash  Stash handle
+ * @param u64    Points to an array of 64-bit integers to be stored. The array
+ *               must be 64-bit aligned in memory.
+ * @param num    Number of integers to store
+ *
+ * @return Number of integers actually stored (0 ... num)
+ * @retval <0 on failure
+ */
+int32_t odp_stash_put_u64(odp_stash_t stash, const uint64_t u64[], int32_t num);
+
+/**
  * Get object handles from a stash
  *
  * Get previously stored object handles from the stash. Application specifies
@@ -323,6 +339,22 @@ int32_t odp_stash_put(odp_stash_t stash, const void *obj, int32_t num);
  * @retval <0 on failure
  */
 int32_t odp_stash_get(odp_stash_t stash, void *obj, int32_t num);
+
+/**
+ * Get 64-bit integers from a stash
+ *
+ * Otherwise like odp_stash_get(), except that this function operates on 64-bit
+ * integers. The stash must have been created with 'obj_size' of 8.
+ *
+ * @param      stash  Stash handle
+ * @param[out] u64    Points to an array of 64-bit integers for output. The
+ *                    array must be 64-bit aligned in memory.
+ * @param      num    Maximum number of integers to get from the stash
+ *
+ * @return Number of integers actually output (0 ... num) to 'u64' array
+ * @retval <0 on failure
+ */
+int32_t odp_stash_get_u64(odp_stash_t stash, uint64_t u64[], int32_t num);
 
 /**
  * Flush object handles from the thread local cache

--- a/include/odp/api/spec/stash.h
+++ b/include/odp/api/spec/stash.h
@@ -307,6 +307,22 @@ uint64_t odp_stash_to_u64(odp_stash_t stash);
 int32_t odp_stash_put(odp_stash_t stash, const void *obj, int32_t num);
 
 /**
+ * Put 32-bit integers into a stash
+ *
+ * Otherwise like odp_stash_put(), except that this function operates on 32-bit
+ * integers. The stash must have been created with 'obj_size' of 4.
+ *
+ * @param stash  Stash handle
+ * @param u32    Points to an array of 32-bit integers to be stored. The array
+ *               must be 32-bit aligned in memory.
+ * @param num    Number of integers to store
+ *
+ * @return Number of integers actually stored (0 ... num)
+ * @retval <0 on failure
+ */
+int32_t odp_stash_put_u32(odp_stash_t stash, const uint32_t u32[], int32_t num);
+
+/**
  * Put 64-bit integers into a stash
  *
  * Otherwise like odp_stash_put(), except that this function operates on 64-bit
@@ -339,6 +355,22 @@ int32_t odp_stash_put_u64(odp_stash_t stash, const uint64_t u64[], int32_t num);
  * @retval <0 on failure
  */
 int32_t odp_stash_get(odp_stash_t stash, void *obj, int32_t num);
+
+/**
+ * Get 32-bit integers from a stash
+ *
+ * Otherwise like odp_stash_get(), except that this function operates on 32-bit
+ * integers. The stash must have been created with 'obj_size' of 4.
+ *
+ * @param      stash  Stash handle
+ * @param[out] u32    Points to an array of 32-bit integers for output. The
+ *                    array must be 32-bit aligned in memory.
+ * @param      num    Maximum number of integers to get from the stash
+ *
+ * @return Number of integers actually output (0 ... num) to 'u32' array
+ * @retval <0 on failure
+ */
+int32_t odp_stash_get_u32(odp_stash_t stash, uint32_t u32[], int32_t num);
 
 /**
  * Get 64-bit integers from a stash

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -143,6 +143,7 @@ noinst_HEADERS = \
 		  include/odp_ring_spsc_internal.h \
 		  include/odp_ring_st_internal.h \
 		  include/odp_ring_u32_internal.h \
+		  include/odp_ring_u64_internal.h \
 		  include/odp_schedule_if.h \
 		  include/odp_schedule_scalable_config.h \
 		  include/odp_schedule_scalable.h \

--- a/platform/linux-generic/include/odp_ring_common.h
+++ b/platform/linux-generic/include/odp_ring_common.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, Nokia
+/* Copyright (c) 2019-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -12,7 +12,8 @@ extern "C" {
 #endif
 
 #define _ODP_RING_TYPE_U32 1
-#define _ODP_RING_TYPE_PTR 2
+#define _ODP_RING_TYPE_U64 2
+#define _ODP_RING_TYPE_PTR 3
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_ring_internal.h
+++ b/platform/linux-generic/include/odp_ring_internal.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2019, Nokia
+ * Copyright (c) 2019-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -50,6 +50,11 @@ typedef struct ODP_ALIGNED_CACHE {
 
 typedef struct ODP_ALIGNED_CACHE {
 	struct ring_common r;
+	uint64_t data[];
+} ring_u64_t;
+
+typedef struct ODP_ALIGNED_CACHE {
+	struct ring_common r;
 	void *data[];
 } ring_ptr_t;
 
@@ -87,6 +92,16 @@ static inline int cas_mo_u32(odp_atomic_u32_t *atom, uint32_t *old_val,
 	#define _RING_ENQ ring_u32_enq
 	#define _RING_ENQ_MULTI ring_u32_enq_multi
 	#define _RING_LEN ring_u32_len
+#elif _ODP_RING_TYPE == _ODP_RING_TYPE_U64
+	#define _ring_gen_t ring_u64_t
+	#define _ring_data_t uint64_t
+
+	#define _RING_INIT ring_u64_init
+	#define _RING_DEQ ring_u64_deq
+	#define _RING_DEQ_MULTI ring_u64_deq_multi
+	#define _RING_ENQ ring_u64_enq
+	#define _RING_ENQ_MULTI ring_u64_enq_multi
+	#define _RING_LEN ring_u64_len
 #elif _ODP_RING_TYPE == _ODP_RING_TYPE_PTR
 	#define _ring_gen_t ring_ptr_t
 	#define _ring_data_t void *

--- a/platform/linux-generic/include/odp_ring_u64_internal.h
+++ b/platform/linux-generic/include/odp_ring_u64_internal.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_RING_U64_INTERNAL_H_
+#define ODP_RING_U64_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp_ring_common.h>
+
+#undef _ODP_RING_TYPE
+#define _ODP_RING_TYPE _ODP_RING_TYPE_U64
+
+#include <odp_ring_internal.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/odp_stash.c
+++ b/platform/linux-generic/odp_stash.c
@@ -358,6 +358,20 @@ int32_t odp_stash_put(odp_stash_t st, const void *obj, int32_t num)
 	return -1;
 }
 
+int32_t odp_stash_put_u32(odp_stash_t st, const uint32_t u32[], int32_t num)
+{
+	stash_t *stash = (stash_t *)(uintptr_t)st;
+
+	if (odp_unlikely(st == ODP_STASH_INVALID))
+		return -1;
+
+	ODP_ASSERT(stash->obj_size == sizeof(uint32_t));
+
+	ring_u32_enq_multi(&stash->ring_u32.hdr, stash->ring_mask,
+			   (uint32_t *)(uintptr_t)u32, num);
+	return num;
+}
+
 int32_t odp_stash_put_u64(odp_stash_t st, const uint64_t u64[], int32_t num)
 {
 	stash_t *stash = (stash_t *)(uintptr_t)st;
@@ -426,6 +440,19 @@ int32_t odp_stash_get(odp_stash_t st, void *obj, int32_t num)
 	}
 
 	return -1;
+}
+
+int32_t odp_stash_get_u32(odp_stash_t st, uint32_t u32[], int32_t num)
+{
+	stash_t *stash = (stash_t *)(uintptr_t)st;
+
+	if (odp_unlikely(st == ODP_STASH_INVALID))
+		return -1;
+
+	ODP_ASSERT(stash->obj_size == sizeof(uint32_t));
+
+	return ring_u32_deq_multi(&stash->ring_u32.hdr, stash->ring_mask, u32,
+				  num);
 }
 
 int32_t odp_stash_get_u64(odp_stash_t st, uint64_t u64[], int32_t num)

--- a/test/validation/api/stash/stash.c
+++ b/test/validation/api/stash/stash.c
@@ -29,6 +29,7 @@
 
 typedef enum stash_op_t {
 	STASH_GEN,
+	STASH_U32,
 	STASH_U64
 } stash_op_t;
 
@@ -421,6 +422,8 @@ static void stash_default_put(uint32_t size, int32_t burst, stash_op_t op)
 	while (num_left) {
 		if (op == STASH_GEN)
 			ret = odp_stash_put(stash, input, burst);
+		else if (op == STASH_U32)
+			ret = odp_stash_put_u32(stash, input_u32, burst);
 		else if (op == STASH_U64)
 			ret = odp_stash_put_u64(stash, input_u64, burst);
 		else
@@ -458,6 +461,8 @@ static void stash_default_put(uint32_t size, int32_t burst, stash_op_t op)
 		}
 		if (op == STASH_GEN)
 			ret = odp_stash_get(stash, output, burst);
+		else if (op == STASH_U32)
+			ret = odp_stash_get_u32(stash, &output_u32[1], burst);
 		else if (op == STASH_U64)
 			ret = odp_stash_get_u64(stash, &output_u64[1], burst);
 		else
@@ -569,6 +574,8 @@ static void stash_fifo_put(uint32_t size, int32_t burst, stash_op_t op)
 		}
 		if (op == STASH_GEN)
 			ret = odp_stash_put(stash, input, burst);
+		else if (op == STASH_U32)
+			ret = odp_stash_put_u32(stash, input_u32, burst);
 		else if (op == STASH_U64)
 			ret = odp_stash_put_u64(stash, input_u64, burst);
 		else
@@ -607,6 +614,8 @@ static void stash_fifo_put(uint32_t size, int32_t burst, stash_op_t op)
 
 		if (op == STASH_GEN)
 			ret = odp_stash_get(stash, output, burst);
+		else if (op == STASH_U32)
+			ret = odp_stash_get_u32(stash, &output_u32[1], burst);
 		else if (op == STASH_U64)
 			ret = odp_stash_get_u64(stash, &output_u64[1], burst);
 		else
@@ -719,6 +728,16 @@ static void stash_default_put_u32_n(void)
 	stash_default_put(sizeof(uint32_t), BURST, STASH_GEN);
 }
 
+static void stash_default_u32_put_u32_1(void)
+{
+	stash_default_put(sizeof(uint32_t), 1, STASH_U32);
+}
+
+static void stash_default_u32_put_u32_n(void)
+{
+	stash_default_put(sizeof(uint32_t), BURST, STASH_U32);
+}
+
 static void stash_default_put_u16_1(void)
 {
 	stash_default_put(sizeof(uint16_t), 1, STASH_GEN);
@@ -769,6 +788,16 @@ static void stash_fifo_put_u32_n(void)
 	stash_fifo_put(sizeof(uint32_t), BURST, STASH_GEN);
 }
 
+static void stash_fifo_u32_put_u32_1(void)
+{
+	stash_fifo_put(sizeof(uint32_t), 1, STASH_U32);
+}
+
+static void stash_fifo_u32_put_u32_n(void)
+{
+	stash_fifo_put(sizeof(uint32_t), BURST, STASH_U32);
+}
+
 static void stash_fifo_put_u16_1(void)
 {
 	stash_fifo_put(sizeof(uint16_t), 1, STASH_GEN);
@@ -800,6 +829,8 @@ odp_testinfo_t stash_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(stash_default_u64_put_u64_n, check_support_64),
 	ODP_TEST_INFO(stash_default_put_u32_1),
 	ODP_TEST_INFO(stash_default_put_u32_n),
+	ODP_TEST_INFO(stash_default_u32_put_u32_1),
+	ODP_TEST_INFO(stash_default_u32_put_u32_n),
 	ODP_TEST_INFO(stash_default_put_u16_1),
 	ODP_TEST_INFO(stash_default_put_u16_n),
 	ODP_TEST_INFO(stash_default_put_u8_1),
@@ -812,6 +843,8 @@ odp_testinfo_t stash_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(stash_fifo_u64_put_u64_n, check_support_fifo_64),
 	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u32_1, check_support_fifo),
 	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u32_n, check_support_fifo),
+	ODP_TEST_INFO_CONDITIONAL(stash_fifo_u32_put_u32_1, check_support_fifo),
+	ODP_TEST_INFO_CONDITIONAL(stash_fifo_u32_put_u32_n, check_support_fifo),
 	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u16_1, check_support_fifo),
 	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u16_n, check_support_fifo),
 	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u8_1,  check_support_fifo),

--- a/test/validation/api/stash/stash.c
+++ b/test/validation/api/stash/stash.c
@@ -30,7 +30,8 @@
 typedef enum stash_op_t {
 	STASH_GEN,
 	STASH_U32,
-	STASH_U64
+	STASH_U64,
+	STASH_PTR
 } stash_op_t;
 
 typedef struct num_obj_t {
@@ -426,6 +427,8 @@ static void stash_default_put(uint32_t size, int32_t burst, stash_op_t op)
 			ret = odp_stash_put_u32(stash, input_u32, burst);
 		else if (op == STASH_U64)
 			ret = odp_stash_put_u64(stash, input_u64, burst);
+		else if (op == STASH_PTR)
+			ret = odp_stash_put_ptr(stash, input, burst);
 		else
 			ret = -1;
 		CU_ASSERT_FATAL(ret >= 0);
@@ -465,6 +468,8 @@ static void stash_default_put(uint32_t size, int32_t burst, stash_op_t op)
 			ret = odp_stash_get_u32(stash, &output_u32[1], burst);
 		else if (op == STASH_U64)
 			ret = odp_stash_get_u64(stash, &output_u64[1], burst);
+		else if (op == STASH_PTR)
+			ret = odp_stash_get_ptr(stash, output, burst);
 		else
 			ret = -1;
 		CU_ASSERT_FATAL(ret >= 0);
@@ -578,6 +583,8 @@ static void stash_fifo_put(uint32_t size, int32_t burst, stash_op_t op)
 			ret = odp_stash_put_u32(stash, input_u32, burst);
 		else if (op == STASH_U64)
 			ret = odp_stash_put_u64(stash, input_u64, burst);
+		else if (op == STASH_PTR)
+			ret = odp_stash_put_ptr(stash, input, burst);
 		else
 			ret = -1;
 		CU_ASSERT_FATAL(ret >= 0);
@@ -618,6 +625,8 @@ static void stash_fifo_put(uint32_t size, int32_t burst, stash_op_t op)
 			ret = odp_stash_get_u32(stash, &output_u32[1], burst);
 		else if (op == STASH_U64)
 			ret = odp_stash_get_u64(stash, &output_u64[1], burst);
+		else if (op == STASH_PTR)
+			ret = odp_stash_get_ptr(stash, output, burst);
 		else
 			ret = -1;
 		CU_ASSERT_FATAL(ret >= 0);
@@ -681,10 +690,27 @@ static int check_support_64(void)
 	return ODP_TEST_INACTIVE;
 }
 
+static int check_support_ptr(void)
+{
+	if (global.capa_default.max_obj_size >= sizeof(uintptr_t))
+		return ODP_TEST_ACTIVE;
+
+	return ODP_TEST_INACTIVE;
+}
+
 static int check_support_fifo_64(void)
 {
 	if (global.fifo_supported &&
 	    global.capa_fifo.max_obj_size >= sizeof(uint64_t))
+		return ODP_TEST_ACTIVE;
+
+	return ODP_TEST_INACTIVE;
+}
+
+static int check_support_fifo_ptr(void)
+{
+	if (global.fifo_supported &&
+	    global.capa_fifo.max_obj_size >= sizeof(uintptr_t))
 		return ODP_TEST_ACTIVE;
 
 	return ODP_TEST_INACTIVE;
@@ -716,6 +742,16 @@ static void stash_default_u64_put_u64_1(void)
 static void stash_default_u64_put_u64_n(void)
 {
 	stash_default_put(sizeof(uint64_t), BURST, STASH_U64);
+}
+
+static void stash_default_put_ptr_1(void)
+{
+	stash_default_put(sizeof(uintptr_t), 1, STASH_PTR);
+}
+
+static void stash_default_put_ptr_n(void)
+{
+	stash_default_put(sizeof(uintptr_t), BURST, STASH_PTR);
 }
 
 static void stash_default_put_u32_1(void)
@@ -778,6 +814,16 @@ static void stash_fifo_u64_put_u64_n(void)
 	stash_fifo_put(sizeof(uint64_t), BURST, STASH_U64);
 }
 
+static void stash_fifo_put_ptr_1(void)
+{
+	stash_fifo_put(sizeof(uintptr_t), 1, STASH_PTR);
+}
+
+static void stash_fifo_put_ptr_n(void)
+{
+	stash_fifo_put(sizeof(uintptr_t), BURST, STASH_PTR);
+}
+
 static void stash_fifo_put_u32_1(void)
 {
 	stash_fifo_put(sizeof(uint32_t), 1, STASH_GEN);
@@ -827,6 +873,8 @@ odp_testinfo_t stash_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(stash_default_put_u64_n, check_support_64),
 	ODP_TEST_INFO_CONDITIONAL(stash_default_u64_put_u64_1, check_support_64),
 	ODP_TEST_INFO_CONDITIONAL(stash_default_u64_put_u64_n, check_support_64),
+	ODP_TEST_INFO_CONDITIONAL(stash_default_put_ptr_1, check_support_ptr),
+	ODP_TEST_INFO_CONDITIONAL(stash_default_put_ptr_n, check_support_ptr),
 	ODP_TEST_INFO(stash_default_put_u32_1),
 	ODP_TEST_INFO(stash_default_put_u32_n),
 	ODP_TEST_INFO(stash_default_u32_put_u32_1),
@@ -841,6 +889,8 @@ odp_testinfo_t stash_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u64_n, check_support_fifo_64),
 	ODP_TEST_INFO_CONDITIONAL(stash_fifo_u64_put_u64_1, check_support_fifo_64),
 	ODP_TEST_INFO_CONDITIONAL(stash_fifo_u64_put_u64_n, check_support_fifo_64),
+	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_ptr_1, check_support_fifo_ptr),
+	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_ptr_n, check_support_fifo_ptr),
 	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u32_1, check_support_fifo),
 	ODP_TEST_INFO_CONDITIONAL(stash_fifo_put_u32_n, check_support_fifo),
 	ODP_TEST_INFO_CONDITIONAL(stash_fifo_u32_put_u32_1, check_support_fifo),


### PR DESCRIPTION
The new functions are safer to use compared to the generic versions due to strict typing and the implementation may be
more optimized.

New functions:
- `odp_stash_put_u32()`
- `odp_stash_get_u32()`
- `odp_stash_put_u64()`
- `odp_stash_get_u64()`
- `odp_stash_put_ptr()`
- `odp_stash_get_ptr()`

V2:
- Squashed the 64-bit implementation commits (Petri)
- API "... with 'obj_size' of" wording (Petri)

V3:
- Fixed cast types (Petri)

V4:
- Rebase
- Added Reviewed-by tags