### PR TITLE
[PATCH v4] api: init: add function for reading current instance handle

### DIFF
--- a/helper/test/odpthreads.c
+++ b/helper/test/odpthreads.c
@@ -28,7 +28,7 @@
 static void main_exit(void);
 
 /* ODP application instance */
-static odp_instance_t odp_instance;
+static odp_instance_t instance;
 
 static int worker_fn(void *arg ODP_UNUSED)
 {
@@ -91,12 +91,12 @@ int main(int argc, char *argv[])
 	odp_init_param_init(&init_param);
 	init_param.mem_model = helper_options.mem_model;
 
-	if (odp_init_global(&odp_instance, &init_param, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		ODPH_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}
 
-	if (odp_init_local(odp_instance, ODP_THREAD_CONTROL)) {
+	if (odp_init_local(instance, ODP_THREAD_CONTROL)) {
 		ODPH_ERR("Error: ODP local init failed.\n");
 		exit(EXIT_FAILURE);
 	}
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
 	printf("new num worker threads:     %i\n\n", num_workers);
 
 	odph_thread_common_param_init(&thr_common);
-	thr_common.instance = odp_instance;
+	thr_common.instance = instance;
 	thr_common.cpumask = &cpu_mask;
 	thr_common.share_param = 1;
 
@@ -213,7 +213,7 @@ static void main_exit(void)
 		_exit(EXIT_FAILURE);
 	}
 
-	if (odp_term_global(odp_instance)) {
+	if (odp_term_global(instance)) {
 		ODPH_ERR("Error: ODP global term failed.\n");
 		_exit(EXIT_FAILURE);
 	}

--- a/include/odp/api/spec/init.h
+++ b/include/odp/api/spec/init.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019, Nokia
+ * Copyright (c) 2019-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -36,11 +36,21 @@ extern "C" {
  * ODP log level.
  */
 typedef enum {
+	/** Debug */
 	ODP_LOG_DBG,
+
+	/** Error */
 	ODP_LOG_ERR,
+
+	/** Unimplemented */
 	ODP_LOG_UNIMPLEMENTED,
+
+	/** Abort */
 	ODP_LOG_ABORT,
+
+	/** Print */
 	ODP_LOG_PRINT
+
 } odp_log_level_t;
 
 /**

--- a/include/odp/api/spec/init.h
+++ b/include/odp/api/spec/init.h
@@ -356,6 +356,20 @@ int odp_term_global(odp_instance_t instance);
 void odp_log_thread_fn_set(odp_log_func_t func);
 
 /**
+ * Get instance handle
+ *
+ * A successful call outputs the calling thread's ODP instance handle.
+ *
+ * @param[out] instance   Instance handle pointer for output
+ *
+ * @retval 0 on success
+ * @retval <0 on failure
+ *
+ * @see odp_init_global(), odp_init_local()
+ */
+int odp_instance(odp_instance_t *instance);
+
+/**
  * @}
  */
 

--- a/include/odp/api/spec/protocols.h
+++ b/include/odp/api/spec/protocols.h
@@ -19,11 +19,9 @@ extern "C" {
 #endif
 
 /**
- * @addtogroup odp_protocols
- * @details
- * <b> Protocols </b>
- *
- *  @{
+ * @defgroup odp_protocols ODP PROTOCOLS
+ * Network protocols
+ * @{
  */
 
 /** IPv4 address size */

--- a/include/odp/api/spec/version.h.in
+++ b/include/odp/api/spec/version.h.in
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2020, Nokia
+ * Copyright (c) 2020-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -21,8 +21,7 @@ extern "C" {
 
 /**
  * @defgroup odp_version ODP VERSION
- * @details
- * <b> ODP API and implementation versions </b>
+ * API and implementation versions
  *
  * ODP API version is identified by ODP_VERSION_API_XXX preprocessor macros.
  * In addition to these macros, API calls can be used to identify implementation

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -630,3 +630,10 @@ void odp_log_thread_fn_set(odp_log_func_t func)
 {
 	_odp_this_thread->log_fn = func;
 }
+
+int odp_instance(odp_instance_t *instance)
+{
+	*instance = (odp_instance_t)odp_global_ro.main_pid;
+
+	return 0;
+}

--- a/test/validation/api/init/init_main.c
+++ b/test/validation/api/init/init_main.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2019, Nokia
+ * Copyright (c) 2019-2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -11,6 +11,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 /* Replacement abort function */
 static void ODP_NORETURN my_abort_func(void)
@@ -51,6 +52,7 @@ static void init_test_defaults(void)
 {
 	int ret;
 	odp_instance_t instance;
+	odp_instance_t current_instance;
 	odp_init_t param;
 
 	odp_init_param_init(&param);
@@ -60,6 +62,9 @@ static void init_test_defaults(void)
 
 	ret = odp_init_local(instance, ODP_THREAD_WORKER);
 	CU_ASSERT_FATAL(ret == 0);
+
+	CU_ASSERT_FATAL(odp_instance(&current_instance) == 0);
+	CU_ASSERT(memcmp(&current_instance, &instance, sizeof(odp_instance_t)) == 0);
 
 	ret = odp_term_local();
 	CU_ASSERT_FATAL(ret == 0);


### PR DESCRIPTION
Add odp_instance() function for reading the current ODP instance handle.

Includes additional minor API changes to fix Doxygen output.

V2:
- Use `memcpm()` in validation test (Petri)

V3:
- Added output parameter for the instance handle