### PR TITLE
[PATCH v2] ci: run odp_sysinfo example after native builds

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -16,9 +16,9 @@ make -j $(nproc)
 make install
 
 pushd ${HOME}
-${CC} ${CFLAGS} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst_dynamic `PKG_CONFIG_PATH=/opt/odp/lib/pkgconfig:${PKG_CONFIG_PATH} pkg-config --cflags --libs libodp-linux`
+${CC} ${CFLAGS} ${OLDPWD}/example/sysinfo/odp_sysinfo.c -o odp_sysinfo_inst_dynamic `PKG_CONFIG_PATH=/opt/odp/lib/pkgconfig:${PKG_CONFIG_PATH} pkg-config --cflags --libs libodp-linux`
 if [ -z "$TARGET_ARCH" ] || [ "$TARGET_ARCH" == "$BUILD_ARCH" ]
 then
-	LD_LIBRARY_PATH="/opt/odp/lib:$LD_LIBRARY_PATH" ./odp_hello_inst_dynamic
+	LD_LIBRARY_PATH="/opt/odp/lib:$LD_LIBRARY_PATH" ./odp_sysinfo_inst_dynamic
 fi
 popd

--- a/scripts/ci/build_riscv64.sh
+++ b/scripts/ci/build_riscv64.sh
@@ -28,5 +28,5 @@ make -j $(nproc)
 make install
 
 pushd ${HOME}
-${CC} ${CFLAGS} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst_dynamic `PKG_CONFIG_PATH=/opt/odp/lib/pkgconfig:${PKG_CONFIG_PATH} pkg-config --cflags --libs libodp-linux`
+${CC} ${CFLAGS} ${OLDPWD}/example/sysinfo/odp_sysinfo.c -o odp_sysinfo_inst_dynamic `PKG_CONFIG_PATH=/opt/odp/lib/pkgconfig:${PKG_CONFIG_PATH} pkg-config --cflags --libs libodp-linux`
 popd


### PR DESCRIPTION
Run odp_sysinfo application after native ODP builds in the CI. This
application can provide more useful information in the CI log (e.g. CPU
model) compared to the previously used odp_hello application. When cross
compiling, the odp_sysinfo application is only built.

Signed-off-by: Matias Elo <matias.elo@nokia.com>