### PR TITLE
[PATCH v2] DEPENDENCIES: update DPDK-20.11 installation instructions

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -252,14 +252,16 @@ Prerequisites for building the OpenDataPlane (ODP) API
    $ meson build
    $ cd build
 
-   # Configure the location where DPDK will be installed
+   # Optionally, configure the location where DPDK will be installed. By default,
+   # DPDK will be installed in /usr/local:
    $ meson configure -Dprefix=$(pwd)/../install
 
    # Build and install DPDK
    $ ninja install
 
    # Configure ODP
-   # Instead of using --with-dpdk-path option, set PKG_CONFIG_PATH
+   $ ./configure --enable-dpdk
+   # Or, if DPDK was not installed to the default location, set PKG_CONFIG_PATH:
    $ PKG_CONFIG_PATH=<dpdk-dir>/install/lib/x86_64-linux-gnu/pkgconfig ./configure --enable-dpdk
 
 3.5.5 Setup system


### PR DESCRIPTION
In the current installation of DPDK-20.11, configuring the location of
DPDK installation to the home directory is a required step. System-wide
installation of DPDK is also an option when ODP-DPDK is not able to link
to DPDK-20.11 by setting of PKG_CONFIG_PATH. This issue was observed on
Arm64 platforms.

Signed-off-by: Malvika Gupta <Malvika.Gupta@arm.com>
Reviewed-by: Govindarajan <govindarajan.mohandoss@arm.com>