### PR TITLE
[PATCH v7] test: performance: ipsec: introduce burst processing

### DIFF
--- a/test/performance/odp_ipsec_run.sh
+++ b/test/performance/odp_ipsec_run.sh
@@ -7,9 +7,9 @@
 
 TEST_DIR="${TEST_DIR:-$(dirname $0)}"
 
-# Run with a small number of iterations in make check
+# Run with a small number of packets in make check
 
-$TEST_DIR/odp_ipsec${EXEEXT} -i 100
+$TEST_DIR/odp_ipsec${EXEEXT} -c 100
 
 if [ $? -ne 0 ] ; then
     echo Test FAILED


### PR DESCRIPTION
Introduce an option to prepare and submit multiple packets for IPsec
processing.

ODP allows multi APIs with packet alloc, free & IPsec processing. Usage
of these APIs would help in improving performance with burst cases. New
option '--burst' or '-b' can be used to enable burst processing. When
specified without any arguments, burst size would be set as 32. User can
control burst size by specifying the optional argument.

Usage: 'odp_ipsec --burst=512'

Signed-off-by: Anoob Joseph <anoobj@marvell.com>