### PR TITLE
[PATCH v5] api: crypto: API clarifications and new session creation error codes

### DIFF
--- a/example/ipsec_crypto/odp_ipsec_cache.c
+++ b/example/ipsec_crypto/odp_ipsec_cache.c
@@ -119,7 +119,7 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 	/* Synchronous session create for now */
 	if (odp_crypto_session_create(&params, &session, &ses_create_rc))
 		return -1;
-	if (ODP_CRYPTO_SES_CREATE_ERR_NONE != ses_create_rc)
+	if (ODP_CRYPTO_SES_ERR_NONE != ses_create_rc)
 		return -1;
 
 	/* Copy remainder */

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -800,6 +800,32 @@ typedef enum {
 	ODP_CRYPTO_SES_ERR_CIPHER,
 	/** Creation failed, bad auth params */
 	ODP_CRYPTO_SES_ERR_AUTH,
+
+	/** Unsupported combination of algorithms
+	 *
+	 *  The combination of cipher and auth algorithms with their
+	 *  specific parameters is not supported even if the algorithms
+	 *  appear in capabilities and are supported in combination with
+	 *  other algorithms or other algorithm specific parameters.
+	 */
+	ODP_CRYPTO_SES_ERR_ALG_COMBO,
+
+	/** Unsupported order of cipher and auth
+	 *
+	 *  The requested mutual order of ciphering and authentication
+	 *  is not supported with the chosen individual cipher and
+	 *  authentication algorithms.
+	 */
+	ODP_CRYPTO_SES_ERR_ALG_ORDER,
+
+	/** Unsupported combination of session creation parameters
+	 *
+	 *  The combination of provided session creation parameters is not
+	 *  supported. This error can occur when there are limitations that
+	 *  are not expressible through crypto capabilities or other error
+	 *  status values.
+	 */
+	ODP_CRYPTO_SES_ERR_PARAMS,
 } odp_crypto_ses_create_err_t;
 
 /** This synonym for backward compatibility will be deprecated later */

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -232,12 +232,14 @@ typedef enum {
 	 *  cipher.
 	 *
 	 *  NIST and RFC specifications of GMAC refer to all data to be
-	 *  authenticated as AAD. In constrast to that, ODP API specifies
-	 *  the bulk of authenticated data to be located in packet payload for
-	 *  all authentication algorithms. Thus GMAC operation authenticates
-	 *  only packet payload and AAD is not used. GMAC needs
-	 *  an initialization vector, which can be passed via session (auth_iv)
-	 *  or packet (auth_iv_ptr) level parameters.
+	 *  authenticated as AAD. In ODP the data to be authenticated, i.e.
+	 *  AAD, is ODP packet data and specified using the auth_range
+	 *  parameter. The aad_length and aad_ptr parameters, which would
+	 *  require the data to be contiguous in memory, are ignored with
+	 *  AES-GMAC.
+	 *
+	 *  GMAC needs an initialization vector, which can be passed via
+	 *  session (auth_iv) or packet (auth_iv_ptr) level parameters.
 	 */
 	ODP_AUTH_ALG_AES_GMAC,
 
@@ -559,6 +561,9 @@ typedef struct odp_crypto_session_param_t {
 	 *  after the cipher operation else before. When decoding, TRUE
 	 *  indicates the reverse order of operation.
 	 *
+	 *  The value is ignored with authenticated encryption algorithms
+	 *  such as AES-GCM.
+	 *
 	 *  true:  Authenticate cipher text
 	 *  false: Authenticate plain text
 	 *
@@ -723,10 +728,18 @@ typedef struct odp_crypto_op_param_t {
 	 */
 	uint8_t *aad_ptr;
 
-	/** Data range to apply cipher */
+	/** Data range to be ciphered */
 	odp_packet_data_range_t cipher_range;
 
-	/** Data range to authenticate */
+	/** Data range to be authenticated
+	 *
+	 *  The value is ignored with authenticated encryption algorithms,
+	 *  such as AES-GCM, which authenticate data in the cipher range
+	 *  and the AAD.
+	 *
+	 *  As a special case AES-GMAC uses this field instead of aad_ptr
+	 *  for the data bytes to be authenticated.
+	 */
 	odp_packet_data_range_t auth_range;
 
 } odp_crypto_op_param_t;

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -793,14 +793,23 @@ typedef struct odp_crypto_packet_op_param_t {
  */
 typedef enum {
 	/** Session created */
-	ODP_CRYPTO_SES_CREATE_ERR_NONE,
+	ODP_CRYPTO_SES_ERR_NONE,
 	/** Creation failed, no resources */
-	ODP_CRYPTO_SES_CREATE_ERR_ENOMEM,
+	ODP_CRYPTO_SES_ERR_ENOMEM,
 	/** Creation failed, bad cipher params */
-	ODP_CRYPTO_SES_CREATE_ERR_INV_CIPHER,
+	ODP_CRYPTO_SES_ERR_CIPHER,
 	/** Creation failed, bad auth params */
-	ODP_CRYPTO_SES_CREATE_ERR_INV_AUTH,
+	ODP_CRYPTO_SES_ERR_AUTH,
 } odp_crypto_ses_create_err_t;
+
+/** This synonym for backward compatibility will be deprecated later */
+#define ODP_CRYPTO_SES_CREATE_ERR_NONE       ODP_CRYPTO_SES_ERR_NONE
+/** This synonym for backward compatibility will be deprecated later */
+#define ODP_CRYPTO_SES_CREATE_ERR_ENOMEM     ODP_CRYPTO_SES_ERR_ENOMEM
+/** This synonym for backward compatibility will be deprecated later */
+#define ODP_CRYPTO_SES_CREATE_ERR_INV_CIPHER ODP_CRYPTO_SES_ERR_CIPHER
+/** This synonym for backward compatibility will be deprecated later */
+#define ODP_CRYPTO_SES_CREATE_ERR_INV_AUTH   ODP_CRYPTO_SES_ERR_AUTH
 
 /**
  * Crypto API algorithm return code

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -2125,7 +2125,7 @@ odp_crypto_session_create(const odp_crypto_session_param_t *param,
 		ODP_ERR("Crypto is disabled\n");
 		/* Dummy output to avoid compiler warning about uninitialized
 		 * variables */
-		*status = ODP_CRYPTO_SES_CREATE_ERR_ENOMEM;
+		*status = ODP_CRYPTO_SES_ERR_ENOMEM;
 		*session_out = ODP_CRYPTO_SESSION_INVALID;
 		return -1;
 	}
@@ -2133,7 +2133,7 @@ odp_crypto_session_create(const odp_crypto_session_param_t *param,
 	/* Allocate memory for this session */
 	session = alloc_session();
 	if (NULL == session) {
-		*status = ODP_CRYPTO_SES_CREATE_ERR_ENOMEM;
+		*status = ODP_CRYPTO_SES_ERR_ENOMEM;
 		goto err;
 	}
 
@@ -2142,13 +2142,13 @@ odp_crypto_session_create(const odp_crypto_session_param_t *param,
 
 	if (session->p.cipher_iv.length > EVP_MAX_IV_LENGTH) {
 		ODP_DBG("Maximum IV length exceeded\n");
-		*status = ODP_CRYPTO_SES_CREATE_ERR_INV_CIPHER;
+		*status = ODP_CRYPTO_SES_ERR_CIPHER;
 		goto err;
 	}
 
 	if (session->p.auth_iv.length > EVP_MAX_IV_LENGTH) {
 		ODP_DBG("Maximum auth IV length exceeded\n");
-		*status = ODP_CRYPTO_SES_CREATE_ERR_INV_CIPHER;
+		*status = ODP_CRYPTO_SES_ERR_CIPHER;
 		goto err;
 	}
 
@@ -2303,7 +2303,7 @@ odp_crypto_session_create(const odp_crypto_session_param_t *param,
 
 	/* Check result */
 	if (rc) {
-		*status = ODP_CRYPTO_SES_CREATE_ERR_INV_CIPHER;
+		*status = ODP_CRYPTO_SES_ERR_CIPHER;
 		goto err;
 	}
 
@@ -2446,13 +2446,13 @@ odp_crypto_session_create(const odp_crypto_session_param_t *param,
 
 	/* Check result */
 	if (rc) {
-		*status = ODP_CRYPTO_SES_CREATE_ERR_INV_AUTH;
+		*status = ODP_CRYPTO_SES_ERR_AUTH;
 		goto err;
 	}
 
 	/* We're happy */
 	*session_out = (intptr_t)session;
-	*status = ODP_CRYPTO_SES_CREATE_ERR_NONE;
+	*status = ODP_CRYPTO_SES_ERR_NONE;
 	return 0;
 
 err:

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
+ * Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:	BSD-3-Clause
@@ -652,6 +652,25 @@ static void alg_test(odp_crypto_op_t op,
 	ses_params.auth_aad_len = ref->aad_length;
 
 	rc = odp_crypto_session_create(&ses_params, &session, &status);
+	/*
+	 * In some cases an individual algorithm cannot be used alone,
+	 * i.e. with the null cipher/auth algorithm.
+	 */
+	if (rc == ODP_CRYPTO_SES_ERR_ALG_COMBO) {
+		printf("\n    Unsupported algorithm combination: %s, %s\n",
+		       cipher_alg_name(cipher_alg),
+		       auth_alg_name(auth_alg));
+		return;
+	}
+	/*
+	 * We do not allow ODP_CRYPTO_SES_ERR_ALG_ORDER since we do
+	 * not combine individual non-null crypto and auth algorithms
+	 * with each other in the tests. Both orders should work when
+	 * only one algorithm is used (i.e. the other one is null).
+	 *
+	 * We do not allow ODP_CRYPTO_SES_ERR_PARAMS until needed for
+	 * some ODP implementation.
+	 */
 	CU_ASSERT_FATAL(!rc);
 	CU_ASSERT(status == ODP_CRYPTO_SES_ERR_NONE);
 	CU_ASSERT(odp_crypto_session_to_u64(session) !=

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -653,7 +653,7 @@ static void alg_test(odp_crypto_op_t op,
 
 	rc = odp_crypto_session_create(&ses_params, &session, &status);
 	CU_ASSERT_FATAL(!rc);
-	CU_ASSERT(status == ODP_CRYPTO_SES_CREATE_ERR_NONE);
+	CU_ASSERT(status == ODP_CRYPTO_SES_ERR_NONE);
 	CU_ASSERT(odp_crypto_session_to_u64(session) !=
 		  odp_crypto_session_to_u64(ODP_CRYPTO_SESSION_INVALID));
 


### PR DESCRIPTION
    api: crypto: add session creation error codes for unsupported combos

    Add crypto session creation error codes for cases where the requested
    combination of algorithms, order of algorithms or other combination
    of creation parameters is not supported. The new errors are for cases
    where a limitation of an ODP implementation cannot be expressed
    through crypto capabilities.


    api: crypto: clarify auth_range parameter with AEAD algorithms

    AEAD algorithms authenticate the plaintext that is to be encrypted
    plus additional authenticated data (AAD). Clarify that in case of AEAD
    algorithms the auth_range parameter is not used, except with AES-GMAC.

    AES-GMAC, as defined, does not take any plaintext to be encrypted
    as input but only AAD. In ODP API the aad_ptr parameter is not used
    but the AAD is provided through auth_range, allowing the data be located
    as non-contiguous pieces in multiple packet segments. Clarify the API
    text to not sound as if ODP did not use AAD as defined in the GMAC
    algorithm specification.

