### PR TITLE
[PATCH v3] example: ipsec_crypto: fix outbound ESP processing to not reuse IVs

### DIFF
--- a/example/ipsec_crypto/odp_ipsec.c
+++ b/example/ipsec_crypto/odp_ipsec.c
@@ -974,20 +974,9 @@ pkt_disposition_e do_ipsec_out_seq(odp_packet_t *pkt,
 	}
 	if (ctx->ipsec.tun_hdr_offset) {
 		odph_ipv4hdr_t *ip;
-		int ret;
 
 		ip = (odph_ipv4hdr_t *)(ctx->ipsec.tun_hdr_offset + buf);
 		ip->id = odp_cpu_to_be_16((*ctx->ipsec.tun_hdr_id)++);
-		if (!ip->id) {
-			/* re-init tunnel hdr id */
-			ret = odp_random_data((uint8_t *)ctx->ipsec.tun_hdr_id,
-					      sizeof(*ctx->ipsec.tun_hdr_id),
-					      1);
-			if (ret != sizeof(*ctx->ipsec.tun_hdr_id)) {
-				ODPH_ERR("Error: Not enough random data\n");
-				exit(EXIT_FAILURE);
-			}
-		}
 	}
 
 	out_pkt = entry->in_place ? *pkt : ODP_PACKET_INVALID;

--- a/example/ipsec_crypto/odp_ipsec.c
+++ b/example/ipsec_crypto/odp_ipsec.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -772,6 +773,20 @@ pkt_disposition_e do_ipsec_in_finish(odp_packet_t pkt,
 	return PKT_CONTINUE;
 }
 
+static int generate_iv(uint8_t *buf, uint32_t size)
+{
+	uint32_t n = 0;
+	int32_t ret;
+
+	while (n < size) {
+		ret = odp_random_data(buf + n, size - n, ODP_RANDOM_CRYPTO);
+		if (ret < 0)
+			return 1;
+		n += ret;
+	}
+	return 0;
+}
+
 /**
  * Packet Processing - Output IPsec packet classification
  *
@@ -859,7 +874,9 @@ pkt_disposition_e do_ipsec_out_classify(odp_packet_t pkt,
 		trl_len = encrypt_len - ip_data_len;
 
 		esp->spi = odp_cpu_to_be_32(entry->esp.spi);
-		memcpy(esp + 1, entry->state.iv, entry->esp.iv_len);
+		if (generate_iv(esp->iv, entry->esp.iv_len))
+			return PKT_DROP;
+		params.cipher_iv_ptr = esp->iv;
 
 		esp_t = (odph_esptrl_t *)(ip_data + encrypt_len) - 1;
 		esp_t->pad_len     = trl_len - sizeof(*esp_t);

--- a/example/ipsec_crypto/odp_ipsec_cache.c
+++ b/example/ipsec_crypto/odp_ipsec_cache.c
@@ -56,6 +56,7 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 	odp_crypto_ses_create_err_t ses_create_rc;
 	odp_crypto_session_t session;
 	sa_mode_t mode = IPSEC_SA_MODE_TRANSPORT;
+	uint8_t unused_iv[cipher_sa ? cipher_sa->iv_len : 1];
 
 	/* Verify we have a good entry */
 	entry = &ipsec_cache->array[ipsec_cache->index];
@@ -95,7 +96,7 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 		params.cipher_alg  = cipher_sa->alg.u.cipher;
 		params.cipher_key.data  = cipher_sa->key.data;
 		params.cipher_key.length  = cipher_sa->key.length;
-		params.cipher_iv.data = entry->state.iv;
+		params.cipher_iv.data = unused_iv;
 		params.cipher_iv.length = cipher_sa->iv_len;
 		mode = cipher_sa->mode;
 	} else {
@@ -113,15 +114,6 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 		mode = auth_sa->mode;
 	} else {
 		params.auth_alg = ODP_AUTH_ALG_NULL;
-	}
-
-	/* Generate an IV */
-	if (params.cipher_iv.length) {
-		int32_t size = params.cipher_iv.length;
-
-		int32_t ret = odp_random_data(params.cipher_iv.data, size, 1);
-		if (ret != size)
-			return -1;
 	}
 
 	/* Synchronous session create for now */

--- a/example/ipsec_crypto/odp_ipsec_cache.h
+++ b/example/ipsec_crypto/odp_ipsec_cache.h
@@ -57,7 +57,6 @@ typedef struct ipsec_cache_entry_s {
 		odp_crypto_session_t session;  /**< Crypto session handle */
 		uint32_t      esp_seq;         /**< ESP TX sequence number */
 		uint32_t      ah_seq;          /**< AH TX sequence number */
-		uint8_t       iv[MAX_IV_LEN];  /**< ESP IV storage */
 		odp_u16be_t    tun_hdr_id;     /**< Tunnel header IP ID */
 	} state;
 } ipsec_cache_entry_t;

--- a/example/ipsec_crypto/odp_ipsec_misc.h
+++ b/example/ipsec_crypto/odp_ipsec_misc.h
@@ -24,7 +24,6 @@ extern "C" {
 #define MAX_DB          32   /**< maximum number of data base entries */
 #define MAX_LOOPBACK    10   /**< maximum number of loop back interfaces */
 #define MAX_STRING      32   /**< maximum string length */
-#define MAX_IV_LEN      32   /**< Maximum IV length in bytes */
 
 #define KEY_BITS_3DES       192  /**< 3DES cipher key length in bits */
 #define KEY_BITS_MD5_96     128  /**< MD5_96 auth key length in bits */


### PR DESCRIPTION
Reusing the same ESP IV within the same SA should not be done. Fix the code to not reuse pre-generated IVs but generate a new random IV for every outbound ESP packet.

Somewhat related to this, I am working on a crypto API change proposal to remove per-session IVs altogether (i.e. require an IV for every packet in the per-crypto-operation parameters), as the per-session IVs are rarely, if ever, used as opposed to per-packet IVs. I will submit a separate PR on that later.

Another change in this PR is simple removal of unnecessary tunnel header IP ID randomization after ID wrap-around.