### PR TITLE
[PATCH v2] linux-gen: stash: make maximum number of stashes configurable

### DIFF
--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -54,6 +54,11 @@ extern "C" {
 #define CONFIG_QUEUE_MAX_ORD_LOCKS 2
 
 /*
+ * Maximum number of stashes
+ */
+#define CONFIG_MAX_STASHES 128
+
+/*
  * Maximum number of packet IO resources
  */
 #define ODP_CONFIG_PKTIO_ENTRIES 64
@@ -119,10 +124,10 @@ extern "C" {
 /*
  * Number of shared memory blocks reserved for implementation internal use.
  *
- * Each pool requires three SHM blocks (buffers, ring, user area). 20 blocks are
- * reserved for per ODP module global data.
+ * Each stash requires one SHM block, each pool requires three blocks (buffers,
+ * ring, user area), and 20 blocks are reserved for per ODP module global data.
  */
-#define CONFIG_INTERNAL_SHM_BLOCKS ((ODP_CONFIG_POOLS * 3)  + 20)
+#define CONFIG_INTERNAL_SHM_BLOCKS (CONFIG_MAX_STASHES + (ODP_CONFIG_POOLS * 3)  + 20)
 
 /*
  * Maximum number of shared memory blocks.

--- a/platform/linux-generic/odp_stash.c
+++ b/platform/linux-generic/odp_stash.c
@@ -12,13 +12,13 @@
 #include <odp/api/stash.h>
 #include <odp/api/plat/strong_types.h>
 
+#include <odp_config_internal.h>
 #include <odp_debug_internal.h>
 #include <odp_global_data.h>
 #include <odp_init_internal.h>
 #include <odp_ring_ptr_internal.h>
 #include <odp_ring_u32_internal.h>
 
-#define MAX_STASHES   32
 #define MAX_RING_SIZE (1024 * 1024)
 #define MIN_RING_SIZE 64
 
@@ -47,8 +47,8 @@ typedef struct stash_t {
 typedef struct stash_global_t {
 	odp_ticketlock_t  lock;
 	odp_shm_t         shm;
-	uint8_t           stash_reserved[MAX_STASHES];
-	stash_t           *stash[MAX_STASHES];
+	uint8_t           stash_reserved[CONFIG_MAX_STASHES];
+	stash_t           *stash[CONFIG_MAX_STASHES];
 
 } stash_global_t;
 
@@ -106,8 +106,8 @@ int odp_stash_capability(odp_stash_capability_t *capa, odp_stash_type_t type)
 	(void)type;
 	memset(capa, 0, sizeof(odp_stash_capability_t));
 
-	capa->max_stashes_any_type = MAX_STASHES;
-	capa->max_stashes          = MAX_STASHES;
+	capa->max_stashes_any_type = CONFIG_MAX_STASHES;
+	capa->max_stashes          = CONFIG_MAX_STASHES;
 	capa->max_num_obj          = MAX_RING_SIZE;
 	capa->max_obj_size         = sizeof(uintptr_t);
 
@@ -129,7 +129,7 @@ static int reserve_index(void)
 
 	odp_ticketlock_lock(&stash_global->lock);
 
-	for (i = 0; i < MAX_STASHES; i++) {
+	for (i = 0; i < CONFIG_MAX_STASHES; i++) {
 		if (stash_global->stash_reserved[i] == 0) {
 			index = i;
 			stash_global->stash_reserved[i] = 1;
@@ -284,7 +284,7 @@ odp_stash_t odp_stash_lookup(const char *name)
 
 	odp_ticketlock_lock(&stash_global->lock);
 
-	for (i = 0; i < MAX_STASHES; i++) {
+	for (i = 0; i < CONFIG_MAX_STASHES; i++) {
 		stash = stash_global->stash[i];
 
 		if (stash && strcmp(stash->name, name) == 0) {


### PR DESCRIPTION
Add CONFIG_MAX_STASHES define for configuring the maximum number of stashes
an application is able to create. The default value has been increased from
32 to 128.

The SHM blocks required by stashes are now taken into account when
calculating the number of required implementation internal SHM blocks.

Signed-off-by: Matias Elo <matias.elo@nokia.com>