### PR TITLE
[PATCH v3] validation: atomic: fix validation in case of 32 bit overflow and underflow

### DIFF
--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021 Nokia
+ * Copyright (c) 2021-2022 Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:	 BSD-3-Clause
@@ -11,9 +11,6 @@
 #include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include <unistd.h>
-
-#define VERBOSE			0
-#define MAX_ITERATIONS		1000
 
 #define ADD_SUB_CNT		5
 

--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -505,21 +505,23 @@ static void test_atomic_cas_dec_64(void)
 	}
 }
 
+#define BUF_SIZE (64 * 1024)
+
 static void test_atomic_xchg_32(void)
 {
 	uint32_t old, new;
 	uint64_t i;
 	odp_atomic_u32_t *a32u_xchg = &global_mem->a32u_xchg;
-	uint8_t buf[CNT];
+	uint8_t buf[BUF_SIZE];
 	uint64_t seed = odp_thread_id();
 	uint64_t count_old = 0, count_new = 0;
 
-	odp_random_test_data(buf, CNT, &seed);
+	odp_random_test_data(buf, BUF_SIZE, &seed);
 
 	odp_barrier_wait(&global_mem->global_barrier);
 
 	for (i = 0; i < CNT; i++) {
-		new = buf[i];
+		new = buf[i & (BUF_SIZE - 1)];
 		old = odp_atomic_xchg_u32(a32u_xchg, new);
 		count_old += old;
 		count_new += new;
@@ -534,16 +536,16 @@ static void test_atomic_xchg_64(void)
 	uint64_t old, new;
 	uint64_t i;
 	odp_atomic_u64_t *a64u_xchg = &global_mem->a64u_xchg;
-	uint8_t buf[CNT];
+	uint8_t buf[BUF_SIZE];
 	uint64_t seed = odp_thread_id();
 	uint64_t count_old = 0, count_new = 0;
 
-	odp_random_test_data(buf, CNT, &seed);
+	odp_random_test_data(buf, BUF_SIZE, &seed);
 
 	odp_barrier_wait(&global_mem->global_barrier);
 
 	for (i = 0; i < CNT; i++) {
-		new = buf[i];
+		new = buf[i & (BUF_SIZE - 1)];
 		old = odp_atomic_xchg_u64(a64u_xchg, new);
 		count_old += old;
 		count_new += new;


### PR DESCRIPTION
```
validation: atomic: limit random buffer size
    
    Set the size of the buffer holding random numbers in the xchg tests to
    64K, so that we don't run out of memory if the test length is
    increased.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

validation: atomic: fix validation in case of 32 bit overflow and underflow
    
    If test length is increased, 32 bit counters will overflow or
    underflow, and min and max variables will be saturated. Fix validation
    for these cases.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
v2:
- Rebase.
- Tuomas' comments.

v3:
- Rebase.
- Add review tags.
