### PR TITLE
[PATCH v1] validation: ipsec: continue tests for pktio create failure

### DIFF
--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -1274,7 +1274,6 @@ int ipsec_init(odp_instance_t *inst, odp_ipsec_op_mode_t mode)
 		pktio = pktio_create(pool);
 		if (ODP_PKTIO_INVALID == pktio) {
 			fprintf(stderr, "IPsec pktio creation failed.\n");
-			return -1;
 		}
 	}
 

--- a/test/validation/api/ipsec/ipsec_inline_in.c
+++ b/test/validation/api/ipsec/ipsec_inline_in.c
@@ -21,8 +21,6 @@ static int ipsec_sync_init(odp_instance_t *inst)
 	if (suite_context.pool == ODP_POOL_INVALID)
 		return -1;
 	suite_context.pktio = odp_pktio_lookup("loop");
-	if (suite_context.pktio == ODP_PKTIO_INVALID)
-		return -1;
 
 	return ipsec_config(*inst);
 }

--- a/test/validation/api/ipsec/ipsec_inline_out.c
+++ b/test/validation/api/ipsec/ipsec_inline_out.c
@@ -21,8 +21,6 @@ static int ipsec_sync_init(odp_instance_t *inst)
 	if (suite_context.pool == ODP_POOL_INVALID)
 		return -1;
 	suite_context.pktio = odp_pktio_lookup("loop");
-	if (suite_context.pktio == ODP_PKTIO_INVALID)
-		return -1;
 
 	return ipsec_config(*inst);
 }


### PR DESCRIPTION
As the tests would be skipped based on the pktio handle,
return success even when pktio creation fails.

Signed-off-by: Aakash Sasidharan <asasidharan@marvell.com>