### PR TITLE
[PATCH v5] api: crypto: change hash generation and verification details

### DIFF
--- a/example/ipsec_crypto/odp_ipsec_cache.c
+++ b/example/ipsec_crypto/odp_ipsec_cache.c
@@ -112,6 +112,7 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 		params.auth_key.length = auth_sa->key.length;
 		params.auth_digest_len = auth_sa->icv_len;
 		mode = auth_sa->mode;
+		params.hash_result_in_auth_range = true;
 	} else {
 		params.auth_alg = ODP_AUTH_ALG_NULL;
 	}

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
+ * Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -566,6 +567,16 @@ typedef struct odp_crypto_session_param_t {
 	 */
 	odp_bool_t auth_cipher_text;
 
+	/** Hash result location may overlap authentication range
+	 *
+	 *  This flag indicates that the hash result location may (but is
+	 *  not required to) overlap authentication range. Setting this
+	 *  flag may reduce performance.
+	 *
+	 *  Default value is false.
+	 */
+	odp_bool_t hash_result_in_auth_range;
+
 	/** Preferred sync vs. async for odp_crypto_operation()
 	 *
 	 *  The default value is ODP_CRYPTO_SYNC.
@@ -710,11 +721,17 @@ typedef struct odp_crypto_op_param_t {
 
 	/** Offset from start of packet for hash result
 	 *
-	 *  Specifies the offset where the hash result is to be stored. In case
-	 *  of decode sessions, input hash values will be read from this offset,
-	 *  and overwritten with hash results. If this offset lies within
-	 *  specified 'auth_range', implementation will mute this field before
-	 *  calculating the hash result.
+	 *  In case of decode sessions, the expected hash will be read from
+	 *  this offset and compared with the calculated hash. After the
+	 *  operation the hash bytes will have undefined values.
+	 *
+	 *  In case of encode sessions the calculated hash will be stored in
+	 *  this offset.
+	 *
+	 *  If the hash_result_in_auth_range session parameter is true,
+	 *  the hash result location may overlap auth_range. In that case
+	 *  the result location will be zeroed in decode sessions before
+	 *  hash calculation. Zeroing is not done in encode sessions.
 	 */
 	uint32_t hash_result_offset;
 
@@ -754,11 +771,17 @@ typedef struct odp_crypto_packet_op_param_t {
 
 	/** Offset from start of packet for hash result
 	 *
-	 *  Specifies the offset where the hash result is to be stored. In case
-	 *  of decode sessions, input hash values will be read from this offset,
-	 *  and overwritten with hash results. If this offset lies within
-	 *  specified 'auth_range', implementation will mute this field before
-	 *  calculating the hash result.
+	 *  In case of decode sessions, the expected hash will be read from
+	 *  this offset and compared with the calculated hash. After the
+	 *  operation the hash bytes will have undefined values.
+	 *
+	 *  In case of encode sessions the calculated hash will be stored in
+	 *  this offset.
+	 *
+	 *  If the hash_result_not_in_auth_range session parameter is false,
+	 *  the hash result location may overlap auth_range. In that case the
+	 *  result location will be zeroed in decode sessions before hash
+	 *  calculation. Zeroing is not done in encode sessions.
 	 */
 	uint32_t hash_result_offset;
 

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
+ * Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -509,8 +509,8 @@ auth_xcbcmac_check(odp_packet_t pkt,
 	odp_packet_copy_to_mem(pkt, param->hash_result_offset,
 			       bytes, hash_in);
 
-	_odp_packet_set_data(pkt, param->hash_result_offset,
-			     0, bytes);
+	if (odp_unlikely(session->p.hash_result_in_auth_range))
+		_odp_packet_set_data(pkt, param->hash_result_offset, 0, bytes);
 
 	/* Hash it */
 	packet_aes_xcbc_mac(pkt, param, session, hash_out);
@@ -591,8 +591,8 @@ odp_crypto_alg_err_t auth_hmac_check(odp_packet_t pkt,
 	odp_packet_copy_to_mem(pkt, param->hash_result_offset,
 			       bytes, hash_in);
 
-	_odp_packet_set_data(pkt, param->hash_result_offset,
-			     0, bytes);
+	if (odp_unlikely(session->p.hash_result_in_auth_range))
+		_odp_packet_set_data(pkt, param->hash_result_offset, 0, bytes);
 
 	/* Hash it */
 	packet_hmac(pkt, param, session, hash_out);
@@ -678,8 +678,8 @@ odp_crypto_alg_err_t auth_cmac_check(odp_packet_t pkt,
 	odp_packet_copy_to_mem(pkt, param->hash_result_offset,
 			       bytes, hash_in);
 
-	_odp_packet_set_data(pkt, param->hash_result_offset,
-			     0, bytes);
+	if (odp_unlikely(session->p.hash_result_in_auth_range))
+		_odp_packet_set_data(pkt, param->hash_result_offset, 0, bytes);
 
 	/* Hash it */
 	packet_cmac(pkt, param, session, hash_out);
@@ -772,8 +772,8 @@ odp_crypto_alg_err_t auth_cmac_eia2_check(odp_packet_t pkt,
 	odp_packet_copy_to_mem(pkt, param->hash_result_offset,
 			       bytes, hash_in);
 
-	_odp_packet_set_data(pkt, param->hash_result_offset,
-			     0, bytes);
+	if (odp_unlikely(session->p.hash_result_in_auth_range))
+		_odp_packet_set_data(pkt, param->hash_result_offset, 0, bytes);
 
 	/* Hash it */
 	ret = packet_cmac_eia2(pkt, param, session, hash_out);
@@ -851,8 +851,8 @@ odp_crypto_alg_err_t auth_digest_check(odp_packet_t pkt,
 	odp_packet_copy_to_mem(pkt, param->hash_result_offset,
 			       bytes, hash_in);
 
-	_odp_packet_set_data(pkt, param->hash_result_offset,
-			     0, bytes);
+	if (odp_unlikely(session->p.hash_result_in_auth_range))
+		_odp_packet_set_data(pkt, param->hash_result_offset, 0, bytes);
 
 	/* Hash it */
 	packet_digest(pkt, param, session, hash_out);
@@ -1455,8 +1455,9 @@ odp_crypto_alg_err_t aes_gmac_check(odp_packet_t pkt,
 			       session->p.auth_digest_len, block);
 	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG,
 			    session->p.auth_digest_len, block);
-	_odp_packet_set_data(pkt, param->hash_result_offset,
-			     0, session->p.auth_digest_len);
+	if (odp_unlikely(session->p.hash_result_in_auth_range))
+		_odp_packet_set_data(pkt, param->hash_result_offset,
+				     0, session->p.auth_digest_len);
 
 	ret = internal_aad(ctx, pkt, param, false);
 

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -624,6 +624,8 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 			ODP_CRYPTO_OP_DECODE :
 			ODP_CRYPTO_OP_ENCODE;
 	crypto_param.auth_cipher_text = 1;
+	if (param->proto == ODP_IPSEC_AH)
+		crypto_param.hash_result_in_auth_range = 1;
 
 	crypto_param.op_mode   = ODP_CRYPTO_SYNC;
 	crypto_param.compl_queue = ODP_QUEUE_INVALID;


### PR DESCRIPTION
Make hash generation and verification spec match linux-gen implementation.
In particular: After verification, the hash field in the packet is left
to undefined value, not the calculated hash value and in generation the
hash field is not cleared before the hash calculation.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>