### PR TITLE
[PATCH v3] api: pool: add odp_pool_print_all() function

### DIFF
--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -105,6 +105,14 @@ int odp_pool_info(odp_pool_t pool, odp_pool_info_t *info);
 void odp_pool_print(odp_pool_t pool);
 
 /**
+ * Print debug info about all pools
+ *
+ * Print implementation defined information about all created pools to the ODP
+ * log. The information is intended to be used for debugging.
+ */
+void odp_pool_print_all(void);
+
+/**
  * Get printable value for an odp_pool_t
  *
  * @param hdl  odp_pool_t handle to be printed

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -140,6 +140,7 @@ static void pool_test_lookup_info_print(void)
 	CU_ASSERT(param.type == info.params.type);
 
 	odp_pool_print(pool);
+	odp_pool_print_all();
 
 	CU_ASSERT(odp_pool_destroy(pool) == 0);
 }


### PR DESCRIPTION
Add new odp_pool_print_all() function for printing implementation defined
information about all created pools to the ODP log. The information is
intended to be used for debugging.

V2:
- Implementation optimization (Petri)