### PR TITLE
[PATCH v2] linux-gen: tm: odp_tm_enq() fix and stale queue removal

### DIFF
--- a/platform/linux-generic/include/odp_traffic_mngr_internal.h
+++ b/platform/linux-generic/include/odp_traffic_mngr_internal.h
@@ -286,7 +286,6 @@ struct tm_queue_obj_s {
 	uint8_t blocked_cnt;
 	odp_bool_t ordered_enqueue;
 	tm_status_t status;
-	odp_queue_t queue;
 	/* Statistics for odp_tm_queue_stats_t */
 	struct {
 		odp_atomic_u64_t discards;

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -4445,6 +4445,7 @@ int odp_tm_enq(odp_tm_queue_t tm_queue, odp_packet_t pkt)
 {
 	tm_queue_obj_t *tm_queue_obj;
 	tm_system_t *tm_system;
+	int rc;
 
 	tm_queue_obj = GET_TM_QUEUE_OBJ(tm_queue);
 	if (!tm_queue_obj)
@@ -4457,7 +4458,10 @@ int odp_tm_enq(odp_tm_queue_t tm_queue, odp_packet_t pkt)
 	if (odp_atomic_load_u64(&tm_system->destroying))
 		return -1;
 
-	return tm_enqueue(tm_system, tm_queue_obj, pkt);
+	rc = tm_enqueue(tm_system, tm_queue_obj, pkt);
+	if (rc < 0)
+		return rc;
+	return 0;
 }
 
 int odp_tm_enq_with_cnt(odp_tm_queue_t tm_queue, odp_packet_t pkt)

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -1150,10 +1150,12 @@ static uint32_t send_pkts(odp_tm_queue_t tm_queue, uint32_t num_pkts)
 		xmt_pkt_desc = &xmt_pkt_descs[xmt_pkt_idx];
 
 		/* Alternate calling with odp_tm_enq and odp_tm_enq_with_cnt */
-		if ((idx & 1) == 0)
+		if ((idx & 1) == 0) {
 			rc = odp_tm_enq(tm_queue, odp_pkt);
-		else
+			CU_ASSERT(rc <= 0);
+		} else {
 			rc = odp_tm_enq_with_cnt(tm_queue, odp_pkt);
+		}
 
 		xmt_pkt_desc->xmt_idx = xmt_pkt_idx;
 		if (0 <= rc) {


### PR DESCRIPTION
    linux-gen: tm: remove unused odp_queue_t instance

    tm_queue_obj contains an instance of odp_queue_t but the ODP queue is
    not used for anything. The queue seems to be a leftover from very early
    revisions and has been unused since 0d6d0923b. Remove the queue and
    associated code.

    linux-gen: tm: fix success return value of odp_tm_enq()

    Currently odp_tm_enq() may (and often does) return a positive value
    after successful enqueue, even though the API specifies that in success
    the function returns 0. Fix the return value.

    validation: tm: check the return value of odp_tm_enq() better

    According to ODP API, odp_tm_enq() will never return a positive value.
    Check that the return value is not positive.
