### PR TITLE
[PATCH v4] api: add packet vectors to ipsec and clarify packet vector API

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -364,6 +364,9 @@ typedef struct odp_ipsec_capability_t {
 	 *  be used for many SAs. */
 	uint32_t max_queues;
 
+	/** Support for returning completion packets as vectors */
+	odp_pktin_vector_capability_t vector;
+
 	/** Maximum anti-replay window size. */
 	uint32_t max_antireplay_ws;
 
@@ -454,6 +457,16 @@ typedef struct odp_ipsec_config_t {
 	 *  @see odp_ipsec_stats(), odp_ipsec_stats_multi()
 	 */
 	odp_bool_t stats_en;
+
+	/**
+	 * Packet vector configuration for async and inline operations
+	 *
+	 * This packet vector configuration affects packets delivered to
+	 * the application through the default queue and the SA destination
+	 * queues. It does not affect packets delivered through pktio
+	 * input queues.
+	 */
+	odp_pktin_vector_config_t vector;
 
 } odp_ipsec_config_t;
 

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -181,7 +181,9 @@ typedef struct odp_pktin_vector_config_t {
 	 *
 	 * When true, packet input vector is enabled and configured with vector
 	 * config parameters. Otherwise, packet input vector configuration
-	 * parameters are ignored.
+	 * parameters are ignored. When vectors are enabled, packets may
+	 * be delivered both as packet vector events and packet events.
+	 * The default value is false.
 	 */
 	odp_bool_t enable;
 

--- a/test/validation/api/classification/odp_classification_common.c
+++ b/test/validation/api/classification/odp_classification_common.c
@@ -207,7 +207,7 @@ odp_packet_t receive_packet(odp_queue_t *queue, uint64_t ns, odp_bool_t enable_p
 	if (ev == ODP_EVENT_INVALID)
 		return ODP_PACKET_INVALID;
 
-	if (!enable_pktv && odp_event_type(ev) == ODP_EVENT_PACKET) {
+	if (odp_event_type(ev) == ODP_EVENT_PACKET) {
 		return odp_packet_from_event(ev);
 	} else if (enable_pktv && odp_event_type(ev) == ODP_EVENT_PACKET_VECTOR) {
 		odp_packet_vector_t pktv;

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -1623,6 +1623,7 @@ static void ipsec_test_default_values(void)
 	CU_ASSERT(!config.inbound.reass_inline);
 	CU_ASSERT(config.outbound.all_chksum == 0);
 	CU_ASSERT(!config.stats_en);
+	CU_ASSERT(!config.vector.enable);
 
 	odp_ipsec_sa_param_init(&sa_param);
 	CU_ASSERT(sa_param.proto == ODP_IPSEC_ESP);

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -685,7 +685,7 @@ static int get_packets(pktio_info_t *pktio_rx, odp_packet_t pkt_tbl[],
 
 	/* convert events to packets, discarding any non-packet events */
 	for (i = 0; i < num_evts; ++i) {
-		if (!vector_mode && odp_event_type(evt_tbl[i]) == ODP_EVENT_PACKET) {
+		if (odp_event_type(evt_tbl[i]) == ODP_EVENT_PACKET) {
 			pkt_tbl[num_pkts++] = odp_packet_from_event(evt_tbl[i]);
 		} else if (vector_mode &&  odp_event_type(evt_tbl[i]) == ODP_EVENT_PACKET_VECTOR &&
 			   num_pkts < num) {


### PR DESCRIPTION
The first API patch tweaks the existing pktin packet vector spec so that when packet vectors are enabled, plain packet events will not be generated by the pktin. The second API patch adds packet vector support to packet completion events in the IPsec API.

This PR also adds more default value checks for the pktio related init functions (except lso). There seem to be an inconsistency or an ambiquity in the ODP API regrading the default value of queue mode, which I will try to handle separately.