### PR TITLE
[PATCH v3] linux-gen: pool: add pool type checks to alloc functions

### DIFF
--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -1273,6 +1273,9 @@ odp_buffer_t odp_buffer_alloc(odp_pool_t pool_hdl)
 	ODP_ASSERT(ODP_POOL_INVALID != pool_hdl);
 
 	pool = pool_entry_from_hdl(pool_hdl);
+
+	ODP_ASSERT(pool->type == ODP_POOL_BUFFER);
+
 	ret  = _odp_buffer_alloc_multi(pool, (odp_buffer_hdr_t **)&buf, 1);
 
 	if (odp_likely(ret == 1))
@@ -1288,6 +1291,8 @@ int odp_buffer_alloc_multi(odp_pool_t pool_hdl, odp_buffer_t buf[], int num)
 	ODP_ASSERT(ODP_POOL_INVALID != pool_hdl);
 
 	pool = pool_entry_from_hdl(pool_hdl);
+
+	ODP_ASSERT(pool->type == ODP_POOL_BUFFER);
 
 	return _odp_buffer_alloc_multi(pool, (odp_buffer_hdr_t **)buf, num);
 }

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1496,20 +1496,26 @@ void *odp_timeout_user_ptr(odp_timeout_t tmo)
 	return (void *)(uintptr_t)timeout_hdr(tmo)->user_ptr;
 }
 
-odp_timeout_t odp_timeout_alloc(odp_pool_t pool)
+odp_timeout_t odp_timeout_alloc(odp_pool_t pool_hdl)
 {
-	odp_buffer_t buf = odp_buffer_alloc(pool);
+	odp_timeout_t tmo;
+	pool_t *pool;
+	int ret;
 
-	if (odp_unlikely(buf == ODP_BUFFER_INVALID))
-		return ODP_TIMEOUT_INVALID;
-	return odp_timeout_from_event(odp_buffer_to_event(buf));
+	ODP_ASSERT(pool_hdl != ODP_POOL_INVALID);
+
+	pool = pool_entry_from_hdl(pool_hdl);
+	ret = _odp_buffer_alloc_multi(pool, (odp_buffer_hdr_t **)&tmo, 1);
+
+	if (odp_likely(ret == 1))
+		return tmo;
+
+	return ODP_TIMEOUT_INVALID;
 }
 
 void odp_timeout_free(odp_timeout_t tmo)
 {
-	odp_event_t ev = odp_timeout_to_event(tmo);
-
-	odp_buffer_free(odp_buffer_from_event(ev));
+	_odp_buffer_free_multi((odp_buffer_hdr_t **)&tmo, 1);
 }
 
 void odp_timer_pool_print(odp_timer_pool_t timer_pool)

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1505,6 +1505,9 @@ odp_timeout_t odp_timeout_alloc(odp_pool_t pool_hdl)
 	ODP_ASSERT(pool_hdl != ODP_POOL_INVALID);
 
 	pool = pool_entry_from_hdl(pool_hdl);
+
+	ODP_ASSERT(pool->type == ODP_POOL_TIMEOUT);
+
 	ret = _odp_buffer_alloc_multi(pool, (odp_buffer_hdr_t **)&tmo, 1);
 
 	if (odp_likely(ret == 1))


### PR DESCRIPTION
Add asserts for checking that buffers are allocated from the right type
of pool.