### PR TITLE
[PATCH v7] api: crypto: deprecate IV data in session parameters

### DIFF
--- a/doc/users-guide/users-guide-crypto.adoc
+++ b/doc/users-guide/users-guide-crypto.adoc
@@ -33,7 +33,7 @@ order of cipher and hashing can be controlled by the `auth_cipher_text`
 session parameter.
 
 Other Session parameters include algorithms, keys, initialization vector
-(optional), encode or decode, output queue for async mode and output packet
+lengths, encode or decode, output queue for async mode and output packet
 pool for allocation of an output packet if required.
 
 The parameters that describe the characteristics of a crypto session are
@@ -72,8 +72,9 @@ notification is expected. In the case of an async operation, the `posted`
 output parameter will be set to true.
 
 The operation arguments specify for each packet the areas that are to be
-encrypted or decrypted and authenticated. Also, there is an option of overriding
-the initialization vector specified in session parameters.
+encrypted or decrypted and authenticated. The parameters include also
+pointers to cipher and authentication initialization vectors as needed,
+depending on the initialization vector lengths specified at session creation.
 
 An operation can be executed in in-place, out-of-place or new buffer mode.
 In in-place mode output packet is same as the input packet.

--- a/example/ipsec_crypto/odp_ipsec_cache.c
+++ b/example/ipsec_crypto/odp_ipsec_cache.c
@@ -56,7 +56,6 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 	odp_crypto_ses_create_err_t ses_create_rc;
 	odp_crypto_session_t session;
 	sa_mode_t mode = IPSEC_SA_MODE_TRANSPORT;
-	uint8_t unused_iv[cipher_sa ? cipher_sa->iv_len : 1];
 
 	/* Verify we have a good entry */
 	entry = &ipsec_cache->array[ipsec_cache->index];
@@ -96,13 +95,11 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 		params.cipher_alg  = cipher_sa->alg.u.cipher;
 		params.cipher_key.data  = cipher_sa->key.data;
 		params.cipher_key.length  = cipher_sa->key.length;
-		params.cipher_iv.data = unused_iv;
-		params.cipher_iv.length = cipher_sa->iv_len;
+		params.cipher_iv_len = cipher_sa->iv_len;
 		mode = cipher_sa->mode;
 	} else {
 		params.cipher_alg = ODP_CIPHER_ALG_NULL;
-		params.cipher_iv.data = NULL;
-		params.cipher_iv.length = 0;
+		params.cipher_iv_len = 0;
 	}
 
 	/* Auth */

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -525,6 +525,8 @@ typedef struct odp_crypto_key {
 
 /**
  * Crypto API IV structure
+ *
+ * @deprecated
  */
 typedef struct odp_crypto_iv {
 	/** IV data
@@ -532,7 +534,7 @@ typedef struct odp_crypto_iv {
 	 *  Ignored when length is zero. Null value indicates that an
 	 *  IV will be provided for each packet through the crypto
 	 *  operation parameters. In that case the per-operation
-	 *  IV override parameter must always point to a valid IV.
+	 *  IV parameter must always point to a valid IV.
 	 *
 	 *  Default value is NULL.
 	 */
@@ -541,7 +543,7 @@ typedef struct odp_crypto_iv {
 	/** IV length in bytes. Default value is zero. */
 	uint32_t length;
 
-} odp_crypto_iv_t;
+} ODP_DEPRECATE(odp_crypto_iv_t);
 
 /**
  * Crypto API data range specifier
@@ -604,19 +606,26 @@ typedef struct odp_crypto_session_param_t {
 	 */
 	odp_crypto_key_t cipher_key;
 
-	/** Cipher Initialization Vector (IV) */
+	/** Cipher Initialization Vector (IV)
+	 *
+	 *  Unless using the deprecated API, this specifies the length of
+	 *  the IV only. The actual IV must then be provided in per-packet
+	 *  parameters of crypto operations.
+	 */
 	union {
+#if ODP_DEPRECATED_API
 		/** @deprecated Use cipher_iv */
 		odp_crypto_iv_t ODP_DEPRECATE(iv);
 
 		/** Cipher Initialization Vector (IV) */
-		odp_crypto_iv_t cipher_iv;
-
+		odp_crypto_iv_t ODP_DEPRECATE(cipher_iv);
+#endif
 		/** Cipher IV length */
 		struct {
+#if ODP_DEPRECATED_API
 			/** Unused padding field */
 			uint8_t *dummy_padding_0;
-
+#endif
 			/** Length of cipher initialization vector.
 			 *  Default value is zero.
 			 */
@@ -647,15 +656,22 @@ typedef struct odp_crypto_session_param_t {
 	 */
 	odp_crypto_key_t auth_key;
 
-	/** Authentication Initialization Vector (IV) */
+	/** Authentication Initialization Vector (IV)
+	 *
+	 *  Unless using the deprecated API, this specifies the length of
+	 *  the IV only. The actual IV must then be provided in per-packet
+	 *  parameters of crypto operations.
+	 */
 	union {
-		odp_crypto_iv_t auth_iv;
-
+#if ODP_DEPRECATED_API
+		odp_crypto_iv_t ODP_DEPRECATE(auth_iv);
+#endif
 		/** Authentication IV length */
 		struct {
+#if ODP_DEPRECATED_API
 			/** Unused padding field */
 			uint8_t *dummy_padding_1;
-
+#endif
 			/** Length of authentication initialization vector.
 			 *  Default value is zero.
 			 */
@@ -730,15 +746,15 @@ typedef struct odp_crypto_op_param_t {
 	 */
 	odp_packet_t out_pkt;
 
-	/** Override session IV pointer for cipher */
+	/** IV pointer for cipher */
 	union {
 		/** @deprecated use cipher_iv_ptr */
 		uint8_t *ODP_DEPRECATE(override_iv_ptr);
-		/** Override session IV pointer for cipher */
+		/** IV pointer for cipher */
 		uint8_t *cipher_iv_ptr;
 	};
 
-	/** Override session authentication IV pointer */
+	/** Authentication IV pointer */
 	uint8_t *auth_iv_ptr;
 
 	/** Offset from start of packet for hash result
@@ -774,15 +790,15 @@ typedef struct odp_crypto_packet_op_param_t {
 	/** Session handle from creation */
 	odp_crypto_session_t session;
 
-	/** Override session IV pointer for cipher */
+	/** IV pointer for cipher */
 	union {
 		/** @deprecated use cipher_iv_ptr */
 		uint8_t *ODP_DEPRECATE(override_iv_ptr);
-		/** Override session IV pointer for cipher */
+		/** IV pointer for cipher */
 		uint8_t *cipher_iv_ptr;
 	};
 
-	/** Override session IV pointer for authentication */
+	/** IV pointer for authentication */
 	uint8_t *auth_iv_ptr;
 
 	/** Offset from start of packet for hash result

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
+ * Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -526,7 +527,15 @@ typedef struct odp_crypto_key {
  * Crypto API IV structure
  */
 typedef struct odp_crypto_iv {
-	/** IV data */
+	/** IV data
+	 *
+	 *  Ignored when length is zero. Null value indicates that an
+	 *  IV will be provided for each packet through the crypto
+	 *  operation parameters. In that case the per-operation
+	 *  IV override parameter must always point to a valid IV.
+	 *
+	 *  Default value is NULL.
+	 */
 	uint8_t *data;
 
 	/** IV length in bytes */

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -538,7 +538,7 @@ typedef struct odp_crypto_iv {
 	 */
 	uint8_t *data;
 
-	/** IV length in bytes */
+	/** IV length in bytes. Default value is zero. */
 	uint32_t length;
 
 } odp_crypto_iv_t;
@@ -611,6 +611,17 @@ typedef struct odp_crypto_session_param_t {
 
 		/** Cipher Initialization Vector (IV) */
 		odp_crypto_iv_t cipher_iv;
+
+		/** Cipher IV length */
+		struct {
+			/** Unused padding field */
+			uint8_t *dummy_padding_0;
+
+			/** Length of cipher initialization vector.
+			 *  Default value is zero.
+			 */
+			uint32_t cipher_iv_len;
+		};
 	};
 
 	/** Authentication algorithm
@@ -637,7 +648,20 @@ typedef struct odp_crypto_session_param_t {
 	odp_crypto_key_t auth_key;
 
 	/** Authentication Initialization Vector (IV) */
-	odp_crypto_iv_t auth_iv;
+	union {
+		odp_crypto_iv_t auth_iv;
+
+		/** Authentication IV length */
+		struct {
+			/** Unused padding field */
+			uint8_t *dummy_padding_1;
+
+			/** Length of authentication initialization vector.
+			 *  Default value is zero.
+			 */
+			uint32_t auth_iv_len;
+		};
+	};
 
 	/** Authentication digest length in bytes
 	 *

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -212,8 +212,10 @@ struct odp_crypto_generic_session_t {
 	odp_bool_t do_cipher_first;
 
 	struct {
+#if ODP_DEPRECATED_API
 		/* Copy of session IV data */
 		uint8_t iv_data[EVP_MAX_IV_LENGTH];
+#endif
 		uint8_t key_data[EVP_MAX_KEY_LENGTH];
 
 		const EVP_CIPHER *evp_cipher;
@@ -223,7 +225,9 @@ struct odp_crypto_generic_session_t {
 
 	struct {
 		uint8_t  key[EVP_MAX_KEY_LENGTH];
+#if ODP_DEPRECATED_API
 		uint8_t  iv_data[EVP_MAX_IV_LENGTH];
+#endif
 		union {
 			const EVP_MD *evp_md;
 			const EVP_CIPHER *evp_cipher;
@@ -704,19 +708,24 @@ int packet_cmac_eia2(odp_packet_t pkt,
 	uint32_t len   = (param->auth_range.length + 7) / 8;
 	size_t outlen;
 
+#if ODP_DEPRECATED_API
 	if (param->auth_iv_ptr)
 		iv_ptr = param->auth_iv_ptr;
 	else if (session->p.auth_iv.data)
 		iv_ptr = session->auth.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
+#else
+	iv_ptr = param->auth_iv_ptr;
+	ODP_ASSERT(session->p.auth_iv_len == 0 || iv_ptr != NULL);
+#endif
 
 	ODP_ASSERT(offset + len <= odp_packet_len(pkt));
 
 	/* Reinitialize CMAC calculation without resetting the key */
 	CMAC_Init(ctx, NULL, 0, NULL, NULL);
 
-	CMAC_Update(ctx, iv_ptr, session->p.auth_iv.length);
+	CMAC_Update(ctx, iv_ptr, session->p.auth_iv_len);
 
 	while (len > 0) {
 		uint32_t seglen = 0; /* GCC */
@@ -1060,12 +1069,17 @@ odp_crypto_alg_err_t cipher_encrypt(odp_packet_t pkt,
 	void *iv_ptr;
 	int ret;
 
+#if ODP_DEPRECATED_API
 	if (param->cipher_iv_ptr)
 		iv_ptr = param->cipher_iv_ptr;
 	else if (session->p.cipher_iv.data)
 		iv_ptr = session->cipher.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
+#else
+	iv_ptr = param->cipher_iv_ptr;
+	ODP_ASSERT(session->p.cipher_iv_len == 0 || iv_ptr != NULL);
+#endif
 
 	EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 
@@ -1094,12 +1108,17 @@ odp_crypto_alg_err_t cipher_decrypt(odp_packet_t pkt,
 	void *iv_ptr;
 	int ret;
 
+#if ODP_DEPRECATED_API
 	if (param->cipher_iv_ptr)
 		iv_ptr = param->cipher_iv_ptr;
 	else if (session->p.cipher_iv.data)
 		iv_ptr = session->cipher.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
+#else
+	iv_ptr = param->cipher_iv_ptr;
+	ODP_ASSERT(session->p.cipher_iv_len == 0 || iv_ptr != NULL);
+#endif
 
 	EVP_DecryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 
@@ -1119,7 +1138,7 @@ static int process_cipher_param(odp_crypto_generic_session_t *session,
 
 	/* Verify IV len is correct */
 	if ((uint32_t)EVP_CIPHER_iv_length(cipher) !=
-	       session->p.cipher_iv.length)
+	       session->p.cipher_iv_len)
 		return -1;
 
 	session->cipher.evp_cipher = cipher;
@@ -1157,13 +1176,17 @@ odp_crypto_alg_err_t cipher_encrypt_bits(odp_packet_t pkt,
 	/* Range offset is in bits in bit mode but must be divisible by 8. */
 	offset = param->cipher_range.offset / 8;
 
+#if ODP_DEPRECATED_API
 	if (param->cipher_iv_ptr)
 		iv_ptr = param->cipher_iv_ptr;
 	else if (session->p.cipher_iv.data)
 		iv_ptr = session->cipher.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
-
+#else
+	iv_ptr = param->cipher_iv_ptr;
+	ODP_ASSERT(session->p.cipher_iv_len == 0 || iv_ptr != NULL);
+#endif
 	EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 
 	odp_packet_copy_to_mem(pkt, offset, in_len, data);
@@ -1197,13 +1220,17 @@ odp_crypto_alg_err_t cipher_decrypt_bits(odp_packet_t pkt,
 	/* Range offset is in bits in bit mode but must be divisible by 8. */
 	offset = param->cipher_range.offset / 8;
 
+#if ODP_DEPRECATED_API
 	if (param->cipher_iv_ptr)
 		iv_ptr = param->cipher_iv_ptr;
 	else if (session->p.cipher_iv.data)
 		iv_ptr = session->cipher.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
-
+#else
+	iv_ptr = param->cipher_iv_ptr;
+	ODP_ASSERT(session->p.cipher_iv_len == 0 || iv_ptr != NULL);
+#endif
 	EVP_DecryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 
 	odp_packet_copy_to_mem(pkt, offset, in_len, data);
@@ -1229,7 +1256,7 @@ static int process_cipher_param_bits(odp_crypto_generic_session_t *session,
 
 	/* Verify IV len is correct */
 	if ((uint32_t)EVP_CIPHER_iv_length(cipher) !=
-	       session->p.cipher_iv.length)
+	       session->p.cipher_iv_len)
 		return -1;
 
 	session->cipher.evp_cipher = cipher;
@@ -1257,7 +1284,7 @@ aes_gcm_encrypt_init(odp_crypto_generic_session_t *session)
 	EVP_EncryptInit_ex(ctx, session->cipher.evp_cipher, NULL,
 			   session->cipher.key_data, NULL);
 	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN,
-			    session->p.cipher_iv.length, NULL);
+			    session->p.cipher_iv_len, NULL);
 	EVP_CIPHER_CTX_set_padding(ctx, 0);
 }
 
@@ -1274,12 +1301,17 @@ odp_crypto_alg_err_t aes_gcm_encrypt(odp_packet_t pkt,
 	uint8_t block[EVP_MAX_MD_SIZE];
 	int ret;
 
+#if ODP_DEPRECATED_API
 	if (param->cipher_iv_ptr)
 		iv_ptr = param->cipher_iv_ptr;
 	else if (session->p.cipher_iv.data)
 		iv_ptr = session->cipher.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
+#else
+	iv_ptr = param->cipher_iv_ptr;
+	ODP_ASSERT(session->p.cipher_iv_len == 0 || iv_ptr != NULL);
+#endif
 
 	EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 
@@ -1307,7 +1339,7 @@ aes_gcm_decrypt_init(odp_crypto_generic_session_t *session)
 	EVP_DecryptInit_ex(ctx, session->cipher.evp_cipher, NULL,
 			   session->cipher.key_data, NULL);
 	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN,
-			    session->p.cipher_iv.length, NULL);
+			    session->p.cipher_iv_len, NULL);
 	EVP_CIPHER_CTX_set_padding(ctx, 0);
 }
 
@@ -1324,12 +1356,17 @@ odp_crypto_alg_err_t aes_gcm_decrypt(odp_packet_t pkt,
 	uint8_t block[EVP_MAX_MD_SIZE];
 	int ret;
 
+#if ODP_DEPRECATED_API
 	if (param->cipher_iv_ptr)
 		iv_ptr = param->cipher_iv_ptr;
 	else if (session->p.cipher_iv.data)
 		iv_ptr = session->cipher.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
+#else
+	iv_ptr = param->cipher_iv_ptr;
+	ODP_ASSERT(session->p.cipher_iv_len == 0 || iv_ptr != NULL);
+#endif
 
 	EVP_DecryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 
@@ -1358,7 +1395,7 @@ static int process_aes_gcm_param(odp_crypto_generic_session_t *session,
 		return -1;
 
 	/* Verify IV len is correct */
-	if (12 != session->p.cipher_iv.length)
+	if (12 != session->p.cipher_iv_len)
 		return -1;
 
 	memcpy(session->cipher.key_data, session->p.cipher_key.data,
@@ -1386,7 +1423,7 @@ aes_gmac_gen_init(odp_crypto_generic_session_t *session)
 	EVP_EncryptInit_ex(ctx, session->auth.evp_cipher, NULL,
 			   session->auth.key, NULL);
 	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN,
-			    session->p.auth_iv.length, NULL);
+			    session->p.auth_iv_len, NULL);
 	EVP_CIPHER_CTX_set_padding(ctx, 0);
 }
 
@@ -1400,12 +1437,17 @@ odp_crypto_alg_err_t aes_gmac_gen(odp_packet_t pkt,
 	uint8_t block[EVP_MAX_MD_SIZE];
 	int ret;
 
+#if ODP_DEPRECATED_API
 	if (param->auth_iv_ptr)
 		iv_ptr = param->auth_iv_ptr;
 	else if (session->p.auth_iv.data)
 		iv_ptr = session->auth.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
+#else
+	iv_ptr = param->auth_iv_ptr;
+	ODP_ASSERT(session->p.auth_iv_len == 0 || iv_ptr != NULL);
+#endif
 
 	EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 
@@ -1428,7 +1470,7 @@ aes_gmac_check_init(odp_crypto_generic_session_t *session)
 	EVP_DecryptInit_ex(ctx, session->auth.evp_cipher, NULL,
 			   session->auth.key, NULL);
 	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN,
-			    session->p.auth_iv.length, NULL);
+			    session->p.auth_iv_len, NULL);
 	EVP_CIPHER_CTX_set_padding(ctx, 0);
 }
 
@@ -1442,12 +1484,17 @@ odp_crypto_alg_err_t aes_gmac_check(odp_packet_t pkt,
 	uint8_t block[EVP_MAX_MD_SIZE];
 	int ret;
 
+#if ODP_DEPRECATED_API
 	if (param->auth_iv_ptr)
 		iv_ptr = param->auth_iv_ptr;
 	else if (session->p.auth_iv.data)
 		iv_ptr = session->auth.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
+#else
+	iv_ptr = param->auth_iv_ptr;
+	ODP_ASSERT(session->p.auth_iv_len == 0 || iv_ptr != NULL);
+#endif
 
 	EVP_DecryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 
@@ -1473,7 +1520,7 @@ static int process_aes_gmac_param(odp_crypto_generic_session_t *session,
 		return -1;
 
 	/* Verify IV len is correct */
-	if (12 != session->p.auth_iv.length)
+	if (12 != session->p.auth_iv_len)
 		return -1;
 
 	memcpy(session->auth.key, session->p.auth_key.data,
@@ -1501,7 +1548,7 @@ aes_ccm_encrypt_init(odp_crypto_generic_session_t *session)
 	EVP_EncryptInit_ex(ctx, session->cipher.evp_cipher, NULL,
 			   NULL, NULL);
 	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_CCM_SET_IVLEN,
-			    session->p.cipher_iv.length, NULL);
+			    session->p.cipher_iv_len, NULL);
 	EVP_CIPHER_CTX_set_padding(ctx, 0);
 }
 
@@ -1521,12 +1568,17 @@ odp_crypto_alg_err_t aes_ccm_encrypt(odp_packet_t pkt,
 	uint8_t block[EVP_MAX_MD_SIZE];
 	int ret;
 
+#if ODP_DEPRECATED_API
 	if (param->cipher_iv_ptr)
 		iv_ptr = param->cipher_iv_ptr;
 	else if (session->p.cipher_iv.data)
 		iv_ptr = session->cipher.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
+#else
+	iv_ptr = param->cipher_iv_ptr;
+	ODP_ASSERT(session->p.cipher_iv_len == 0 || iv_ptr != NULL);
+#endif
 
 	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_CCM_SET_TAG,
 			    session->p.auth_digest_len, NULL);
@@ -1568,7 +1620,7 @@ aes_ccm_decrypt_init(odp_crypto_generic_session_t *session)
 	EVP_DecryptInit_ex(ctx, session->cipher.evp_cipher, NULL,
 			   session->cipher.key_data, NULL);
 	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN,
-			    session->p.cipher_iv.length, NULL);
+			    session->p.cipher_iv_len, NULL);
 	EVP_CIPHER_CTX_set_padding(ctx, 0);
 }
 
@@ -1588,12 +1640,17 @@ odp_crypto_alg_err_t aes_ccm_decrypt(odp_packet_t pkt,
 	uint8_t block[EVP_MAX_MD_SIZE];
 	int ret;
 
+#if ODP_DEPRECATED_API
 	if (param->cipher_iv_ptr)
 		iv_ptr = param->cipher_iv_ptr;
 	else if (session->p.cipher_iv.data)
 		iv_ptr = session->cipher.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
+#else
+	iv_ptr = param->cipher_iv_ptr;
+	ODP_ASSERT(session->p.cipher_iv_len == 0 || iv_ptr != NULL);
+#endif
 
 	odp_packet_copy_to_mem(pkt, param->hash_result_offset,
 			       session->p.auth_digest_len, block);
@@ -1633,8 +1690,8 @@ static int process_aes_ccm_param(odp_crypto_generic_session_t *session,
 		return -1;
 
 	/* Verify IV len is correct */
-	if (11 != session->p.cipher_iv.length &&
-	    13 != session->p.cipher_iv.length)
+	if (11 != session->p.cipher_iv_len &&
+	    13 != session->p.cipher_iv_len)
 		return -1;
 
 	memcpy(session->cipher.key_data, session->p.cipher_key.data,
@@ -1667,12 +1724,17 @@ odp_crypto_alg_err_t xts_encrypt(odp_packet_t pkt,
 	uint8_t data[in_len];
 	int ret;
 
+#if ODP_DEPRECATED_API
 	if (param->cipher_iv_ptr)
 		iv_ptr = param->cipher_iv_ptr;
 	else if (session->p.cipher_iv.data)
 		iv_ptr = session->cipher.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
+#else
+	iv_ptr = param->cipher_iv_ptr;
+	ODP_ASSERT(session->p.cipher_iv_len == 0 || iv_ptr != NULL);
+#endif
 
 	EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 
@@ -1704,12 +1766,17 @@ odp_crypto_alg_err_t xts_decrypt(odp_packet_t pkt,
 	uint8_t data[in_len];
 	int ret;
 
+#if ODP_DEPRECATED_API
 	if (param->cipher_iv_ptr)
 		iv_ptr = param->cipher_iv_ptr;
 	else if (session->p.cipher_iv.data)
 		iv_ptr = session->cipher.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
+#else
+	iv_ptr = param->cipher_iv_ptr;
+	ODP_ASSERT(session->p.cipher_iv_len == 0 || iv_ptr != NULL);
+#endif
 
 	EVP_DecryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 
@@ -1738,7 +1805,7 @@ static int process_xts_param(odp_crypto_generic_session_t *session,
 
 	/* Verify IV len is correct */
 	if ((uint32_t)EVP_CIPHER_iv_length(cipher) !=
-	       session->p.cipher_iv.length)
+	       session->p.cipher_iv_len)
 		return -1;
 
 	session->cipher.evp_cipher = cipher;
@@ -1762,7 +1829,7 @@ static int process_auth_hmac_param(odp_crypto_generic_session_t *session,
 				   const EVP_MD *evp_md)
 {
 	/* Verify IV len is correct */
-	if (0 != session->p.auth_iv.length)
+	if (0 != session->p.auth_iv_len)
 		return -1;
 
 	/* Set function */
@@ -1793,7 +1860,7 @@ static int process_auth_cmac_param(odp_crypto_generic_session_t *session,
 	    session->p.auth_key.length)
 		return -1;
 
-	if (0 != session->p.auth_iv.length)
+	if (0 != session->p.auth_iv_len)
 		return -1;
 
 	/* Set function */
@@ -1826,7 +1893,7 @@ static int process_auth_cmac_eia2_param(odp_crypto_generic_session_t *session,
 		return -1;
 
 	/* Verify IV len is correct */
-	if (8 != session->p.auth_iv.length)
+	if (8 != session->p.auth_iv_len)
 		return -1;
 
 	/* Set function */
@@ -2140,18 +2207,19 @@ odp_crypto_session_create(const odp_crypto_session_param_t *param,
 	/* Copy parameters */
 	session->p = *param;
 
-	if (session->p.cipher_iv.length > EVP_MAX_IV_LENGTH) {
+	if (session->p.cipher_iv_len > EVP_MAX_IV_LENGTH) {
 		ODP_DBG("Maximum IV length exceeded\n");
 		*status = ODP_CRYPTO_SES_CREATE_ERR_INV_CIPHER;
 		goto err;
 	}
 
-	if (session->p.auth_iv.length > EVP_MAX_IV_LENGTH) {
+	if (session->p.auth_iv_len > EVP_MAX_IV_LENGTH) {
 		ODP_DBG("Maximum auth IV length exceeded\n");
 		*status = ODP_CRYPTO_SES_CREATE_ERR_INV_CIPHER;
 		goto err;
 	}
 
+#if ODP_DEPRECATED_API
 	/* Copy IV data */
 	if (session->p.cipher_iv.data)
 		memcpy(session->cipher.iv_data, session->p.cipher_iv.data,
@@ -2160,6 +2228,7 @@ odp_crypto_session_create(const odp_crypto_session_param_t *param,
 	if (session->p.auth_iv.data)
 		memcpy(session->auth.iv_data, session->p.auth_iv.data,
 		       session->p.auth_iv.length);
+#endif
 
 	/* Derive order */
 	if (ODP_CRYPTO_OP_ENCODE == param->op)

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -634,7 +634,7 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 	crypto_param.auth_alg = param->crypto.auth_alg;
 	crypto_param.auth_key = param->crypto.auth_key;
 
-	crypto_param.cipher_iv.length =
+	crypto_param.cipher_iv_len =
 		_odp_ipsec_cipher_iv_len(crypto_param.cipher_alg);
 
 	crypto_param.auth_digest_len =
@@ -644,7 +644,7 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 	    param->crypto.icv_len != crypto_param.auth_digest_len)
 		goto error;
 
-	if ((uint32_t)-1 == crypto_param.cipher_iv.length ||
+	if ((uint32_t)-1 == crypto_param.cipher_iv_len ||
 	    (uint32_t)-1 == crypto_param.auth_digest_len)
 		goto error;
 
@@ -729,7 +729,7 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 		ipsec_sa->use_counter_iv = 1;
 		ipsec_sa->esp_iv_len = 8;
 		ipsec_sa->esp_pad_mask = esp_block_len_to_mask(1);
-		crypto_param.auth_iv.length = 12;
+		crypto_param.auth_iv_len = 12;
 		ipsec_sa->salt_length = 4;
 		salt_param = &param->crypto.auth_key_extra;
 		break;

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -219,10 +219,7 @@ static crypto_alg_config_t algs_config[] = {
 				.data = test_key24,
 				.length = sizeof(test_key24)
 			},
-			.cipher_iv = {
-				.data = test_iv,
-				.length = 8,
-			},
+			.cipher_iv_len = 8,
 			.auth_alg = ODP_AUTH_ALG_NULL
 		},
 	},
@@ -234,10 +231,7 @@ static crypto_alg_config_t algs_config[] = {
 				.data = test_key24,
 				.length = sizeof(test_key24)
 			},
-			.cipher_iv = {
-				.data = test_iv,
-				.length = 8,
-			},
+			.cipher_iv_len = 8,
 			.auth_alg = ODP_AUTH_ALG_MD5_HMAC,
 			.auth_key = {
 				.data = test_key16,
@@ -266,10 +260,7 @@ static crypto_alg_config_t algs_config[] = {
 				.data = test_key16,
 				.length = sizeof(test_key16)
 			},
-			.cipher_iv = {
-				.data = test_iv,
-				.length = 16,
-			},
+			.cipher_iv_len = 16,
 			.auth_alg = ODP_AUTH_ALG_NULL
 		},
 	},
@@ -281,10 +272,7 @@ static crypto_alg_config_t algs_config[] = {
 				.data = test_key16,
 				.length = sizeof(test_key16)
 			},
-			.cipher_iv = {
-				.data = test_iv,
-				.length = 16,
-			},
+			.cipher_iv_len = 16,
 			.auth_alg = ODP_AUTH_ALG_SHA1_HMAC,
 			.auth_key = {
 				.data = test_key20,
@@ -313,10 +301,7 @@ static crypto_alg_config_t algs_config[] = {
 				.data = test_key16,
 				.length = sizeof(test_key16)
 			},
-			.cipher_iv = {
-				.data = test_iv,
-				.length = 16,
-			},
+			.cipher_iv_len = 16,
 			.auth_alg = ODP_AUTH_ALG_NULL
 		},
 	},
@@ -328,10 +313,7 @@ static crypto_alg_config_t algs_config[] = {
 				.data = test_key16,
 				.length = sizeof(test_key16)
 			},
-			.cipher_iv = {
-				.data = test_iv,
-				.length = 16,
-			},
+			.cipher_iv_len = 16,
 			.auth_alg = ODP_AUTH_ALG_SHA1_HMAC,
 			.auth_key = {
 				.data = test_key20,
@@ -373,10 +355,7 @@ static crypto_alg_config_t algs_config[] = {
 				.data = test_key16,
 				.length = sizeof(test_key16)
 			},
-			.auth_iv = {
-				.data = test_iv,
-				.length = 12,
-			},
+			.auth_iv_len = 12,
 			.auth_digest_len = 16,
 		},
 	},
@@ -388,10 +367,7 @@ static crypto_alg_config_t algs_config[] = {
 				.data = test_key16,
 				.length = sizeof(test_key16)
 			},
-			.cipher_iv = {
-				.data = test_iv,
-				.length = 12,
-			},
+			.cipher_iv_len = 12,
 			.auth_alg = ODP_AUTH_ALG_AES_GCM,
 			.auth_digest_len = 16,
 		},
@@ -404,10 +380,7 @@ static crypto_alg_config_t algs_config[] = {
 				.data = test_key16,
 				.length = sizeof(test_key16)
 			},
-			.cipher_iv = {
-				.data = test_iv,
-				.length = 11,
-			},
+			.cipher_iv_len = 11,
 			.auth_alg = ODP_AUTH_ALG_AES_CCM,
 			.auth_digest_len = 16,
 		},
@@ -420,10 +393,7 @@ static crypto_alg_config_t algs_config[] = {
 				.data = test_key32,
 				.length = sizeof(test_key32)
 			},
-			.cipher_iv = {
-				.data = test_iv,
-				.length = 12,
-			},
+			.cipher_iv_len = 12,
 			.auth_alg = ODP_AUTH_ALG_CHACHA20_POLY1305,
 			.auth_digest_len = 16,
 		},
@@ -725,6 +695,8 @@ run_measure_one(crypto_args_t *cargs,
 	/* Initialize parameters block */
 	memset(&params, 0, sizeof(params));
 	params.session = *session;
+	params.cipher_iv_ptr = test_iv;
+	params.auth_iv_ptr = test_iv;
 
 	params.cipher_range.offset = 0;
 	params.cipher_range.length = payload_length;

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -717,7 +717,6 @@ static void check_alg(odp_crypto_op_t op,
 		      odp_auth_alg_t auth_alg,
 		      crypto_test_reference_t *ref,
 		      size_t count,
-		      odp_bool_t ovr_iv,
 		      odp_bool_t bit_mode)
 {
 	int rc, i;
@@ -797,7 +796,10 @@ static void check_alg(odp_crypto_op_t op,
 			continue;
 		}
 
-		alg_test(op, cipher_alg, auth_alg, &ref[idx], ovr_iv, bit_mode);
+		/* test with per-packet IV */
+		alg_test(op, cipher_alg, auth_alg, &ref[idx], true, bit_mode);
+		/* test with per-session IV */
+		alg_test(op, cipher_alg, auth_alg, &ref[idx], false, bit_mode);
 
 		cipher_tested[cipher_idx] = true;
 		auth_tested[auth_idx] = true;
@@ -1066,7 +1068,6 @@ static void crypto_test_enc_alg_null(void)
 		  ODP_AUTH_ALG_NULL,
 		  null_reference,
 		  ARRAY_SIZE(null_reference),
-		  false,
 		  false);
 }
 
@@ -1077,7 +1078,6 @@ static void crypto_test_dec_alg_null(void)
 		  ODP_AUTH_ALG_NULL,
 		  null_reference,
 		  ARRAY_SIZE(null_reference),
-		  false,
 		  false);
 }
 
@@ -1093,18 +1093,6 @@ static void crypto_test_enc_alg_3des_cbc(void)
 		  ODP_AUTH_ALG_NULL,
 		  tdes_cbc_reference,
 		  ARRAY_SIZE(tdes_cbc_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_enc_alg_3des_cbc_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_3DES_CBC,
-		  ODP_AUTH_ALG_NULL,
-		  tdes_cbc_reference,
-		  ARRAY_SIZE(tdes_cbc_reference),
-		  true,
 		  false);
 }
 
@@ -1115,18 +1103,6 @@ static void crypto_test_dec_alg_3des_cbc(void)
 		  ODP_AUTH_ALG_NULL,
 		  tdes_cbc_reference,
 		  ARRAY_SIZE(tdes_cbc_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_dec_alg_3des_cbc_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_3DES_CBC,
-		  ODP_AUTH_ALG_NULL,
-		  tdes_cbc_reference,
-		  ARRAY_SIZE(tdes_cbc_reference),
-		  true,
 		  false);
 }
 
@@ -1142,7 +1118,6 @@ static void crypto_test_enc_alg_3des_ecb(void)
 		  ODP_AUTH_ALG_NULL,
 		  tdes_ecb_reference,
 		  ARRAY_SIZE(tdes_ecb_reference),
-		  false,
 		  false);
 }
 
@@ -1153,7 +1128,6 @@ static void crypto_test_dec_alg_3des_ecb(void)
 		  ODP_AUTH_ALG_NULL,
 		  tdes_ecb_reference,
 		  ARRAY_SIZE(tdes_ecb_reference),
-		  false,
 		  false);
 }
 
@@ -1170,18 +1144,6 @@ static void crypto_test_enc_alg_chacha20_poly1305(void)
 		  ODP_AUTH_ALG_CHACHA20_POLY1305,
 		  chacha20_poly1305_reference,
 		  ARRAY_SIZE(chacha20_poly1305_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_enc_alg_chacha20_poly1305_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_CHACHA20_POLY1305,
-		  ODP_AUTH_ALG_CHACHA20_POLY1305,
-		  chacha20_poly1305_reference,
-		  ARRAY_SIZE(chacha20_poly1305_reference),
-		  true,
 		  false);
 }
 
@@ -1192,18 +1154,6 @@ static void crypto_test_dec_alg_chacha20_poly1305(void)
 		  ODP_AUTH_ALG_CHACHA20_POLY1305,
 		  chacha20_poly1305_reference,
 		  ARRAY_SIZE(chacha20_poly1305_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_dec_alg_chacha20_poly1305_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_CHACHA20_POLY1305,
-		  ODP_AUTH_ALG_CHACHA20_POLY1305,
-		  chacha20_poly1305_reference,
-		  ARRAY_SIZE(chacha20_poly1305_reference),
-		  true,
 		  false);
 }
 
@@ -1219,18 +1169,6 @@ static void crypto_test_enc_alg_aes_gcm(void)
 		  ODP_AUTH_ALG_AES_GCM,
 		  aes_gcm_reference,
 		  ARRAY_SIZE(aes_gcm_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_enc_alg_aes_gcm_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_AES_GCM,
-		  ODP_AUTH_ALG_AES_GCM,
-		  aes_gcm_reference,
-		  ARRAY_SIZE(aes_gcm_reference),
-		  true,
 		  false);
 }
 
@@ -1241,18 +1179,6 @@ static void crypto_test_dec_alg_aes_gcm(void)
 		  ODP_AUTH_ALG_AES_GCM,
 		  aes_gcm_reference,
 		  ARRAY_SIZE(aes_gcm_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_dec_alg_aes_gcm_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_AES_GCM,
-		  ODP_AUTH_ALG_AES_GCM,
-		  aes_gcm_reference,
-		  ARRAY_SIZE(aes_gcm_reference),
-		  true,
 		  false);
 }
 
@@ -1268,18 +1194,6 @@ static void crypto_test_enc_alg_aes_ccm(void)
 		  ODP_AUTH_ALG_AES_CCM,
 		  aes_ccm_reference,
 		  ARRAY_SIZE(aes_ccm_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_enc_alg_aes_ccm_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_AES_CCM,
-		  ODP_AUTH_ALG_AES_CCM,
-		  aes_ccm_reference,
-		  ARRAY_SIZE(aes_ccm_reference),
-		  true,
 		  false);
 }
 
@@ -1290,18 +1204,6 @@ static void crypto_test_dec_alg_aes_ccm(void)
 		  ODP_AUTH_ALG_AES_CCM,
 		  aes_ccm_reference,
 		  ARRAY_SIZE(aes_ccm_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_dec_alg_aes_ccm_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_AES_CCM,
-		  ODP_AUTH_ALG_AES_CCM,
-		  aes_ccm_reference,
-		  ARRAY_SIZE(aes_ccm_reference),
-		  true,
 		  false);
 }
 
@@ -1317,18 +1219,6 @@ static void crypto_test_enc_alg_aes_cbc(void)
 		  ODP_AUTH_ALG_NULL,
 		  aes_cbc_reference,
 		  ARRAY_SIZE(aes_cbc_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_enc_alg_aes_cbc_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_AES_CBC,
-		  ODP_AUTH_ALG_NULL,
-		  aes_cbc_reference,
-		  ARRAY_SIZE(aes_cbc_reference),
-		  true,
 		  false);
 }
 
@@ -1339,18 +1229,6 @@ static void crypto_test_dec_alg_aes_cbc(void)
 		  ODP_AUTH_ALG_NULL,
 		  aes_cbc_reference,
 		  ARRAY_SIZE(aes_cbc_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_dec_alg_aes_cbc_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_AES_CBC,
-		  ODP_AUTH_ALG_NULL,
-		  aes_cbc_reference,
-		  ARRAY_SIZE(aes_cbc_reference),
-		  true,
 		  false);
 }
 
@@ -1366,18 +1244,6 @@ static void crypto_test_enc_alg_aes_ctr(void)
 		  ODP_AUTH_ALG_NULL,
 		  aes_ctr_reference,
 		  ARRAY_SIZE(aes_ctr_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_enc_alg_aes_ctr_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_AES_CTR,
-		  ODP_AUTH_ALG_NULL,
-		  aes_ctr_reference,
-		  ARRAY_SIZE(aes_ctr_reference),
-		  true,
 		  false);
 }
 
@@ -1388,18 +1254,6 @@ static void crypto_test_dec_alg_aes_ctr(void)
 		  ODP_AUTH_ALG_NULL,
 		  aes_ctr_reference,
 		  ARRAY_SIZE(aes_ctr_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_dec_alg_aes_ctr_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_AES_CTR,
-		  ODP_AUTH_ALG_NULL,
-		  aes_ctr_reference,
-		  ARRAY_SIZE(aes_ctr_reference),
-		  true,
 		  false);
 }
 
@@ -1415,7 +1269,6 @@ static void crypto_test_enc_alg_aes_ecb(void)
 		  ODP_AUTH_ALG_NULL,
 		  aes_ecb_reference,
 		  ARRAY_SIZE(aes_ecb_reference),
-		  false,
 		  false);
 }
 
@@ -1426,7 +1279,6 @@ static void crypto_test_dec_alg_aes_ecb(void)
 		  ODP_AUTH_ALG_NULL,
 		  aes_ecb_reference,
 		  ARRAY_SIZE(aes_ecb_reference),
-		  false,
 		  false);
 }
 
@@ -1442,18 +1294,6 @@ static void crypto_test_enc_alg_aes_cfb128(void)
 		  ODP_AUTH_ALG_NULL,
 		  aes_cfb128_reference,
 		  ARRAY_SIZE(aes_cfb128_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_enc_alg_aes_cfb128_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_AES_CFB128,
-		  ODP_AUTH_ALG_NULL,
-		  aes_cfb128_reference,
-		  ARRAY_SIZE(aes_cfb128_reference),
-		  true,
 		  false);
 }
 
@@ -1464,18 +1304,6 @@ static void crypto_test_dec_alg_aes_cfb128(void)
 		  ODP_AUTH_ALG_NULL,
 		  aes_cfb128_reference,
 		  ARRAY_SIZE(aes_cfb128_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_dec_alg_aes_cfb128_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_AES_CFB128,
-		  ODP_AUTH_ALG_NULL,
-		  aes_cfb128_reference,
-		  ARRAY_SIZE(aes_cfb128_reference),
-		  true,
 		  false);
 }
 
@@ -1491,18 +1319,6 @@ static void crypto_test_enc_alg_aes_xts(void)
 		  ODP_AUTH_ALG_NULL,
 		  aes_xts_reference,
 		  ARRAY_SIZE(aes_xts_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_enc_alg_aes_xts_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_AES_XTS,
-		  ODP_AUTH_ALG_NULL,
-		  aes_xts_reference,
-		  ARRAY_SIZE(aes_xts_reference),
-		  true,
 		  false);
 }
 
@@ -1513,18 +1329,6 @@ static void crypto_test_dec_alg_aes_xts(void)
 		  ODP_AUTH_ALG_NULL,
 		  aes_xts_reference,
 		  ARRAY_SIZE(aes_xts_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_dec_alg_aes_xts_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_AES_XTS,
-		  ODP_AUTH_ALG_NULL,
-		  aes_xts_reference,
-		  ARRAY_SIZE(aes_xts_reference),
-		  true,
 		  false);
 }
 
@@ -1540,18 +1344,6 @@ static void crypto_test_enc_alg_kasumi_f8(void)
 		  ODP_AUTH_ALG_NULL,
 		  kasumi_f8_reference,
 		  ARRAY_SIZE(kasumi_f8_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_enc_alg_kasumi_f8_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_KASUMI_F8,
-		  ODP_AUTH_ALG_NULL,
-		  kasumi_f8_reference,
-		  ARRAY_SIZE(kasumi_f8_reference),
-		  true,
 		  true);
 }
 
@@ -1562,18 +1354,6 @@ static void crypto_test_dec_alg_kasumi_f8(void)
 		  ODP_AUTH_ALG_NULL,
 		  kasumi_f8_reference,
 		  ARRAY_SIZE(kasumi_f8_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_dec_alg_kasumi_f8_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_KASUMI_F8,
-		  ODP_AUTH_ALG_NULL,
-		  kasumi_f8_reference,
-		  ARRAY_SIZE(kasumi_f8_reference),
-		  true,
 		  true);
 }
 
@@ -1589,18 +1369,6 @@ static void crypto_test_enc_alg_snow3g_uea2(void)
 		  ODP_AUTH_ALG_NULL,
 		  snow3g_uea2_reference,
 		  ARRAY_SIZE(snow3g_uea2_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_enc_alg_snow3g_uea2_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_SNOW3G_UEA2,
-		  ODP_AUTH_ALG_NULL,
-		  snow3g_uea2_reference,
-		  ARRAY_SIZE(snow3g_uea2_reference),
-		  true,
 		  true);
 }
 
@@ -1611,18 +1379,6 @@ static void crypto_test_dec_alg_snow3g_uea2(void)
 		  ODP_AUTH_ALG_NULL,
 		  snow3g_uea2_reference,
 		  ARRAY_SIZE(snow3g_uea2_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_dec_alg_snow3g_uea2_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_SNOW3G_UEA2,
-		  ODP_AUTH_ALG_NULL,
-		  snow3g_uea2_reference,
-		  ARRAY_SIZE(snow3g_uea2_reference),
-		  true,
 		  true);
 }
 
@@ -1639,18 +1395,6 @@ static void crypto_test_enc_alg_aes_eea2(void)
 		  ODP_AUTH_ALG_NULL,
 		  aes_eea2_reference,
 		  ARRAY_SIZE(aes_eea2_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_enc_alg_aes_eea2_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_AES_EEA2,
-		  ODP_AUTH_ALG_NULL,
-		  aes_eea2_reference,
-		  ARRAY_SIZE(aes_eea2_reference),
-		  true,
 		  true);
 }
 
@@ -1661,18 +1405,6 @@ static void crypto_test_dec_alg_aes_eea2(void)
 		  ODP_AUTH_ALG_NULL,
 		  aes_eea2_reference,
 		  ARRAY_SIZE(aes_eea2_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_dec_alg_aes_eea2_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_AES_EEA2,
-		  ODP_AUTH_ALG_NULL,
-		  aes_eea2_reference,
-		  ARRAY_SIZE(aes_eea2_reference),
-		  true,
 		  true);
 }
 
@@ -1688,18 +1420,6 @@ static void crypto_test_enc_alg_zuc_eea3(void)
 		  ODP_AUTH_ALG_NULL,
 		  zuc_eea3_reference,
 		  ARRAY_SIZE(zuc_eea3_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_enc_alg_zuc_eea3_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_ZUC_EEA3,
-		  ODP_AUTH_ALG_NULL,
-		  zuc_eea3_reference,
-		  ARRAY_SIZE(zuc_eea3_reference),
-		  true,
 		  true);
 }
 
@@ -1710,18 +1430,6 @@ static void crypto_test_dec_alg_zuc_eea3(void)
 		  ODP_AUTH_ALG_NULL,
 		  zuc_eea3_reference,
 		  ARRAY_SIZE(zuc_eea3_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_dec_alg_zuc_eea3_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_ZUC_EEA3,
-		  ODP_AUTH_ALG_NULL,
-		  zuc_eea3_reference,
-		  ARRAY_SIZE(zuc_eea3_reference),
-		  true,
 		  true);
 }
 
@@ -1737,7 +1445,6 @@ static void crypto_test_gen_alg_hmac_md5(void)
 		  ODP_AUTH_ALG_MD5_HMAC,
 		  hmac_md5_reference,
 		  ARRAY_SIZE(hmac_md5_reference),
-		  false,
 		  false);
 }
 
@@ -1748,7 +1455,6 @@ static void crypto_test_check_alg_hmac_md5(void)
 		  ODP_AUTH_ALG_MD5_HMAC,
 		  hmac_md5_reference,
 		  ARRAY_SIZE(hmac_md5_reference),
-		  false,
 		  false);
 }
 
@@ -1764,7 +1470,6 @@ static void crypto_test_gen_alg_hmac_sha1(void)
 		  ODP_AUTH_ALG_SHA1_HMAC,
 		  hmac_sha1_reference,
 		  ARRAY_SIZE(hmac_sha1_reference),
-		  false,
 		  false);
 }
 
@@ -1775,7 +1480,6 @@ static void crypto_test_check_alg_hmac_sha1(void)
 		  ODP_AUTH_ALG_SHA1_HMAC,
 		  hmac_sha1_reference,
 		  ARRAY_SIZE(hmac_sha1_reference),
-		  false,
 		  false);
 }
 
@@ -1791,7 +1495,6 @@ static void crypto_test_gen_alg_hmac_sha224(void)
 		  ODP_AUTH_ALG_SHA224_HMAC,
 		  hmac_sha224_reference,
 		  ARRAY_SIZE(hmac_sha224_reference),
-		  false,
 		  false);
 }
 
@@ -1802,7 +1505,6 @@ static void crypto_test_check_alg_hmac_sha224(void)
 		  ODP_AUTH_ALG_SHA224_HMAC,
 		  hmac_sha224_reference,
 		  ARRAY_SIZE(hmac_sha224_reference),
-		  false,
 		  false);
 }
 
@@ -1818,7 +1520,6 @@ static void crypto_test_gen_alg_hmac_sha256(void)
 		  ODP_AUTH_ALG_SHA256_HMAC,
 		  hmac_sha256_reference,
 		  ARRAY_SIZE(hmac_sha256_reference),
-		  false,
 		  false);
 }
 
@@ -1829,7 +1530,6 @@ static void crypto_test_check_alg_hmac_sha256(void)
 		  ODP_AUTH_ALG_SHA256_HMAC,
 		  hmac_sha256_reference,
 		  ARRAY_SIZE(hmac_sha256_reference),
-		  false,
 		  false);
 }
 
@@ -1845,7 +1545,6 @@ static void crypto_test_gen_alg_hmac_sha384(void)
 		  ODP_AUTH_ALG_SHA384_HMAC,
 		  hmac_sha384_reference,
 		  ARRAY_SIZE(hmac_sha384_reference),
-		  false,
 		  false);
 }
 
@@ -1856,7 +1555,6 @@ static void crypto_test_check_alg_hmac_sha384(void)
 		  ODP_AUTH_ALG_SHA384_HMAC,
 		  hmac_sha384_reference,
 		  ARRAY_SIZE(hmac_sha384_reference),
-		  false,
 		  false);
 }
 
@@ -1872,7 +1570,6 @@ static void crypto_test_gen_alg_hmac_sha512(void)
 		  ODP_AUTH_ALG_SHA512_HMAC,
 		  hmac_sha512_reference,
 		  ARRAY_SIZE(hmac_sha512_reference),
-		  false,
 		  false);
 }
 
@@ -1883,7 +1580,6 @@ static void crypto_test_check_alg_hmac_sha512(void)
 		  ODP_AUTH_ALG_SHA512_HMAC,
 		  hmac_sha512_reference,
 		  ARRAY_SIZE(hmac_sha512_reference),
-		  false,
 		  false);
 }
 
@@ -1900,7 +1596,6 @@ static void crypto_test_gen_alg_aes_xcbc(void)
 		  ODP_AUTH_ALG_AES_XCBC_MAC,
 		  aes_xcbc_reference,
 		  ARRAY_SIZE(aes_xcbc_reference),
-		  false,
 		  false);
 }
 
@@ -1911,7 +1606,6 @@ static void crypto_test_check_alg_aes_xcbc(void)
 		  ODP_AUTH_ALG_AES_XCBC_MAC,
 		  aes_xcbc_reference,
 		  ARRAY_SIZE(aes_xcbc_reference),
-		  false,
 		  false);
 }
 
@@ -1927,18 +1621,6 @@ static void crypto_test_gen_alg_aes_gmac(void)
 		  ODP_AUTH_ALG_AES_GMAC,
 		  aes_gmac_reference,
 		  ARRAY_SIZE(aes_gmac_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_gen_alg_aes_gmac_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_NULL,
-		  ODP_AUTH_ALG_AES_GMAC,
-		  aes_gmac_reference,
-		  ARRAY_SIZE(aes_gmac_reference),
-		  true,
 		  false);
 }
 
@@ -1949,18 +1631,6 @@ static void crypto_test_check_alg_aes_gmac(void)
 		  ODP_AUTH_ALG_AES_GMAC,
 		  aes_gmac_reference,
 		  ARRAY_SIZE(aes_gmac_reference),
-		  false,
-		  false);
-}
-
-static void crypto_test_check_alg_aes_gmac_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_NULL,
-		  ODP_AUTH_ALG_AES_GMAC,
-		  aes_gmac_reference,
-		  ARRAY_SIZE(aes_gmac_reference),
-		  false,
 		  false);
 }
 
@@ -1976,7 +1646,6 @@ static void crypto_test_gen_alg_aes_cmac(void)
 		  ODP_AUTH_ALG_AES_CMAC,
 		  aes_cmac_reference,
 		  ARRAY_SIZE(aes_cmac_reference),
-		  false,
 		  false);
 }
 
@@ -1987,7 +1656,6 @@ static void crypto_test_check_alg_aes_cmac(void)
 		  ODP_AUTH_ALG_AES_CMAC,
 		  aes_cmac_reference,
 		  ARRAY_SIZE(aes_cmac_reference),
-		  false,
 		  false);
 }
 
@@ -2003,18 +1671,6 @@ static void crypto_test_gen_alg_kasumi_f9(void)
 		  ODP_AUTH_ALG_KASUMI_F9,
 		  kasumi_f9_reference,
 		  ARRAY_SIZE(kasumi_f9_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_gen_alg_kasumi_f9_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_NULL,
-		  ODP_AUTH_ALG_KASUMI_F9,
-		  kasumi_f9_reference,
-		  ARRAY_SIZE(kasumi_f9_reference),
-		  true,
 		  true);
 }
 
@@ -2025,18 +1681,6 @@ static void crypto_test_check_alg_kasumi_f9(void)
 		  ODP_AUTH_ALG_KASUMI_F9,
 		  kasumi_f9_reference,
 		  ARRAY_SIZE(kasumi_f9_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_check_alg_kasumi_f9_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_NULL,
-		  ODP_AUTH_ALG_KASUMI_F9,
-		  kasumi_f9_reference,
-		  ARRAY_SIZE(kasumi_f9_reference),
-		  true,
 		  true);
 }
 
@@ -2052,18 +1696,6 @@ static void crypto_test_gen_alg_snow3g_uia2(void)
 		  ODP_AUTH_ALG_SNOW3G_UIA2,
 		  snow3g_uia2_reference,
 		  ARRAY_SIZE(snow3g_uia2_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_gen_alg_snow3g_uia2_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_NULL,
-		  ODP_AUTH_ALG_SNOW3G_UIA2,
-		  snow3g_uia2_reference,
-		  ARRAY_SIZE(snow3g_uia2_reference),
-		  true,
 		  true);
 }
 
@@ -2074,18 +1706,6 @@ static void crypto_test_check_alg_snow3g_uia2(void)
 		  ODP_AUTH_ALG_SNOW3G_UIA2,
 		  snow3g_uia2_reference,
 		  ARRAY_SIZE(snow3g_uia2_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_check_alg_snow3g_uia2_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_NULL,
-		  ODP_AUTH_ALG_SNOW3G_UIA2,
-		  snow3g_uia2_reference,
-		  ARRAY_SIZE(snow3g_uia2_reference),
-		  true,
 		  true);
 }
 
@@ -2102,18 +1722,6 @@ static void crypto_test_gen_alg_aes_eia2(void)
 		  ODP_AUTH_ALG_AES_EIA2,
 		  aes_eia2_reference,
 		  ARRAY_SIZE(aes_eia2_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_gen_alg_aes_eia2_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_NULL,
-		  ODP_AUTH_ALG_AES_EIA2,
-		  aes_eia2_reference,
-		  ARRAY_SIZE(aes_eia2_reference),
-		  true,
 		  true);
 }
 
@@ -2124,18 +1732,6 @@ static void crypto_test_check_alg_aes_eia2(void)
 		  ODP_AUTH_ALG_AES_EIA2,
 		  aes_eia2_reference,
 		  ARRAY_SIZE(aes_eia2_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_check_alg_aes_eia2_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_NULL,
-		  ODP_AUTH_ALG_AES_EIA2,
-		  aes_eia2_reference,
-		  ARRAY_SIZE(aes_eia2_reference),
-		  true,
 		  true);
 }
 
@@ -2151,18 +1747,6 @@ static void crypto_test_gen_alg_zuc_eia3(void)
 		  ODP_AUTH_ALG_ZUC_EIA3,
 		  zuc_eia3_reference,
 		  ARRAY_SIZE(zuc_eia3_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_gen_alg_zuc_eia3_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_ENCODE,
-		  ODP_CIPHER_ALG_NULL,
-		  ODP_AUTH_ALG_ZUC_EIA3,
-		  zuc_eia3_reference,
-		  ARRAY_SIZE(zuc_eia3_reference),
-		  true,
 		  true);
 }
 
@@ -2173,18 +1757,6 @@ static void crypto_test_check_alg_zuc_eia3(void)
 		  ODP_AUTH_ALG_ZUC_EIA3,
 		  zuc_eia3_reference,
 		  ARRAY_SIZE(zuc_eia3_reference),
-		  false,
-		  true);
-}
-
-static void crypto_test_check_alg_zuc_eia3_ovr_iv(void)
-{
-	check_alg(ODP_CRYPTO_OP_DECODE,
-		  ODP_CIPHER_ALG_NULL,
-		  ODP_AUTH_ALG_ZUC_EIA3,
-		  zuc_eia3_reference,
-		  ARRAY_SIZE(zuc_eia3_reference),
-		  true,
 		  true);
 }
 
@@ -2200,7 +1772,6 @@ static void crypto_test_gen_alg_md5(void)
 		  ODP_AUTH_ALG_MD5,
 		  md5_reference,
 		  ARRAY_SIZE(md5_reference),
-		  false,
 		  false);
 }
 
@@ -2211,7 +1782,6 @@ static void crypto_test_check_alg_md5(void)
 		  ODP_AUTH_ALG_MD5,
 		  md5_reference,
 		  ARRAY_SIZE(md5_reference),
-		  false,
 		  false);
 }
 
@@ -2227,7 +1797,6 @@ static void crypto_test_gen_alg_sha1(void)
 		  ODP_AUTH_ALG_SHA1,
 		  sha1_reference,
 		  ARRAY_SIZE(sha1_reference),
-		  false,
 		  false);
 }
 
@@ -2238,7 +1807,6 @@ static void crypto_test_check_alg_sha1(void)
 		  ODP_AUTH_ALG_SHA1,
 		  sha1_reference,
 		  ARRAY_SIZE(sha1_reference),
-		  false,
 		  false);
 }
 
@@ -2254,7 +1822,6 @@ static void crypto_test_gen_alg_sha224(void)
 		  ODP_AUTH_ALG_SHA224,
 		  sha224_reference,
 		  ARRAY_SIZE(sha224_reference),
-		  false,
 		  false);
 }
 
@@ -2265,7 +1832,6 @@ static void crypto_test_check_alg_sha224(void)
 		  ODP_AUTH_ALG_SHA224,
 		  sha224_reference,
 		  ARRAY_SIZE(sha224_reference),
-		  false,
 		  false);
 }
 
@@ -2281,7 +1847,6 @@ static void crypto_test_gen_alg_sha256(void)
 		  ODP_AUTH_ALG_SHA256,
 		  sha256_reference,
 		  ARRAY_SIZE(sha256_reference),
-		  false,
 		  false);
 }
 
@@ -2292,7 +1857,6 @@ static void crypto_test_check_alg_sha256(void)
 		  ODP_AUTH_ALG_SHA256,
 		  sha256_reference,
 		  ARRAY_SIZE(sha256_reference),
-		  false,
 		  false);
 }
 
@@ -2308,7 +1872,6 @@ static void crypto_test_gen_alg_sha384(void)
 		  ODP_AUTH_ALG_SHA384,
 		  sha384_reference,
 		  ARRAY_SIZE(sha384_reference),
-		  false,
 		  false);
 }
 
@@ -2319,7 +1882,6 @@ static void crypto_test_check_alg_sha384(void)
 		  ODP_AUTH_ALG_SHA384,
 		  sha384_reference,
 		  ARRAY_SIZE(sha384_reference),
-		  false,
 		  false);
 }
 
@@ -2335,7 +1897,6 @@ static void crypto_test_gen_alg_sha512(void)
 		  ODP_AUTH_ALG_SHA512,
 		  sha512_reference,
 		  ARRAY_SIZE(sha512_reference),
-		  false,
 		  false);
 }
 
@@ -2346,7 +1907,6 @@ static void crypto_test_check_alg_sha512(void)
 		  ODP_AUTH_ALG_SHA512,
 		  sha512_reference,
 		  ARRAY_SIZE(sha512_reference),
-		  false,
 		  false);
 }
 
@@ -2512,10 +2072,6 @@ odp_testinfo_t crypto_suite[] = {
 				  check_alg_3des_cbc),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_3des_cbc,
 				  check_alg_3des_cbc),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_3des_cbc_ovr_iv,
-				  check_alg_3des_cbc),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_3des_cbc_ovr_iv,
-				  check_alg_3des_cbc),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_3des_ecb,
 				  check_alg_3des_ecb),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_3des_ecb,
@@ -2524,17 +2080,9 @@ odp_testinfo_t crypto_suite[] = {
 				  check_alg_aes_cbc),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_cbc,
 				  check_alg_aes_cbc),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_cbc_ovr_iv,
-				  check_alg_aes_cbc),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_cbc_ovr_iv,
-				  check_alg_aes_cbc),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_ctr,
 				  check_alg_aes_ctr),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_ctr,
-				  check_alg_aes_ctr),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_ctr_ovr_iv,
-				  check_alg_aes_ctr),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_ctr_ovr_iv,
 				  check_alg_aes_ctr),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_ecb,
 				  check_alg_aes_ecb),
@@ -2544,73 +2092,37 @@ odp_testinfo_t crypto_suite[] = {
 				  check_alg_aes_cfb128),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_cfb128,
 				  check_alg_aes_cfb128),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_cfb128_ovr_iv,
-				  check_alg_aes_cfb128),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_cfb128_ovr_iv,
-				  check_alg_aes_cfb128),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_xts,
 				  check_alg_aes_xts),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_xts,
-				  check_alg_aes_xts),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_xts_ovr_iv,
-				  check_alg_aes_xts),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_xts_ovr_iv,
 				  check_alg_aes_xts),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_kasumi_f8,
 				  check_alg_kasumi_f8),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_kasumi_f8,
 				  check_alg_kasumi_f8),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_kasumi_f8_ovr_iv,
-				  check_alg_kasumi_f8),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_kasumi_f8_ovr_iv,
-				  check_alg_kasumi_f8),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_snow3g_uea2,
 				  check_alg_snow3g_uea2),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_snow3g_uea2,
-				  check_alg_snow3g_uea2),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_snow3g_uea2_ovr_iv,
-				  check_alg_snow3g_uea2),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_snow3g_uea2_ovr_iv,
 				  check_alg_snow3g_uea2),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_eea2,
 				  check_alg_aes_eea2),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_eea2,
 				  check_alg_aes_eea2),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_eea2_ovr_iv,
-				  check_alg_aes_eea2),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_eea2_ovr_iv,
-				  check_alg_aes_eea2),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_zuc_eea3,
 				  check_alg_zuc_eea3),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_zuc_eea3,
 				  check_alg_zuc_eea3),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_zuc_eea3_ovr_iv,
-				  check_alg_zuc_eea3),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_zuc_eea3_ovr_iv,
-				  check_alg_zuc_eea3),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_gcm,
-				  check_alg_aes_gcm),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_gcm_ovr_iv,
 				  check_alg_aes_gcm),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_gcm,
 				  check_alg_aes_gcm),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_gcm_ovr_iv,
-				  check_alg_aes_gcm),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_ccm,
-				  check_alg_aes_ccm),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_aes_ccm_ovr_iv,
 				  check_alg_aes_ccm),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_ccm,
 				  check_alg_aes_ccm),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_aes_ccm_ovr_iv,
-				  check_alg_aes_ccm),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_chacha20_poly1305,
 				  check_alg_chacha20_poly1305),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_chacha20_poly1305_ovr_iv,
-				  check_alg_chacha20_poly1305),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_chacha20_poly1305,
-				  check_alg_chacha20_poly1305),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_chacha20_poly1305_ovr_iv,
 				  check_alg_chacha20_poly1305),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_gen_alg_hmac_md5,
 				  check_alg_hmac_md5),
@@ -2642,11 +2154,7 @@ odp_testinfo_t crypto_suite[] = {
 				  check_alg_aes_xcbc),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_gen_alg_aes_gmac,
 				  check_alg_aes_gmac),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_gen_alg_aes_gmac_ovr_iv,
-				  check_alg_aes_gmac),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_check_alg_aes_gmac,
-				  check_alg_aes_gmac),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_check_alg_aes_gmac_ovr_iv,
 				  check_alg_aes_gmac),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_gen_alg_aes_cmac,
 				  check_alg_aes_cmac),
@@ -2656,33 +2164,17 @@ odp_testinfo_t crypto_suite[] = {
 				  check_alg_kasumi_f9),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_check_alg_kasumi_f9,
 				  check_alg_kasumi_f9),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_gen_alg_kasumi_f9_ovr_iv,
-				  check_alg_kasumi_f9),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_check_alg_kasumi_f9_ovr_iv,
-				  check_alg_kasumi_f9),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_gen_alg_snow3g_uia2,
 				  check_alg_snow3g_uia2),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_check_alg_snow3g_uia2,
-				  check_alg_snow3g_uia2),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_gen_alg_snow3g_uia2_ovr_iv,
-				  check_alg_snow3g_uia2),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_check_alg_snow3g_uia2_ovr_iv,
 				  check_alg_snow3g_uia2),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_gen_alg_aes_eia2,
 				  check_alg_aes_eia2),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_check_alg_aes_eia2,
 				  check_alg_aes_eia2),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_gen_alg_aes_eia2_ovr_iv,
-				  check_alg_aes_eia2),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_check_alg_aes_eia2_ovr_iv,
-				  check_alg_aes_eia2),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_gen_alg_zuc_eia3,
 				  check_alg_zuc_eia3),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_check_alg_zuc_eia3,
-				  check_alg_zuc_eia3),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_gen_alg_zuc_eia3_ovr_iv,
-				  check_alg_zuc_eia3),
-	ODP_TEST_INFO_CONDITIONAL(crypto_test_check_alg_zuc_eia3_ovr_iv,
 				  check_alg_zuc_eia3),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_gen_alg_md5,
 				  check_alg_md5),

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -26,6 +26,31 @@ struct suite_context_s {
 
 static struct suite_context_s suite_context;
 
+static void test_default_values(void)
+{
+	odp_crypto_session_param_t param;
+
+	memset(&param, 0x55, sizeof(param));
+	odp_crypto_session_param_init(&param);
+
+	CU_ASSERT_EQUAL(param.op, ODP_CRYPTO_OP_ENCODE);
+	CU_ASSERT_EQUAL(param.auth_cipher_text, false);
+	CU_ASSERT_EQUAL(param.pref_mode, ODP_CRYPTO_SYNC);
+	CU_ASSERT_EQUAL(param.op_mode, ODP_CRYPTO_SYNC);
+	CU_ASSERT_EQUAL(param.cipher_alg, ODP_CIPHER_ALG_NULL);
+	CU_ASSERT_EQUAL(param.cipher_iv_len, 0);
+	CU_ASSERT_EQUAL(param.auth_alg, ODP_AUTH_ALG_NULL);
+	CU_ASSERT_EQUAL(param.auth_iv_len, 0);
+	CU_ASSERT_EQUAL(param.auth_aad_len, 0);
+
+#if ODP_DEPRECATED_API
+	CU_ASSERT_EQUAL(param.cipher_iv.data, NULL);
+	CU_ASSERT_EQUAL(param.cipher_iv.length, 0);
+	CU_ASSERT_EQUAL(param.auth_iv.data, NULL);
+	CU_ASSERT_EQUAL(param.auth_iv.length, 0);
+#endif
+}
+
 static int packet_cmp_mem_bits(odp_packet_t pkt, uint32_t offset,
 			       uint8_t *s, uint32_t len)
 {
@@ -2090,6 +2115,7 @@ static int crypto_suite_term(void)
 
 odp_testinfo_t crypto_suite[] = {
 	ODP_TEST_INFO(test_capability),
+	ODP_TEST_INFO(test_default_values),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_enc_alg_null,
 				  check_alg_null),
 	ODP_TEST_INFO_CONDITIONAL(crypto_test_dec_alg_null,


### PR DESCRIPTION
Reusing the same initialization vector (IV) with the same key is almost always wrong and results in weakened security. Therefore the ability of specifying IV in crypto session creation and reusing it in multiple crypto operations is of questionable value. It complicates both the API and implementations and may encourage incorrect IV reuse (see PR 1446).

This PR deprecates odp_crypto_iv_t type (which holds IV length and IV data) and the cipher_iv and auth_iv parameters of odp_crypto_session_param_t. New session parameters, cipher_iv_len and auth_iv_len, are introduced for setting IV lengths in the session. From now on, IV data must always be passed through the existing cipher_iv_ptr and auth_iv_ptr parameters of odp_crypto_op_param_t and odp_crypto_packet_op_param_t.
