### PR TITLE
[PATCH v2] linux-gen: ipsec: fix handling of poor quality random data

### DIFF
--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -67,7 +67,6 @@ typedef struct odp_global_data_ro_t {
 	uint8_t has_config_rt;
 	config_t libconfig_default;
 	config_t libconfig_runtime;
-	odp_random_kind_t ipsec_rand_kind;
 
 	/* Disabled features during global init */
 	struct {

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -487,6 +487,10 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 	odp_crypto_ses_create_err_t ses_create_rc;
 	const odp_crypto_key_t *salt_param = NULL;
 
+	if (!odp_ipsec_cipher_capability(param->crypto.cipher_alg, NULL, 0) ||
+	    !odp_ipsec_auth_capability(param->crypto.auth_alg, NULL, 0))
+		return ODP_IPSEC_SA_INVALID;
+
 	ipsec_sa = ipsec_sa_reserve();
 	if (NULL == ipsec_sa) {
 		ODP_ERR("No more free SA\n");


### PR DESCRIPTION
IPsec requires unpredictable IVs with several algorithms and the current
implementation uses the ODP random number generator for the generation
of such IVs. The implementation tries to use ODP_RANDOM_CRYPTO kind of
random data but settles for weaker kinds if ODP_RANDOM_CRYPTO is not
available. This can make the IVs predictable.

Fix the problem by using only cryptographically strong random data and by
disabling all algorithms that require it if it is not available.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>