### PR TITLE
[PATCH v2] checkpatch: fix ARRAY_SIZE ignore option

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,17 +1,15 @@
 --no-tree
 --strict
 --ignore=SPLIT_STRING
---ignore SSCANF_TO_KSTRTO
+--ignore=SSCANF_TO_KSTRTO
 --ignore=NEW_TYPEDEFS
 --ignore=DEPRECATED_VARIABLE
 --ignore=COMPARISON_TO_NULL
 --ignore=BIT_MACRO
---ignore=PREFER_PRINTF
---ignore=PREFER_SCANF
 --ignore=VOLATILE
 --ignore=AVOID_EXTERNS
 --ignore=CONST_STRUCT
---ignore=PREFER_ARRAY_SIZE
+--ignore=ARRAY_SIZE
 --ignore=PREFER_KERNEL_TYPES
 --ignore=CONSTANT_COMPARISON
 --ignore=BLOCK_COMMENT_STYLE


### PR DESCRIPTION
```
The checkpatch ignore option is ARRAY_SIZE, not
PREFER_ARRAY_SIZE. Also, PREFER_PRINTF and PREFER_SCANF don't exist
anymore, remove those.

Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```