### PR TITLE
[PATCH v3] api: crypto session and IPsec SA creation parameters can be fully freed afterwards

### DIFF
--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -1053,6 +1053,9 @@ int odp_crypto_auth_capability(odp_auth_alg_t auth,
  * default values. If call ends up with an error no new session will be
  * created.
  *
+ * The parameter structure as well as the key and IV data pointed to by it
+ * can be freed after the call.
+ *
  * @param      param        Session parameters
  * @param[out] session      Created session else ODP_CRYPTO_SESSION_INVALID
  * @param[out] status       Failure code if unsuccessful

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -1178,6 +1178,9 @@ void odp_ipsec_sa_param_init(odp_ipsec_sa_param_t *param);
  *
  * Create a new IPSEC SA according to the parameters.
  *
+ * The parameter structure as well as all key, address and other memory
+ * buffers pointed to by it can be freed after the call.
+ *
  * @param param   IPSEC SA parameters
  *
  * @return IPSEC SA handle


### PR DESCRIPTION
Clarify the API that session/SA creation parameters, including memory buffers pointed to be pointers in the parameter structure, can be freed after the creation call. This has been the intention of the API already. If an ODP implementation needs to remember some parameters after session creation, it must to copy them. Linux-gen already works this way.

Made crypto API validation test clear the parameters, including key data, after session creation to better catch non-compliant implementations. The PR does not have a similar patch for IPsec API validation tests as it is not as trivial to add there.