### PR TITLE
[PATCH v2] helper: cli: remove unused instance parameter from odph_cli_init()

### DIFF
--- a/example/cli/odp_cli.c
+++ b/example/cli/odp_cli.c
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
 		cli_param.port = opt.port;
 
 	/* Initialize CLI helper. */
-	if (odph_cli_init(inst, &cli_param)) {
+	if (odph_cli_init(&cli_param)) {
 		ODPH_ERR("CLI helper initialization failed.\n");
 		exit(EXIT_FAILURE);
 	}

--- a/helper/cli.c
+++ b/helper/cli.c
@@ -43,7 +43,6 @@ typedef struct {
 	/* Guards cli_fd and run, which must be accessed atomically. */
 	odp_spinlock_t lock;
 	odp_spinlock_t api_lock;
-	odp_instance_t instance;
 	odph_cli_param_t cli_param;
 	struct sockaddr_in addr;
 	uint32_t num_user_commands;
@@ -75,7 +74,7 @@ static cli_shm_t *shm_lookup(void)
 	return shm;
 }
 
-int odph_cli_init(odp_instance_t instance, const odph_cli_param_t *param)
+int odph_cli_init(const odph_cli_param_t *param)
 {
 	if (odp_shm_lookup(shm_name) != ODP_SHM_INVALID) {
 		ODPH_ERR("Error: shm %s already exists\n", shm_name);
@@ -101,7 +100,6 @@ int odph_cli_init(odp_instance_t instance, const odph_cli_param_t *param)
 	odp_spinlock_init(&shm->api_lock);
 	shm->listen_fd = -1;
 	shm->cli_fd = -1;
-	shm->instance = instance;
 
 	shm->addr.sin_family = AF_INET;
 	shm->addr.sin_port = htons(param->port);

--- a/helper/include/odp/helper/cli.h
+++ b/helper/include/odp/helper/cli.h
@@ -76,12 +76,11 @@ void odph_cli_param_init(odph_cli_param_t *param);
  * In process mode (ODPH_PROC_MODE), this function must be called before
  * creating the thread which calls odph_cli_run().
  *
- * @param instance ODP instance
  * @param param CLI server parameters to use
  * @retval 0 Success
  * @retval <0 Failure
  */
-int odph_cli_init(odp_instance_t instance, const odph_cli_param_t *param);
+int odph_cli_init(const odph_cli_param_t *param);
 
 /**
  * Register a user defined command

--- a/helper/test/cli.c
+++ b/helper/test/cli.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
 
 	odph_cli_param_init(&cli_param);
 
-	if (odph_cli_init(instance, &cli_param)) {
+	if (odph_cli_init(&cli_param)) {
 		ODPH_ERR("Error: odph_cli_init() failed.\n");
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
Now that the CLI helper no longer creates a thread, the ODP instance is not needed by odph_cli_init().

v2:
- Add review tags.
