### PR TITLE
[PATCH v4] test: sched_perf: add option to use packet pool

### DIFF
--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -12,13 +12,13 @@ EXECUTABLES = odp_atomic_perf \
 	      odp_pktio_perf \
 	      odp_pool_perf \
 	      odp_queue_perf \
-	      odp_random \
-	      odp_sched_perf
+	      odp_random
 
 COMPILE_ONLY = odp_l2fwd \
 	       odp_packet_gen \
 	       odp_pktio_ordered \
 	       odp_sched_latency \
+	       odp_sched_perf \
 	       odp_sched_pktio \
 	       odp_scheduling \
 	       odp_timer_perf
@@ -26,6 +26,7 @@ COMPILE_ONLY = odp_l2fwd \
 TESTSCRIPTS = odp_l2fwd_run.sh \
 	      odp_packet_gen_run.sh \
 	      odp_sched_latency_run.sh \
+	      odp_sched_perf_run.sh \
 	      odp_sched_pktio_run.sh \
 	      odp_scheduling_run.sh \
 	      odp_timer_perf_run.sh

--- a/test/performance/odp_sched_perf_run.sh
+++ b/test/performance/odp_sched_perf_run.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Copyright (c) 2021, Nokia
+# All rights reserved.
+#
+# SPDX-License-Identifier:	BSD-3-Clause
+#
+
+TEST_DIR="${TEST_DIR:-$(dirname $0)}"
+
+echo odp_sched_perf: buffer pool
+echo ===============================================
+
+$TEST_DIR/odp_sched_perf${EXEEXT} -p 0
+
+RET_VAL=$?
+if [ $RET_VAL -ne 0 ]; then
+	echo odp_sched_perf -p 0: FAILED
+	exit $RET_VAL
+fi
+
+echo odp_sched_perf: packet pool
+echo ===============================================
+
+$TEST_DIR/odp_sched_perf${EXEEXT} -p 1
+
+RET_VAL=$?
+if [ $RET_VAL -ne 0 ]; then
+	echo odp_sched_perf -p 1: FAILED
+	exit $RET_VAL
+fi
+
+exit 0


### PR DESCRIPTION
Add command line option '-p, --pool_type' for using a packet pool instead
of buffer pool for allocating test events.