### PR TITLE
[PATCH v3] linux-gen: shm: stop listing deprecated ODP_SHM_SW_ONLY flag as supported

### DIFF
--- a/platform/linux-generic/odp_shared_memory.c
+++ b/platform/linux-generic/odp_shared_memory.c
@@ -8,6 +8,7 @@
 #include <odp_config_internal.h>
 #include <odp_debug_internal.h>
 #include <odp/api/debug.h>
+#include <odp/api/deprecated.h>
 #include <odp/api/std_types.h>
 #include <odp/api/shared_memory.h>
 #include <odp/api/plat/strong_types.h>
@@ -17,8 +18,14 @@
 #include <string.h>
 
 /* Supported ODP_SHM_* flags */
-#define SUPPORTED_SHM_FLAGS (ODP_SHM_SW_ONLY | ODP_SHM_PROC | ODP_SHM_SINGLE_VA | ODP_SHM_EXPORT | \
-			     ODP_SHM_HP | ODP_SHM_NO_HP)
+#if ODP_DEPRECATED_API
+	#define DEPRECATED_SHM_FLAGS (ODP_SHM_SW_ONLY)
+#else
+	#define DEPRECATED_SHM_FLAGS 0
+#endif
+
+#define SUPPORTED_SHM_FLAGS (ODP_SHM_PROC | ODP_SHM_SINGLE_VA | ODP_SHM_EXPORT | \
+			     ODP_SHM_HP | ODP_SHM_NO_HP | DEPRECATED_SHM_FLAGS)
 
 static inline uint32_t from_handle(odp_shm_t shm)
 {

--- a/test/performance/odp_random.c
+++ b/test/performance/odp_random.c
@@ -336,7 +336,7 @@ int main(int argc, char **argv)
 
 	test_shm_t *shm = NULL;
 	odp_shm_t shm_hdl = odp_shm_reserve(shm_name, sizeof(test_shm_t), 64,
-					    ODP_SHM_SW_ONLY);
+					    0);
 
 	if (shm_hdl != ODP_SHM_INVALID)
 		shm = (test_shm_t *)odp_shm_addr(shm_hdl);


### PR DESCRIPTION
Stop listing deprecated SHM flag ODP_SHM_SW_ONLY as supported as it is no
longer used by any example applications or tests.

V2:
- Enable usage of `ODP_SHM_SW_ONLY` flag with `--enable-deprecated` configuration option (Janne)