### PR TITLE
[PATCH v2] api: random: explicitly require the same series of calls to generate repeatable test data

### DIFF
--- a/include/odp/api/spec/random.h
+++ b/include/odp/api/spec/random.h
@@ -85,7 +85,7 @@ int32_t odp_random_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind);
  * For testing purposes it is often useful to generate "random" sequences that
  * are repeatable. This is accomplished by supplying a seed value that is used
  * for pseudo-random data generation. The caller-provided seed value is
- * updated for each call to continue the sequence. Restarting a series of
+ * updated for each call to continue the sequence. Restarting the same series of
  * calls with the same initial seed value will generate the same sequence of
  * random test data.
  *


### PR DESCRIPTION
```
Explicitly state that the same series of odp_random_test_data() calls
is required to generate the same data. This is already the
interpretation in linux-gen, this change is only a clarification to
the API text.

Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
v2:
- Add review tag.
