### PR TITLE
[PATCH v2] linux-gen: cpu: add configuration option to use static cpu frequency

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.18"
+config_file_version = "0.1.19"
 
 # System options
 system: {
@@ -29,6 +29,14 @@ system: {
 	# odp_cpu_hz_max_id() calls on platforms where max frequency isn't
 	# available using standard Linux methods.
 	cpu_mhz_max = 1400
+
+	# When enabled (1), implementation reads the CPU frequency values from
+	# OS only once during ODP initialization. Enabling this option removes
+	# system calls from odp_cpu_hz() and odp_cpu_hz_id() implementations.
+	#
+	# NOTE: This option should only be used on systems where CPU frequency
+	# scaling is disabled.
+	cpu_hz_static = 0
 
 	# Maximum number of ODP threads that can be created.
 	# odp_thread_count_max() returns this value or the build time

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -11,26 +11,31 @@
 extern "C" {
 #endif
 
-#include <odp/api/init.h>
 #include <odp/api/cpumask.h>
+#include <odp/api/init.h>
 #include <odp/api/random.h>
 #include <odp/api/system_info.h>
-#include <sys/types.h>
+#include <odp/api/std_types.h>
+
+#include <odp_config_internal.h>
+
+#include <libconfig.h>
 #include <pthread.h>
 #include <stdint.h>
-#include <libconfig.h>
-#include <odp_config_internal.h>
+#include <sys/types.h>
 
 #define MODEL_STR_SIZE 128
 #define UID_MAXLEN 30
 
 typedef struct {
 	uint64_t cpu_hz_max[CONFIG_NUM_CPU_IDS];
+	uint64_t cpu_hz[CONFIG_NUM_CPU_IDS];
 	uint64_t default_cpu_hz_max;
 	uint64_t default_cpu_hz;
 	uint64_t page_size;
 	int      cache_line_size;
 	int      cpu_count;
+	odp_bool_t cpu_hz_static;
 	odp_cpu_arch_t cpu_arch;
 	odp_cpu_arch_isa_t cpu_isa_sw;
 	odp_cpu_arch_isa_t cpu_isa_hw;

--- a/platform/linux-generic/include/odp_sysinfo_internal.h
+++ b/platform/linux-generic/include/odp_sysinfo_internal.h
@@ -17,7 +17,6 @@ extern "C" {
 #include <string.h>
 
 int _odp_cpuinfo_parser(FILE *file, system_info_t *sysinfo);
-uint64_t odp_cpu_hz_current(int id);
 uint64_t odp_cpu_arch_hz_current(int id);
 void _odp_sys_info_print_arch(void);
 

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -3,7 +3,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [18])
+m4_define([_odp_config_version_minor], [19])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.18"
+config_file_version = "0.1.19"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/packet_align.conf
+++ b/platform/linux-generic/test/packet_align.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.18"
+config_file_version = "0.1.19"
 
 pool: {
 	pkt: {

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.18"
+config_file_version = "0.1.19"
 
 # Shared memory options
 shm: {

--- a/platform/linux-generic/test/sched-basic.conf
+++ b/platform/linux-generic/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.18"
+config_file_version = "0.1.19"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {


### PR DESCRIPTION
Add 'system:cpu_hz_static' configuration option for using a static CPU
frequency value. When enabled, CPU frequency values returned by
odp_cpu_hz() and odp_cpu_hz_id() calls are read from the OS only once
during ODP initialization. Enabling this option removes system calls from
odp_cpu_hz() and odp_cpu_hz_id() implementations.

NOTE: This option should only be used on systems where CPU frequency
scaling is disabled.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reviewed-by: Petri Savolainen <petri.savolainen@nokia.com>