### PR TITLE
[PATCH v2] github_ci: prevent automatic documentation rebuild

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,6 +39,7 @@ jobs:
         cp users-guide/users-guide.html gh-pages/users-guide/index.html
         mkdir gh-pages/process-guide
         cp process-guide/*.html gh-pages/process-guide/
+        touch gh-pages/.nojekyll
         popd
 
     - name: Deploy


### PR DESCRIPTION
Prevent automatic GitHub workflow 'pages-build-deployment' from rebuilding
ODP documentation. The documentation is already built by 'GitHub Pages'
workflow.

Signed-off-by: Matias Elo <matias.elo@nokia.com>