### PR TITLE
[PATCH v2] test: performance: dma_perf: fix potential overflow issue

### DIFF
--- a/test/performance/odp_dma_perf.c
+++ b/test/performance/odp_dma_perf.c
@@ -550,7 +550,7 @@ static void free_packets(test_config_t *config)
 
 static int allocate_memory(test_config_t *config)
 {
-	const uint64_t size = config->num_in_seg * config->seg_size;
+	const uint64_t size = config->num_in_seg * (uint64_t)config->seg_size;
 
 	config->seg_config.shm_src = ODP_SHM_INVALID;
 	config->seg_config.shm_dst = ODP_SHM_INVALID;


### PR DESCRIPTION
Use wider types when calculating size for shared memory reservation to
prevent a potential integer overflow.

v2:
- add reviewed-by tag