### PR TITLE
[PATCH v2] linux-gen: tm: synchronize with TM thread when configuring shaper

### DIFF
--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -3918,6 +3918,7 @@ int odp_tm_node_shaper_config(odp_tm_node_t tm_node,
 {
 	tm_node_obj_t *tm_node_obj;
 	tm_system_t *tm_system;
+	odp_bool_t sync_needed;
 
 	tm_node_obj = GET_TM_NODE_OBJ(tm_node);
 	if (!tm_node_obj)
@@ -3928,8 +3929,13 @@ int odp_tm_node_shaper_config(odp_tm_node_t tm_node,
 		return -1;
 
 	odp_ticketlock_lock(&tm_glb->profile_lock);
+	sync_needed = tm_glb->main_loop_running;
+	if (sync_needed)
+		signal_request();
 	tm_shaper_config_set(tm_system, shaper_profile,
 			     &tm_node_obj->shaper_obj);
+	if (sync_needed)
+		signal_request_done();
 	odp_ticketlock_unlock(&tm_glb->profile_lock);
 	return 0;
 }


### PR DESCRIPTION
Use the signal_request/check_request mechanism to make sure the TM
system thread is not accessing shaper parameters at the same time
when they are being changed by another thread.

This should prevent the crash that sometimes occurs when running TM
validation tests that disable shapers on the fly, changing the shaper
parameter pointer in shaper objects NULL just when the TM system thread
is about to dereference it.

This patch does not fix other issues in the synchronization mechanism:
The mechanism is not always used when needed, it uses relaxed atomics
that do not guarantee memory ordering and it does not work with
multiple TM system threads.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>