### PR TITLE
[PATCH v2] linux-gen: ipsec: fix ICV calculation with AES-CCM

### DIFF
--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -700,6 +700,7 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 	case ODP_AUTH_ALG_AES128_GCM:
 #endif
 	case ODP_AUTH_ALG_AES_GCM:
+	case ODP_AUTH_ALG_AES_CCM:
 		crypto_param.auth_aad_len = sizeof(ipsec_aad_t);
 		break;
 	case ODP_AUTH_ALG_AES_GMAC:


### PR DESCRIPTION
ICV calculation with AES-CCM is supposed to include SPI and sequence
number through AAD, but the current code passes zero length AAD to the
algorithm. Fix the AAD length when using AES-CCM.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>