### PR TITLE
[PATCH v5] linux-gen: random: implement crypto random and true random data on x86

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -339,6 +339,21 @@ AM_CONDITIONAL([WITH_OPENSSL], [test x$with_openssl != xno])
 AC_DEFINE_UNQUOTED([_ODP_OPENSSL], [$have_openssl],
 	  [Define to 1 to enable OpenSSL support])
 
+have_openssl_rand=1
+AC_ARG_ENABLE([openssl-rand],
+	[AS_HELP_STRING([--disable-openssl-rand],
+			[Disable OpenSSL random data (use arch-specific instead)]
+			[[default=enabled]])],
+	[if test "x$enableval" = "xno"; then
+		have_openssl_rand=0
+	fi])
+
+AS_IF([test "$have_openssl" != "1"], [have_openssl_rand=0])
+AS_IF([test "$have_openssl_rand" = "1"], [openssl_rand=yes], [openssl_rand=no])
+
+AC_DEFINE_UNQUOTED([_ODP_OPENSSL_RAND], [$have_openssl_rand],
+	  [Define to 1 to enable OpenSSL support])
+
 ##########################################################################
 # Include m4 files
 ##########################################################################
@@ -523,6 +538,7 @@ AC_MSG_RESULT([
 	testdir:		${testdir}
 	WITH_ARCH:              ${WITH_ARCH}
 	with_openssl:           ${with_openssl}
+	openssl_rand:           ${openssl_rand}
 
 	cc:			${CC}
 	cc version:             ${CC_VERSION}

--- a/include/odp/api/spec/random.h
+++ b/include/odp/api/spec/random.h
@@ -18,6 +18,8 @@
 extern "C" {
 #endif
 
+#include <odp/api/std_types.h>
+
 /** @defgroup odp_random ODP RANDOM
  *  Random number generation.
  *  @{

--- a/include/odp/autoheader_internal.h.in
+++ b/include/odp/autoheader_internal.h.in
@@ -29,4 +29,7 @@
 /* Define to 1 to enable OpenSSL support */
 #undef _ODP_OPENSSL
 
+/* Define to 1 to enable OpenSSL random data */
+#undef _ODP_OPENSSL_RAND
+
 #endif

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -276,6 +276,7 @@ __LIB__libodp_linux_la_SOURCES += arch/default/odp_atomic.c \
 				  arch/default/odp_cpu_cycles.c \
 				  arch/default/odp_global_time.c \
 				  arch/default/odp_hash_crc32.c \
+				  arch/default/odp_random.c \
 				  arch/arm/odp_sysinfo_parse.c
 odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/cpu_time.h \
 				arch/default/odp/api/abi/hash_crc32.h
@@ -292,7 +293,8 @@ noinst_HEADERS += arch/arm/odp_atomic.h \
 		  arch/arm/odp_llsc.h \
 		  arch/default/odp_atomic.h \
 		  arch/default/odp_cpu.h \
-		  arch/default/odp_cpu_idling.h
+		  arch/default/odp_cpu_idling.h \
+		  arch/default/odp_random.h
 endif
 if ARCH_IS_AARCH64
 __LIB__libodp_linux_la_SOURCES += arch/aarch64/odp_atomic.c \
@@ -300,6 +302,7 @@ __LIB__libodp_linux_la_SOURCES += arch/aarch64/odp_atomic.c \
 				  arch/aarch64/cpu_flags.c \
 				  arch/aarch64/odp_global_time.c \
 				  arch/default/odp_hash_crc32.c \
+				  arch/default/odp_random.c \
 				  arch/aarch64/odp_sysinfo_parse.c
 odpapiabiarchinclude_HEADERS += arch/aarch64/odp/api/abi/cpu_time.h \
 				arch/aarch64/odp/api/abi/hash_crc32.h
@@ -315,13 +318,15 @@ noinst_HEADERS += arch/aarch64/odp_atomic.h \
 		  arch/aarch64/odp_cpu.h \
 		  arch/aarch64/cpu_flags.h \
 		  arch/aarch64/odp_cpu_idling.h \
-		  arch/aarch64/odp_llsc.h
+		  arch/aarch64/odp_llsc.h \
+		  arch/default/odp_random.h
 endif
 if ARCH_IS_DEFAULT
 __LIB__libodp_linux_la_SOURCES += arch/default/odp_atomic.c \
 				  arch/default/odp_cpu_cycles.c \
 				  arch/default/odp_global_time.c \
 				  arch/default/odp_hash_crc32.c \
+				  arch/default/odp_random.c \
 				  arch/default/odp_sysinfo_parse.c
 odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/cpu_time.h \
 				arch/default/odp/api/abi/hash_crc32.h
@@ -334,12 +339,14 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 endif
 noinst_HEADERS += arch/default/odp_atomic.h \
 		  arch/default/odp_cpu.h \
-		  arch/default/odp_cpu_idling.h
+		  arch/default/odp_cpu_idling.h \
+		  arch/default/odp_random.h
 endif
 if ARCH_IS_MIPS64
 __LIB__libodp_linux_la_SOURCES += arch/default/odp_atomic.c \
 				  arch/default/odp_global_time.c \
 				  arch/default/odp_hash_crc32.c \
+				  arch/default/odp_random.c \
 				  arch/mips64/odp_sysinfo_parse.c
 odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/cpu_time.h \
 				arch/default/odp/api/abi/hash_crc32.h
@@ -352,13 +359,15 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 endif
 noinst_HEADERS += arch/default/odp_atomic.h \
 		  arch/default/odp_cpu.h \
-		  arch/default/odp_cpu_idling.h
+		  arch/default/odp_cpu_idling.h \
+		  arch/default/odp_random.h
 endif
 if ARCH_IS_POWERPC
 __LIB__libodp_linux_la_SOURCES += arch/default/odp_atomic.c \
 				  arch/default/odp_cpu_cycles.c \
 				  arch/default/odp_global_time.c \
 				  arch/default/odp_hash_crc32.c \
+				  arch/default/odp_random.c \
 				  arch/powerpc/odp_sysinfo_parse.c
 odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/cpu_time.h \
 				arch/default/odp/api/abi/hash_crc32.h
@@ -371,7 +380,8 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 endif
 noinst_HEADERS += arch/default/odp_atomic.h \
 		  arch/default/odp_cpu.h \
-		  arch/default/odp_cpu_idling.h
+		  arch/default/odp_cpu_idling.h \
+		  arch/default/odp_random.h
 endif
 if ARCH_IS_X86
 __LIB__libodp_linux_la_SOURCES += arch/default/odp_atomic.c \
@@ -379,6 +389,7 @@ __LIB__libodp_linux_la_SOURCES += arch/default/odp_atomic.c \
 				  arch/x86/odp_cpu_cycles.c \
 				  arch/x86/odp_global_time.c \
 				  arch/default/odp_hash_crc32.c \
+				  arch/default/odp_random.c \
 				  arch/x86/odp_sysinfo_parse.c
 odpapiabiarchinclude_HEADERS += arch/x86/odp/api/abi/cpu_rdtsc.h \
 				arch/x86/odp/api/abi/cpu_time.h \
@@ -391,6 +402,7 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 endif
 noinst_HEADERS += arch/x86/cpu_flags.h \
 		  arch/x86/odp_cpu.h \
+		  arch/x86/odp_random.h \
 		  arch/default/odp_atomic.h \
 		  arch/default/odp_cpu.h \
 		  arch/default/odp_cpu_idling.h

--- a/platform/linux-generic/README
+++ b/platform/linux-generic/README
@@ -41,3 +41,21 @@ SPDX-License-Identifier:        BSD-3-Clause
         socket
         socket_mmap
         tap
+
+5. Random data
+    On x86 ODP_RANDOM_TRUE type random data is generated using rdseed [1] via
+    compiler builtin functions. If OpenSSL is not available or its use for
+    generating random data is disabled with the --disable-openssl-rand
+    configure option, ODP_RANDOM_CRYPTO type random data is generated using
+    rdrand [1].
+
+    Note that there may be issues with the quality or security of rdrand and
+    rdseed. [2]
+
+6. References
+    [1] Intel Digital Random Number Generator (DRNG) Software Implementation
+        Guide. John P Mechalas, 17 October 2018.
+        https://www.intel.com/content/www/us/en/developer/articles/guide/intel-digital-random-number-generator-drng-software-implementation-guide.html
+
+    [2] RDRAND. Wikipedia, 29 September 2021.
+        https://en.wikipedia.org/wiki/RDRAND#Reception

--- a/platform/linux-generic/arch/default/odp_random.c
+++ b/platform/linux-generic/arch/default/odp_random.c
@@ -1,0 +1,33 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp_random.h>
+#include <odp/api/spec/random.h>
+
+#include <odp/visibility_begin.h>
+
+odp_random_kind_t _odp_random_max_kind_generic(void)
+{
+	return ODP_RANDOM_BASIC;
+}
+
+int32_t _odp_random_true_data_generic(uint8_t *buf, uint32_t len)
+{
+	(void)buf;
+	(void)len;
+
+	return -1;
+}
+
+int32_t _odp_random_crypto_data_generic(uint8_t *buf, uint32_t len)
+{
+	(void)buf;
+	(void)len;
+
+	return -1;
+}
+
+#include <odp/visibility_end.h>

--- a/platform/linux-generic/arch/default/odp_random.h
+++ b/platform/linux-generic/arch/default/odp_random.h
@@ -1,0 +1,41 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_DEFAULT_RANDOM_H_
+#define ODP_DEFAULT_RANDOM_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/spec/random.h>
+
+#include <stdint.h>
+
+odp_random_kind_t _odp_random_max_kind_generic(void);
+int32_t _odp_random_true_data_generic(uint8_t *buf, uint32_t len);
+int32_t _odp_random_crypto_data_generic(uint8_t *buf, uint32_t len);
+
+static inline odp_random_kind_t _odp_random_max_kind(void)
+{
+	return _odp_random_max_kind_generic();
+}
+
+static inline int32_t _odp_random_true_data(uint8_t *buf, uint32_t len)
+{
+	return _odp_random_true_data_generic(buf, len);
+}
+
+static inline int32_t _odp_random_crypto_data(uint8_t *buf, uint32_t len)
+{
+	return _odp_random_crypto_data_generic(buf, len);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/arch/x86/odp_random.h
+++ b/platform/linux-generic/arch/x86/odp_random.h
@@ -1,0 +1,160 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/*
+ * These functions implement ODP_RANDOM_CRYPTO random data using rdrand [1],
+ * and ODP_RANDOM_TRUE random data using rdseed [1], via compiler builtin
+ * functions.
+ *
+ * Note that there may be issues with the quality or security of rdrand and
+ * rdseed. [2]
+ *
+ * [1] Intel Digital Random Number Generator (DRNG) Software Implementation
+ *     Guide. John P Mechalas, 17 October 2018.
+ *     https://www.intel.com/content/www/us/en/developer/articles/guide/intel-digital-random-number-generator-drng-software-implementation-guide.html
+ *
+ * [2] RDRAND. Wikipedia, 29 September 2021.
+ *     https://en.wikipedia.org/wiki/RDRAND#Reception
+ */
+
+#ifndef ODP_X86_RANDOM_H_
+#define ODP_X86_RANDOM_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/spec/random.h>
+
+#include <stdint.h>
+
+odp_random_kind_t _odp_random_max_kind_generic(void);
+int32_t _odp_random_true_data_generic(uint8_t *buf, uint32_t len);
+int32_t _odp_random_crypto_data_generic(uint8_t *buf, uint32_t len);
+
+#ifdef __RDRND__
+
+static inline int _odp_random_max_kind(void)
+{
+#ifdef __RDSEED__
+	return ODP_RANDOM_TRUE;
+#else
+	return ODP_RANDOM_CRYPTO;
+#endif
+}
+
+#else
+
+static inline int _odp_random_max_kind(void)
+{
+	return _odp_random_max_kind_generic();
+}
+
+#endif
+
+#ifdef __RDSEED__
+
+static inline int32_t _odp_random_true_data(uint8_t *buf, uint32_t len)
+{
+#ifdef __x86_64__
+	for (uint32_t i = 0; i < len / 8; i++) {
+		while (!__builtin_ia32_rdseed_di_step((unsigned long long *)buf))
+			;
+		buf += 8;
+	}
+
+	if (len & 4) {
+		while (!__builtin_ia32_rdseed_si_step((unsigned int *)buf))
+			;
+		buf += 4;
+	}
+#else
+	for (uint32_t i = 0; i < len / 4; i++) {
+		while (!__builtin_ia32_rdseed_si_step((unsigned int *)buf))
+			;
+		buf += 4;
+	}
+#endif
+	if (len & 2) {
+		while (!__builtin_ia32_rdseed_hi_step((unsigned short int *)buf))
+			;
+		buf += 2;
+	}
+
+	if (len & 1) {
+		uint16_t w;
+
+		while (!__builtin_ia32_rdseed_hi_step(&w))
+			;
+		*((uint8_t *)buf) = w & 0xff;
+	}
+
+	return len;
+}
+
+#else
+
+static inline int32_t _odp_random_true_data(uint8_t *buf, uint32_t len)
+{
+	return _odp_random_true_data_generic(buf, len);
+}
+
+#endif
+
+#ifdef __RDRND__
+
+static inline int32_t _odp_random_crypto_data(uint8_t *buf, uint32_t len)
+{
+#ifdef __x86_64__
+	for (uint32_t i = 0; i < len / 8; i++) {
+		while (!__builtin_ia32_rdrand64_step((unsigned long long *)buf))
+			;
+		buf += 8;
+	}
+
+	if (len & 4) {
+		while (!__builtin_ia32_rdrand32_step((unsigned int *)buf))
+			;
+		buf += 4;
+	}
+#else
+	for (uint32_t i = 0; i < len / 4; i++) {
+		while (!__builtin_ia32_rdrand32_step((unsigned int *)buf))
+			;
+		buf += 4;
+	}
+#endif
+	if (len & 2) {
+		while (!__builtin_ia32_rdrand16_step((unsigned short int *)buf))
+			;
+		buf += 2;
+	}
+
+	if (len & 1) {
+		uint16_t w;
+
+		while (!__builtin_ia32_rdrand16_step(&w))
+			;
+		*((uint8_t *)buf) = w & 0xff;
+	}
+
+	return len;
+}
+
+#else
+
+static inline int32_t _odp_random_crypto_data(uint8_t *buf, uint32_t len)
+{
+	return _odp_random_crypto_data_generic(buf, len);
+}
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp_random_openssl_internal.h
+++ b/platform/linux-generic/include/odp_random_openssl_internal.h
@@ -13,10 +13,7 @@ extern "C" {
 
 #include <stdint.h>
 
-#include <odp/api/random.h>
-
-odp_random_kind_t _odp_random_openssl_max_kind(void);
-int32_t _odp_random_openssl_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind);
+int32_t _odp_random_openssl_data(uint8_t *buf, uint32_t len);
 int _odp_random_openssl_init_local(void);
 int _odp_random_openssl_term_local(void);
 

--- a/platform/linux-generic/include/odp_random_std_internal.h
+++ b/platform/linux-generic/include/odp_random_std_internal.h
@@ -13,11 +13,8 @@ extern "C" {
 
 #include <stdint.h>
 
-#include <odp/api/random.h>
-
-odp_random_kind_t _odp_random_std_max_kind(void);
 int32_t _odp_random_std_test_data(uint8_t *buf, uint32_t len, uint64_t *seed);
-int32_t _odp_random_std_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind);
+int32_t _odp_random_std_data(uint8_t *buf, uint32_t len);
 int _odp_random_std_init_local(void);
 int _odp_random_std_term_local(void);
 

--- a/platform/linux-generic/odp_random.c
+++ b/platform/linux-generic/odp_random.c
@@ -18,7 +18,7 @@ odp_random_kind_t odp_random_max_kind(void)
 {
 	odp_random_kind_t kind, max_kind = ODP_RANDOM_BASIC;
 
-	if (_ODP_OPENSSL)
+	if (_ODP_OPENSSL_RAND)
 		max_kind = ODP_RANDOM_CRYPTO;
 
 	kind = _odp_random_max_kind();
@@ -32,11 +32,11 @@ int32_t odp_random_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
 {
 	switch (kind) {
 	case ODP_RANDOM_BASIC:
-		if (_ODP_OPENSSL)
+		if (_ODP_OPENSSL_RAND)
 			return _odp_random_openssl_data(buf, len);
 		return _odp_random_std_data(buf, len);
 	case ODP_RANDOM_CRYPTO:
-		if (_ODP_OPENSSL)
+		if (_ODP_OPENSSL_RAND)
 			return _odp_random_openssl_data(buf, len);
 		return _odp_random_crypto_data(buf, len);
 	case ODP_RANDOM_TRUE:
@@ -53,14 +53,14 @@ int32_t odp_random_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
 
 int _odp_random_init_local(void)
 {
-	if (_ODP_OPENSSL)
+	if (_ODP_OPENSSL_RAND)
 		return _odp_random_openssl_init_local();
 	return _odp_random_std_init_local();
 }
 
 int _odp_random_term_local(void)
 {
-	if (_ODP_OPENSSL)
+	if (_ODP_OPENSSL_RAND)
 		return _odp_random_openssl_term_local();
 	return _odp_random_std_term_local();
 }

--- a/platform/linux-generic/odp_random.c
+++ b/platform/linux-generic/odp_random.c
@@ -12,19 +12,38 @@
 #include <odp_init_internal.h>
 #include <odp_random_std_internal.h>
 #include <odp_random_openssl_internal.h>
+#include <odp_random.h>
 
 odp_random_kind_t odp_random_max_kind(void)
 {
+	odp_random_kind_t kind, max_kind = ODP_RANDOM_BASIC;
+
 	if (_ODP_OPENSSL)
-		return _odp_random_openssl_max_kind();
-	return _odp_random_std_max_kind();
+		max_kind = ODP_RANDOM_CRYPTO;
+
+	kind = _odp_random_max_kind();
+	if (kind > max_kind)
+		max_kind = kind;
+
+	return max_kind;
 }
 
 int32_t odp_random_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
 {
-	if (_ODP_OPENSSL)
-		return _odp_random_openssl_data(buf, len, kind);
-	return _odp_random_std_data(buf, len, kind);
+	switch (kind) {
+	case ODP_RANDOM_BASIC:
+		if (_ODP_OPENSSL)
+			return _odp_random_openssl_data(buf, len);
+		return _odp_random_std_data(buf, len);
+	case ODP_RANDOM_CRYPTO:
+		if (_ODP_OPENSSL)
+			return _odp_random_openssl_data(buf, len);
+		return _odp_random_crypto_data(buf, len);
+	case ODP_RANDOM_TRUE:
+		return _odp_random_true_data(buf, len);
+	}
+
+	return -1;
 }
 
 int32_t odp_random_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)

--- a/platform/linux-generic/odp_random_openssl.c
+++ b/platform/linux-generic/odp_random_openssl.c
@@ -7,7 +7,6 @@
 
 #include <odp_posix_extensions.h>
 #include <stdint.h>
-#include <odp/api/random.h>
 #include <odp/autoheader_internal.h>
 #include <odp_init_internal.h>
 #include <odp_random_openssl_internal.h>
@@ -15,37 +14,17 @@
 #if _ODP_OPENSSL
 #include <openssl/rand.h>
 
-odp_random_kind_t _odp_random_openssl_max_kind(void)
-{
-	return ODP_RANDOM_CRYPTO;
-}
-
-int32_t _odp_random_openssl_data(uint8_t *buf, uint32_t len,
-				 odp_random_kind_t kind)
+int32_t _odp_random_openssl_data(uint8_t *buf, uint32_t len)
 {
 	int rc;
 
-	switch (kind) {
-	case ODP_RANDOM_BASIC:
-	case ODP_RANDOM_CRYPTO:
-		rc = RAND_bytes(buf, len);
-		return (1 == rc) ? (int)len /*success*/: -1 /*failure*/;
-
-	case ODP_RANDOM_TRUE:
-	default:
-		return -1;
-	}
+	rc = RAND_bytes(buf, len);
+	return (1 == rc) ? (int)len /*success*/: -1 /*failure*/;
 }
 #else
 /* Dummy functions for building without OpenSSL support */
-odp_random_kind_t _odp_random_openssl_max_kind(void)
-{
-	return ODP_RANDOM_BASIC;
-}
-
 int32_t _odp_random_openssl_data(uint8_t *buf ODP_UNUSED,
-				 uint32_t len ODP_UNUSED,
-				 odp_random_kind_t kind ODP_UNUSED)
+				 uint32_t len ODP_UNUSED)
 {
 	return -1;
 }

--- a/platform/linux-generic/odp_random_openssl.c
+++ b/platform/linux-generic/odp_random_openssl.c
@@ -11,7 +11,7 @@
 #include <odp_init_internal.h>
 #include <odp_random_openssl_internal.h>
 
-#if _ODP_OPENSSL
+#if _ODP_OPENSSL_RAND
 #include <openssl/rand.h>
 
 int32_t _odp_random_openssl_data(uint8_t *buf, uint32_t len)
@@ -28,7 +28,7 @@ int32_t _odp_random_openssl_data(uint8_t *buf ODP_UNUSED,
 {
 	return -1;
 }
-#endif /* _ODP_OPENSSL */
+#endif /* _ODP_OPENSSL_RAND */
 
 int _odp_random_openssl_init_local(void)
 {

--- a/platform/linux-generic/odp_random_std.c
+++ b/platform/linux-generic/odp_random_std.c
@@ -7,7 +7,6 @@
 #include <odp_posix_extensions.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <odp/api/random.h>
 #include <odp/api/byteorder.h>
 #include <odp/api/cpu.h>
 #include <odp/api/debug.h>
@@ -19,11 +18,6 @@
 /* Assume at least two rand bytes are available and RAND_MAX is power of two - 1 */
 ODP_STATIC_ASSERT(RAND_MAX >= UINT16_MAX, "RAND_MAX too small");
 ODP_STATIC_ASSERT((RAND_MAX & (RAND_MAX + 1ULL))  ==  0, "RAND_MAX not power of two - 1");
-
-odp_random_kind_t _odp_random_std_max_kind(void)
-{
-	return ODP_RANDOM_BASIC;
-}
 
 static int32_t _random_data(uint8_t *buf, uint32_t len, uint32_t *seed)
 {
@@ -57,11 +51,8 @@ int32_t _odp_random_std_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
 
 static __thread uint32_t this_seed;
 
-int32_t _odp_random_std_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
+int32_t _odp_random_std_data(uint8_t *buf, uint32_t len)
 {
-	if (kind != ODP_RANDOM_BASIC)
-		return -1;
-
 	return _random_data(buf, len, &this_seed);
 }
 

--- a/test/performance/.gitignore
+++ b/test/performance/.gitignore
@@ -14,6 +14,7 @@ odp_pktio_ordered
 odp_pktio_perf
 odp_pool_perf
 odp_queue_perf
+odp_random
 odp_sched_latency
 odp_sched_perf
 odp_sched_pktio

--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -12,6 +12,7 @@ EXECUTABLES = odp_atomic_perf \
 	      odp_pktio_perf \
 	      odp_pool_perf \
 	      odp_queue_perf \
+	      odp_random \
 	      odp_sched_perf
 
 COMPILE_ONLY = odp_l2fwd \
@@ -56,6 +57,7 @@ odp_scheduling_SOURCES = odp_scheduling.c
 odp_pktio_perf_SOURCES = odp_pktio_perf.c
 odp_pool_perf_SOURCES = odp_pool_perf.c
 odp_queue_perf_SOURCES = odp_queue_perf.c
+odp_random_SOURCES = odp_random.c
 odp_sched_perf_SOURCES = odp_sched_perf.c
 odp_timer_perf_SOURCES = odp_timer_perf.c
 

--- a/test/performance/odp_random.c
+++ b/test/performance/odp_random.c
@@ -1,0 +1,377 @@
+/* Copyright (c) 2021, Nokia
+ *
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <getopt.h>
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#define MB (1024ull * 1024ull)
+
+/* Command line options */
+typedef struct {
+	int num_threads;
+	uint32_t size;
+	uint32_t rounds;
+} options_t;
+
+static options_t options;
+static const options_t options_def = {
+	.num_threads = 1,
+	.size = 256,
+	.rounds = 100000,
+};
+
+static void print_usage(void)
+{
+	printf("\n"
+	       "random data performance test\n"
+	       "\n"
+	       "Usage: odp_random [options]\n"
+	       "\n"
+	       "  -t, --threads Number of worker threads (default %u)\n"
+	       "  -s, --size    Size of buffer in bytes (default %u)\n"
+	       "  -r, --rounds  Number of test rounds (default %u)\n"
+	       "                Rounded down to nearest multiple of 8\n"
+	       "  -h, --help    This help\n"
+	       "\n",
+	       options_def.num_threads, options_def.size, options_def.rounds);
+}
+
+static int parse_options(int argc, char *argv[])
+{
+	int opt;
+	int long_index;
+	int ret = 0;
+
+	static const struct option longopts[] = {
+		{ "threads", required_argument, NULL, 't' },
+		{ "size", required_argument, NULL, 's' },
+		{ "rounds", required_argument, NULL, 'r' },
+		{ "help", no_argument, NULL, 'h' },
+		{ NULL, 0, NULL, 0 }
+	};
+
+	static const char *shortopts = "+t:s:r:h";
+
+	options = options_def;
+
+	while (1) {
+		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+
+		if (opt == -1)
+			break;
+
+		switch (opt) {
+		case 't':
+			options.num_threads = atol(optarg);
+			break;
+		case 's':
+			options.size = atol(optarg);
+			break;
+		case 'r':
+			options.rounds = atol(optarg);
+			break;
+		case 'h':
+			/* fall through */
+		default:
+			print_usage();
+			ret = -1;
+			break;
+		}
+	}
+
+	if (options.size < 1) {
+		ODPH_ERR("Invalid size: %" PRIu32 "\n", options.size);
+		return -1;
+	}
+
+	return ret;
+}
+
+const char *shm_name = "odp_random_test";
+
+typedef struct test_shm_t {
+	odp_barrier_t barrier;
+	odp_random_kind_t type;
+	uint64_t nsec[ODP_THREAD_COUNT_MAX];
+} test_shm_t;
+
+static test_shm_t *shm_lookup(void)
+{
+	test_shm_t *shm = NULL;
+	odp_shm_t shm_hdl = odp_shm_lookup(shm_name);
+
+	if (shm_hdl != ODP_SHM_INVALID)
+		shm = (test_shm_t *)odp_shm_addr(shm_hdl);
+
+	return shm;
+}
+
+static int test_random(void *p)
+{
+	(void)p;
+
+	uint8_t *buf, *data;
+	const unsigned long page = ODP_PAGE_SIZE;
+	odp_time_t start;
+	uint64_t nsec;
+	test_shm_t *shm = shm_lookup();
+
+	if (!shm) {
+		ODPH_ERR("Failed to look up shm %s\n", shm_name);
+		exit(EXIT_FAILURE);
+	}
+
+	/* One extra page for alignment. */
+	buf = (uint8_t *)malloc(options.size + page);
+
+	if (!buf) {
+		ODPH_ERR("Memory allocation failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	/* Align to start of page. */
+	data = (uint8_t *)(((uintptr_t)buf + (page - 1)) & ~(page - 1));
+
+	odp_barrier_wait(&shm->barrier);
+	start = odp_time_local();
+
+	for (uint32_t i = 0; i < options.rounds; i++) {
+		uint32_t pos = 0;
+
+		while (pos < options.size) {
+			int32_t n = odp_random_data(data + pos,
+						    options.size - pos,
+						    shm->type);
+
+			if (n < 0) {
+				ODPH_ERR("odp_random_data() failed\n");
+				exit(EXIT_FAILURE);
+			}
+
+			pos += n;
+		}
+	}
+
+	nsec = odp_time_diff_ns(odp_time_local(), start);
+	shm->nsec[odp_thread_id()] = nsec;
+	free(buf);
+
+	return 0;
+}
+
+static int test_random_test(void *p)
+{
+	(void)p;
+
+	uint8_t *buf, *data;
+	const unsigned long page = ODP_PAGE_SIZE;
+	odp_time_t start;
+	uint64_t nsec;
+	uint64_t seed = 0;
+	test_shm_t *shm = shm_lookup();
+
+	if (!shm) {
+		ODPH_ERR("Failed to look up shm %s\n", shm_name);
+		exit(EXIT_FAILURE);
+	}
+
+	/* One extra page for alignment. */
+	buf = (uint8_t *)malloc(options.size + page);
+
+	if (!buf) {
+		ODPH_ERR("Memory allocation failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	/* Align to start of page. */
+	data = (uint8_t *)(((uintptr_t)buf + (page - 1)) & ~(page - 1));
+
+	odp_barrier_wait(&shm->barrier);
+	start = odp_time_local();
+
+	for (uint32_t i = 0; i < options.rounds; i++) {
+		uint32_t pos = 0;
+
+		while (pos < options.size) {
+			int32_t n = odp_random_test_data(data + pos,
+							 options.size - pos,
+							 &seed);
+
+			if (n < 0) {
+				ODPH_ERR("odp_random_data() failed\n");
+				exit(EXIT_FAILURE);
+			}
+
+			pos += n;
+		}
+	}
+
+	nsec = odp_time_diff_ns(odp_time_local(), start);
+	shm->nsec[odp_thread_id()] = nsec;
+	free(buf);
+
+	return 0;
+}
+
+static void test_type(odp_instance_t instance, test_shm_t *shm,
+		      odp_random_kind_t type)
+{
+	memset(shm, 0, sizeof(test_shm_t));
+	shm->type = type;
+	odp_barrier_init(&shm->barrier, options.num_threads);
+
+	odp_cpumask_t cpumask;
+	odph_thread_common_param_t thr_common;
+	odph_thread_param_t thr_param;
+	odph_thread_t thr_worker[options.num_threads];
+
+	if (odp_cpumask_default_worker(&cpumask, options.num_threads) !=
+	    options.num_threads) {
+		ODPH_ERR("Failed to get default CPU mask.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odph_thread_common_param_init(&thr_common);
+	thr_common.instance = instance;
+	thr_common.cpumask = &cpumask;
+	thr_common.share_param = 1;
+
+	odph_thread_param_init(&thr_param);
+	thr_param.thr_type = ODP_THREAD_WORKER;
+	thr_param.start = test_random;
+
+	if (type == (odp_random_kind_t)-1)
+		thr_param.start = test_random_test;
+
+	memset(&thr_worker, 0, sizeof(thr_worker));
+
+	if (odph_thread_create(thr_worker, &thr_common, &thr_param,
+			       options.num_threads) != options.num_threads) {
+		ODPH_ERR("Failed to create worker threads.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (odph_thread_join(thr_worker, options.num_threads) !=
+	    options.num_threads) {
+		ODPH_ERR("Failed to join worker threads.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	double mb, seconds, nsec = 0;
+
+	for (int i = 0; i < ODP_THREAD_COUNT_MAX; i++)
+		nsec += shm->nsec[i];
+
+	nsec /= options.num_threads;
+
+	switch (type) {
+	case ODP_RANDOM_BASIC:
+		printf("ODP_RANDOM_BASIC\n");
+		break;
+	case ODP_RANDOM_CRYPTO:
+		printf("ODP_RANDOM_CRYPTO\n");
+		break;
+	case ODP_RANDOM_TRUE:
+		printf("ODP_RANDOM_TRUE\n");
+		break;
+	default:
+		printf("odp_random_test_data\n");
+	}
+
+	printf("--------------------\n");
+	printf("threads: %d  size: %u B  rounds: %u  ", options.num_threads,
+	       options.size, options.rounds);
+	mb = (uint64_t)options.num_threads * (uint64_t)options.size *
+	     (uint64_t)options.rounds;
+	mb /= MB;
+	seconds = (double)nsec / (double)ODP_TIME_SEC_IN_NS;
+	printf("MB: %.3f  seconds: %.3f  ", mb, seconds);
+	printf("MB/s: %.3f  ", mb / seconds);
+	printf("MB/s/thread: %.3f", mb / seconds / (double)options.num_threads);
+	printf("\n\n");
+}
+
+int main(int argc, char **argv)
+{
+	odp_instance_t instance;
+	odp_init_t init;
+
+	if (parse_options(argc, argv))
+		exit(EXIT_FAILURE);
+
+	/* List features not to be used */
+	odp_init_param_init(&init);
+	init.not_used.feat.cls = 1;
+	init.not_used.feat.compress = 1;
+	init.not_used.feat.crypto = 1;
+	init.not_used.feat.ipsec = 1;
+	init.not_used.feat.schedule = 1;
+	init.not_used.feat.stash = 1;
+	init.not_used.feat.timer = 1;
+	init.not_used.feat.tm = 1;
+
+	/* Init ODP before calling anything else */
+	if (odp_init_global(&instance, &init, NULL)) {
+		ODPH_ERR("Global init failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	/* Init this thread */
+	if (odp_init_local(instance, ODP_THREAD_CONTROL)) {
+		ODPH_ERR("Local init failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_sys_info_print();
+
+	test_shm_t *shm = NULL;
+	odp_shm_t shm_hdl = odp_shm_reserve(shm_name, sizeof(test_shm_t), 64,
+					    ODP_SHM_SW_ONLY);
+
+	if (shm_hdl != ODP_SHM_INVALID)
+		shm = (test_shm_t *)odp_shm_addr(shm_hdl);
+
+	if (!shm) {
+		ODPH_ERR("Failed to reserve shm %s\n", shm_name);
+		exit(EXIT_FAILURE);
+	}
+
+	switch (odp_random_max_kind()) {
+	case ODP_RANDOM_TRUE:
+		test_type(instance, shm, ODP_RANDOM_TRUE);
+		/* fall through */
+	case ODP_RANDOM_CRYPTO:
+		test_type(instance, shm, ODP_RANDOM_CRYPTO);
+		/* fall through */
+	default:
+		test_type(instance, shm, ODP_RANDOM_BASIC);
+		test_type(instance, shm, -1);
+	}
+
+	if (odp_shm_free(shm_hdl)) {
+		ODPH_ERR("odp_shm_free() failed\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (odp_term_local()) {
+		ODPH_ERR("Local terminate failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (odp_term_global(instance)) {
+		ODPH_ERR("Global terminate failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
```
linux-gen: random: implement crypto random and true random data on x86
    
    Implement crypto random data using rdrand, and true random data using
    rdseed, via compiler builtin functions.
    
    Add architecture-specific file for crypto random and true random
    functions.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

configure: add option to disable openssl random
    
    Add configure option --disable-openssl-rand, which disables the use of
    OpenSSL RAND_bytes() to generate basic random and crypto random data.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

test: perf: implement random data throughput test
    
    This test measures megabytes per second throughput of the random data
    generation API functions.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

linux-gen: README: add note about random data on x86
    
    Add a note about usage of rdrand and rdseed.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```

v2:
- Revise comments and add the same information in linux-gen README.

v3:
- Use rdrand for crypto and rdseed for true random.
- Add configure option --disable-openssl-rand.
- Simplify and clean up *_max_kind() functions and kind parameters.
- Revise README.

v4:
- Janne's comments.

v5:
- Fix checkpatch errors.
- Add review tags.
