### PR TITLE
[PATCH v2] Pull request for buffer starvation due to caching

### DIFF
--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -4139,7 +4139,9 @@ static int create_pool(const char *iface, int num)
 
 	odp_pool_param_init(&params);
 	set_pool_len(&params, &pool_capa);
-	params.pkt.num     = PKT_BUF_NUM;
+	/* Allocate enough buffers taking into consideration core starvation
+	 * due to caching */
+	params.pkt.num     = PKT_BUF_NUM + params.pkt.cache_size;
 	params.type        = ODP_POOL_PACKET;
 
 	snprintf(pool_name, sizeof(pool_name), "pkt_pool_%s_%d",

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -84,7 +84,9 @@ static int queue_suite_init(void)
 	odp_pool_param_init(&params);
 
 	params.buf.size  = 4;
-	params.buf.num   = MAX_NUM_EVENT;
+	/* Allocate enough buffers taking into consideration core starvation
+	 * due to caching */
+	params.buf.num   = MAX_NUM_EVENT + params.buf.cache_size;
 	params.type      = ODP_POOL_BUFFER;
 
 	pool = odp_pool_create("msg_pool", &params);


### PR DESCRIPTION
## validation: pktio: create pools with enough buffers

While creating pools, take into consideration buffer starvation
that can occur on a core due to buffers being cached on a different
core. So ensure that pools are created with enough buffers.

Signed-off-by: Ashwin Sekhar T K <asekhar@marvell.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>

## validation: queue: create pools with enough buffers

While creating pools, take into consideration buffer starvation
that can occur on a core due to buffers being cached on a different
core. So ensure that pools are created with enough buffers.

Signed-off-by: Ashwin Sekhar T K <asekhar@marvell.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>
