### PR TITLE
[PATCH v1] linux-gen: pktio: move packet free on send to pktio level

### DIFF
--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -234,6 +234,8 @@ typedef struct pktio_if_ops {
 				   const odp_pktin_queue_param_t *param);
 	int (*output_queues_config)(pktio_entry_t *pktio_entry,
 				    const odp_pktout_queue_param_t *p);
+	/* Indicate if packets need freeing after successfully sent */
+	uint8_t is_sent_free_req;
 } pktio_if_ops_t;
 
 extern void *_odp_pktio_entry_ptr[];

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -2879,6 +2879,7 @@ int odp_pktout_send(odp_pktout_queue_t queue, const odp_packet_t packets[],
 {
 	pktio_entry_t *entry;
 	odp_pktio_t pktio = queue.pktio;
+	int num_sent;
 
 	entry = get_pktio_entry(pktio);
 	if (entry == NULL) {
@@ -2892,7 +2893,12 @@ int odp_pktout_send(odp_pktout_queue_t queue, const odp_packet_t packets[],
 	if (_ODP_PCAPNG)
 		_odp_dump_pcapng_pkts(entry, queue.index, packets, num);
 
-	return entry->s.ops->send(entry, queue.index, packets, num);
+	num_sent = entry->s.ops->send(entry, queue.index, packets, num);
+
+	if (entry->s.ops->is_sent_free_req && num_sent > 0)
+		odp_packet_free_multi(packets, num_sent);
+
+	return num_sent;
 }
 
 /** Get printable format of odp_pktio_t */

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -2118,8 +2118,6 @@ static int dpdk_send(pktio_entry_t *pktio_entry, int index,
 		if (odp_unlikely(tx_pkts == 0)) {
 			if (_odp_errno != 0)
 				return -1;
-		} else {
-			odp_packet_free_multi(pkt_table, tx_pkts);
 		}
 	}
 
@@ -2436,7 +2434,12 @@ const pktio_if_ops_t _odp_dpdk_pktio_ops = {
 	.pktio_time = NULL,
 	.config = NULL,
 	.input_queues_config = dpdk_input_queues_config,
-	.output_queues_config = dpdk_output_queues_config
+	.output_queues_config = dpdk_output_queues_config,
+#if _ODP_DPDK_ZERO_COPY
+	.is_sent_free_req = 0
+#else
+	.is_sent_free_req = 1
+#endif
 };
 
 #else

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -983,5 +983,6 @@ const pktio_if_ops_t _odp_ipc_pktio_ops = {
 	.pktio_ts_res = NULL,
 	.pktio_ts_from_ns = NULL,
 	.pktio_time = NULL,
-	.config = NULL
+	.config = NULL,
+	.is_sent_free_req = 0
 };

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -577,4 +577,5 @@ const pktio_if_ops_t _odp_loopback_pktio_ops = {
 	.config = NULL,
 	.input_queues_config = NULL,
 	.output_queues_config = NULL,
+	.is_sent_free_req = 0
 };

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -1164,8 +1164,6 @@ static int netmap_send(pktio_entry_t *pktio_entry, int index,
 	} else {
 		if (odp_unlikely(tx_ts_idx && nb_tx >= tx_ts_idx))
 			_odp_pktio_tx_ts_set(pktio_entry);
-
-		odp_packet_free_multi(pkt_table, nb_tx);
 	}
 
 	return nb_tx;
@@ -1329,7 +1327,8 @@ const pktio_if_ops_t _odp_netmap_pktio_ops = {
 	.recv_tmo = netmap_recv_tmo,
 	.recv_mq_tmo = netmap_recv_mq_tmo,
 	.send = netmap_send,
-	.fd_set = netmap_fd_set
+	.fd_set = netmap_fd_set,
+	.is_sent_free_req = 1
 };
 #else /* _ODP_PKTIO_NETMAP */
 /* Avoid warning about empty translation unit */

--- a/platform/linux-generic/pktio/null.c
+++ b/platform/linux-generic/pktio/null.c
@@ -106,8 +106,6 @@ static int null_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 		}
 	}
 
-	odp_packet_free_multi(pkt_table, num);
-
 	if (odp_unlikely(set_tx_ts))
 		_odp_pktio_tx_ts_set(pktio_entry);
 
@@ -224,5 +222,6 @@ const pktio_if_ops_t _odp_null_pktio_ops = {
 	.input_queues_config = null_inqueues_config,
 	.output_queues_config = null_outqueues_config,
 	.link_status = null_link_status,
-	.link_info = null_link_info
+	.link_info = null_link_info,
+	.is_sent_free_req = 1
 };

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -381,8 +381,6 @@ static int pcapif_send_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 		if (odp_unlikely(tx_ts_enabled && packet_hdr(pkts[i])->p.flags.ts_set))
 			_odp_pktio_tx_ts_set(pktio_entry);
-
-		odp_packet_free(pkts[i]);
 	}
 
 	pktio_entry->s.stats.out_packets += i;
@@ -559,5 +557,6 @@ const pktio_if_ops_t _odp_pcap_pktio_ops = {
 	.input_queues_config = NULL,
 	.output_queues_config = NULL,
 	.link_status = pcapif_link_status,
-	.link_info = pcapif_link_info
+	.link_info = pcapif_link_info,
+	.is_sent_free_req = 1
 };

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -476,8 +476,6 @@ static int sock_mmsg_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 	odp_ticketlock_unlock(&pkt_sock->tx_lock);
 
-	odp_packet_free_multi(pkt_table, i);
-
 	return i;
 }
 
@@ -654,4 +652,5 @@ const pktio_if_ops_t _odp_sock_mmsg_pktio_ops = {
 	.config = NULL,
 	.input_queues_config = NULL,
 	.output_queues_config = NULL,
+	.is_sent_free_req = 1
 };

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -402,9 +402,6 @@ static inline int pkt_mmap_v2_tx(pktio_entry_t *pktio_entry, int sock,
 	if (odp_unlikely(tx_ts_idx && num_tx >= tx_ts_idx))
 		_odp_pktio_tx_ts_set(pktio_entry);
 
-	/* Free sent packets */
-	odp_packet_free_multi(pkt_table, num_tx);
-
 	return num_tx;
 }
 
@@ -968,4 +965,5 @@ const pktio_if_ops_t _odp_sock_mmap_pktio_ops = {
 	.config = NULL,
 	.input_queues_config = NULL,
 	.output_queues_config = NULL,
+	.is_sent_free_req = 1
 };

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -370,7 +370,7 @@ static int tap_pktio_send_lockless(pktio_entry_t *pktio_entry,
 {
 	pkt_tap_t *tap = pkt_priv(pktio_entry);
 	ssize_t retval;
-	int i, n;
+	int i;
 	uint32_t pkt_len;
 	uint32_t mtu = tap->mtu;
 	uint8_t tx_ts_enabled = _odp_pktio_tx_ts_enabled(pktio_entry);
@@ -417,9 +417,6 @@ static int tap_pktio_send_lockless(pktio_entry_t *pktio_entry,
 				_odp_pktio_tx_ts_set(pktio_entry);
 		}
 	}
-
-	for (n = 0; n < i; n++)
-		odp_packet_free(pkts[n]);
 
 	return i;
 }
@@ -557,5 +554,6 @@ const pktio_if_ops_t _odp_tap_pktio_ops = {
 	.pktio_ts_res = NULL,
 	.pktio_ts_from_ns = NULL,
 	.pktio_time = NULL,
-	.config = NULL
+	.config = NULL,
+	.is_sent_free_req = 1
 };


### PR DESCRIPTION
Expose packet consumption behavior of different pktio implementations
when sending packets to pktio ops interface and remove packet freeing
from implementation level when possible.

In practice, zero-copy-type (e.g. DPDK zero-copy) and move-type
implementations (e.g. loop) always consume passed packets while copy-type
implementations leave packet freeing to upper levels.

This enables potential post-send actions to be done based on the sent
packets centrally inside `odp_pktout_send()` (such as completion event
handling) before freeing them.

Signed-off-by: Tuomas Taipale <tuomas.taipale@nokia.com>