### PR TITLE
[PATCH v3] test: performance: dma_perf: add test script

### DIFF
--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -7,7 +7,6 @@ EXECUTABLES = odp_atomic_perf \
 	      odp_cpu_bench \
 	      odp_crc \
 	      odp_crypto \
-	      odp_dma_perf \
 	      odp_ipsec \
 	      odp_lock_perf \
 	      odp_mem_perf \
@@ -16,7 +15,8 @@ EXECUTABLES = odp_atomic_perf \
 	      odp_queue_perf \
 	      odp_random
 
-COMPILE_ONLY = odp_l2fwd \
+COMPILE_ONLY = odp_dma_perf \
+	       odp_l2fwd \
 	       odp_packet_gen \
 	       odp_pktio_ordered \
 	       odp_sched_latency \
@@ -25,7 +25,8 @@ COMPILE_ONLY = odp_l2fwd \
 	       odp_scheduling \
 	       odp_timer_perf
 
-TESTSCRIPTS = odp_l2fwd_run.sh \
+TESTSCRIPTS = odp_dma_perf_run.sh \
+	      odp_l2fwd_run.sh \
 	      odp_packet_gen_run.sh \
 	      odp_sched_latency_run.sh \
 	      odp_sched_perf_run.sh \

--- a/test/performance/odp_dma_perf_run.sh
+++ b/test/performance/odp_dma_perf_run.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+#
+# Copyright (c) 2022, Nokia
+# All rights reserved.
+#
+# SPDX-License-Identifier:	BSD-3-Clause
+
+TEST_DIR="${TEST_DIR:-$(dirname $0)}"
+BIN_NAME=odp_dma_perf
+SEG_SIZE=1024
+ROUNDS=1000
+TESTS_RUN=0
+
+check_result()
+{
+	if [ $1 -eq 0 ]; then
+		TESTS_RUN=`expr $TESTS_RUN + 1`
+	elif [ $1 -eq 1 ]; then
+		echo "Test FAILED, exiting"
+		exit 1
+	else
+		echo "Test SKIPPED"
+	fi
+}
+
+echo "odp_dma_perf: synchronous transfer 1"
+echo "===================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 0 -g 0 -i 6 -s $SEG_SIZE -T 0 -r $ROUNDS
+
+check_result $?
+
+echo "odp_dma_perf: synchronous transfer 2"
+echo "===================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 0 -g 1 -i 6 -s $SEG_SIZE -T 0 -r $ROUNDS
+
+check_result $?
+
+echo "odp_dma_perf: synchronous transfer 3"
+echo "===================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 0 -g 0 -i 6 -s $SEG_SIZE -T 1 -r $ROUNDS
+
+check_result $?
+
+echo "odp_dma_perf: synchronous transfer 4"
+echo "===================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 0 -g 1 -i 6 -s $SEG_SIZE -T 1 -r $ROUNDS
+
+check_result $?
+
+echo "odp_dma_perf: asynchronous transfer 1"
+echo "====================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -g 0 -i 6 -s $SEG_SIZE -T 0 -m 0 -r $ROUNDS
+
+check_result $?
+
+echo "odp_dma_perf: asynchronous transfer 2"
+echo "====================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -g 1 -i 6 -s $SEG_SIZE -T 0 -m 0,0,0,0,0,0 -r $ROUNDS
+
+check_result $?
+
+echo "odp_dma_perf: asynchronous transfer 3"
+echo "====================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -g 1 -i 6 -s $SEG_SIZE -T 0 -m 0,0,0,0,0,1 -r $ROUNDS
+
+check_result $?
+
+echo "odp_dma_perf: asynchronous transfer 4"
+echo "====================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -g 0 -i 6 -s $SEG_SIZE -T 1 -m 0 -r $ROUNDS
+
+check_result $?
+
+echo "odp_dma_perf: asynchronous transfer 5"
+echo "====================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -g 1 -i 6 -s $SEG_SIZE -T 1 -m 0,0,0,0,0,0 -r $ROUNDS
+
+check_result $?
+
+echo "odp_dma_perf: asynchronous transfer 6"
+echo "====================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -g 1 -i 6 -s $SEG_SIZE -T 1 -m 0,0,0,0,0,1 -r $ROUNDS
+
+check_result $?
+
+if [ $TESTS_RUN -eq 0 ]; then
+	exit 77
+fi
+
+exit 0


### PR DESCRIPTION
Add test script for running `odp_dma_perf` with a few different
scenarios during `make check`.

v2:
- reduce test rounds to 1000
- utilize exit code of `odp_dma_perf`
- move `odp_dma_perf` to compile only
- always use 1024B segment size

v3:
- rebase
- add reviewed-by tag