### PR TITLE
[PATCH v1] linux-gen: config: add string lookup function

### DIFF
--- a/platform/linux-generic/include/odp_libconfig_internal.h
+++ b/platform/linux-generic/include/odp_libconfig_internal.h
@@ -21,6 +21,8 @@ int _odp_libconfig_init_global(void);
 int _odp_libconfig_term_global(void);
 
 int _odp_libconfig_lookup_int(const char *path, int *value);
+int _odp_libconfig_lookup_str(const char *path, char *value,
+			      unsigned int str_size);
 int _odp_libconfig_lookup_array(const char *path, int value[], int max_num);
 int _odp_libconfig_lookup_array_str(const char *path, char **value,
 				    int max_count, unsigned int max_str);


### PR DESCRIPTION
Adds a new function to get a string from config

Signed-off-by: Vijay Ram Inavolu <vinavolu@marvell.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>