### PR TITLE
[PATCH v3] api: clarify default values that were underspecified

### DIFF
--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -149,7 +149,8 @@ typedef union odp_cls_pmr_terms_t {
 typedef struct odp_red_param_t {
 	/** A boolean to enable RED
 	 * When true, RED is enabled and configured with RED parameters.
-	 * Otherwise, RED parameters are ignored. */
+	 * Otherwise, RED parameters are ignored. Default value is false.
+	 */
 	odp_bool_t enable;
 
 	/** Threshold parameters for RED
@@ -166,7 +167,8 @@ typedef struct odp_red_param_t {
 typedef struct odp_bp_param_t {
 	/** A boolean to enable Back pressure
 	 * When true, back pressure is enabled and configured with the BP
-	 * parameters. Otherwise BP parameters are ignored.
+	 * parameters. Otherwise BP parameters are ignored. Default value
+	 * is false.
 	 */
 	odp_bool_t enable;
 
@@ -329,6 +331,8 @@ typedef struct odp_cls_cos_param {
 	 * the class of service.
 	 * Depending on the implementation this number might be rounded-off to
 	 * nearest supported value (e.g power of 2)
+	 *
+	 * Default value is 1.
 	 */
 	uint32_t num_queue;
 
@@ -695,7 +699,7 @@ typedef struct odp_pmr_param_t {
 	/** Packet Matching Rule term */
 	odp_cls_pmr_term_t  term;
 
-	/** True if the value is range and false if match */
+	/** True if the value is range and false if match. Default is false. */
 	odp_bool_t range_term;
 
 	/** Variant mappings for types of matches */

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -267,7 +267,8 @@ typedef struct odp_pktin_queue_param_t {
 	  * These are used for input queue creation in ODP_PKTIN_MODE_QUEUE
 	  * or ODP_PKTIN_MODE_SCHED modes. Scheduler parameters are considered
 	  * only in ODP_PKTIN_MODE_SCHED mode. Default values are defined in
-	  * odp_queue_param_t documentation.
+	  * odp_queue_param_t documentation. The type field is ignored
+	  * and the queue type is deduced from the pktio input mode.
 	  * When classifier is enabled in odp_pktin_queue_config() this
 	  * value is ignored. */
 	odp_queue_param_t queue_param;

--- a/test/validation/api/classification/odp_classification_basic.c
+++ b/test/validation/api/classification/odp_classification_basic.c
@@ -10,6 +10,23 @@
 
 #define PMR_SET_NUM	5
 
+static void classification_test_default_values(void)
+{
+	odp_cls_cos_param_t cos_param;
+	odp_pmr_param_t pmr_param;
+
+	memset(&cos_param, 0x55, sizeof(cos_param));
+	odp_cls_cos_param_init(&cos_param);
+	CU_ASSERT_EQUAL(cos_param.num_queue, 1);
+	CU_ASSERT_EQUAL(cos_param.red.enable, false);
+	CU_ASSERT_EQUAL(cos_param.bp.enable, false);
+	CU_ASSERT_EQUAL(cos_param.vector.enable, false);
+
+	memset(&pmr_param, 0x55, sizeof(pmr_param));
+	odp_cls_pmr_param_init(&pmr_param);
+	CU_ASSERT_EQUAL(pmr_param.range_term, false);
+}
+
 static void classification_test_create_cos(void)
 {
 	odp_cos_t cos;
@@ -326,6 +343,7 @@ static void classification_test_pmr_composite_create(void)
 }
 
 odp_testinfo_t classification_suite_basic[] = {
+	ODP_TEST_INFO(classification_test_default_values),
 	ODP_TEST_INFO(classification_test_create_cos),
 	ODP_TEST_INFO(classification_test_destroy_cos),
 	ODP_TEST_INFO(classification_test_create_pmr_match),

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1579,6 +1579,57 @@ static void pktio_test_mac(void)
 	CU_ASSERT(0 == ret);
 }
 
+static void pktio_test_default_values(void)
+{
+	odp_pktio_param_t pktio_p;
+	odp_pktin_queue_param_t qp_in;
+	odp_pktout_queue_param_t qp_out;
+	odp_pktio_config_t pktio_conf;
+
+	memset(&pktio_p, 0x55, sizeof(pktio_p));
+	odp_pktio_param_init(&pktio_p);
+	CU_ASSERT_EQUAL(pktio_p.in_mode, ODP_PKTIN_MODE_DIRECT);
+	CU_ASSERT_EQUAL(pktio_p.out_mode, ODP_PKTOUT_MODE_DIRECT);
+
+	memset(&qp_in, 0x55, sizeof(qp_in));
+	odp_pktin_queue_param_init(&qp_in);
+	CU_ASSERT_EQUAL(qp_in.op_mode, ODP_PKTIO_OP_MT);
+	CU_ASSERT_EQUAL(qp_in.classifier_enable, 0);
+	CU_ASSERT_EQUAL(qp_in.hash_enable, 0);
+	CU_ASSERT_EQUAL(qp_in.hash_proto.all_bits, 0);
+	CU_ASSERT_EQUAL(qp_in.num_queues, 1);
+	CU_ASSERT_EQUAL(qp_in.queue_param.enq_mode, ODP_QUEUE_OP_MT);
+	CU_ASSERT_EQUAL(qp_in.queue_param.sched.prio, odp_schedule_default_prio());
+	CU_ASSERT_EQUAL(qp_in.queue_param.sched.sync, ODP_SCHED_SYNC_PARALLEL);
+	CU_ASSERT_EQUAL(qp_in.queue_param.sched.group, ODP_SCHED_GROUP_ALL);
+	CU_ASSERT_EQUAL(qp_in.queue_param.sched.lock_count, 0);
+	CU_ASSERT_EQUAL(qp_in.queue_param.order, ODP_QUEUE_ORDER_KEEP);
+	CU_ASSERT_EQUAL(qp_in.queue_param.nonblocking, ODP_BLOCKING);
+	CU_ASSERT_EQUAL(qp_in.queue_param.context, NULL);
+	CU_ASSERT_EQUAL(qp_in.queue_param.context_len, 0);
+	CU_ASSERT_EQUAL(qp_in.queue_param_ovr, NULL);
+	CU_ASSERT_EQUAL(qp_in.vector.enable, false);
+
+	memset(&qp_out, 0x55, sizeof(qp_out));
+	odp_pktout_queue_param_init(&qp_out);
+	CU_ASSERT_EQUAL(qp_out.op_mode, ODP_PKTIO_OP_MT);
+	CU_ASSERT_EQUAL(qp_out.num_queues, 1);
+
+	memset(&pktio_conf, 0x55, sizeof(pktio_conf));
+	odp_pktio_config_init(&pktio_conf);
+	CU_ASSERT_EQUAL(pktio_conf.pktin.all_bits, 0);
+	CU_ASSERT_EQUAL(pktio_conf.pktout.all_bits, 0);
+	CU_ASSERT_EQUAL(pktio_conf.parser.layer, ODP_PROTO_LAYER_ALL);
+	CU_ASSERT_EQUAL(pktio_conf.enable_loop, false);
+	CU_ASSERT_EQUAL(pktio_conf.inbound_ipsec, false);
+	CU_ASSERT_EQUAL(pktio_conf.outbound_ipsec, false);
+	CU_ASSERT_EQUAL(pktio_conf.enable_lso, false);
+	CU_ASSERT_EQUAL(pktio_conf.reassembly.en_ipv4, false);
+	CU_ASSERT_EQUAL(pktio_conf.reassembly.en_ipv6, false);
+	CU_ASSERT_EQUAL(pktio_conf.reassembly.max_wait_time, 0);
+	CU_ASSERT_EQUAL(pktio_conf.reassembly.max_num_frags, 2);
+}
+
 static void pktio_test_open(void)
 {
 	odp_pktio_t pktio;
@@ -4752,6 +4803,7 @@ static int pktv_suite_term(void)
 }
 
 odp_testinfo_t pktio_suite_unsegmented[] = {
+	ODP_TEST_INFO(pktio_test_default_values),
 	ODP_TEST_INFO(pktio_test_open),
 	ODP_TEST_INFO(pktio_test_lookup),
 	ODP_TEST_INFO(pktio_test_index),


### PR DESCRIPTION
Specify that odp_pktin_queue_config() ignores the queue type passed in the parameter struct but deduces the queue type from the pktio input mode. This is the current behaviour in linux-gen and the expected behaviour in the API validation tests.

Specify a few more default values for classifier config structures. The added defaults were already assumed by the API validation tests.

Add validation tests to check the defaults.

This PR assumes that PR 1416 gets merged first (for the vector.enable default value spec).