### PR TITLE
[PATCH v6] api: timer: expiration mode parameter

### DIFF
--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -134,9 +134,17 @@ uint64_t odp_timer_ns_to_tick(odp_timer_pool_t timer_pool, uint64_t ns);
 /**
  * Current tick value
  *
+ * Returns the current tick value of the timer pool. Timer tick is an implementation defined unit
+ * of time. Timer tick value increments with a constant, timer pool specific frequency. Tick
+ * frequency may be equal or higher than the requested timer pool resolution. The frequency can be
+ * checked with odp_timer_pool_info(). Tick value increments with implementation specific step
+ * sizes. The value will not wrap around in at least 10 years from the ODP instance startup.
+ *
  * @param timer_pool  Timer pool
  *
  * @return Current time in timer ticks
+ *
+ * @see odp_timer_tick_info_t
  */
 uint64_t odp_timer_current_tick(odp_timer_pool_t timer_pool);
 

--- a/include/odp/api/spec/timer_types.h
+++ b/include/odp/api/spec/timer_types.h
@@ -203,9 +203,46 @@ typedef enum {
 #define ODP_CLOCK_EXT ODP_CLOCK_SRC_1
 
 /**
+ * Timer expiration mode
+ *
+ * Expiration mode selects how timer expiration tick is interpreted. In ODP_TIMER_EXP_RELAXED mode,
+ * timer implementation may round the requested time up or down within resolution limits, and
+ * therefore application may receive timeouts slightly before or after the requested time.
+ * In ODP_TIMER_EXP_AFTER mode, timers are limited to expire exactly on the requested time or
+ * after it, but never before the time.
+ */
+typedef enum {
+	/**
+	 * Expiration after the target time
+	 *
+	 * Timers expire on the specified time or after it, but never before it. */
+	ODP_TIMER_EXP_AFTER = 0,
+
+	/**
+	 * Expiration relaxed
+	 *
+	 * Timers may expire before or after the specified time (within resolution limits).
+	 * Depending on implementation, this may improve expiration accuracy compared to
+	 * ODP_TIMER_EXP_AFTER.
+	 */
+	ODP_TIMER_EXP_RELAXED
+
+} odp_timer_exp_mode_t;
+
+/**
  * Timer pool parameters
  */
 typedef struct {
+	/** Clock source for timers
+	 *
+	 *  The default value is ODP_CLOCK_DEFAULT. */
+	odp_timer_clk_src_t clk_src;
+
+	/** Timer expiration mode
+	 *
+	 *  The default value is ODP_TIMER_EXP_AFTER. */
+	odp_timer_exp_mode_t exp_mode;
+
 	/** Timeout resolution in nanoseconds. Timer pool must serve timeouts
 	 *  with this or higher resolution. The minimum valid value (highest
 	 *  resolution) is defined by timer resolution capability. When this
@@ -238,11 +275,6 @@ typedef struct {
 	 *  timer pool concurrently. When non-zero, only single thread uses the
 	 *  timer pool (concurrently). The default value is zero. */
 	int priv;
-
-	/** Clock source for timers
-	 *
-	 *  The default value is ODP_CLOCK_DEFAULT. */
-	odp_timer_clk_src_t clk_src;
 
 } odp_timer_pool_param_t;
 

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1307,6 +1307,7 @@ void odp_timer_pool_param_init(odp_timer_pool_param_t *param)
 {
 	memset(param, 0, sizeof(odp_timer_pool_param_t));
 	param->clk_src = ODP_CLOCK_DEFAULT;
+	param->exp_mode = ODP_TIMER_EXP_AFTER;
 }
 
 odp_timer_pool_t odp_timer_pool_create(const char *name,

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -683,6 +683,9 @@ static void timer_pool_tick_info_run(odp_timer_clk_src_t clk_src)
 	CU_ASSERT(((double)(ticks_per_sec - 1)) <= tick_hz);
 	CU_ASSERT(((double)(ticks_per_sec + 1)) >= tick_hz);
 
+	/* Tick frequency must be the same or higher that resolution */
+	CU_ASSERT(tick_hz >= tp_param.res_hz);
+
 	printf("\nClock source %i\n", clk_src);
 	printf("  Ticks per second:     %" PRIu64 "\n", ticks_per_sec);
 	printf("  Tick info freq:       %" PRIu64 " + %" PRIu64 " / %" PRIu64 "\n",


### PR DESCRIPTION
New timer pool parameter which allows application to force timers not to expire before target time.