### PR TITLE
[PATCH v2] doc: user-guide: fix DOT image format

### DIFF
--- a/doc/images/pktio_fsm.gv
+++ b/doc/images/pktio_fsm.gv
@@ -1,6 +1,5 @@
 digraph pktio_state_machine {
 	rankdir=LR;
-	size="9,12";
 	node [fontsize=28];
 	edge [fontsize=28];
 	node [shape=doublecircle]; Unallocated Ready;

--- a/doc/images/timeout_fsm.gv
+++ b/doc/images/timeout_fsm.gv
@@ -1,6 +1,5 @@
 digraph timer_state_machine {
 	rankdir=LR;
-	size="12,20";
 	node [fontsize=28];
 	edge [fontsize=28];
 	node [shape=doublecircle]; TO_Unalloc;

--- a/doc/images/timer_fsm.gv
+++ b/doc/images/timer_fsm.gv
@@ -1,6 +1,5 @@
 digraph timer_state_machine {
 	rankdir=LR;
-	size="12,20";
 	node [fontsize=28];
 	edge [fontsize=28];
 	node [shape=doublecircle]; Timer_Unalloc;


### PR DESCRIPTION
Remove 'size' option from DOT images, which was causing SVG images to be
rendered incorrectly.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reported-by: Baofeng Wang <baofeng.wang@nokia.com>