### PR TITLE
[PATCH v6] linux-gen: implement tx packet aging

### DIFF
--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -115,7 +115,7 @@ typedef union {
 	uint32_t all_flags;
 
 	struct {
-		uint32_t reserved1:      7;
+		uint32_t reserved1:      6;
 
 	/*
 	 * Init flags
@@ -133,6 +133,7 @@ typedef union {
 		uint32_t l4_chksum:      1; /* L4 chksum override */
 		uint32_t ts_set:         1; /* Set Tx timestamp */
 		uint32_t tx_compl:       1; /* Tx completion event requested */
+		uint32_t tx_aging:       1; /* Packet aging at Tx requested */
 		uint32_t shaper_len_adj: 8; /* Adjustment for traffic mgr */
 
 	/*
@@ -150,8 +151,8 @@ typedef union {
 
 	/* Flag groups */
 	struct {
-		uint32_t reserved2:      7;
-		uint32_t other:         17; /* All other flags */
+		uint32_t reserved2:      6;
+		uint32_t other:         18; /* All other flags */
 		uint32_t error:          8; /* All error flags */
 	} all;
 

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -146,6 +146,10 @@ typedef struct ODP_ALIGNED_CACHE odp_packet_hdr_t {
 	/* Max payload size in a LSO segment */
 	uint16_t lso_max_payload;
 
+	/* Packet aging drop timeout before enqueue. Once enqueued holds the maximum age (time of
+	 * request + requested drop timeout). */
+	uint64_t tx_aging_ns;
+
 	/* LSO profile index */
 	uint8_t lso_profile_idx;
 

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -93,6 +93,8 @@ struct pktio_entry {
 				uint8_t tx_ts : 1;
 				/* Tx completion events */
 				uint8_t tx_compl : 1;
+				/* Packet aging */
+				uint8_t tx_aging : 1;
 			};
 		};
 	} enabled;
@@ -289,6 +291,11 @@ static inline int _odp_pktio_tx_ts_enabled(pktio_entry_t *entry)
 static inline int _odp_pktio_tx_compl_enabled(const pktio_entry_t *entry)
 {
 	return entry->s.enabled.tx_compl;
+}
+
+static inline int _odp_pktio_tx_aging_enabled(pktio_entry_t *entry)
+{
+	return entry->s.enabled.tx_aging;
 }
 
 static inline void _odp_pktio_tx_ts_set(pktio_entry_t *entry)

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2879,14 +2879,17 @@ int odp_packet_payload_offset_set(odp_packet_t pkt, uint32_t offset)
 
 void odp_packet_aging_tmo_set(odp_packet_t pkt, uint64_t tmo_ns)
 {
-	(void)pkt;
-	(void)tmo_ns;
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
+
+	pkt_hdr->p.flags.tx_aging = tmo_ns ? 1 : 0;
+	pkt_hdr->tx_aging_ns = tmo_ns;
 }
 
 uint64_t odp_packet_aging_tmo(odp_packet_t pkt)
 {
-	(void)pkt;
-	return 0;
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
+
+	return pkt_hdr->p.flags.tx_aging ? pkt_hdr->tx_aging_ns : 0;
 }
 
 int odp_packet_tx_compl_request(odp_packet_t pkt, const odp_packet_tx_compl_opt_t *opt)

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -52,6 +52,10 @@
 /* Max wait time supported to avoid potential overflow */
 #define MAX_WAIT_TIME (UINT64_MAX / 1024)
 
+/* One hour maximum aging timeout, no real limitations imposed by the implementation other than
+ * integer width, so just use some value. */
+#define MAX_TX_AGING_TMO_NS 3600000000000ULL
+
 typedef struct {
 	const void *user_ptr;
 	odp_queue_t queue;
@@ -622,6 +626,8 @@ int odp_pktio_config(odp_pktio_t hdl, const odp_pktio_config_t *config)
 			ODP_ERR("Unable to configure Tx event completion\n");
 			return -1;
 		}
+
+	entry->s.enabled.tx_aging = config->pktout.bit.aging_ena;
 
 	if (entry->s.ops->config)
 		res = entry->s.ops->config(entry, config);
@@ -1885,6 +1891,9 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 		capa->tx_compl.queue_type_sched = 1;
 		capa->tx_compl.queue_type_plain = 1;
 		capa->tx_compl.mode_all = 1;
+
+		capa->config.pktout.bit.aging_ena = 1;
+		capa->max_tx_aging_tmo_ns = MAX_TX_AGING_TMO_NS;
 	}
 
 	/* Packet vector generation is common for all pktio types */


### PR DESCRIPTION
Add aging support for packets enqeued for transmission to linux-gen. This ends up affecting traffic manager only as in practice there is no long output queuing elsewhere.

v2:
- address Jere's comments

v3:
- address Matias' comment

v4:
- rebase on-top-of #1495 
- add reviewed-by tags

v5:
- rebase