### PR TITLE
[PATCH v1] linux-gen: pktio: implement tx completion event

### DIFF
--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2019-2020, Nokia
+ * Copyright (c) 2019-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -115,7 +115,7 @@ typedef union {
 	uint32_t all_flags;
 
 	struct {
-		uint32_t reserved1:      8;
+		uint32_t reserved1:      7;
 
 	/*
 	 * Init flags
@@ -132,6 +132,7 @@ typedef union {
 		uint32_t l4_chksum_set:  1; /* L4 chksum bit is valid */
 		uint32_t l4_chksum:      1; /* L4 chksum override */
 		uint32_t ts_set:         1; /* Set Tx timestamp */
+		uint32_t tx_compl:       1; /* Tx completion event requested */
 		uint32_t shaper_len_adj: 8; /* Adjustment for traffic mgr */
 
 	/*
@@ -149,8 +150,8 @@ typedef union {
 
 	/* Flag groups */
 	struct {
-		uint32_t reserved2:      8;
-		uint32_t other:         16; /* All other flags */
+		uint32_t reserved2:      7;
+		uint32_t other:         17; /* All other flags */
 		uint32_t error:          8; /* All error flags */
 	} all;
 

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -69,6 +69,8 @@
 	#define odp_packet_from_event_multi __odp_packet_from_event_multi
 	#define odp_packet_to_event_multi __odp_packet_to_event_multi
 	#define odp_packet_subtype __odp_packet_subtype
+	#define odp_packet_tx_compl_from_event __odp_packet_tx_compl_from_event
+	#define odp_packet_tx_compl_to_event __odp_packet_tx_compl_to_event
 #else
 	#undef _ODP_INLINE
 	#define _ODP_INLINE
@@ -356,6 +358,16 @@ _ODP_INLINE void odp_packet_to_event_multi(const odp_packet_t pkt[],
 _ODP_INLINE odp_event_subtype_t odp_packet_subtype(odp_packet_t pkt)
 {
 	return (odp_event_subtype_t)_odp_pkt_get(pkt, int8_t, subtype);
+}
+
+_ODP_INLINE odp_packet_tx_compl_t odp_packet_tx_compl_from_event(odp_event_t ev)
+{
+	return (odp_packet_tx_compl_t)(uintptr_t)ev;
+}
+
+_ODP_INLINE odp_event_t odp_packet_tx_compl_to_event(odp_packet_tx_compl_t tx_compl)
+{
+	return (odp_event_t)(uintptr_t)tx_compl;
 }
 
 /** @endcond */

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -145,6 +145,12 @@ typedef struct ODP_ALIGNED_CACHE odp_packet_hdr_t {
 	/* LSO profile index */
 	uint8_t lso_profile_idx;
 
+	/* Tx completion event queue */
+	odp_queue_t tx_compl_queue;
+
+	/* Tx completion event mode */
+	odp_packet_tx_compl_mode_t tx_compl_mode;
+
 	union {
 		struct {
 			/* Result for crypto packet op */

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2020-2021, Nokia
+ * Copyright (c) 2020-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -73,6 +73,9 @@ void odp_event_free(odp_event_t event)
 		break;
 	case ODP_EVENT_IPSEC_STATUS:
 		_odp_ipsec_status_free(_odp_ipsec_status_from_event(event));
+		break;
+	case ODP_EVENT_PACKET_TX_COMPL:
+		odp_packet_tx_compl_free(odp_packet_tx_compl_from_event(event));
 		break;
 	case ODP_EVENT_DMA_COMPL:
 		odp_dma_compl_free(odp_dma_compl_from_event(event));

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2958,43 +2958,44 @@ uint64_t odp_packet_aging_tmo(odp_packet_t pkt)
 
 int odp_packet_tx_compl_request(odp_packet_t pkt, const odp_packet_tx_compl_opt_t *opt)
 {
-	(void)pkt;
-	(void)opt;
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
-	return -1;
-}
-
-int odp_packet_has_tx_compl_request(odp_packet_t pkt)
-{
-	(void)pkt;
+	pkt_hdr->p.flags.tx_compl = 1;
+	pkt_hdr->tx_compl_queue = opt->queue;
+	pkt_hdr->tx_compl_mode = opt->mode;
 
 	return 0;
 }
 
-odp_packet_tx_compl_t odp_packet_tx_compl_from_event(odp_event_t ev)
+int odp_packet_has_tx_compl_request(odp_packet_t pkt)
 {
-	(void)ev;
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
-	return ODP_PACKET_TX_COMPL_INVALID;
-}
-
-odp_event_t odp_packet_tx_compl_to_event(odp_packet_tx_compl_t tx_compl)
-{
-	(void)tx_compl;
-
-	return ODP_EVENT_INVALID;
+	return pkt_hdr->p.flags.tx_compl;
 }
 
 void odp_packet_tx_compl_free(odp_packet_tx_compl_t tx_compl)
 {
-	(void)tx_compl;
+	odp_buffer_t buf = (odp_buffer_t)(uintptr_t)tx_compl;
+
+	if (odp_unlikely(tx_compl == ODP_PACKET_TX_COMPL_INVALID)) {
+		ODP_ERR("Bad TX completion event handle\n");
+		return;
+	}
+
+	odp_buffer_free(buf);
 }
 
 void *odp_packet_tx_compl_user_ptr(odp_packet_tx_compl_t tx_compl)
 {
-	(void)tx_compl;
+	odp_buffer_t buf = (odp_buffer_t)(uintptr_t)tx_compl;
 
-	return NULL;
+	if (odp_unlikely(tx_compl == ODP_PACKET_TX_COMPL_INVALID)) {
+		ODP_ERR("Bad TX completion event handle\n");
+		return NULL;
+	}
+
+	return *(void **)odp_buffer_addr(buf);
 }
 
 odp_packet_reass_status_t

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2020-2021, Nokia
+ * Copyright (c) 2020-2022, Nokia
  * Copyright (c) 2020, Marvell
  * All rights reserved.
  *
@@ -3316,7 +3316,7 @@ static void pktio_test_pktout_compl(bool use_plain_queue)
 		opt.queue = compl_queue[i];
 		opt.mode = ODP_PACKET_TX_COMPL_ALL;
 		odp_packet_tx_compl_request(pkt_tbl[i], &opt);
-
+		CU_ASSERT(odp_packet_has_tx_compl_request(pkt_tbl[i]) == 1);
 		/* Set pkt sequence number as its user ptr */
 		odp_packet_user_ptr_set(pkt_tbl[i], (const void *)&pkt_seq[i]);
 	}


### PR DESCRIPTION
Add support for event completion for transmitted and dropped packets.

New `odp_packet_hdr_t` fields to be added to metadata copy once #1477 is merged.