### PR TITLE
[PATCH v4] linux-gen: queue: add missing include directive

### DIFF
--- a/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <odp/api/event.h>
 #include <odp/api/queue_types.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */


### PR DESCRIPTION
linux-gen: queue: add missing include directive
    
Include odp/api/event.h in queue_inline_types.h, since it uses odp_event_t. This omission also prevented the proto_stats.h API header from being compiled on its own.
    
Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

v3:
- Include order.

v4:
- Rebase.
- Add review tags.
