### PR TITLE
[PATCH v2] ci: update codecov uploader version

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -221,7 +221,7 @@ jobs:
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v1.2.1
+        uses: codecov/codecov-action@v2
 
   Run_distcheck:
     runs-on: ubuntu-18.04

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -29,4 +29,7 @@ ODP_SCHEDULER=scalable CI_SKIP=pktio_test_pktin_event_sched make check
 ODP_SCHEDULER=sp       make check
 popd
 
+# Convert gcno files into gcov (required by Codecov)
+find . -type f -name '*.gcno' -exec gcov -pb {} +
+
 umount /mnt/huge


### PR DESCRIPTION
Upgrade to Codecov uploader V2 as V1 is being discontinued. The new
uploader doesn't convert *.gcno files into *.gcov files automatically
anymore, so this has to be done now manually in the coverage.sh script.

Signed-off-by: Matias Elo <matias.elo@nokia.com>