### PR TITLE
[PATCH v3] linux-gen: remove odp_api.h includes from implementation

### DIFF
--- a/platform/linux-generic/include/odp/api/plat/byteorder_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/byteorder_inlines.h
@@ -17,6 +17,8 @@
 extern "C" {
 #endif
 
+#include <odp/api/abi/byteorder.h>
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef __odp_force

--- a/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
@@ -15,7 +15,7 @@
 #define _ODP_PLAT_PACKET_VECTOR_INLINES_H_
 
 #include <odp/api/abi/event.h>
-#include <odp/api/abi/packet.h>
+#include <odp/api/abi/packet_types.h>
 #include <odp/api/abi/pool.h>
 
 #include <odp/api/plat/event_vector_inline_types.h>

--- a/platform/linux-generic/include/odp/api/plat/ticketlock_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/ticketlock_inlines.h
@@ -10,6 +10,8 @@
 #include <odp/api/atomic.h>
 #include <odp/api/cpu.h>
 
+#include <odp/api/abi/ticketlock.h>
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE

--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2017-2018, Linaro Limited
- * Copyright (c) 2018, 2020-2021, Nokia
+ * Copyright (c) 2018, 2020-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:	BSD-3-Clause
@@ -23,7 +23,7 @@ extern "C" {
 
 #include <odp/api/byteorder.h>
 #include <odp/api/ipsec.h>
-#include <odp/api/ticketlock.h>
+#include <odp/api/spinlock.h>
 
 #include <protocols/ip.h>
 

--- a/platform/linux-generic/include/odp_name_table_internal.h
+++ b/platform/linux-generic/include/odp_name_table_internal.h
@@ -14,7 +14,6 @@ extern "C" {
 #endif
 
 #include <stdint.h>
-#include <odp_api.h>
 
 typedef enum {
 	ODP_COS_HANDLE,

--- a/platform/linux-generic/include/odp_pkt_queue_internal.h
+++ b/platform/linux-generic/include/odp_pkt_queue_internal.h
@@ -13,8 +13,9 @@
 extern "C" {
 #endif
 
+#include <odp/api/packet.h>
+
 #include <stdint.h>
-#include <odp_api.h>
 
 typedef uint64_t _odp_int_queue_pool_t;
 typedef uint32_t _odp_int_pkt_queue_t;

--- a/platform/linux-generic/include/odp_traffic_mngr_internal.h
+++ b/platform/linux-generic/include/odp_traffic_mngr_internal.h
@@ -19,9 +19,10 @@
 extern "C" {
 #endif
 
-#include <pthread.h>
-#include <odp/api/traffic_mngr.h>
+#include <odp/api/barrier.h>
 #include <odp/api/packet_io.h>
+#include <odp/api/traffic_mngr.h>
+
 #include <odp_name_table_internal.h>
 #include <odp_timer_wheel_internal.h>
 #include <odp_pkt_queue_internal.h>
@@ -30,6 +31,8 @@ extern "C" {
 #include <odp_buffer_internal.h>
 #include <odp_queue_if.h>
 #include <odp_packet_internal.h>
+
+#include <pthread.h>
 
 typedef struct stat  file_stat_t;
 

--- a/platform/linux-generic/include/protocols/eth.h
+++ b/platform/linux-generic/include/protocols/eth.h
@@ -17,7 +17,11 @@
 extern "C" {
 #endif
 
-#include <odp_api.h>
+#include <odp/api/align.h>
+#include <odp/api/byteorder.h>
+#include <odp/api/debug.h>
+
+#include <stdint.h>
 
 /** @addtogroup odp_header ODP HEADER
  *  @{

--- a/platform/linux-generic/include/protocols/ip.h
+++ b/platform/linux-generic/include/protocols/ip.h
@@ -17,7 +17,9 @@
 extern "C" {
 #endif
 
-#include <odp_api.h>
+#include <odp/api/align.h>
+#include <odp/api/byteorder.h>
+#include <odp/api/debug.h>
 
 /** @addtogroup odp_header ODP HEADER
  *  @{

--- a/platform/linux-generic/include/protocols/ipsec.h
+++ b/platform/linux-generic/include/protocols/ipsec.h
@@ -18,7 +18,11 @@
 extern "C" {
 #endif
 
-#include <odp_api.h>
+#include <odp/api/align.h>
+#include <odp/api/byteorder.h>
+#include <odp/api/debug.h>
+
+#include <stdint.h>
 
 /** @addtogroup odp_header ODP HEADER
  *  @{

--- a/platform/linux-generic/include/protocols/sctp.h
+++ b/platform/linux-generic/include/protocols/sctp.h
@@ -17,7 +17,9 @@
 extern "C" {
 #endif
 
-#include <odp_api.h>
+#include <odp/api/align.h>
+#include <odp/api/byteorder.h>
+#include <odp/api/debug.h>
 
 /** @addtogroup odp_header ODP HEADER
  *  @{

--- a/platform/linux-generic/include/protocols/tcp.h
+++ b/platform/linux-generic/include/protocols/tcp.h
@@ -18,7 +18,8 @@
 extern "C" {
 #endif
 
-#include <odp_api.h>
+#include <odp/api/align.h>
+#include <odp/api/byteorder.h>
 
 /** @addtogroup odp_header ODP HEADER
  *  @{

--- a/platform/linux-generic/include/protocols/thash.h
+++ b/platform/linux-generic/include/protocols/thash.h
@@ -17,7 +17,13 @@
 extern "C" {
 #endif
 
+#include <odp/api/align.h>
+#include <odp/api/byteorder.h>
+#include <odp/api/debug.h>
+
 #include <protocols/ip.h>
+
+#include <stdint.h>
 
 /** rss data type */
 typedef union {

--- a/platform/linux-generic/include/protocols/udp.h
+++ b/platform/linux-generic/include/protocols/udp.h
@@ -17,7 +17,9 @@
 extern "C" {
 #endif
 
-#include <odp_api.h>
+#include <odp/api/align.h>
+#include <odp/api/byteorder.h>
+#include <odp/api/debug.h>
 
 /** @addtogroup odp_header ODP HEADER
  *  @{

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2020-2021, Nokia
+ * Copyright (c) 2020-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -8,9 +8,11 @@
 #include <odp/api/event.h>
 #include <odp/api/buffer.h>
 #include <odp/api/crypto.h>
+#include <odp/api/dma.h>
 #include <odp/api/packet.h>
 #include <odp/api/timer.h>
 #include <odp/api/pool.h>
+
 #include <odp_buffer_internal.h>
 #include <odp_ipsec_internal.h>
 #include <odp_debug_internal.h>

--- a/platform/linux-generic/odp_name_table.c
+++ b/platform/linux-generic/odp_name_table.c
@@ -6,14 +6,18 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <odp/api/hash.h>
+#include <odp/api/ticketlock.h>
+
+#include <odp_name_table_internal.h>
+#include <odp_debug_internal.h>
+#include <odp_macros_internal.h>
+
 #include <stdint.h>
 #include <string.h>
 #include <malloc.h>
 #include <stdlib.h>
 #include <inttypes.h>
-#include <odp_name_table_internal.h>
-#include <odp_debug_internal.h>
-#include <odp_macros_internal.h>
 
  /* The following constants define some tunable parameters of this module.
  * They are set to fairly reasonable values (perhaps somewhat biased toward

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -7,24 +7,27 @@
 
 #include <odp/autoheader_external.h>
 
-#include <odp/api/packet.h>
-#include <odp/api/plat/packet_inlines.h>
-#include <odp_packet_internal.h>
-#include <odp_debug_internal.h>
-#include <odp_macros_internal.h>
-#include <odp_chksum_internal.h>
-#include <odp_errno_define.h>
-#include <odp/api/hints.h>
 #include <odp/api/byteorder.h>
-#include <odp/api/plat/byteorder_inlines.h>
+#include <odp/api/hash.h>
+#include <odp/api/hints.h>
+#include <odp/api/packet.h>
+#include <odp/api/packet_flags.h>
 #include <odp/api/packet_io.h>
-#include <odp/api/plat/pktio_inlines.h>
 #include <odp/api/proto_stats.h>
+#include <odp/api/timer.h>
 
+#include <odp_chksum_internal.h>
+#include <odp_debug_internal.h>
+#include <odp_errno_define.h>
 #include <odp_event_internal.h>
+#include <odp_macros_internal.h>
+#include <odp_packet_internal.h>
 
 /* Inlined API functions */
+#include <odp/api/plat/byteorder_inlines.h>
 #include <odp/api/plat/event_inlines.h>
+#include <odp/api/plat/packet_inlines.h>
+#include <odp/api/plat/pktio_inlines.h>
 
 #include <protocols/eth.h>
 #include <protocols/ip.h>

--- a/platform/linux-generic/odp_pkt_queue.c
+++ b/platform/linux-generic/odp_pkt_queue.c
@@ -6,16 +6,18 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <odp/api/packet.h>
+
+#include <odp_pkt_queue_internal.h>
+#include <odp_traffic_mngr_internal.h>
+#include <odp_debug_internal.h>
+#include <odp_macros_internal.h>
+
 #include <stdint.h>
 #include <string.h>
 #include <malloc.h>
 #include <stdio.h>
 #include <inttypes.h>
-#include <odp_api.h>
-#include <odp_pkt_queue_internal.h>
-#include <odp_traffic_mngr_internal.h>
-#include <odp_debug_internal.h>
-#include <odp_macros_internal.h>
 
 #define NUM_PKTS     7
 

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -9,6 +9,27 @@
 
 #include <odp_posix_extensions.h>
 
+#include <odp/api/packet.h>
+#include <odp/api/packet_flags.h>
+#include <odp/api/std_types.h>
+#include <odp/api/time.h>
+
+#include <odp/api/plat/byteorder_inlines.h>
+#include <odp/api/plat/packet_inlines.h>
+#include <odp/api/plat/time_inlines.h>
+
+#include <odp_packet_io_internal.h>
+#include <odp_traffic_mngr_internal.h>
+#include <odp_macros_internal.h>
+#include <odp_init_internal.h>
+#include <odp_errno_define.h>
+#include <odp_global_data.h>
+#include <odp_schedule_if.h>
+#include <odp_event_internal.h>
+
+#include <protocols/eth.h>
+#include <protocols/ip.h>
+
 #include <stdint.h>
 #include <string.h>
 #include <malloc.h>
@@ -20,21 +41,6 @@
 #include <sched.h>
 #include <unistd.h>
 #include <pthread.h>
-#include <odp/api/std_types.h>
-#include <protocols/eth.h>
-#include <protocols/ip.h>
-#include <odp_packet_io_internal.h>
-#include <odp_traffic_mngr_internal.h>
-#include <odp/api/plat/packet_inlines.h>
-#include <odp/api/plat/byteorder_inlines.h>
-#include <odp/api/time.h>
-#include <odp/api/plat/time_inlines.h>
-#include <odp_macros_internal.h>
-#include <odp_init_internal.h>
-#include <odp_errno_define.h>
-#include <odp_global_data.h>
-#include <odp_schedule_if.h>
-#include <odp_event_internal.h>
 
 /* Local vars */
 static const

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -1,24 +1,32 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2013-2021, Nokia Solutions and Networks
+ * Copyright (c) 2013-2022, Nokia Solutions and Networks
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp_api.h>
-#include <odp_packet_internal.h>
-#include <odp_packet_io_internal.h>
+#include <odp/api/debug.h>
+#include <odp/api/event.h>
+#include <odp/api/hints.h>
+#include <odp/api/packet.h>
+#include <odp/api/packet_io.h>
+#include <odp/api/queue.h>
+#include <odp/api/ticketlock.h>
+#include <odp/api/time.h>
+
+#include <odp/api/plat/byteorder_inlines.h>
+#include <odp/api/plat/packet_flag_inlines.h>
+#include <odp/api/plat/queue_inlines.h>
+
 #include <odp_classification_internal.h>
-#include <odp_ipsec_internal.h>
 #include <odp_debug_internal.h>
 #include <odp_errno_define.h>
-#include <odp/api/plat/packet_flag_inlines.h>
-#include <odp/api/hints.h>
-#include <odp/api/plat/byteorder_inlines.h>
-#include <odp_queue_if.h>
-#include <odp/api/plat/queue_inlines.h>
-#include <odp_global_data.h>
 #include <odp_event_internal.h>
+#include <odp_global_data.h>
+#include <odp_ipsec_internal.h>
+#include <odp_packet_internal.h>
+#include <odp_packet_io_internal.h>
+#include <odp_queue_if.h>
 
 #include <protocols/eth.h>
 #include <protocols/ip.h>

--- a/platform/linux-generic/pktio/null.c
+++ b/platform/linux-generic/pktio/null.c
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp_api.h>
+#include <odp/api/debug.h>
+#include <odp/api/hints.h>
+#include <odp/api/packet_io.h>
+
 #include <odp_packet_io_internal.h>
 
 #include <stdint.h>

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
+ * Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -38,9 +38,16 @@
 
 #include <odp_posix_extensions.h>
 
-#include <odp_api.h>
+#include <odp/api/debug.h>
+#include <odp/api/hints.h>
+#include <odp/api/packet.h>
+#include <odp/api/packet_io.h>
+#include <odp/api/ticketlock.h>
+
 #include <odp/api/plat/packet_inlines.h>
+
 #include <odp_classification_internal.h>
+#include <odp_debug_internal.h>
 #include <odp_global_data.h>
 #include <odp_packet_internal.h>
 #include <odp_packet_io_internal.h>

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -1,11 +1,26 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2013-2021, Nokia Solutions and Networks
+ * Copyright (c) 2013-2022, Nokia Solutions and Networks
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
 #include <odp_posix_extensions.h>
+
+#include <odp/api/align.h>
+#include <odp/api/debug.h>
+#include <odp/api/hints.h>
+#include <odp/api/packet.h>
+#include <odp/api/packet_io.h>
+#include <odp/api/ticketlock.h>
+
+#include <odp_socket_common.h>
+#include <odp_packet_internal.h>
+#include <odp_packet_io_internal.h>
+#include <odp_packet_io_stats.h>
+#include <odp_debug_internal.h>
+#include <odp_errno_define.h>
+#include <odp_classification_internal.h>
 
 #include <sys/socket.h>
 #include <stdio.h>
@@ -19,15 +34,6 @@
 #include <sys/ioctl.h>
 #include <errno.h>
 #include <sys/syscall.h>
-
-#include <odp_api.h>
-#include <odp_socket_common.h>
-#include <odp_packet_internal.h>
-#include <odp_packet_io_internal.h>
-#include <odp_packet_io_stats.h>
-#include <odp_debug_internal.h>
-#include <odp_errno_define.h>
-#include <odp_classification_internal.h>
 
 typedef struct {
 	odp_ticketlock_t rx_lock ODP_ALIGNED_CACHE;

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -5,10 +5,28 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-
 #include <odp_posix_extensions.h>
 
+#include <odp/api/debug.h>
+#include <odp/api/hints.h>
+#include <odp/api/packet.h>
+#include <odp/api/packet_io.h>
+#include <odp/api/ticketlock.h>
+
+#include <odp/api/plat/packet_inlines.h>
+
+#include <odp_socket_common.h>
+#include <odp_packet_internal.h>
 #include <odp_packet_io_internal.h>
+#include <odp_packet_io_stats.h>
+#include <odp_debug_internal.h>
+#include <odp_errno_define.h>
+#include <odp_classification_datamodel.h>
+#include <odp_classification_internal.h>
+#include <odp_global_data.h>
+
+#include <protocols/eth.h>
+#include <protocols/ip.h>
 
 #include <sys/socket.h>
 #include <stdio.h>
@@ -24,22 +42,6 @@
 #include <errno.h>
 #include <time.h>
 #include <linux/if_packet.h>
-
-#include <odp_api.h>
-#include <odp/api/plat/packet_inlines.h>
-#include <odp_socket_common.h>
-#include <odp_packet_internal.h>
-#include <odp_packet_io_internal.h>
-#include <odp_packet_io_stats.h>
-#include <odp_debug_internal.h>
-#include <odp_errno_define.h>
-#include <odp_classification_datamodel.h>
-#include <odp_classification_internal.h>
-#include <odp/api/hints.h>
-#include <odp_global_data.h>
-
-#include <protocols/eth.h>
-#include <protocols/ip.h>
 
 /* VLAN flags in tpacket2_hdr status */
 #ifdef TP_STATUS_VLAN_TPID_VALID

--- a/platform/linux-generic/pktio/stats/ethtool_stats.c
+++ b/platform/linux-generic/pktio/stats/ethtool_stats.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
+ * Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -7,17 +7,18 @@
 
 #include <odp_posix_extensions.h>
 
+#include <odp/api/packet_io_stats.h>
+
+#include <odp_debug_internal.h>
+#include <odp_errno_define.h>
+#include <odp_ethtool_stats.h>
+
 #include <sys/ioctl.h>
 #include <netinet/in.h>
 #include <linux/sockios.h>
 #include <linux/ethtool.h>
 #include <errno.h>
 #include <net/if.h>
-
-#include <odp_api.h>
-#include <odp_ethtool_stats.h>
-#include <odp_debug_internal.h>
-#include <odp_errno_define.h>
 
 /*
  * Suppress bounds warnings about interior zero length arrays. Such an array

--- a/platform/linux-generic/pktio/stats/sysfs_stats.c
+++ b/platform/linux-generic/pktio/stats/sysfs_stats.c
@@ -1,13 +1,16 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
+ * Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp_api.h>
-#include <odp_sysfs_stats.h>
+#include <odp/api/packet_io_stats.h>
+
+#include <odp_debug_internal.h>
 #include <odp_errno_define.h>
+#include <odp_sysfs_stats.h>
+
 #include <dirent.h>
 #include <errno.h>
 #include <string.h>

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -30,6 +30,21 @@
 
 #include <odp_posix_extensions.h>
 
+#include <odp/api/debug.h>
+#include <odp/api/hints.h>
+#include <odp/api/packet_io.h>
+#include <odp/api/random.h>
+#include <odp/api/ticketlock.h>
+
+#include <odp/api/plat/packet_inlines.h>
+
+#include <odp_debug_internal.h>
+#include <odp_socket_common.h>
+#include <odp_packet_internal.h>
+#include <odp_packet_io_internal.h>
+#include <odp_classification_internal.h>
+#include <odp_errno_define.h>
+
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -39,14 +54,6 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <linux/if_tun.h>
-
-#include <odp_api.h>
-#include <odp/api/plat/packet_inlines.h>
-#include <odp_socket_common.h>
-#include <odp_packet_internal.h>
-#include <odp_packet_io_internal.h>
-#include <odp_classification_internal.h>
-#include <odp_errno_define.h>
 
 typedef struct {
 	int fd;				/**< file descriptor for tap interface*/


### PR DESCRIPTION
Don't include odp_api.h header inside the implementation files as it
unnecessarily includes all API headers. The remaining includes have been
cleaned up and grouped.

Signed-off-by: Matias Elo <matias.elo@nokia.com>