### PR TITLE
[PATCH v7] random data improvements and tests

### DIFF
--- a/platform/linux-generic/odp_random_std.c
+++ b/platform/linux-generic/odp_random_std.c
@@ -4,52 +4,88 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp_posix_extensions.h>
-#include <stdint.h>
-#include <stdlib.h>
 #include <odp/api/byteorder.h>
 #include <odp/api/cpu.h>
 #include <odp/api/debug.h>
 #include <odp_init_internal.h>
 #include <odp_random_std_internal.h>
+#include <odp_cpu.h>
 
+#include <stdint.h>
 #include <time.h>
 
-/* Assume at least two rand bytes are available and RAND_MAX is power of two - 1 */
-ODP_STATIC_ASSERT(RAND_MAX >= UINT16_MAX, "RAND_MAX too small");
-ODP_STATIC_ASSERT((RAND_MAX & (RAND_MAX + 1ULL))  ==  0, "RAND_MAX not power of two - 1");
-
-static int32_t _random_data(uint8_t *buf, uint32_t len, uint32_t *seed)
+/*
+ * Xorshift64*, adapted from [1], and modified to return only the high 32 bits.
+ *
+ * [1] An experimental exploration of Marsaglia's xorshift generators, scrambled
+ *     Sebastiano Vigna, July 2016.
+ *     http://vigna.di.unimi.it/ftp/papers/xorshift.pdf
+ */
+static inline uint32_t xorshift64s32(uint64_t *x)
 {
-	union {
-		uint32_t rand_word;
-		uint8_t rand_byte[4];
-	} u;
-	uint32_t i = 0, j, k;
+	/* The variable x should be initialized to a nonzero seed. [1] */
+	if (!*x)
+		/*
+		 * 2^64 / phi. As far away as possible from any small integer
+		 * fractions, which the caller might be likely to use for the
+		 * next seed after 0.
+		 */
+		*x = 11400714819323198485ull;
 
-	while (i < len) {
-		u.rand_word = rand_r(seed);
+	*x ^= *x >> 12; /* a */
+	*x ^= *x << 25; /* b */
+	*x ^= *x >> 27; /* c */
+	return (*x * 2685821657736338717ull) >> 32;
+}
 
-		/* Use two least significant bytes */
-		j = ODP_LITTLE_ENDIAN ? 0 : 2;
-		for (k = 0; k < 2 && i < len; i++, j++, k++)
-			*buf++ = u.rand_byte[j];
+static int32_t _random_data(uint8_t *buf, uint32_t len, uint64_t *seed)
+{
+	const uint32_t ret = len;
+
+	if (!_ODP_UNALIGNED && ((uintptr_t)buf & 3) && len) {
+		uint32_t r = xorshift64s32(seed);
+
+		if ((uintptr_t)buf & 1) {
+			*(uint8_t *)(uintptr_t)buf = r & 0xff;
+			r >>= 8;
+			buf += 1;
+			len -= 1;
+		}
+
+		if (((uintptr_t)buf & 2) && len >= 2) {
+			*(uint16_t *)(uintptr_t)buf = r & 0xffff;
+			buf += 2;
+			len -= 2;
+		}
 	}
 
-	return len;
+	for (uint32_t i = 0; i < len / 4; i++) {
+		*(uint32_t *)(uintptr_t)buf = xorshift64s32(seed);
+		buf += 4;
+	}
+
+	if (len & 3) {
+		uint32_t r = xorshift64s32(seed);
+
+		if (len & 2) {
+			*(uint16_t *)(uintptr_t)buf = r & 0xffff;
+			r >>= 16;
+			buf += 2;
+		}
+
+		if (len & 1)
+			*(uint8_t *)(uintptr_t)buf = r & 0xff;
+	}
+
+	return ret;
 }
 
 int32_t _odp_random_std_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
 {
-	uint32_t seed32 = (*seed) & 0xffffffff;
-
-	_random_data(buf, len, &seed32);
-
-	*seed = seed32;
-	return len;
+	return _random_data(buf, len, seed);
 }
 
-static __thread uint32_t this_seed;
+static __thread uint64_t this_seed;
 
 int32_t _odp_random_std_data(uint8_t *buf, uint32_t len)
 {
@@ -59,7 +95,7 @@ int32_t _odp_random_std_data(uint8_t *buf, uint32_t len)
 int _odp_random_std_init_local(void)
 {
 	this_seed = time(NULL);
-	this_seed ^= odp_cpu_id() << 16;
+	this_seed ^= (uint64_t)odp_cpu_id() << 32;
 
 	return 0;
 }

--- a/test/validation/api/random/Makefile.am
+++ b/test/validation/api/random/Makefile.am
@@ -2,3 +2,4 @@ include ../Makefile.inc
 
 test_PROGRAMS = random_main
 random_main_SOURCES = random.c
+LDADD += -lm

--- a/test/validation/api/random/random.c
+++ b/test/validation/api/random/random.c
@@ -135,6 +135,342 @@ static void random_test_align_and_overflow_true(void)
 	random_test_align_and_overflow(ODP_RANDOM_TRUE);
 }
 
+/*
+ * Randomness tests
+ *
+ * The purpose of the following tests is to check that random data looks random.
+ * Some of the tests are based on [1].
+ *
+ * [1] Special Publication 800-22 revision 1a: A Statistical Test Suite for
+ *     Random and Pseudorandom Number Generators for Cryptographic Applications
+ *     National Institute of Standards and Technology (NIST), April 2010
+ *     https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-22r1a.pdf
+ */
+
+/*
+ * Alpha for P-value tests. This does not affect the tests that use a
+ * precomputed critical value.
+ */
+static const double alpha = 0.00000001;
+
+static uint32_t random_bits(int n, odp_random_kind_t kind)
+{
+	static uint8_t buf[32 * 1024];
+	const int size = sizeof(buf);
+	static int cur_n;
+	static odp_random_kind_t cur_kind;
+	static int bit;
+	uint32_t r = 0;
+
+	if (n != cur_n || kind != cur_kind) {
+		cur_n = n;
+		cur_kind = kind;
+		bit = size * 8;
+	}
+
+	for (int i = 0; i < n; ) {
+		if (bit >= size * 8) {
+			random_data(buf, size, kind);
+			bit = 0;
+		}
+		if (n - i >= 8 && !(bit & 7)) {
+			/* Full byte. */
+			r <<= 8;
+			r |= buf[bit / 8];
+			bit += 8;
+			i += 8;
+			continue;
+		}
+		/* Single bit. */
+		r <<= 1;
+		r |= (buf[bit / 8] >> (7 - (bit & 7))) & 1;
+		bit++;
+		i++;
+	}
+
+	return r;
+}
+
+static const char *res_str(int pass)
+{
+	return pass ? "pass" : "FAIL";
+}
+
+/*
+ * Pearson's chi-squared goodness-of-fit test for uniform distribution. The test
+ * is run with multiple different bit block lengths. The null hypothesis is that
+ * each possible bit pattern is equally likely. If the chi-squared statistic is
+ * equal to or larger than the critical value, we conclude that the data is
+ * biased.
+ */
+static void random_test_frequency(odp_random_kind_t kind)
+{
+	/* Mean number of hits per cell. */
+	const uint32_t expected = 100;
+
+	/* From LibreOffice CHISQ.INV.RT(0.00000001; df). */
+	const double critical[] = {
+		32.8413, 40.1300, 50.8129, 68.0293,
+		97.0285, 147.463, 237.614, 402.685,
+		711.187, 1297.50, 2426.64, 4623.37,
+		8929.74, 17419.3, 34224.0, 67587.1,
+	};
+
+	printf("\n\n");
+
+	for (int bits = 1; bits <= 16; bits++) {
+		const uint32_t cells = 1 << bits;
+		const uint64_t num = expected * cells;
+		uint64_t f[256 * 256] = { 0 };
+
+		for (uint64_t i = 0; i < num; i++)
+			f[random_bits(bits, kind)]++;
+
+		double chisq = 0, crit = critical[bits - 1];
+
+		for (uint64_t i = 0; i < cells; i++) {
+			double dif = (double)f[i] - expected;
+
+			chisq += dif * dif / expected;
+		}
+
+		printf("bits %d ; chisq %g ; df %u ; crit %g ; %s\n",
+		       bits, chisq, cells - 1, crit, res_str(chisq < crit));
+
+		CU_ASSERT(chisq < crit);
+	}
+
+	printf("\n");
+}
+
+static void random_test_frequency_crypto(void)
+{
+	random_test_frequency(ODP_RANDOM_CRYPTO);
+}
+
+static void random_test_frequency_true(void)
+{
+	random_test_frequency(ODP_RANDOM_TRUE);
+}
+
+/*
+ * Pearson's chi-squared test for independence. The null hypothesis is that the
+ * values of different bytes are independent. If the chi-squared statistic is
+ * equal to or greater than the critical value, we conclude that the bytes in
+ * the byte pairs selected from the data are not independent.
+ */
+static void random_test_independence(odp_random_kind_t kind)
+{
+	/* Mean number of hits per cell. */
+	const uint32_t expected = 100;
+
+	/* LibreOffice CHISQ.INV.RT(0.00000001; 255*255) */
+	const double critical = 67069.2;
+
+	printf("\n\n");
+	printf("critical value: %g\n", critical);
+
+	for (int lag = 1; lag <= 8; lag++) {
+		const uint32_t cells = 256 * 256;
+		const uint64_t num = expected * cells;
+		const int size = 32 * 1024;
+		int pos = size;
+		uint8_t buf[size];
+		uint64_t freq[256][256] = { { 0 } };
+		uint32_t row[256] = { 0 }, col[256] = { 0 };
+
+		for (uint64_t i = 0; i < num; i++) {
+			if (pos + lag >= size) {
+				random_data(buf, size, kind);
+				pos = 0;
+			}
+
+			uint8_t r = buf[pos], c = buf[pos + lag];
+
+			freq[r][c]++;
+			row[r]++;
+			col[c]++;
+			pos++;
+		}
+
+		double chisq = 0;
+
+		for (int i = 0; i < 256; i++) {
+			for (int j = 0; j < 256; j++) {
+				double expected =
+					(double)row[i] * (double)col[j] / (double)num;
+				double diff =
+					(double)freq[i][j] - expected;
+				chisq += diff * diff / expected;
+			}
+		}
+
+		printf("lag %d ; chisq %g ; %s\n",
+		       lag, chisq, res_str(chisq < critical));
+
+		CU_ASSERT(chisq < critical);
+	}
+
+	printf("\n");
+}
+
+static void random_test_independence_crypto(void)
+{
+	random_test_independence(ODP_RANDOM_CRYPTO);
+}
+
+static void random_test_independence_true(void)
+{
+	random_test_independence(ODP_RANDOM_TRUE);
+}
+
+/*
+ * Sec. 2.3 Runs Test [1]. The test is run with several different n values. A
+ * few long runs may go unnoticed if n is large, while longer period
+ * non-randomness may go unnoticed if n is small.
+ */
+static void random_test_runs(odp_random_kind_t kind)
+{
+	printf("\n\n");
+	printf("alpha: %g\n", alpha);
+
+	for (int n = 128; n <= 1024 * 1024; n *= 2) {
+		double pi, P_value;
+		int bit = random_bits(1, kind);
+		uint64_t ones = bit, V = 1;
+
+		for (int i = 1; i < n; i++) {
+			int prev_bit = bit;
+
+			bit = random_bits(1, kind);
+			ones += bit;
+			V += (bit != prev_bit);
+		}
+
+		pi = (double)ones / n;
+
+		/*
+			* Skip the prerequisite frequency test (Sec. 2.3.4
+			* step (2)), since it's effectively the same as
+			* random_test_frequency() with bits = 1.
+			*/
+
+		P_value = erfc(fabs(V - 2 * n * pi * (1 - pi)) /
+				(2 * sqrt(2 * n) * pi * (1 - pi)));
+		printf("n %d ; pi %g ; V %" PRIu64 " ; P_value %g ; %s\n",
+		       n, pi, V, P_value, res_str(P_value >= alpha));
+
+		CU_ASSERT(P_value >= alpha);
+	}
+
+	printf("\n");
+}
+
+static void random_test_runs_crypto(void)
+{
+	random_test_runs(ODP_RANDOM_CRYPTO);
+}
+
+static void random_test_runs_true(void)
+{
+	random_test_runs(ODP_RANDOM_TRUE);
+}
+
+static int mx_bit(uint32_t *m, int r, int c)
+{
+	return (m[r] >> c) & 1;
+}
+
+static int mx_rank(uint32_t *m, int rows, int cols)
+{
+	int rank = 0;
+
+	for (int r = 0, c = 0; r < rows && c < cols; ) {
+		int swapped = r;
+
+		if (!mx_bit(m, r, c)) {
+			for (int sr = r + 1; sr < rows; sr++) {
+				if (mx_bit(m, sr, c)) {
+					uint32_t t = m[r];
+
+					m[r] = m[sr];
+					m[sr] = t;
+					swapped = sr;
+					break;
+				}
+			}
+			if (!mx_bit(m, r, c)) {
+				c++;
+				continue;
+			}
+		}
+
+		rank++;
+
+		for (int sr = swapped + 1; sr < rows; sr++) {
+			if (mx_bit(m, sr, c))
+				m[sr] ^= m[r];
+		}
+
+		r++;
+	}
+
+	return rank;
+}
+
+/*
+ * Sec. 2.5 Binary Matrix Rank Test [1].
+ */
+static void random_test_matrix_rank(odp_random_kind_t kind)
+{
+	const int N = 40000; /* From Marsaglia's Diehard. */
+	const double p[3] = { 0.2888, 0.5776, 0.1336 };
+
+	printf("\n\n");
+	printf("alpha: %g\n", alpha);
+	printf("N: %d\n", N);
+
+	int F[3] = { 0 };
+
+	for (int i = 0; i < N; i++) {
+		uint32_t mx[32];
+
+		random_data((uint8_t *)mx, sizeof(mx), kind);
+
+		switch (mx_rank(mx, 32, 32)) {
+		case 32:
+			F[0]++;
+			break;
+		case 31:
+			F[1]++;
+			break;
+		default:
+			F[2]++;
+		}
+	}
+
+	double chisq, P_value;
+
+	chisq = pow(F[0] - p[0] * N, 2) / (p[0] * N) +
+		pow(F[1] - p[1] * N, 2) / (p[1] * N) +
+		pow(F[2] - p[2] * N, 2) / (p[2] * N);
+	P_value = exp(-chisq / 2);
+
+	printf("P_value %g ; %s\n", P_value, res_str(P_value >= alpha));
+
+	CU_ASSERT(P_value >= alpha);
+}
+
+static void random_test_matrix_rank_crypto(void)
+{
+	random_test_matrix_rank(ODP_RANDOM_CRYPTO);
+}
+
+static void random_test_matrix_rank_true(void)
+{
+	random_test_matrix_rank(ODP_RANDOM_TRUE);
+}
+
 static int check_kind_basic(void)
 {
 	return odp_random_max_kind() >= ODP_RANDOM_BASIC;
@@ -158,6 +494,14 @@ odp_testinfo_t random_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(random_test_align_and_overflow_basic, check_kind_basic),
 	ODP_TEST_INFO_CONDITIONAL(random_test_align_and_overflow_crypto, check_kind_crypto),
 	ODP_TEST_INFO_CONDITIONAL(random_test_align_and_overflow_true, check_kind_true),
+	ODP_TEST_INFO_CONDITIONAL(random_test_frequency_crypto, check_kind_crypto),
+	ODP_TEST_INFO_CONDITIONAL(random_test_frequency_true, check_kind_true),
+	ODP_TEST_INFO_CONDITIONAL(random_test_independence_crypto, check_kind_crypto),
+	ODP_TEST_INFO_CONDITIONAL(random_test_independence_true, check_kind_true),
+	ODP_TEST_INFO_CONDITIONAL(random_test_runs_crypto, check_kind_crypto),
+	ODP_TEST_INFO_CONDITIONAL(random_test_runs_true, check_kind_true),
+	ODP_TEST_INFO_CONDITIONAL(random_test_matrix_rank_crypto, check_kind_crypto),
+	ODP_TEST_INFO_CONDITIONAL(random_test_matrix_rank_true, check_kind_true),
 	ODP_TEST_INFO_NULL,
 };
 


### PR DESCRIPTION
```
linux-gen: random: improve ODP_RANDOM_BASIC data and random test data
    
    Improve the quality of data generated by and the speed of
    odp_random_test_data() and _odp_random_std_data() (used when OpenSSL
    random is not enabled).
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

validation: random: add test for buffer overflow and alignment problems
    
    Add a new test, which checks that odp_random_data() and
    odp_random_test_data() do not modify bytes outside the given buffer.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
    Reviewed-by: Petri Savolainen <petri.savolainen@nokia.com>

validation: random: test randomness
    
    Test that random data looks random by adding four new tests:
    
    random_test_frequency checks that random data is uniformly
    distributed.
    
    random_test_independence checks that bytes are independent.
    
    random_test_runs checks that the number of runs (uninterrupted
    sequence of identical bits) is what is expected of random data.
    
    random_test_matrix_rank checks that the ranks of 32x32 binary matrices
    correspond to expected probabilities.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
v2:
- Tuomas' comments.

v3:
- Rebase.
- Remove API change (separate it into its own PR).

v4:
- Add review tags.

v6:
- Rebase.
- Remove commit "validation: chksum: use odp_random_test_data()".
- Petri's comments.
- Add review tags.
