### PR TITLE
[PATCH v3] linux-gen: use common base event header for all pool types

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -106,6 +106,7 @@ noinst_HEADERS = \
 		  include/odp_config_internal.h \
 		  include/odp_debug_internal.h \
 		  include/odp_errno_define.h \
+		  include/odp_event_internal.h \
 		  include/odp_fdserver_internal.h \
 		  include/odp_forward_typedefs_internal.h \
 		  include/odp_global_data.h \

--- a/platform/linux-generic/include/odp_event_internal.h
+++ b/platform/linux-generic/include/odp_event_internal.h
@@ -1,0 +1,93 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP event descriptor - implementation internal
+ */
+
+#ifndef ODP_EVENT_INTERNAL_H_
+#define ODP_EVENT_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/atomic.h>
+#include <odp/api/debug.h>
+#include <odp/api/event.h>
+#include <odp/api/std_types.h>
+
+#include <odp_config_internal.h>
+
+typedef union buf_index_t {
+	uint32_t u32;
+
+	struct {
+		uint32_t pool   :8;
+		uint32_t buffer :24;
+	};
+} buf_index_t;
+
+/* Check that pool index fit into bit field */
+ODP_STATIC_ASSERT(ODP_CONFIG_POOLS    <= (0xFF + 1), "TOO_MANY_POOLS");
+
+/* Check that buffer index fit into bit field */
+ODP_STATIC_ASSERT(CONFIG_POOL_MAX_NUM <= (0xFFFFFF + 1), "TOO_LARGE_POOL");
+
+/* Type size limits number of flow IDs supported */
+#define BUF_HDR_MAX_FLOW_ID 255
+
+/* Common header for all event types without alignment constraints. */
+typedef struct _odp_event_hdr_t {
+	/* Initial buffer data pointer */
+	uint8_t  *base_data;
+
+	/* Pool pointer */
+	void     *pool_ptr;
+
+	/* --- Mostly read only data --- */
+	const void *user_ptr;
+
+	/* Initial buffer tail pointer */
+	uint8_t  *buf_end;
+
+	/* User area pointer */
+	void    *uarea_addr;
+
+	/* Combined pool and buffer index */
+	buf_index_t index;
+
+	/* Reference count */
+	odp_atomic_u32_t ref_cnt;
+
+	/* Pool type */
+	int8_t    type;
+
+	/* Event type. Maybe different than pool type (crypto compl event) */
+	int8_t    event_type;
+
+	/* Event flow id */
+	uint8_t   flow_id;
+
+} _odp_event_hdr_t;
+
+static inline odp_event_t _odp_event_from_hdr(_odp_event_hdr_t *hdr)
+{
+	return (odp_event_t)hdr;
+}
+
+static inline _odp_event_hdr_t *_odp_event_hdr(odp_event_t event)
+{
+	return (_odp_event_hdr_t *)(uintptr_t)event;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp_event_internal.h
+++ b/platform/linux-generic/include/odp_event_internal.h
@@ -24,14 +24,14 @@ extern "C" {
 
 #include <odp_config_internal.h>
 
-typedef union buf_index_t {
+typedef union buffer_index_t {
 	uint32_t u32;
 
 	struct {
 		uint32_t pool   :8;
 		uint32_t buffer :24;
 	};
-} buf_index_t;
+} buffer_index_t;
 
 /* Check that pool index fit into bit field */
 ODP_STATIC_ASSERT(ODP_CONFIG_POOLS    <= (0xFF + 1), "TOO_MANY_POOLS");
@@ -60,7 +60,7 @@ typedef struct _odp_event_hdr_t {
 	void    *uarea_addr;
 
 	/* Combined pool and buffer index */
-	buf_index_t index;
+	buffer_index_t index;
 
 	/* Reference count */
 	odp_atomic_u32_t ref_cnt;
@@ -84,6 +84,16 @@ static inline odp_event_t _odp_event_from_hdr(_odp_event_hdr_t *hdr)
 static inline _odp_event_hdr_t *_odp_event_hdr(odp_event_t event)
 {
 	return (_odp_event_hdr_t *)(uintptr_t)event;
+}
+
+static inline odp_event_type_t _odp_event_type(odp_event_t event)
+{
+	return _odp_event_hdr(event)->event_type;
+}
+
+static inline void _odp_event_type_set(odp_event_t event, int ev)
+{
+	_odp_event_hdr(event)->event_type = ev;
 }
 
 #ifdef __cplusplus

--- a/platform/linux-generic/include/odp_event_vector_internal.h
+++ b/platform/linux-generic/include/odp_event_vector_internal.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020, Nokia
+/* Copyright (c) 2020-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -13,18 +13,20 @@
 #ifndef ODP_EVENT_VECTOR_INTERNAL_H_
 #define ODP_EVENT_VECTOR_INTERNAL_H_
 
-#include <stdint.h>
+#include <odp/api/align.h>
+#include <odp/api/debug.h>
 #include <odp/api/packet.h>
-#include <odp_buffer_internal.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
+#include <odp_event_internal.h>
+
+#include <stdint.h>
+
 /**
  * Internal event vector header
  */
-typedef struct {
-	/* Common buffer header */
-	odp_buffer_hdr_t buf_hdr;
+typedef struct ODP_ALIGNED_CACHE odp_event_vector_hdr_t {
+	/* Common event header */
+	_odp_event_hdr_t event_hdr;
 
 	/* Event vector size */
 	uint32_t size;
@@ -33,7 +35,11 @@ typedef struct {
 	odp_packet_t packet[];
 
 } odp_event_vector_hdr_t;
-#pragma GCC diagnostic pop
+
+/* Vector header size is critical for performance. Ensure that it does not accidentally
+ * grow over cache line size. */
+ODP_STATIC_ASSERT(sizeof(odp_event_vector_hdr_t) <= ODP_CACHE_LINE_SIZE,
+		  "EVENT_VECTOR_HDR_SIZE_ERROR");
 
 /**
  * Return the vector header

--- a/platform/linux-generic/include/odp_forward_typedefs_internal.h
+++ b/platform/linux-generic/include/odp_forward_typedefs_internal.h
@@ -10,7 +10,7 @@
  * ODP forward typedefs - implementation internal
  *
  * This needs to be a separate file because it is needed by both
- * odp_queue_internal.h and odp_buffer_internal.h and clang prohibits forward
+ * odp_queue_internal.h and odp_queue_lf.h and clang prohibits forward
  * "redefining" typedefs. Note that this file can be extended with additional
  * forward typedefs as needed.
  */
@@ -22,7 +22,6 @@
 extern "C" {
 #endif
 
-typedef struct odp_buffer_hdr_t odp_buffer_hdr_t;
 typedef union queue_entry_u queue_entry_t;
 
 #ifdef __cplusplus

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -170,14 +170,14 @@ static inline odp_packet_t packet_handle(odp_packet_hdr_t *pkt_hdr)
 	return (odp_packet_t)pkt_hdr;
 }
 
-static inline odp_buffer_hdr_t *packet_to_buf_hdr(odp_packet_t pkt)
+static inline _odp_event_hdr_t *packet_to_event_hdr(odp_packet_t pkt)
 {
-	return (odp_buffer_hdr_t *)(uintptr_t)&packet_hdr(pkt)->event_hdr;
+	return (_odp_event_hdr_t *)(uintptr_t)&packet_hdr(pkt)->event_hdr;
 }
 
-static inline odp_packet_t packet_from_buf_hdr(odp_buffer_hdr_t *buf_hdr)
+static inline odp_packet_t packet_from_event_hdr(_odp_event_hdr_t *event_hdr)
 {
-	return (odp_packet_t)(odp_packet_hdr_t *)buf_hdr;
+	return (odp_packet_t)(uintptr_t)event_hdr;
 }
 
 static inline odp_packet_hdr_t *packet_last_seg(odp_packet_hdr_t *hdr)

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -141,27 +141,22 @@ static inline pool_t *pool_entry_from_hdl(odp_pool_t pool_hdl)
 	return &_odp_pool_glb->pool[_odp_typeval(pool_hdl) - 1];
 }
 
-static inline odp_buffer_hdr_t *buf_hdl_to_hdr(odp_buffer_t buf)
-{
-	return (odp_buffer_hdr_t *)(uintptr_t)buf;
-}
-
-static inline odp_buffer_hdr_t *buf_hdr_from_index(pool_t *pool,
-						   uint32_t buffer_idx)
+static inline _odp_event_hdr_t *event_hdr_from_index(pool_t *pool,
+						     uint32_t event_idx)
 {
 	uint64_t block_offset;
-	odp_buffer_hdr_t *buf_hdr;
+	_odp_event_hdr_t *event_hdr;
 
-	block_offset = (buffer_idx * (uint64_t)pool->block_size) +
+	block_offset = (event_idx * (uint64_t)pool->block_size) +
 			pool->block_offset;
 
 	/* clang requires cast to uintptr_t */
-	buf_hdr = (odp_buffer_hdr_t *)(uintptr_t)&pool->base_addr[block_offset];
+	event_hdr = (_odp_event_hdr_t *)(uintptr_t)&pool->base_addr[block_offset];
 
-	return buf_hdr;
+	return event_hdr;
 }
 
-static inline odp_buffer_hdr_t *buf_hdr_from_index_u32(uint32_t u32)
+static inline _odp_event_hdr_t *_odp_event_hdr_from_index_u32(uint32_t u32)
 {
 	buffer_index_t index;
 	uint32_t pool_idx, buffer_idx;
@@ -172,7 +167,7 @@ static inline odp_buffer_hdr_t *buf_hdr_from_index_u32(uint32_t u32)
 	buffer_idx = index.buffer;
 	pool       = pool_entry(pool_idx);
 
-	return buf_hdr_from_index(pool, buffer_idx);
+	return event_hdr_from_index(pool, buffer_idx);
 }
 
 int _odp_buffer_alloc_multi(pool_t *pool, odp_buffer_hdr_t *buf_hdr[], int num);

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -32,22 +32,22 @@ typedef struct ODP_ALIGNED_CACHE pool_cache_t {
 	/* Number of buffers in cache */
 	uint32_t cache_num;
 	/* Cached buffers */
-	odp_buffer_hdr_t *buf_hdr[CONFIG_POOL_CACHE_MAX_SIZE];
+	_odp_event_hdr_t *event_hdr[CONFIG_POOL_CACHE_MAX_SIZE];
 
 } pool_cache_t;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
-/* Buffer header ring */
+/* Event header ring */
 typedef struct ODP_ALIGNED_CACHE {
 	/* Ring header */
 	ring_ptr_t hdr;
 
 	/* Ring data: buffer handles */
-	odp_buffer_hdr_t *buf_hdr[CONFIG_POOL_MAX_NUM + 1];
+	_odp_event_hdr_t *event_hdr[CONFIG_POOL_MAX_NUM + 1];
 
 	/* Index to pointer look-up table for external memory pool */
-	odp_buffer_hdr_t *buf_hdr_by_index[];
+	_odp_event_hdr_t *event_hdr_by_index[];
 
 } pool_ring_t;
 #pragma GCC diagnostic pop
@@ -170,30 +170,14 @@ static inline _odp_event_hdr_t *_odp_event_hdr_from_index_u32(uint32_t u32)
 	return event_hdr_from_index(pool, buffer_idx);
 }
 
-int _odp_buffer_alloc_multi(pool_t *pool, odp_buffer_hdr_t *buf_hdr[], int num);
-void _odp_buffer_free_multi(odp_buffer_hdr_t *buf_hdr[], int num_free);
-int _odp_buffer_is_valid(odp_buffer_t buf);
-
 odp_event_t _odp_event_alloc(pool_t *pool);
-
-static inline int _odp_event_is_valid(odp_event_t event)
-{
-	return _odp_buffer_is_valid((odp_buffer_t)event);
-}
-
-static inline int _odp_event_alloc_multi(pool_t *pool, _odp_event_hdr_t *event_hdr[], int num)
-{
-	return _odp_buffer_alloc_multi(pool, (odp_buffer_hdr_t **)event_hdr, num);
-}
+int _odp_event_alloc_multi(pool_t *pool, _odp_event_hdr_t *event_hdr[], int num);
+void _odp_event_free_multi(_odp_event_hdr_t *event_hdr[], int num_free);
+int _odp_event_is_valid(odp_event_t event);
 
 static inline void _odp_event_free(odp_event_t event)
 {
-	_odp_buffer_free_multi((odp_buffer_hdr_t **)&event, 1);
-}
-
-static inline void _odp_event_free_multi(_odp_event_hdr_t *event_hdr[], int num_free)
-{
-	_odp_buffer_free_multi((odp_buffer_hdr_t **)event_hdr, num_free);
+	_odp_event_free_multi((_odp_event_hdr_t **)&event, 1);
 }
 
 #ifdef __cplusplus

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -23,6 +23,7 @@ extern "C" {
 #include <odp/api/align.h>
 
 #include <odp_buffer_internal.h>
+#include <odp_event_internal.h>
 #include <odp_config_internal.h>
 #include <odp_ring_ptr_internal.h>
 #include <odp/api/plat/strong_types.h>
@@ -177,6 +178,28 @@ static inline odp_buffer_hdr_t *buf_hdr_from_index_u32(uint32_t u32)
 int _odp_buffer_alloc_multi(pool_t *pool, odp_buffer_hdr_t *buf_hdr[], int num);
 void _odp_buffer_free_multi(odp_buffer_hdr_t *buf_hdr[], int num_free);
 int _odp_buffer_is_valid(odp_buffer_t buf);
+
+odp_event_t _odp_event_alloc(pool_t *pool);
+
+static inline int _odp_event_is_valid(odp_event_t event)
+{
+	return _odp_buffer_is_valid((odp_buffer_t)event);
+}
+
+static inline int _odp_event_alloc_multi(pool_t *pool, _odp_event_hdr_t *event_hdr[], int num)
+{
+	return _odp_buffer_alloc_multi(pool, (odp_buffer_hdr_t **)event_hdr, num);
+}
+
+static inline void _odp_event_free(odp_event_t event)
+{
+	_odp_buffer_free_multi((odp_buffer_hdr_t **)&event, 1);
+}
+
+static inline void _odp_event_free_multi(_odp_event_hdr_t *event_hdr[], int num_free)
+{
+	_odp_buffer_free_multi((odp_buffer_hdr_t **)event_hdr, num_free);
+}
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_queue_if.h
+++ b/platform/linux-generic/include/odp_queue_if.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2017, ARM Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -14,6 +15,8 @@ extern "C" {
 #include <odp/api/queue.h>
 #include <odp/api/schedule.h>
 #include <odp/api/packet_io.h>
+
+#include <odp_event_internal.h>
 #include <odp_forward_typedefs_internal.h>
 
 #define QUEUE_MULTI_MAX CONFIG_BURST_SIZE
@@ -22,12 +25,12 @@ typedef int (*queue_init_global_fn_t)(void);
 typedef int (*queue_term_global_fn_t)(void);
 typedef int (*queue_init_local_fn_t)(void);
 typedef int (*queue_term_local_fn_t)(void);
-typedef int (*queue_enq_fn_t)(odp_queue_t queue, odp_buffer_hdr_t *buf_hdr);
+typedef int (*queue_enq_fn_t)(odp_queue_t queue, _odp_event_hdr_t *event_hdr);
 typedef int (*queue_enq_multi_fn_t)(odp_queue_t queue,
-				    odp_buffer_hdr_t **buf_hdr, int num);
-typedef odp_buffer_hdr_t *(*queue_deq_fn_t)(odp_queue_t queue);
+				    _odp_event_hdr_t **event_hdr, int num);
+typedef _odp_event_hdr_t *(*queue_deq_fn_t)(odp_queue_t queue);
 typedef int (*queue_deq_multi_fn_t)(odp_queue_t queue,
-				    odp_buffer_hdr_t **buf_hdr, int num);
+				    _odp_event_hdr_t **event_hdr, int num);
 typedef odp_pktout_queue_t (*queue_get_pktout_fn_t)(odp_queue_t queue);
 typedef void (*queue_set_pktout_fn_t)(odp_queue_t queue, odp_pktio_t pktio,
 				      int index);

--- a/platform/linux-generic/include/odp_queue_scalable_internal.h
+++ b/platform/linux-generic/include/odp_queue_scalable_internal.h
@@ -17,7 +17,7 @@ extern "C" {
 #include <odp/api/queue.h>
 #include <odp_forward_typedefs_internal.h>
 #include <odp_queue_if.h>
-#include <odp_buffer_internal.h>
+#include <odp_event_internal.h>
 #include <odp_align_internal.h>
 #include <odp/api/packet_io.h>
 #include <odp/api/align.h>
@@ -58,10 +58,10 @@ union queue_entry_u {
 	uint8_t pad[ROUNDUP_CACHE_LINE(sizeof(struct queue_entry_s))];
 };
 
-int _odp_queue_deq(sched_elem_t *q, odp_buffer_hdr_t *buf_hdr[], int num);
+int _odp_queue_deq(sched_elem_t *q, _odp_event_hdr_t *event_hdr[], int num);
 int _odp_queue_deq_sc(sched_elem_t *q, odp_event_t *evp, int num);
 int _odp_queue_deq_mc(sched_elem_t *q, odp_event_t *evp, int num);
-int _odp_queue_enq_sp(sched_elem_t *q, odp_buffer_hdr_t *buf_hdr[], int num);
+int _odp_queue_enq_sp(sched_elem_t *q, _odp_event_hdr_t *event_hdr[], int num);
 queue_entry_t *_odp_qentry_from_ext(odp_queue_t handle);
 
 /* Round up memory size to next cache line size to

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -13,9 +13,10 @@ extern "C" {
 #endif
 
 #include <odp/api/queue.h>
-#include <odp_queue_if.h>
 #include <odp/api/schedule.h>
-#include <odp_forward_typedefs_internal.h>
+
+#include <odp_event_internal.h>
+#include <odp_queue_if.h>
 
 #define _ODP_SCHED_ID_BASIC    0
 #define _ODP_SCHED_ID_SP       1
@@ -45,8 +46,8 @@ typedef int (*schedule_create_queue_fn_t)(uint32_t queue_index,
 typedef void (*schedule_destroy_queue_fn_t)(uint32_t queue_index);
 typedef int (*schedule_sched_queue_fn_t)(uint32_t queue_index);
 typedef int (*schedule_unsched_queue_fn_t)(uint32_t queue_index);
-typedef int (*schedule_ord_enq_multi_fn_t)(odp_queue_t queue,
-					   void *buf_hdr[], int num, int *ret);
+typedef int (*schedule_ord_enq_multi_fn_t)(odp_queue_t queue, void *event_hdr[],
+					   int num, int *ret);
 typedef int (*schedule_init_global_fn_t)(void);
 typedef int (*schedule_term_global_fn_t)(void);
 typedef int (*schedule_init_local_fn_t)(void);
@@ -87,7 +88,7 @@ extern const schedule_fn_t *_odp_sched_fn;
 
 /* Interface for the scheduler */
 int _odp_sched_cb_pktin_poll(int pktio_index, int pktin_index,
-			     odp_buffer_hdr_t *hdr_tbl[], int num);
+			     _odp_event_hdr_t *hdr_tbl[], int num);
 int _odp_sched_cb_pktin_poll_one(int pktio_index, int rx_queue, odp_event_t evts[]);
 void _odp_sched_cb_pktio_stop_finalize(int pktio_index);
 

--- a/platform/linux-generic/include/odp_schedule_scalable.h
+++ b/platform/linux-generic/include/odp_schedule_scalable.h
@@ -13,6 +13,7 @@
 #include <odp/api/schedule.h>
 #include <odp/api/ticketlock.h>
 
+#include <odp_event_internal.h>
 #include <odp_schedule_scalable_config.h>
 #include <odp_schedule_scalable_ordered.h>
 #include <odp_llqueue.h>
@@ -74,13 +75,13 @@ typedef struct ODP_ALIGNED_CACHE {
 	ringidx_t prod_read SPLIT_PC;
 	ringidx_t prod_write;
 	ringidx_t prod_mask;
-	odp_buffer_hdr_t **prod_ring;
+	_odp_event_hdr_t **prod_ring;
 	ringidx_t cons_write SPLIT_PC;
 	ringidx_t cons_read;
 	reorder_window_t *rwin;
 	void *user_ctx;
 #ifdef CONFIG_SPLIT_PRODCONS
-	odp_buffer_hdr_t **cons_ring;
+	_odp_event_hdr_t **cons_ring;
 	ringidx_t cons_mask;
 	uint16_t cons_type;
 #else

--- a/platform/linux-generic/include/odp_schedule_scalable_ordered.h
+++ b/platform/linux-generic/include/odp_schedule_scalable_ordered.h
@@ -13,6 +13,7 @@
 
 #include <odp_align_internal.h>
 #include <odp_bitset.h>
+#include <odp_event_internal.h>
 #include <odp_ishmpool_internal.h>
 
 /* High level functioning of reordering
@@ -106,7 +107,7 @@ struct ODP_ALIGNED_CACHE reorder_context {
 	/* Number of events stored in this reorder context */
 	uint8_t numevts;
 	/* Events stored in this context */
-	odp_buffer_hdr_t *events[RC_EVT_SIZE];
+	_odp_event_hdr_t *events[RC_EVT_SIZE];
 	queue_entry_t *destq[RC_EVT_SIZE];
 };
 
@@ -119,6 +120,6 @@ void _odp_rwin_unreserve_sc(reorder_window_t *rwin, uint32_t sn);
 void _odp_rctx_init(reorder_context_t *rctx, uint16_t idx,
 		    reorder_window_t *rwin, uint32_t sn);
 void _odp_rctx_release(reorder_context_t *rctx);
-int _odp_rctx_save(queue_entry_t *queue, odp_buffer_hdr_t *buf_hdr[], int num);
+int _odp_rctx_save(queue_entry_t *queue, _odp_event_hdr_t *event_hdr[], int num);
 
 #endif  /* ODP_SCHEDULE_SCALABLE_ORDERED_H */

--- a/platform/linux-generic/include/odp_timer_internal.h
+++ b/platform/linux-generic/include/odp_timer_internal.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -15,19 +16,18 @@
 
 #include <odp/api/align.h>
 #include <odp/api/debug.h>
-#include <odp_buffer_internal.h>
-#include <odp_pool_internal.h>
 #include <odp/api/timer.h>
-#include <odp_global_data.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
+#include <odp_event_internal.h>
+#include <odp_global_data.h>
+#include <odp_pool_internal.h>
+
 /**
  * Internal Timeout header
  */
-typedef struct {
-	/* common buffer header */
-	odp_buffer_hdr_t buf_hdr;
+typedef struct ODP_ALIGNED_CACHE odp_timeout_hdr_t {
+	/* Common event header */
+	_odp_event_hdr_t event_hdr;
 
 	/* Requested expiration time */
 	uint64_t expiration;
@@ -39,7 +39,6 @@ typedef struct {
 	odp_timer_t timer;
 
 } odp_timeout_hdr_t;
-#pragma GCC diagnostic pop
 
 /* A larger decrement value should be used after receiving events compared to
  * an 'empty' call. */

--- a/platform/linux-generic/odp_buffer.c
+++ b/platform/linux-generic/odp_buffer.c
@@ -20,16 +20,16 @@
 /* Fill in buffer header field offsets for inline functions */
 const _odp_buffer_inline_offset_t
 _odp_buffer_inline_offset ODP_ALIGNED_CACHE = {
-	.event_type = offsetof(odp_buffer_hdr_t, event_type),
-	.base_data  = offsetof(odp_buffer_hdr_t, base_data)
+	.event_type = offsetof(odp_buffer_hdr_t, event_hdr.event_type),
+	.base_data  = offsetof(odp_buffer_hdr_t, event_hdr.base_data)
 };
 
 #include <odp/visibility_end.h>
 
 uint32_t odp_buffer_size(odp_buffer_t buf)
 {
-	odp_buffer_hdr_t *hdr = buf_hdl_to_hdr(buf);
-	pool_t *pool = hdr->pool_ptr;
+	odp_buffer_hdr_t *hdr = _odp_buf_hdr(buf);
+	pool_t *pool = hdr->event_hdr.pool_ptr;
 
 	return pool->seg_len;
 }
@@ -47,12 +47,13 @@ void odp_buffer_print(odp_buffer_t buf)
 		return;
 	}
 
-	hdr = buf_hdl_to_hdr(buf);
+	hdr = _odp_buf_hdr(buf);
 
 	len += snprintf(&str[len], n - len, "Buffer\n------\n");
-	len += snprintf(&str[len], n - len, "  pool index    %u\n", hdr->index.pool);
-	len += snprintf(&str[len], n - len, "  buffer index  %u\n", hdr->index.buffer);
-	len += snprintf(&str[len], n - len, "  addr          %p\n", (void *)hdr->base_data);
+	len += snprintf(&str[len], n - len, "  pool index    %u\n", hdr->event_hdr.index.pool);
+	len += snprintf(&str[len], n - len, "  buffer index  %u\n", hdr->event_hdr.index.buffer);
+	len += snprintf(&str[len], n - len, "  addr          %p\n",
+			(void *)hdr->event_hdr.base_data);
 	len += snprintf(&str[len], n - len, "  size          %u\n", odp_buffer_size(buf));
 	str[len] = 0;
 

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2020, Nokia
+ * Copyright (c) 2020-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -15,6 +15,7 @@
 #include <odp_ipsec_internal.h>
 #include <odp_debug_internal.h>
 #include <odp_packet_internal.h>
+#include <odp_event_internal.h>
 #include <odp_event_vector_internal.h>
 
 /* Inlined API functions */
@@ -24,8 +25,7 @@
 
 odp_event_subtype_t odp_event_subtype(odp_event_t event)
 {
-	if (_odp_buffer_event_type(odp_buffer_from_event(event)) !=
-			ODP_EVENT_PACKET)
+	if (_odp_event_type(event) != ODP_EVENT_PACKET)
 		return ODP_EVENT_NO_SUBTYPE;
 
 	return odp_packet_subtype(odp_packet_from_event(event));
@@ -34,8 +34,7 @@ odp_event_subtype_t odp_event_subtype(odp_event_t event)
 odp_event_type_t odp_event_types(odp_event_t event,
 				 odp_event_subtype_t *subtype)
 {
-	odp_buffer_t buf = odp_buffer_from_event(event);
-	odp_event_type_t event_type = _odp_buffer_event_type(buf);
+	odp_event_type_t event_type = _odp_event_type(event);
 
 	*subtype = event_type == ODP_EVENT_PACKET ?
 			odp_packet_subtype(odp_packet_from_event(event)) :
@@ -100,13 +99,10 @@ uint64_t odp_event_to_u64(odp_event_t hdl)
 
 int odp_event_is_valid(odp_event_t event)
 {
-	odp_buffer_t buf;
-
 	if (event == ODP_EVENT_INVALID)
 		return 0;
 
-	buf = odp_buffer_from_event(event);
-	if (_odp_buffer_is_valid(buf) == 0)
+	if (_odp_event_is_valid(event) == 0)
 		return 0;
 
 	switch (odp_event_type(event)) {

--- a/platform/linux-generic/odp_ipsec_events.c
+++ b/platform/linux-generic/odp_ipsec_events.c
@@ -93,7 +93,7 @@ static odp_event_t ipsec_status_to_event(ipsec_status_t status)
 
 static ipsec_status_hdr_t *ipsec_status_hdr_from_buf(odp_buffer_t buf)
 {
-	return (ipsec_status_hdr_t *)(void *)buf_hdl_to_hdr(buf);
+	return (ipsec_status_hdr_t *)(void *)_odp_buf_hdr(buf);
 }
 
 static ipsec_status_hdr_t *ipsec_status_hdr(ipsec_status_t status)
@@ -110,7 +110,7 @@ static ipsec_status_t odp_ipsec_status_alloc(void)
 	if (odp_unlikely(buf == ODP_BUFFER_INVALID))
 		return ODP_IPSEC_STATUS_INVALID;
 
-	_odp_buffer_event_type_set(buf, ODP_EVENT_IPSEC_STATUS);
+	_odp_event_type_set(odp_buffer_to_event(buf), ODP_EVENT_IPSEC_STATUS);
 
 	return _odp_ipsec_status_from_event(odp_buffer_to_event(buf));
 }

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -63,7 +63,7 @@ static inline pktio_entry_t *pktio_entry_by_index(int index)
 
 static inline odp_buffer_hdr_t *packet_vector_to_buf_hdr(odp_packet_vector_t pktv)
 {
-	return &_odp_packet_vector_hdr(pktv)->buf_hdr;
+	return (odp_buffer_hdr_t *)(uintptr_t)&_odp_packet_vector_hdr(pktv)->event_hdr;
 }
 
 static int read_config_file(pktio_global_t *pktio_glb)

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -1295,6 +1295,19 @@ odp_buffer_t odp_buffer_alloc(odp_pool_t pool_hdl)
 	return ODP_BUFFER_INVALID;
 }
 
+odp_event_t _odp_event_alloc(pool_t *pool)
+{
+	odp_event_t event;
+	int ret;
+
+	ret  = _odp_buffer_alloc_multi(pool, (odp_buffer_hdr_t **)&event, 1);
+
+	if (odp_likely(ret == 1))
+		return event;
+
+	return ODP_EVENT_INVALID;
+}
+
 int odp_buffer_alloc_multi(odp_pool_t pool_hdl, odp_buffer_t buf[], int num)
 {
 	pool_t *pool;

--- a/platform/linux-generic/odp_queue_spsc.c
+++ b/platform/linux-generic/odp_queue_spsc.c
@@ -1,38 +1,40 @@
 /* Copyright (c) 2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
  */
+
+#include <odp_debug_internal.h>
+#include <odp_event_internal.h>
+#include <odp_pool_internal.h>
+#include <odp_queue_basic_internal.h>
+
 #include <string.h>
 #include <stdio.h>
 
-#include <odp_queue_basic_internal.h>
-#include <odp_pool_internal.h>
-
-#include <odp_debug_internal.h>
-
-static inline void buffer_index_from_buf(uint32_t buffer_index[],
-					 odp_buffer_hdr_t *buf_hdr[], int num)
+static inline void event_index_from_hdr(uint32_t event_index[],
+					_odp_event_hdr_t *event_hdr[], int num)
 {
 	int i;
 
 	for (i = 0; i < num; i++)
-		buffer_index[i] = buf_hdr[i]->index.u32;
+		event_index[i] = event_hdr[i]->index.u32;
 }
 
-static inline void buffer_index_to_buf(odp_buffer_hdr_t *buf_hdr[],
-				       uint32_t buffer_index[], int num)
+static inline void event_index_to_hdr(_odp_event_hdr_t *event_hdr[],
+				      uint32_t event_index[], int num)
 {
 	int i;
 
 	for (i = 0; i < num; i++) {
-		buf_hdr[i] = buf_hdr_from_index_u32(buffer_index[i]);
-		odp_prefetch(buf_hdr[i]);
+		event_hdr[i] = _odp_event_hdr_from_index_u32(event_index[i]);
+		odp_prefetch(event_hdr[i]);
 	}
 }
 
 static inline int spsc_enq_multi(odp_queue_t handle,
-				 odp_buffer_hdr_t *buf_hdr[], int num)
+				 _odp_event_hdr_t *event_hdr[], int num)
 {
 	queue_entry_t *queue;
 	ring_spsc_t *ring_spsc;
@@ -41,7 +43,7 @@ static inline int spsc_enq_multi(odp_queue_t handle,
 	queue = qentry_from_handle(handle);
 	ring_spsc = &queue->s.ring_spsc;
 
-	buffer_index_from_buf(buf_idx, buf_hdr, num);
+	event_index_from_hdr(buf_idx, event_hdr, num);
 
 	if (odp_unlikely(queue->s.status < QUEUE_STATUS_READY)) {
 		ODP_ERR("Bad queue status\n");
@@ -53,7 +55,7 @@ static inline int spsc_enq_multi(odp_queue_t handle,
 }
 
 static inline int spsc_deq_multi(odp_queue_t handle,
-				 odp_buffer_hdr_t *buf_hdr[], int num)
+				 _odp_event_hdr_t *event_hdr[], int num)
 {
 	queue_entry_t *queue;
 	int num_deq;
@@ -74,22 +76,22 @@ static inline int spsc_deq_multi(odp_queue_t handle,
 	if (num_deq == 0)
 		return 0;
 
-	buffer_index_to_buf(buf_hdr, buf_idx, num_deq);
+	event_index_to_hdr(event_hdr, buf_idx, num_deq);
 
 	return num_deq;
 }
 
-static int queue_spsc_enq_multi(odp_queue_t handle, odp_buffer_hdr_t *buf_hdr[],
+static int queue_spsc_enq_multi(odp_queue_t handle, _odp_event_hdr_t *event_hdr[],
 				int num)
 {
-	return spsc_enq_multi(handle, buf_hdr, num);
+	return spsc_enq_multi(handle, event_hdr, num);
 }
 
-static int queue_spsc_enq(odp_queue_t handle, odp_buffer_hdr_t *buf_hdr)
+static int queue_spsc_enq(odp_queue_t handle, _odp_event_hdr_t *event_hdr)
 {
 	int ret;
 
-	ret = spsc_enq_multi(handle, &buf_hdr, 1);
+	ret = spsc_enq_multi(handle, &event_hdr, 1);
 
 	if (ret == 1)
 		return 0;
@@ -97,21 +99,21 @@ static int queue_spsc_enq(odp_queue_t handle, odp_buffer_hdr_t *buf_hdr)
 		return -1;
 }
 
-static int queue_spsc_deq_multi(odp_queue_t handle, odp_buffer_hdr_t *buf_hdr[],
+static int queue_spsc_deq_multi(odp_queue_t handle, _odp_event_hdr_t *event_hdr[],
 				int num)
 {
-	return spsc_deq_multi(handle, buf_hdr, num);
+	return spsc_deq_multi(handle, event_hdr, num);
 }
 
-static odp_buffer_hdr_t *queue_spsc_deq(odp_queue_t handle)
+static _odp_event_hdr_t *queue_spsc_deq(odp_queue_t handle)
 {
-	odp_buffer_hdr_t *buf_hdr = NULL;
+	_odp_event_hdr_t *event_hdr = NULL;
 	int ret;
 
-	ret = spsc_deq_multi(handle, &buf_hdr, 1);
+	ret = spsc_deq_multi(handle, &event_hdr, 1);
 
 	if (ret == 1)
-		return buf_hdr;
+		return event_hdr;
 	else
 		return NULL;
 }

--- a/platform/linux-generic/odp_schedule_scalable_ordered.c
+++ b/platform/linux-generic/odp_schedule_scalable_ordered.c
@@ -9,9 +9,11 @@
 #include <odp/api/shared_memory.h>
 #include <odp/api/cpu.h>
 #include <odp/api/plat/cpu_inlines.h>
+
+#include <odp_bitset.h>
+#include <odp_event_internal.h>
 #include <odp_queue_scalable_internal.h>
 #include <odp_schedule_if.h>
-#include <odp_bitset.h>
 
 #include <string.h>
 
@@ -255,7 +257,7 @@ static void olock_release(const reorder_context_t *rctx)
 		olock_unlock(rctx, rwin, i);
 }
 
-static void blocking_enqueue(queue_entry_t *q, odp_buffer_hdr_t **evts, int num)
+static void blocking_enqueue(queue_entry_t *q, _odp_event_hdr_t **evts, int num)
 {
 	int actual;
 
@@ -315,7 +317,7 @@ void _odp_rctx_release(reorder_context_t *rctx)
 /* Save destination queue and events in the reorder context for deferred
  * enqueue.
  */
-int _odp_rctx_save(queue_entry_t *queue, odp_buffer_hdr_t *buf_hdr[], int num)
+int _odp_rctx_save(queue_entry_t *queue, _odp_event_hdr_t *event_hdr[], int num)
 {
 	int i;
 	sched_scalable_thread_state_t *ts;
@@ -361,7 +363,7 @@ int _odp_rctx_save(queue_entry_t *queue, odp_buffer_hdr_t *buf_hdr[], int num)
 			/* The last rctx (so far) */
 			cur->next_idx = first->idx;
 		}
-		cur->events[cur->numevts] = buf_hdr[i];
+		cur->events[cur->numevts] = event_hdr[i];
 		cur->destq[cur->numevts] = queue;
 		cur->numevts++;
 	}

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -20,10 +20,12 @@
 #include <odp/api/plat/time_inlines.h>
 #include <odp/api/schedule.h>
 #include <odp/api/shared_memory.h>
+
 #include <odp_schedule_if.h>
 #include <odp_debug_internal.h>
 #include <odp_align_internal.h>
 #include <odp_config_internal.h>
+#include <odp_event_internal.h>
 #include <odp_ring_u32_internal.h>
 #include <odp_timer_internal.h>
 #include <odp_queue_basic_internal.h>
@@ -600,7 +602,7 @@ static uint64_t schedule_wait_time(uint64_t ns)
 }
 
 static inline void enqueue_packets(odp_queue_t queue,
-				   odp_buffer_hdr_t *hdr_tbl[], int num_pkt)
+				   _odp_event_hdr_t *hdr_tbl[], int num_pkt)
 {
 	int num_enq, num_drop;
 
@@ -644,7 +646,7 @@ static int schedule_multi(odp_queue_t *from, uint64_t wait,
 		cmd = sched_cmd();
 
 		if (cmd && cmd->s.type == CMD_PKTIO) {
-			odp_buffer_hdr_t *hdr_tbl[CONFIG_BURST_SIZE];
+			_odp_event_hdr_t *hdr_tbl[CONFIG_BURST_SIZE];
 			int i;
 			int num_pkt = 0;
 			int max_num = CONFIG_BURST_SIZE;

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -33,6 +33,7 @@
 #include <odp_errno_define.h>
 #include <odp_global_data.h>
 #include <odp_schedule_if.h>
+#include <odp_event_internal.h>
 
 /* Local vars */
 static const
@@ -166,19 +167,19 @@ static inline tm_node_obj_t *tm_nobj_from_index(uint32_t node_id)
 	return &tm_glb->node_obj.obj[node_id];
 }
 
-static int queue_tm_reenq(odp_queue_t queue, odp_buffer_hdr_t *buf_hdr)
+static int queue_tm_reenq(odp_queue_t queue, _odp_event_hdr_t *event_hdr)
 {
 	odp_tm_queue_t tm_queue = MAKE_ODP_TM_QUEUE(odp_queue_context(queue));
-	odp_packet_t pkt = packet_from_buf_hdr(buf_hdr);
+	odp_packet_t pkt = packet_from_event_hdr(event_hdr);
 
 	return odp_tm_enq(tm_queue, pkt);
 }
 
-static int queue_tm_reenq_multi(odp_queue_t queue, odp_buffer_hdr_t *buf[],
+static int queue_tm_reenq_multi(odp_queue_t queue, _odp_event_hdr_t *event[],
 				int num)
 {
 	(void)queue;
-	(void)buf;
+	(void)event;
 	(void)num;
 	ODP_ABORT("Invalid call to queue_tm_reenq_multi()\n");
 	return 0;

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -305,7 +305,7 @@ static void pktmbuf_init(struct rte_mempool *mp, void *opaque_arg ODP_UNUSED,
 	void *buf_addr;
 
 	pkt_hdr = pkt_hdr_from_mbuf(m);
-	buf_addr = pkt_hdr->buf_hdr.base_data - RTE_PKTMBUF_HEADROOM;
+	buf_addr = pkt_hdr->event_hdr.base_data - RTE_PKTMBUF_HEADROOM;
 
 	priv_size = rte_pktmbuf_priv_size(mp);
 	mbuf_size = sizeof(struct rte_mbuf);

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -787,7 +787,7 @@ static int ipc_pktio_send_lockless(pktio_entry_t *pktio_entry,
 		pool_t *pool;
 
 		pkt_hdr = packet_hdr(pkt);
-		pool = pkt_hdr->buf_hdr.pool_ptr;
+		pool = pkt_hdr->event_hdr.pool_ptr;
 
 		if (pool->pool_idx != ipc_pool->pool_idx ||
 		    odp_packet_has_ref(pkt)) {

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -18,6 +18,7 @@
 #include <odp_queue_if.h>
 #include <odp/api/plat/queue_inlines.h>
 #include <odp_global_data.h>
+#include <odp_event_internal.h>
 
 #include <protocols/eth.h>
 #include <protocols/ip.h>
@@ -97,7 +98,7 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			 odp_packet_t pkts[], int num)
 {
 	int nbr, i;
-	odp_buffer_hdr_t *hdr_tbl[QUEUE_MULTI_MAX];
+	_odp_event_hdr_t *hdr_tbl[QUEUE_MULTI_MAX];
 	odp_queue_t queue;
 	odp_packet_hdr_t *pkt_hdr;
 	odp_packet_t pkt;
@@ -123,7 +124,7 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	for (i = 0; i < nbr; i++) {
 		uint32_t pkt_len;
 
-		pkt = packet_from_buf_hdr(hdr_tbl[i]);
+		pkt = packet_from_event_hdr(hdr_tbl[i]);
 		pkt_len = odp_packet_len(pkt);
 		pkt_hdr = packet_hdr(pkt);
 
@@ -297,7 +298,7 @@ static int loopback_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			 const odp_packet_t pkt_tbl[], int num)
 {
 	pkt_loop_t *pkt_loop = pkt_priv(pktio_entry);
-	odp_buffer_hdr_t *hdr_tbl[QUEUE_MULTI_MAX];
+	_odp_event_hdr_t *hdr_tbl[QUEUE_MULTI_MAX];
 	odp_queue_t queue;
 	int i;
 	int ret;
@@ -323,7 +324,7 @@ static int loopback_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			}
 			break;
 		}
-		hdr_tbl[i] = packet_to_buf_hdr(pkt_tbl[i]);
+		hdr_tbl[i] = packet_to_event_hdr(pkt_tbl[i]);
 		bytes += pkt_len;
 		/* Store cumulative byte counts to update 'stats.out_octets'
 		 * correctly in case enq_multi() fails to enqueue all packets.


### PR DESCRIPTION
Use the same base event header `_odp_event_hdr_t` for all pool types. This new type has no alignment constraint to enable more efficient struct packing. Alignment constraints have been added to the pool type specific headers.