### PR TITLE
[PATCH v3] example: timer_accuracy: close output file on failure

### DIFF
--- a/example/timer/odp_timer_accuracy.c
+++ b/example/timer/odp_timer_accuracy.c
@@ -1,10 +1,11 @@
 /* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2019-2021, Nokia
+ * Copyright (c) 2019-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
@@ -717,15 +718,6 @@ int main(int argc, char *argv[])
 	if (parse_options(argc, argv, &test_global))
 		return -1;
 
-	if (test_global.opt.output) {
-		test_global.file = fopen(test_global.filename, "w");
-		if (test_global.file == NULL) {
-			printf("Failed to open file: %s\n",
-			       test_global.filename);
-			return -1;
-		}
-	}
-
 	/* List features not to be used (may optimize performance) */
 	odp_init_param_init(&init);
 	init.not_used.feat.cls      = 1;
@@ -766,6 +758,14 @@ int main(int argc, char *argv[])
 		odp_shm_t shm;
 		void *addr;
 		uint64_t size = test_global.tot_timers * sizeof(test_log_t);
+
+		test_global.file = fopen(test_global.filename, "w");
+		if (test_global.file == NULL) {
+			printf("Failed to open output file %s: %s\n",
+			       test_global.filename, strerror(errno));
+			ret = -1;
+			goto quit;
+		}
 
 		shm = odp_shm_reserve("timer_accuracy_log", size,
 				      sizeof(test_log_t), 0);

--- a/example/timer/odp_timer_accuracy.c
+++ b/example/timer/odp_timer_accuracy.c
@@ -751,6 +751,7 @@ int main(int argc, char *argv[])
 
 	if (test_global.timer_ctx == NULL) {
 		printf("Timer context table calloc failed.\n");
+		ret = -1;
 		goto quit;
 	}
 
@@ -772,6 +773,7 @@ int main(int argc, char *argv[])
 
 		if (shm == ODP_SHM_INVALID) {
 			printf("Test log alloc failed.\n");
+			ret = -1;
 			goto quit;
 		}
 
@@ -781,7 +783,8 @@ int main(int argc, char *argv[])
 		test_global.log_shm = shm;
 	}
 
-	if (start_timers(&test_global))
+	ret = start_timers(&test_global);
+	if (ret)
 		goto quit;
 
 	run_test(&test_global);


### PR DESCRIPTION
V2:
- Updated copyright year
- Print error string in case of `fopen()` failure