### PR TITLE
[PATCH v2] example: ipsec_crypto: add capability checking and bit mode support

### DIFF
--- a/example/ipsec_api/odp_ipsec.c
+++ b/example/ipsec_api/odp_ipsec.c
@@ -1396,3 +1396,10 @@ static void usage(char *progname)
 	       "\n", NO_PATH(progname), NO_PATH(progname)
 		);
 }
+
+odp_bool_t sa_config_supported(const sa_db_entry_t *sa_entry);
+
+odp_bool_t sa_config_supported(const sa_db_entry_t *sa_entry ODP_UNUSED)
+{
+	return true;
+}

--- a/example/ipsec_api/odp_ipsec.c
+++ b/example/ipsec_api/odp_ipsec.c
@@ -1397,9 +1397,9 @@ static void usage(char *progname)
 		);
 }
 
-odp_bool_t sa_config_supported(const sa_db_entry_t *sa_entry);
+odp_bool_t sa_config_supported(const sa_db_entry_t *sa_entry, int *sa_flags);
 
-odp_bool_t sa_config_supported(const sa_db_entry_t *sa_entry ODP_UNUSED)
+odp_bool_t sa_config_supported(const sa_db_entry_t *sa_entry ODP_UNUSED, int *sa_flags ODP_UNUSED)
 {
 	return true;
 }

--- a/example/ipsec_crypto/odp_ipsec_cache.c
+++ b/example/ipsec_crypto/odp_ipsec_cache.c
@@ -89,6 +89,7 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 	else
 		entry->in_place = TRUE;
 
+	entry->sa_flags = 0;
 
 	/* Cipher */
 	if (cipher_sa) {
@@ -97,6 +98,8 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 		params.cipher_key.length  = cipher_sa->key.length;
 		params.cipher_iv_len = cipher_sa->iv_len;
 		mode = cipher_sa->mode;
+		if (cipher_sa->flags & BIT_MODE_CIPHER)
+			entry->sa_flags |= BIT_MODE_CIPHER;
 	} else {
 		params.cipher_alg = ODP_CIPHER_ALG_NULL;
 		params.cipher_iv_len = 0;
@@ -110,6 +113,8 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 		params.auth_digest_len = auth_sa->icv_len;
 		mode = auth_sa->mode;
 		params.hash_result_in_auth_range = true;
+		if (auth_sa->flags & BIT_MODE_AUTH)
+			entry->sa_flags |= BIT_MODE_AUTH;
 	} else {
 		params.auth_alg = ODP_AUTH_ALG_NULL;
 	}

--- a/example/ipsec_crypto/odp_ipsec_cache.h
+++ b/example/ipsec_crypto/odp_ipsec_cache.h
@@ -33,6 +33,7 @@ typedef struct ipsec_cache_entry_s {
 	struct ipsec_cache_entry_s  *next;        /**< Next entry on list */
 	odp_bool_t                   in_place;    /**< Crypto API mode */
 	odp_bool_t                   async;       /**< ASYNC or SYNC mode */
+	int                          sa_flags;
 	uint32_t                     src_ip;      /**< Source v4 address */
 	uint32_t                     dst_ip;      /**< Destination v4 address */
 	sa_mode_t		     mode;        /**< SA mode - transport/tun */

--- a/example/ipsec_crypto/odp_ipsec_sa_db.c
+++ b/example/ipsec_crypto/odp_ipsec_sa_db.c
@@ -17,6 +17,8 @@
 
 #include <odp_ipsec_sa_db.h>
 
+odp_bool_t sa_config_supported(const sa_db_entry_t *sa);
+
 /** Global pointer to sa db */
 static sa_db_t *sa_db;
 
@@ -159,6 +161,11 @@ int create_sa_db_entry(char *input, odp_bool_t cipher)
 		printf("ERROR: \"%s\" contains %d tokens, expected 5\n",
 		       input,
 		       pos);
+		free(local);
+		return -1;
+	}
+
+	if (!sa_config_supported(entry)) {
 		free(local);
 		return -1;
 	}

--- a/example/ipsec_crypto/odp_ipsec_sa_db.c
+++ b/example/ipsec_crypto/odp_ipsec_sa_db.c
@@ -17,7 +17,7 @@
 
 #include <odp_ipsec_sa_db.h>
 
-odp_bool_t sa_config_supported(const sa_db_entry_t *sa);
+odp_bool_t sa_config_supported(const sa_db_entry_t *sa, int *sa_flags);
 
 /** Global pointer to sa db */
 static sa_db_t *sa_db;
@@ -165,7 +165,7 @@ int create_sa_db_entry(char *input, odp_bool_t cipher)
 		return -1;
 	}
 
-	if (!sa_config_supported(entry)) {
+	if (!sa_config_supported(entry, &entry->flags)) {
 		free(local);
 		return -1;
 	}

--- a/example/ipsec_crypto/odp_ipsec_sa_db.h
+++ b/example/ipsec_crypto/odp_ipsec_sa_db.h
@@ -17,6 +17,12 @@ typedef enum sa_mode_s {
 	IPSEC_SA_MODE_TRANSPORT,
 	IPSEC_SA_MODE_TUNNEL
 } sa_mode_t;
+
+typedef enum sa_flags_s {
+	BIT_MODE_CIPHER = 1,
+	BIT_MODE_AUTH = 2,
+} sa_flags_t;
+
 /**
  * Security Association (SA) data base entry
  */
@@ -31,6 +37,7 @@ typedef struct sa_db_entry_s {
 	uint32_t              iv_len;    /**< Initialization Vector length */
 	uint32_t              icv_len;   /**< Integrity Check Value length */
 	sa_mode_t             mode;      /**< SA mode - transport/tun */
+	int                   flags;     /**< Miscellaneous flags */
 } sa_db_entry_t;
 
 /**


### PR DESCRIPTION
    example: ipsec_crypto: fix crypto capability checking

    Check that the used algorithm as well as key length etc are supported
    before trying to create a crypto session. Give up if the used ODP
    implementation supports the algorithm in bit mode since the code expects
    byte mode and would pass incorrect auth_range to an implementation which
    works in bit mode.


    example: ipsec_crypto: support bit mode algorithm implementations too

    Do not give up if the underlying ODP supports an algorithm in bit mode
    but scale the range parameter as appropriate.