### PR TITLE
[PATCH v3] Speed up make check

### DIFF
--- a/example/classifier/odp_classifier.c
+++ b/example/classifier/odp_classifier.c
@@ -187,6 +187,8 @@ static inline void print_cls_statistics(appl_args_t *args)
 		infinite = 1;
 
 	for (; timeout > 0 || infinite; timeout--) {
+		sleep(1);
+		printf("\r");
 		for (i = 0; i < args->policy_count; i++) {
 			printf("%-6" PRIu64 " ",
 			       odp_atomic_load_u64(&args->stats[i]
@@ -198,13 +200,10 @@ static inline void print_cls_statistics(appl_args_t *args)
 
 		printf("%-" PRIu64, odp_atomic_load_u64(&args->
 							total_packets));
+		fflush(stdout);
 
 		if (args->shutdown_sig)
 			break;
-
-		sleep(1);
-		printf("\r");
-		fflush(stdout);
 	}
 
 	printf("\n");

--- a/example/ipsec_api/odp_ipsec.c
+++ b/example/ipsec_api/odp_ipsec.c
@@ -1099,7 +1099,7 @@ main(int argc, char *argv[])
 
 		do {
 			done = verify_stream_db_outputs();
-			sleep(1);
+			usleep(100000);
 		} while (!done);
 		printf("All received\n");
 		odp_atomic_store_u32(&global->exit_threads, 1);

--- a/example/ipsec_crypto/odp_ipsec.c
+++ b/example/ipsec_crypto/odp_ipsec.c
@@ -1391,7 +1391,7 @@ main(int argc, char *argv[])
 
 		do {
 			done = verify_stream_db_outputs();
-			sleep(1);
+			usleep(100000);
 		} while (!done);
 		printf("All received\n");
 		odp_atomic_store_u32(&global->exit_threads, 1);

--- a/example/l3fwd/odp_l3fwd.c
+++ b/example/l3fwd/odp_l3fwd.c
@@ -28,7 +28,7 @@
 #define MAX_NB_ROUTE	32
 
 #define INVALID_ID	(-1)
-#define PRINT_INTERVAL	10	/* interval seconds of printing stats */
+#define PRINT_INTERVAL	1	/* interval seconds of printing stats */
 
 /** Get rid of path in filename - only for unix-type paths using '/' */
 #define NO_PATH(file_name) (strrchr((file_name), '/') ? \

--- a/example/l3fwd/odp_l3fwd_run.sh
+++ b/example/l3fwd/odp_l3fwd_run.sh
@@ -16,7 +16,7 @@ fi
 
 setup_interfaces
 
-./odp_l3fwd${EXEEXT} -i $IF0,$IF1 -r "10.0.0.0/24,$IF1" -d 30
+./odp_l3fwd${EXEEXT} -i $IF0,$IF1 -r "10.0.0.0/24,$IF1" -d 1
 
 STATUS=$?
 

--- a/example/packet/pktio_run.sh
+++ b/example/packet/pktio_run.sh
@@ -17,7 +17,7 @@ fi
 setup_interfaces
 
 # burst mode
-./odp_pktio${EXEEXT} -i $IF1 -t 5 -m 0
+./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 0
 STATUS=$?
 if [ ${STATUS} -ne 0 ]; then
 	echo "Error: status ${STATUS}"
@@ -28,7 +28,7 @@ validate_result
 echo "Pass -m 0: status ${STATUS}"
 
 # queue mode
-./odp_pktio${EXEEXT} -i $IF1 -t 5 -m 1
+./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 1
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then
@@ -40,7 +40,7 @@ validate_result
 echo "Pass -m 1: status ${STATUS}"
 
 # sched/queue mode
-./odp_pktio${EXEEXT} -i $IF1 -t 5 -m 2
+./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 2
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then
@@ -52,7 +52,7 @@ validate_result
 echo "Pass -m 2: status ${STATUS}"
 
 # cpu number option test 1
-./odp_pktio${EXEEXT} -i $IF1 -t 5 -m 0 -c 1
+./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 0 -c 1
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then

--- a/example/simple_pipeline/simple_pipeline_run.sh
+++ b/example/simple_pipeline/simple_pipeline_run.sh
@@ -24,7 +24,7 @@ fi
 
 setup_interfaces
 
-./odp_simple_pipeline${EXEEXT} -i $IF0,$IF1 -e -t 2
+./odp_simple_pipeline${EXEEXT} -i $IF0,$IF1 -e -t 1 -a 1
 STATUS=$?
 
 if [ "$STATUS" -ne 0 ]; then

--- a/example/switch/switch_run.sh
+++ b/example/switch/switch_run.sh
@@ -18,7 +18,7 @@ fi
 
 setup_interfaces
 
-./odp_switch${EXEEXT} -i $IF0,$IF1,$IF2,$IF3 -t 1
+./odp_switch${EXEEXT} -i $IF0,$IF1,$IF2,$IF3 -t 1 -a 1
 STATUS=$?
 if [ "$STATUS" -ne 0 ]; then
   echo "Error: status was: $STATUS, expected 0"

--- a/platform/linux-generic/test/example/classifier/pktio_env
+++ b/platform/linux-generic/test/example/classifier/pktio_env
@@ -20,7 +20,7 @@ PCAP_IN=`find . ${TEST_DIR} $(dirname $0) -name udp64.pcap -print -quit`
 echo "using PCAP in=${PCAP_IN}"
 
 IF0=pcap:in=${PCAP_IN}
-TIME_OUT_VAL=10
+TIME_OUT_VAL=1
 CPASS_COUNT_ARG1=100
 CPASS_COUNT_ARG2=100
 

--- a/platform/linux-generic/test/pktio_ipc/pktio_ipc1.c
+++ b/platform/linux-generic/test/pktio_ipc/pktio_ipc1.c
@@ -69,6 +69,8 @@ static int pktio_run_loop(odp_pool_t pool)
 			break;
 		if (!master_pid)
 			break;
+
+		odp_time_wait_ns(50 * ODP_TIME_MSEC_IN_NS);
 	}
 
 	if (ipc_pktio == ODP_PKTIO_INVALID)

--- a/platform/linux-generic/test/pktio_ipc/pktio_ipc2.c
+++ b/platform/linux-generic/test/pktio_ipc/pktio_ipc2.c
@@ -66,6 +66,8 @@ static int ipc_second_process(int master_pid)
 			break;
 		if (!master_pid)
 			break;
+
+		odp_time_wait_ns(50 * ODP_TIME_MSEC_IN_NS);
 	}
 
 	if (ipc_pktio == ODP_PKTIO_INVALID) {

--- a/platform/linux-generic/test/pktio_ipc/pktio_ipc_run.sh
+++ b/platform/linux-generic/test/pktio_ipc/pktio_ipc_run.sh
@@ -17,9 +17,9 @@ PATH=$(dirname $0):$PATH
 PATH=$(dirname $0)/../../../../platform/linux-generic/test/pktio_ipc:$PATH
 PATH=.:$PATH
 
-RUNTIME1=10
-RUNTIME2=5
-TIMEOUT=13
+RUNTIME1=3
+RUNTIME2=1
+TIMEOUT=3
 if [ "${TEST}" = "coverage" ]; then
 	RUNTIME1=30
 	RUNTIME2=15

--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -4,10 +4,7 @@ TESTS_ENVIRONMENT += TEST_DIR=${builddir}
 
 EXECUTABLES = odp_atomic_perf \
 	      odp_bench_packet \
-	      odp_cpu_bench \
 	      odp_crc \
-	      odp_crypto \
-	      odp_ipsec \
 	      odp_lock_perf \
 	      odp_mem_perf \
 	      odp_pktio_perf \
@@ -15,7 +12,10 @@ EXECUTABLES = odp_atomic_perf \
 	      odp_queue_perf \
 	      odp_random
 
-COMPILE_ONLY = odp_dma_perf \
+COMPILE_ONLY = odp_cpu_bench \
+	       odp_crypto \
+	       odp_dma_perf \
+	       odp_ipsec \
 	       odp_l2fwd \
 	       odp_packet_gen \
 	       odp_pktio_ordered \
@@ -25,7 +25,10 @@ COMPILE_ONLY = odp_dma_perf \
 	       odp_scheduling \
 	       odp_timer_perf
 
-TESTSCRIPTS = odp_dma_perf_run.sh \
+TESTSCRIPTS = odp_cpu_bench_run.sh \
+	      odp_crypto_run.sh \
+	      odp_dma_perf_run.sh \
+	      odp_ipsec_run.sh \
 	      odp_l2fwd_run.sh \
 	      odp_packet_gen_run.sh \
 	      odp_sched_latency_run.sh \

--- a/test/performance/odp_cpu_bench_run.sh
+++ b/test/performance/odp_cpu_bench_run.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Copyright (c) 2022, Nokia
+# All rights reserved.
+#
+# SPDX-License-Identifier:      BSD-3-Clause
+
+TEST_DIR="${TEST_DIR:-$(dirname $0)}"
+
+# Use short run time in make check
+
+$TEST_DIR/odp_cpu_bench${EXEEXT} -t 1
+
+if [ $? -ne 0 ] ; then
+    echo Test FAILED
+    exit 1
+fi
+
+exit 0

--- a/test/performance/odp_crypto_run.sh
+++ b/test/performance/odp_crypto_run.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Copyright (c) 2022, Nokia
+# All rights reserved.
+#
+# SPDX-License-Identifier:      BSD-3-Clause
+
+TEST_DIR="${TEST_DIR:-$(dirname $0)}"
+
+# Run with a small number of iterations in make check
+
+$TEST_DIR/odp_crypto${EXEEXT} -i 100
+
+if [ $? -ne 0 ] ; then
+    echo Test FAILED
+    exit 1
+fi
+
+exit 0

--- a/test/performance/odp_ipsec_run.sh
+++ b/test/performance/odp_ipsec_run.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Copyright (c) 2022, Nokia
+# All rights reserved.
+#
+# SPDX-License-Identifier:      BSD-3-Clause
+
+TEST_DIR="${TEST_DIR:-$(dirname $0)}"
+
+# Run with a small number of iterations in make check
+
+$TEST_DIR/odp_ipsec${EXEEXT} -i 100
+
+if [ $? -ne 0 ] ; then
+    echo Test FAILED
+    exit 1
+fi
+
+exit 0

--- a/test/performance/odp_pktio_ordered_run.sh
+++ b/test/performance/odp_pktio_ordered_run.sh
@@ -8,7 +8,7 @@
 TEST_SRC_DIR=$(dirname $0)
 TEST_DIR="${TEST_DIR:-$(dirname $0)}"
 
-DURATION=5
+DURATION=1
 LOG=odp_pktio_ordered.log
 LOOPS=100000000
 PASS_PPS=100

--- a/test/validation/api/system/system.c
+++ b/test/validation/api/system/system.c
@@ -197,16 +197,25 @@ static void system_test_cpu_cycles_diff(void)
 static void system_test_cpu_cycles_long_period(void)
 {
 	int i;
+	int periods = PERIODS_100_MSEC;
 	uint64_t c2, c1, c3, max;
 	uint64_t tmp, diff, res;
-
-	printf("\n        Testing CPU cycles for %i seconds... ", PERIODS_100_MSEC / 10);
 
 	res = odp_cpu_cycles_resolution();
 	max = odp_cpu_cycles_max();
 
+	/*
+	 * We can virtually never see a 64 bit cycle counter wrap around,
+	 * so let's not even try. Use small a number of periods to speed
+	 * up testing in this common case.
+	 */
+	if (max == UINT64_MAX)
+		periods = 10;
+
+	printf("\n        Testing CPU cycles for %i seconds... ", periods / 10);
+
 	c3 = odp_cpu_cycles();
-	for (i = 0; i < PERIODS_100_MSEC; i++) {
+	for (i = 0; i < periods; i++) {
 		c1 = odp_cpu_cycles();
 		odp_time_wait_ns(100 * ODP_TIME_MSEC_IN_NS + i);
 		c2 = odp_cpu_cycles();


### PR DESCRIPTION
Many tests run unnecessarily long during make check, especially on slower platforms. Often just a small number of iterations or short test time is sufficient for checking that things work and longer run time just wastes cycles without much benefit.

Reduce the run time of various tests for which it was easy to do.