### PR TITLE
[PATCH v3] validation: atomic: some improvements

### DIFF
--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -41,54 +41,22 @@ typedef struct {
 	odp_atomic_u32_t a32u_xchg;
 
 	uint32_t g_num_threads;
-	uint32_t g_iterations;
-	uint32_t g_verbose;
 
 	odp_barrier_t global_barrier;
 } global_shared_mem_t;
-
-/* Per-thread memory */
-typedef struct {
-	global_shared_mem_t *global_mem;
-
-	int thread_id;
-	int thread_core;
-
-	volatile_u64_t delay_counter;
-} per_thread_mem_t;
 
 static odp_shm_t global_shm;
 static global_shared_mem_t *global_mem;
 
 /* Initialise per-thread memory */
-static per_thread_mem_t *thread_init(void)
+static void thread_init(void)
 {
 	global_shared_mem_t *global_mem;
-	per_thread_mem_t *per_thread_mem;
 	odp_shm_t global_shm;
-	uint32_t per_thread_mem_len;
-
-	per_thread_mem_len = sizeof(per_thread_mem_t);
-	per_thread_mem = malloc(per_thread_mem_len);
-	memset(per_thread_mem, 0, per_thread_mem_len);
-
-	per_thread_mem->delay_counter = 1;
-
-	per_thread_mem->thread_id = odp_thread_id();
-	per_thread_mem->thread_core = odp_cpu_id();
 
 	global_shm = odp_shm_lookup(GLOBAL_SHM_NAME);
 	global_mem = odp_shm_addr(global_shm);
 	CU_ASSERT_PTR_NOT_NULL(global_mem);
-
-	per_thread_mem->global_mem = global_mem;
-
-	return per_thread_mem;
-}
-
-static void thread_finalize(per_thread_mem_t *per_thread_mem)
-{
-	free(per_thread_mem);
 }
 
 static void test_atomic_inc_32(void)
@@ -846,8 +814,6 @@ static int atomic_init(odp_instance_t *inst)
 	memset(global_mem, 0, sizeof(global_shared_mem_t));
 
 	global_mem->g_num_threads = MAX_WORKERS;
-	global_mem->g_iterations = MAX_ITERATIONS;
-	global_mem->g_verbose = VERBOSE;
 
 	workers_count = odp_cpumask_default_worker(&mask, 0);
 
@@ -896,131 +862,91 @@ static int atomic_term(odp_instance_t inst)
 /* Atomic tests */
 static int test_atomic_inc_dec_thread(void *arg UNUSED)
 {
-	per_thread_mem_t *per_thread_mem;
-
-	per_thread_mem = thread_init();
+	thread_init();
 	test_atomic_inc_dec_32();
 	test_atomic_inc_dec_64();
-
-	thread_finalize(per_thread_mem);
 
 	return CU_get_number_of_failures();
 }
 
 static int test_atomic_add_sub_thread(void *arg UNUSED)
 {
-	per_thread_mem_t *per_thread_mem;
-
-	per_thread_mem = thread_init();
+	thread_init();
 	test_atomic_add_sub_32();
 	test_atomic_add_sub_64();
-
-	thread_finalize(per_thread_mem);
 
 	return CU_get_number_of_failures();
 }
 
 static int test_atomic_fetch_inc_dec_thread(void *arg UNUSED)
 {
-	per_thread_mem_t *per_thread_mem;
-
-	per_thread_mem = thread_init();
+	thread_init();
 	test_atomic_fetch_inc_dec_32();
 	test_atomic_fetch_inc_dec_64();
-
-	thread_finalize(per_thread_mem);
 
 	return CU_get_number_of_failures();
 }
 
 static int test_atomic_fetch_add_sub_thread(void *arg UNUSED)
 {
-	per_thread_mem_t *per_thread_mem;
-
-	per_thread_mem = thread_init();
+	thread_init();
 	test_atomic_fetch_add_sub_32();
 	test_atomic_fetch_add_sub_64();
-
-	thread_finalize(per_thread_mem);
 
 	return CU_get_number_of_failures();
 }
 
 static int test_atomic_inc_add_thread(void *arg UNUSED)
 {
-	per_thread_mem_t *per_thread_mem;
-
-	per_thread_mem = thread_init();
+	thread_init();
 	test_atomic_inc_add_32();
 	test_atomic_inc_add_64();
-
-	thread_finalize(per_thread_mem);
 
 	return CU_get_number_of_failures();
 }
 
 static int test_atomic_dec_sub_thread(void *arg UNUSED)
 {
-	per_thread_mem_t *per_thread_mem;
-
-	per_thread_mem = thread_init();
+	thread_init();
 	test_atomic_dec_sub_32();
 	test_atomic_dec_sub_64();
-
-	thread_finalize(per_thread_mem);
 
 	return CU_get_number_of_failures();
 }
 
 static int test_atomic_max_min_thread(void *arg UNUSED)
 {
-	per_thread_mem_t *per_thread_mem;
-
-	per_thread_mem = thread_init();
+	thread_init();
 	test_atomic_max_min_32();
 	test_atomic_max_min_64();
-
-	thread_finalize(per_thread_mem);
 
 	return CU_get_number_of_failures();
 }
 
 static int test_atomic_cas_inc_dec_thread(void *arg UNUSED)
 {
-	per_thread_mem_t *per_thread_mem;
-
-	per_thread_mem = thread_init();
+	thread_init();
 	test_atomic_cas_inc_dec_32();
 	test_atomic_cas_inc_dec_64();
 	test_atomic_cas_inc_128();
-
-	thread_finalize(per_thread_mem);
 
 	return CU_get_number_of_failures();
 }
 
 static int test_atomic_xchg_thread(void *arg UNUSED)
 {
-	per_thread_mem_t *per_thread_mem;
-
-	per_thread_mem = thread_init();
+	thread_init();
 	test_atomic_xchg_32();
 	test_atomic_xchg_64();
-
-	thread_finalize(per_thread_mem);
 
 	return CU_get_number_of_failures();
 }
 
 static int test_atomic_non_relaxed_thread(void *arg UNUSED)
 {
-	per_thread_mem_t *per_thread_mem;
-
-	per_thread_mem = thread_init();
+	thread_init();
 	test_atomic_non_relaxed_32();
 	test_atomic_non_relaxed_64();
-
-	thread_finalize(per_thread_mem);
 
 	return CU_get_number_of_failures();
 }

--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -721,10 +721,13 @@ static void test_atomic_validate_max_min(void)
 {
 	test_atomic_validate_init_val();
 
-	CU_ASSERT(odp_atomic_load_u32(&global_mem->a32u_max) >
-		  odp_atomic_load_u32(&global_mem->a32u_min));
-	CU_ASSERT(odp_atomic_load_u64(&global_mem->a64u_max) >
-		  odp_atomic_load_u64(&global_mem->a64u_min));
+	const uint64_t total_count = CNT * global_mem->g_num_threads;
+
+	/* Max is the result of fetch_inc, so the final max value is total_count - 1. */
+	CU_ASSERT(odp_atomic_load_u32(&global_mem->a32u_max) == U32_INIT_VAL + total_count - 1);
+	CU_ASSERT(odp_atomic_load_u32(&global_mem->a32u_min) == U32_INIT_VAL);
+	CU_ASSERT(odp_atomic_load_u64(&global_mem->a64u_max) == U64_INIT_VAL + total_count - 1);
+	CU_ASSERT(odp_atomic_load_u64(&global_mem->a64u_min) == U64_INIT_VAL);
 }
 
 static void test_atomic_validate_xchg(void)
@@ -739,8 +742,14 @@ static void test_atomic_validate_xchg(void)
 
 static void test_atomic_validate_non_relaxed(void)
 {
-	test_atomic_validate_max_min();
 	test_atomic_validate_xchg();
+
+	const uint64_t total_count = CNT * global_mem->g_num_threads;
+
+	CU_ASSERT(odp_atomic_load_u32(&global_mem->a32u_max) == U32_INIT_VAL + total_count);
+	CU_ASSERT(odp_atomic_load_u32(&global_mem->a32u_min) == U32_INIT_VAL - total_count);
+	CU_ASSERT(odp_atomic_load_u64(&global_mem->a64u_max) == U64_INIT_VAL + total_count);
+	CU_ASSERT(odp_atomic_load_u64(&global_mem->a64u_min) == U64_INIT_VAL - total_count);
 }
 
 static int atomic_init(odp_instance_t *inst)

--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -445,9 +445,7 @@ static void test_atomic_non_relaxed_32(void)
 			;
 
 		tmp = odp_atomic_load_u32(a32u_xchg);
-		/* finally set value for validation */
-		while (odp_atomic_cas_acq_rel_u32(a32u_xchg, &tmp, U32_MAGIC)
-		       == 0)
+		while (odp_atomic_cas_acq_rel_u32(a32u_xchg, &tmp, tmp + 1) == 0)
 			;
 	}
 }
@@ -482,9 +480,7 @@ static void test_atomic_non_relaxed_64(void)
 			;
 
 		tmp = odp_atomic_load_u64(a64u_xchg);
-		/* finally set value for validation */
-		while (odp_atomic_cas_acq_rel_u64(a64u_xchg, &tmp, U64_MAGIC)
-		       == 0)
+		while (odp_atomic_cas_acq_rel_u64(a64u_xchg, &tmp, tmp + 1) == 0)
 			;
 	}
 }
@@ -802,10 +798,11 @@ static void test_atomic_validate_non_relaxed(void)
 {
 	test_atomic_validate_init_val();
 
-	CU_ASSERT(odp_atomic_load_u32(&global_mem->a32u_xchg) == U32_MAGIC);
-	CU_ASSERT(odp_atomic_load_u64(&global_mem->a64u_xchg) == U64_MAGIC);
-
 	const uint64_t total_count = CNT * global_mem->g_num_threads;
+
+	/* 3 increments per round. */
+	CU_ASSERT(odp_atomic_load_u32(&global_mem->a32u_xchg) == U32_INIT_VAL + 3 * total_count);
+	CU_ASSERT(odp_atomic_load_u64(&global_mem->a64u_xchg) == U64_INIT_VAL + 3 * total_count);
 
 	CU_ASSERT(odp_atomic_load_u32(&global_mem->a32u_max) == U32_INIT_VAL + total_count);
 	CU_ASSERT(odp_atomic_load_u32(&global_mem->a32u_min) == U32_INIT_VAL - total_count);

--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
+ * Copyright (c) 2021 Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:	 BSD-3-Clause
@@ -16,7 +17,7 @@
 
 #define ADD_SUB_CNT		5
 
-#define CNT			50000
+#define CNT			100000
 #define U32_INIT_VAL		(1UL << 28)
 #define U64_INIT_VAL		(1ULL << 33)
 #define U32_MAGIC		0xa23f65b2

--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -619,6 +619,42 @@ static void test_atomic_fetch_add_sub_64(void)
 	test_atomic_fetch_sub_64();
 }
 
+static void test_atomic_inc_add_32(void)
+{
+	test_atomic_inc_32();
+	test_atomic_fetch_inc_32();
+	test_atomic_add_32();
+	test_atomic_fetch_add_32();
+	test_atomic_cas_inc_32();
+}
+
+static void test_atomic_inc_add_64(void)
+{
+	test_atomic_inc_64();
+	test_atomic_fetch_inc_64();
+	test_atomic_add_64();
+	test_atomic_fetch_add_64();
+	test_atomic_cas_inc_64();
+}
+
+static void test_atomic_dec_sub_32(void)
+{
+	test_atomic_dec_32();
+	test_atomic_fetch_dec_32();
+	test_atomic_sub_32();
+	test_atomic_fetch_sub_32();
+	test_atomic_cas_dec_32();
+}
+
+static void test_atomic_dec_sub_64(void)
+{
+	test_atomic_dec_64();
+	test_atomic_fetch_dec_64();
+	test_atomic_sub_64();
+	test_atomic_fetch_sub_64();
+	test_atomic_cas_dec_64();
+}
+
 static void test_atomic_max_min_32(void)
 {
 	test_atomic_max_32();
@@ -705,6 +741,28 @@ static void test_atomic_validate_init_val(void)
 {
 	test_atomic_validate_init_val_32_64();
 	test_atomic_validate_init_val_128();
+}
+
+static void test_atomic_validate_inc_add(void)
+{
+	test_atomic_validate_init_val_128();
+
+	/* Two increment tests, one cas increment test and two add tests. */
+	const uint64_t total_count = CNT * (3 + 2 * ADD_SUB_CNT) * global_mem->g_num_threads;
+
+	CU_ASSERT(U32_INIT_VAL + total_count == odp_atomic_load_u32(&global_mem->a32u));
+	CU_ASSERT(U64_INIT_VAL + total_count == odp_atomic_load_u64(&global_mem->a64u));
+}
+
+static void test_atomic_validate_dec_sub(void)
+{
+	test_atomic_validate_init_val_128();
+
+	/* Two decrement tests, one cas decrement test and two sub tests. */
+	const uint64_t total_count = CNT * (3 + 2 * ADD_SUB_CNT) * global_mem->g_num_threads;
+
+	CU_ASSERT(U32_INIT_VAL - total_count == odp_atomic_load_u32(&global_mem->a32u));
+	CU_ASSERT(U64_INIT_VAL - total_count == odp_atomic_load_u64(&global_mem->a64u));
 }
 
 static void test_atomic_validate_cas(void)
@@ -882,6 +940,32 @@ static int test_atomic_fetch_add_sub_thread(void *arg UNUSED)
 	per_thread_mem = thread_init();
 	test_atomic_fetch_add_sub_32();
 	test_atomic_fetch_add_sub_64();
+
+	thread_finalize(per_thread_mem);
+
+	return CU_get_number_of_failures();
+}
+
+static int test_atomic_inc_add_thread(void *arg UNUSED)
+{
+	per_thread_mem_t *per_thread_mem;
+
+	per_thread_mem = thread_init();
+	test_atomic_inc_add_32();
+	test_atomic_inc_add_64();
+
+	thread_finalize(per_thread_mem);
+
+	return CU_get_number_of_failures();
+}
+
+static int test_atomic_dec_sub_thread(void *arg UNUSED)
+{
+	per_thread_mem_t *per_thread_mem;
+
+	per_thread_mem = thread_init();
+	test_atomic_dec_sub_32();
+	test_atomic_dec_sub_64();
 
 	thread_finalize(per_thread_mem);
 
@@ -1123,6 +1207,16 @@ static void atomic_test_atomic_fetch_add_sub(void)
 	test_atomic_functional(test_atomic_fetch_add_sub_thread, test_atomic_validate_init_val);
 }
 
+static void atomic_test_atomic_inc_add(void)
+{
+	test_atomic_functional(test_atomic_inc_add_thread, test_atomic_validate_inc_add);
+}
+
+static void atomic_test_atomic_dec_sub(void)
+{
+	test_atomic_functional(test_atomic_dec_sub_thread, test_atomic_validate_dec_sub);
+}
+
 static void atomic_test_atomic_max_min(void)
 {
 	test_atomic_functional(test_atomic_max_min_thread, test_atomic_validate_max_min);
@@ -1156,6 +1250,8 @@ odp_testinfo_t atomic_suite_atomic[] = {
 	ODP_TEST_INFO(atomic_test_atomic_add_sub),
 	ODP_TEST_INFO(atomic_test_atomic_fetch_inc_dec),
 	ODP_TEST_INFO(atomic_test_atomic_fetch_add_sub),
+	ODP_TEST_INFO(atomic_test_atomic_inc_add),
+	ODP_TEST_INFO(atomic_test_atomic_dec_sub),
 	ODP_TEST_INFO(atomic_test_atomic_max_min),
 	ODP_TEST_INFO(atomic_test_atomic_cas_inc_dec),
 	ODP_TEST_INFO(atomic_test_atomic_xchg),


### PR DESCRIPTION
```
validation: atomic: break validation function into multiple functions
    
    Break the validation function into multiple separate validation
    functions. This way existing code (the single validation function)
    doesn't need to be changed when adding new tests.

validation: atomic: validate max and min values
    
    Validate the resulting max and min values, instead of just max > min.
    
validation: atomic: add increment/add and decrement/sub tests
    
    Test increments and adds separately from decrements and subs. This is
    in addition to the existing tests, which test that a counter reaches
    its starting value after matching increments and decrements, and after
    matching adds and subs.
    
validation: atomic: test xchg operations with random data
    
    Add a new test, which uses random bytes with xchg operations and
    counts the sums of the input and output values of xchg operations. The
    difference of those sums must be equal to the initial value of the
    atomic variable.

validation: atomic: validate resulting value from cas operations
    
    Validate the resulting value from cas operations, instead of just a
    magic number set at the end of the test.
```

v2:
- Increase test rounds.
- Remove unused global and thread specific data.
- Tuomas' comments.
