### PR TITLE
[PATCH v13] api: cls: add cos action and cos specific counters

### DIFF
--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -36,9 +36,7 @@ extern "C" {
 
 /**
  * @def ODP_COS_INVALID
- * This value is returned from odp_cls_cos_create() on failure,
- * May also be used as a sink class of service that
- * results in packets being discarded.
+ * This value is returned from odp_cls_cos_create() on failure.
  */
 
 /**
@@ -315,10 +313,42 @@ typedef enum {
 } odp_cos_hdr_flow_fields_t;
 
 /**
+ * Enumeration of actions for CoS.
+ */
+typedef enum {
+	/**
+	 * Enqueue packet
+	 *
+	 * Packets that arrive in the CoS are enqueued to a destination queue.
+	 */
+	ODP_COS_ACTION_ENQUEUE,
+
+	/**
+	 * Drop packet
+	 *
+	 * Packets that arrive in the CoS are dropped. Packets are freed into
+	 * their originating pool.
+	 */
+	ODP_COS_ACTION_DROP,
+} odp_cos_action_t;
+
+/**
  * Class of service parameters
  * Used to communicate class of service creation options
  */
 typedef struct odp_cls_cos_param {
+	/** Action to take. When action is ODP_COS_ACTION_DROP, all the other
+	 * parameters are ignored.
+	 *
+	 * The final match in the CoS chain defines the action for a packet.
+	 * I.e. packet is dropped only when the CoS of the last matching rule
+	 * has drop action. Actions in the previous CoSes in the chain are
+	 * ignored.
+	 *
+	 * Default is ODP_COS_ACTION_ENQUEUE.
+	 */
+	odp_cos_action_t action;
+
 	/** Number of queues to be linked to this CoS.
 	 * If the number is greater than 1 then hashing is enabled.
 	 * If number is equal to 1 then hashing is disabled.
@@ -391,6 +421,9 @@ int odp_cls_capability(odp_cls_capability_t *capability);
 /**
  * Create a class-of-service
  *
+ * Depending on the action parameter, packets to the CoS are either enqueued to
+ * a destination queue, or dropped.
+ *
  * The use of class-of-service name is optional. Unique names are not required.
  * Use odp_cls_cos_param_init() to initialize parameters into their default
  * values.
@@ -401,10 +434,6 @@ int odp_cls_capability(odp_cls_capability_t *capability);
  *
  * @retval Class-of-service handle
  * @retval ODP_COS_INVALID on failure.
- *
- * @note ODP_QUEUE_INVALID and ODP_POOL_INVALID are valid values for queue
- * and pool associated with a class of service. When either of these values
- * is configured as INVALID packets assigned to the CoS get dropped.
  */
 odp_cos_t odp_cls_cos_create(const char *name,
 			     const odp_cls_cos_param_t *param);

--- a/platform/linux-generic/include/odp_classification_datamodel.h
+++ b/platform/linux-generic/include/odp_classification_datamodel.h
@@ -146,10 +146,11 @@ struct cos_s {
 	odp_queue_param_t queue_param;
 	char name[ODP_COS_NAME_LEN];	/* name */
 	uint8_t index;
+	odp_bool_t stats_enable;
 	struct {
 		odp_atomic_u64_t discards;
 		odp_atomic_u64_t packets;
-	} stats[CLS_COS_QUEUE_MAX];
+	} stats, queue_stats[CLS_COS_QUEUE_MAX];
 };
 
 typedef union cos_u {

--- a/platform/linux-generic/include/odp_classification_datamodel.h
+++ b/platform/linux-generic/include/odp_classification_datamodel.h
@@ -129,6 +129,7 @@ typedef struct pmr_term_value {
 Class Of Service
 */
 struct cos_s {
+	odp_cos_action_t action;	/* Action */
 	odp_queue_t queue;		/* Associated Queue */
 	odp_pool_t pool;		/* Associated Buffer pool */
 	odp_pktin_vector_config_t vector;	/* Packet vector config */

--- a/platform/linux-generic/include/odp_classification_internal.h
+++ b/platform/linux-generic/include/odp_classification_internal.h
@@ -67,9 +67,9 @@ static inline void _odp_cos_queue_stats_add(cos_t *cos, odp_queue_t queue,
 	}
 
 	if (packets)
-		odp_atomic_add_u64(&cos->s.stats[queue_idx].packets, packets);
+		odp_atomic_add_u64(&cos->s.queue_stats[queue_idx].packets, packets);
 	if (discards)
-		odp_atomic_add_u64(&cos->s.stats[queue_idx].discards, discards);
+		odp_atomic_add_u64(&cos->s.queue_stats[queue_idx].discards, discards);
 }
 
 /** Classification Internal function **/

--- a/test/validation/api/classification/classification.h
+++ b/test/validation/api/classification/classification.h
@@ -23,6 +23,11 @@
 #define CLS_DEFAULT_SMAC	{0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c}
 #define CLS_MAGIC_VAL		0xdeadbeef
 
+/* Config values for Drop CoS */
+#define TEST_DROP		1
+#define CLS_DROP		6
+#define CLS_DROP_PORT		4001
+
 /* Config values for Error CoS */
 #define TEST_ERROR		1
 #define CLS_ERROR		1
@@ -47,7 +52,7 @@
 
 /* Config values for CoS L2 Priority */
 #define TEST_L2_QOS		1
-#define CLS_L2_QOS_0		6
+#define CLS_L2_QOS_0		7
 #define CLS_L2_QOS_MAX		5
 
 #define CLS_ENTRIES		(CLS_L2_QOS_0 + CLS_L2_QOS_MAX)

--- a/test/validation/api/classification/odp_classification_testsuites.h
+++ b/test/validation/api/classification/odp_classification_testsuites.h
@@ -34,6 +34,7 @@ typedef struct cls_packet_info {
 typedef union odp_cls_testcase {
 	struct  {
 		uint32_t default_cos:1;
+		uint32_t drop_cos:1;
 		uint32_t error_cos:1;
 		uint32_t pmr_chain:1;
 		uint32_t l2_priority:1;
@@ -72,6 +73,8 @@ odp_pool_t pktv_pool_create(const char *poolname);
 odp_queue_t queue_create(const char *queuename, bool sched);
 void configure_pktio_default_cos(odp_bool_t enable_pktv);
 void test_pktio_default_cos(odp_bool_t enable_pktv);
+void configure_pktio_drop_cos(odp_bool_t enable_pktv, uint32_t max_cos_stats);
+void test_pktio_drop_cos(odp_bool_t enable_pktv);
 void configure_pktio_error_cos(odp_bool_t enable_pktv);
 void test_pktio_error_cos(odp_bool_t enable_pktv);
 void configure_cls_pmr_chain(odp_bool_t enable_pktv);


### PR DESCRIPTION
Add an action parameter to CoS parameters (odp_cls_cos_param_t). Action may be to accept or drop the packet classified to the CoS.

Add CoS specific statistics counters (odp_cls_cos_stats_t) and matching capabilities (in odp_cls_stats_capability_t). Statistics counters can be read with odp_cls_cos_stats().

Branched from #1498.

v1 - v4:
- Add commit linux-gen: cls: return odp_cos_action_t from _odp_cls_classify_packet()
- loop: Fix in_errors.

v5:
- Rebase on #1498.
- Rename ACTION_DROP to ACTION_ENQUEUE and tweak documentation accordingly.
- Add mention of final matching CoS.

v6:
- Add capability for max number of CoS with statistics.
- Add validation test for max number of CoS.
- Add validation test for max number of CoS with statistics.

v7:
- Rebase.

v8:
- Petri's comments.

v9 - v11:
- Petri's comments.

v12:
- Rebase.
- Add review tags.
