### PR TITLE
[PATCH v2] configure: move openssl options under linux-gen platform

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -324,37 +324,6 @@ then
 fi
 
 ##########################################################################
-# Configure/disable usage of OpenSSL library
-##########################################################################
-AC_ARG_WITH([openssl],
-	    [AS_HELP_STRING([--without-openssl],
-			    [compile without OpenSSL (may result in disabled crypto and random support)]
-			    [[default=with]])],
-	    [],
-	    [with_openssl=yes])
-AS_IF([test "$with_openssl" != "no"],
-      [ODP_OPENSSL
-       have_openssl=1], [have_openssl=0])
-AM_CONDITIONAL([WITH_OPENSSL], [test x$with_openssl != xno])
-AC_DEFINE_UNQUOTED([_ODP_OPENSSL], [$have_openssl],
-	  [Define to 1 to enable OpenSSL support])
-
-have_openssl_rand=1
-AC_ARG_ENABLE([openssl-rand],
-	[AS_HELP_STRING([--disable-openssl-rand],
-			[Disable OpenSSL random data (use arch-specific instead)]
-			[[default=enabled]])],
-	[if test "x$enableval" = "xno"; then
-		have_openssl_rand=0
-	fi])
-
-AS_IF([test "$have_openssl" != "1"], [have_openssl_rand=0])
-AS_IF([test "$have_openssl_rand" = "1"], [openssl_rand=yes], [openssl_rand=no])
-
-AC_DEFINE_UNQUOTED([_ODP_OPENSSL_RAND], [$have_openssl_rand],
-	  [Define to 1 to enable OpenSSL support])
-
-##########################################################################
 # Include m4 files
 ##########################################################################
 m4_include([./doc/m4/configure.m4])
@@ -537,8 +506,6 @@ AC_MSG_RESULT([
 	includedir:		${includedir}
 	testdir:		${testdir}
 	WITH_ARCH:              ${WITH_ARCH}
-	with_openssl:           ${with_openssl}
-	openssl_rand:           ${openssl_rand}
 
 	cc:			${CC}
 	cc version:             ${CC_VERSION}
@@ -569,7 +536,3 @@ AC_MSG_RESULT([
 	user_guides:		${user_guides}
 ${PLAT_CFG_TEXT}
 ])
-
-AS_IF([test "${with_openssl}" = "no"],
-      [AC_MSG_WARN([Strong cryptography is not available without OpenSSL])]
-      )

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -23,6 +23,7 @@ AM_CONDITIONAL([ODP_PKTIO_PCAP], [test x$have_pcap = xyes])
 ])
 
 m4_include([platform/linux-generic/m4/odp_libconfig.m4])
+m4_include([platform/linux-generic/m4/odp_openssl.m4])
 m4_include([platform/linux-generic/m4/odp_pcapng.m4])
 m4_include([platform/linux-generic/m4/odp_netmap.m4])
 m4_include([platform/linux-generic/m4/odp_dpdk.m4])
@@ -33,6 +34,8 @@ AS_VAR_APPEND([PLAT_DEP_LIBS], ["${ATOMIC_LIBS} ${LIBCONFIG_LIBS} ${OPENSSL_LIBS
 # Add text to the end of configure with platform specific settings.
 # Make sure it's aligned same as other lines in configure.ac.
 AS_VAR_APPEND([PLAT_CFG_TEXT], ["
+	openssl:                ${with_openssl}
+	openssl_rand:           ${openssl_rand}
 	pcap:			${have_pcap}
 	pcapng:			${have_pcapng}
 	default_config_path:	${default_config_path}"])

--- a/platform/linux-generic/m4/odp_openssl.m4
+++ b/platform/linux-generic/m4/odp_openssl.m4
@@ -1,0 +1,36 @@
+##########################################################################
+# Enable/disable usage of OpenSSL library
+##########################################################################
+AC_ARG_WITH([openssl],
+	    [AS_HELP_STRING([--without-openssl],
+			    [compile without OpenSSL (may result in disabled crypto and random support)]
+			    [[default=with] (linux-generic)])],
+	    [],
+	    [with_openssl=yes])
+AS_IF([test "$with_openssl" != "no"],
+      [ODP_OPENSSL
+       have_openssl=1], [have_openssl=0])
+AM_CONDITIONAL([WITH_OPENSSL], [test x$with_openssl != xno])
+AC_DEFINE_UNQUOTED([_ODP_OPENSSL], [$have_openssl],
+	  [Define to 1 to enable OpenSSL support])
+
+AS_IF([test "${with_openssl}" = "no"],
+      [AC_MSG_WARN([Strong cryptography is not available without OpenSSL])])
+
+##########################################################################
+# Enable/disable usage of OpenSSL for random data
+##########################################################################
+have_openssl_rand=1
+AC_ARG_ENABLE([openssl-rand],
+	[AS_HELP_STRING([--disable-openssl-rand],
+			[disable OpenSSL random data (use arch-specific instead)]
+			[[default=enabled] (linux-generic)])],
+	[if test "x$enableval" = "xno"; then
+		have_openssl_rand=0
+	fi])
+
+AS_IF([test "$have_openssl" != "1"], [have_openssl_rand=0])
+AS_IF([test "$have_openssl_rand" = "1"], [openssl_rand=yes], [openssl_rand=no])
+
+AC_DEFINE_UNQUOTED([_ODP_OPENSSL_RAND], [$have_openssl_rand],
+	  [Define to 1 to enable OpenSSL support])


### PR DESCRIPTION
OpenSSL crypto and random implementations are platform specific, so move
the configuration options under linux-genec platform.

Signed-off-by: Matias Elo <matias.elo@nokia.com>