### PR TITLE
[PATCH v6] api: pktio: add packet output queue size configuration option

### DIFF
--- a/include/odp/api/abi-default/packet_io.h
+++ b/include/odp/api/abi-default/packet_io.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2020, Nokia
+ * Copyright (c) 2020-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -52,6 +52,8 @@ typedef struct odp_pktout_queue_t {
 #define ODP_PKTIO_MACADDR_MAXSIZE 16
 
 #define ODP_PKTIN_NO_WAIT 0
+
+#define ODP_PKTOUT_MAX_QUEUES 64
 
 #define ODP_PKTIO_STATS_EXTRA_NAME_LEN 64
 

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -317,6 +317,16 @@ typedef struct odp_pktout_queue_param_t {
 	  * 1 and interface capability. The default value is 1. */
 	unsigned int num_queues;
 
+	/** Output queue size array
+	  *
+	  * An array containing queue sizes for each 'num_queues' output queues.
+	  * The value of zero means implementation specific default size.
+	  * Nonzero values must be between 'min_output_queue_size' and
+	  * 'max_output_queue_size' capabilities. The implementation may
+	  * round-up given values. The default value is zero.
+	  */
+	uint32_t queue_size[ODP_PKTOUT_MAX_QUEUES];
+
 } odp_pktout_queue_param_t;
 
 /**
@@ -847,6 +857,16 @@ typedef struct odp_pktio_capability_t {
 	 *
 	 * Value does not exceed ODP_PKTOUT_MAX_QUEUES. */
 	unsigned int max_output_queues;
+
+	/** Minimum output queue size
+	 *
+	 *  Zero if configuring queue size is not supported. */
+	uint32_t min_output_queue_size;
+
+	/** Maximum output queue size
+	 *
+	 *  Zero if configuring queue size is not supported. */
+	uint32_t max_output_queue_size;
 
 	/** Supported pktio configuration options */
 	odp_pktio_config_t config;

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2020-2021, Nokia
+ * Copyright (c) 2020-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -81,6 +81,12 @@ extern "C" {
 /**
  * @def ODP_PKTIN_NO_WAIT
  * Do not wait on packet input
+ */
+
+/**
+ * @def ODP_PKTOUT_MAX_QUEUES
+ * Maximum number of packet output queues supported by the API. Use
+ * odp_pktio_capability() to check the maximum number of queues per interface.
  */
 
 /**
@@ -837,7 +843,9 @@ typedef struct odp_pktio_capability_t {
 	/** Maximum number of input queues */
 	unsigned int max_input_queues;
 
-	/** Maximum number of output queues */
+	/** Maximum number of output queues
+	 *
+	 * Value does not exceed ODP_PKTOUT_MAX_QUEUES. */
 	unsigned int max_output_queues;
 
 	/** Supported pktio configuration options */

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_io.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_io.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2020, Nokia
+ * Copyright (c) 2020-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -48,7 +48,6 @@ typedef struct odp_pktout_queue_t {
 #define ODP_PKTIO_MACADDR_MAXSIZE 16
 
 #define ODP_PKTIN_NO_WAIT 0
-#define ODP_PKTIN_WAIT    UINT64_MAX
 
 #define ODP_PKTIO_STATS_EXTRA_NAME_LEN 64
 

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_io.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_io.h
@@ -49,6 +49,8 @@ typedef struct odp_pktout_queue_t {
 
 #define ODP_PKTIN_NO_WAIT 0
 
+#define ODP_PKTOUT_MAX_QUEUES 64
+
 #define ODP_PKTIO_STATS_EXTRA_NAME_LEN 64
 
 /**

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -38,7 +38,7 @@ extern "C" {
 #include <sys/select.h>
 #include <inttypes.h>
 
-#define PKTIO_MAX_QUEUES 64
+#define PKTIO_MAX_QUEUES ODP_PKTOUT_MAX_QUEUES
 #define PKTIO_LSO_PROFILES 16
 /* Assume at least Ethernet header per each segment */
 #define PKTIO_LSO_MIN_PAYLOAD_OFFSET 14

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -42,6 +42,8 @@
 #define LOOP_MTU_MIN 68
 #define LOOP_MTU_MAX UINT16_MAX
 
+#define LOOP_MAX_TX_QUEUE_SIZE 1024
+
 typedef struct {
 	odp_queue_t loopq;		/**< loopback queue for "loop" device */
 	odp_bool_t promisc;		/**< promiscuous mode state */
@@ -63,12 +65,11 @@ static const uint8_t pktio_loop_mac[] = {0x02, 0xe9, 0x34, 0x80, 0x73, 0x01};
 static int loopback_stats_reset(pktio_entry_t *pktio_entry);
 static int loopback_init_capability(pktio_entry_t *pktio_entry);
 
-static int loopback_open(odp_pktio_t id, pktio_entry_t *pktio_entry,
+static int loopback_open(odp_pktio_t id ODP_UNUSED, pktio_entry_t *pktio_entry,
 			 const char *devname, odp_pool_t pool ODP_UNUSED)
 {
 	pkt_loop_t *pkt_loop = pkt_priv(pktio_entry);
 	long idx;
-	char loopq_name[ODP_QUEUE_NAME_LEN];
 
 	if (!strcmp(devname, "loop")) {
 		idx = 0;
@@ -82,14 +83,9 @@ static int loopback_open(odp_pktio_t id, pktio_entry_t *pktio_entry,
 		return -1;
 	}
 
-	snprintf(loopq_name, sizeof(loopq_name), "%" PRIu64 "-pktio_loopq",
-		 odp_pktio_to_u64(id));
 	pkt_loop->idx = idx;
 	pkt_loop->mtu = LOOP_MTU_MAX;
-	pkt_loop->loopq = odp_queue_create(loopq_name, NULL);
-
-	if (pkt_loop->loopq == ODP_QUEUE_INVALID)
-		return -1;
+	pkt_loop->loopq = ODP_QUEUE_INVALID;
 
 	loopback_stats_reset(pktio_entry);
 	loopback_init_capability(pktio_entry);
@@ -97,9 +93,44 @@ static int loopback_open(odp_pktio_t id, pktio_entry_t *pktio_entry,
 	return 0;
 }
 
+static int loopback_pktout_queue_config(pktio_entry_t *pktio_entry,
+					const odp_pktout_queue_param_t *param)
+{
+	pkt_loop_t *pkt_loop = pkt_priv(pktio_entry);
+	odp_queue_param_t queue_param;
+	char queue_name[ODP_QUEUE_NAME_LEN];
+
+	/* Destroy old queue */
+	if (pkt_loop->loopq != ODP_QUEUE_INVALID) {
+		if (odp_queue_destroy(pkt_loop->loopq)) {
+			ODP_ERR("Destroying old loopback pktio queue failed\n");
+			return -1;
+		}
+	}
+
+	odp_queue_param_init(&queue_param);
+	queue_param.size = param->queue_size[0];
+
+	snprintf(queue_name, sizeof(queue_name), "_odp_pktio_loopq-%" PRIu64 "",
+		 odp_pktio_to_u64(pktio_entry->s.handle));
+
+	pkt_loop->loopq = odp_queue_create(queue_name, &queue_param);
+	if (pkt_loop->loopq == ODP_QUEUE_INVALID) {
+		ODP_ERR("Creating loopback pktio queue failed\n");
+		return -1;
+	}
+
+	return 0;
+}
+
 static int loopback_close(pktio_entry_t *pktio_entry)
 {
-	return odp_queue_destroy(pkt_priv(pktio_entry)->loopq);
+	pkt_loop_t *pkt_loop = pkt_priv(pktio_entry);
+
+	if (pkt_loop->loopq != ODP_QUEUE_INVALID)
+		return odp_queue_destroy(pkt_loop->loopq);
+
+	return 0;
 }
 
 static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
@@ -432,6 +463,12 @@ static int loopback_link_info(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_l
 static int loopback_init_capability(pktio_entry_t *pktio_entry)
 {
 	odp_pktio_capability_t *capa = &pktio_entry->s.capa;
+	odp_queue_capability_t queue_capa;
+
+	if (odp_queue_capability(&queue_capa)) {
+		ODP_ERR("Queue capability failed\n");
+		return -1;
+	}
 
 	memset(capa, 0, sizeof(odp_pktio_capability_t));
 
@@ -445,6 +482,11 @@ static int loopback_init_capability(pktio_entry_t *pktio_entry)
 	capa->maxlen.max_input = LOOP_MTU_MAX;
 	capa->maxlen.min_output = LOOP_MTU_MIN;
 	capa->maxlen.max_output = LOOP_MTU_MAX;
+
+	capa->min_output_queue_size = 1;
+	capa->max_output_queue_size = queue_capa.plain.max_size;
+	if (capa->max_output_queue_size == 0)
+		capa->max_output_queue_size = LOOP_MAX_TX_QUEUE_SIZE;
 
 	odp_pktio_config_init(&capa->config);
 	capa->config.enable_loop = 1;
@@ -576,5 +618,5 @@ const pktio_if_ops_t _odp_loopback_pktio_ops = {
 	.pktio_time = NULL,
 	.config = NULL,
 	.input_queues_config = NULL,
-	.output_queues_config = NULL,
+	.output_queues_config = loopback_pktout_queue_config,
 };

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -5560,6 +5560,7 @@ sub process {
 			    $var !~ /^(?:Clear|Set|TestClear|TestSet|)Page[A-Z]/ &&
 #ODP ignores
 			    $var !~ /\bCU_/ &&
+			    $var !~ /\bPRI[diux]PTR/ &&
 			    $var !~ /\bPRI[diux]8/ &&
 			    $var !~ /\bPRI[diux]16/ &&
 			    $var !~ /\bPRI[diux]32/ &&


### PR DESCRIPTION
Add new packet output queue size configuration option `odp_pktout_queue_param_t.queue_size`
and matching capabilities `odp_pktio_capability_t.min_output_queue_size` and `odp_pktio_capability_t.max_output_queue_size`.

V2:
- Mention `ODP_PKTOUT_MAX_QUEUES` in `odp_pktio_capability_t.max_output_queues` spec (Jerin)

V3:
- `ODP_PKTOUT_MAX_QUEUES` spec clarification (Petri)
-  Added output queue size validity check to implementation (Petri)
- Ignore camel case warnings from `PRIuPTR` usage

V4:
- Fixed commit message typos (Jere)
- Removed loopback pktio include changes (Jere)
- Clean loopback pktio internal plain queue before reconfigure/destroy

V5:
- Reviewed-by tags