### PR TITLE
[PATCH v2] configure: move project to C standard revision 11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -172,7 +172,7 @@ AS_IF([test "$GCC" == yes],
       )
 )
 
-ODP_CFLAGS="$ODP_CFLAGS -std=c99"
+ODP_CFLAGS="$ODP_CFLAGS -std=c11"
 ODP_CXXFLAGS="$ODP_CXXFLAGS -std=c++11"
 
 # Extra flags for example to suppress certain warning types

--- a/doc/implementers-guide/implementers-guide.adoc
+++ b/doc/implementers-guide/implementers-guide.adoc
@@ -182,9 +182,9 @@ divided in two distinct areas:
 This grouping defines tests that are expected to be executable and succeed on
 any platform, though possibly with very different performance, depending on
 the underlying platform.  They are written in plain C code, and may only use
-functions defined in the standard libC (C99) library (besides the ODP
-functions being tested, of course).  A free C99 specification can be found at
-the http://www.open-std.org/JTC1/sc22/wg14/www/docs/n1256.pdf[open-std.org]
+functions defined in the standard libC (C11) library (besides the ODP
+functions being tested, of course).  A free C11 draft specification can be found
+at the http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf[open-std.org]
 web site. No other languages (like scripting) are allowed as their usage
 would make assumptions on the platform capability.
 


### PR DESCRIPTION
Some C11 features (e.g. anonymous structures and unions) have been already
used by the project. Move from C99 to C11 to be standard compliant and
enable usage of new features.

Signed-off-by: Matias Elo <matias.elo@nokia.com>