### PR TITLE
[PATCH v2] linux-gen: 128-bit integer type cleanups

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -160,6 +160,7 @@ noinst_HEADERS = \
 		  include/odp_timer_internal.h \
 		  include/odp_timer_wheel_internal.h \
 		  include/odp_traffic_mngr_internal.h \
+		  include/odp_types_internal.h \
 		  include/odp_event_vector_internal.h \
 		  include/protocols/eth.h \
 		  include/protocols/ip.h \

--- a/platform/linux-generic/arch/aarch64/odp_atomic.h
+++ b/platform/linux-generic/arch/aarch64/odp_atomic.h
@@ -37,22 +37,18 @@ do {							\
 #define LL_MO(mo) (HAS_ACQ((mo)) ? __ATOMIC_ACQUIRE : __ATOMIC_RELAXED)
 #define SC_MO(mo) (HAS_RLS((mo)) ? __ATOMIC_RELEASE : __ATOMIC_RELAXED)
 
-/* Prevent warnings about ISO C not supporting __int128 */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-
 #ifndef __ARM_FEATURE_QRDMX /* Feature only available in v8.1a and beyond */
 static inline bool
-__lockfree_compare_exchange_16(register __int128 *var, __int128 *exp,
-			       register __int128 neu, bool weak, int mo_success,
+__lockfree_compare_exchange_16(register _odp_u128_t *var, _odp_u128_t *exp,
+			       register _odp_u128_t neu, bool weak, int mo_success,
 			       int mo_failure)
 {
 	(void)weak; /* Always do strong CAS or we can't perform atomic read */
 	/* Ignore memory ordering for failure, memory order for
 	 * success must be stronger or equal. */
 	(void)mo_failure;
-	register __int128 old;
-	register __int128 expected;
+	register _odp_u128_t old;
+	register _odp_u128_t expected;
 	int ll_mo = LL_MO(mo_success);
 	int sc_mo = SC_MO(mo_success);
 
@@ -67,10 +63,10 @@ __lockfree_compare_exchange_16(register __int128 *var, __int128 *exp,
 	return old == expected;
 }
 
-static inline __int128 __lockfree_exchange_16(__int128 *var, __int128 neu,
-					      int mo)
+static inline _odp_u128_t __lockfree_exchange_16(_odp_u128_t *var,
+						 _odp_u128_t neu, int mo)
 {
-	register __int128 old;
+	register _odp_u128_t old;
 	int ll_mo = LL_MO(mo);
 	int sc_mo = SC_MO(mo);
 
@@ -82,10 +78,10 @@ static inline __int128 __lockfree_exchange_16(__int128 *var, __int128 neu,
 	return old;
 }
 
-static inline __int128 __lockfree_fetch_and_16(__int128 *var, __int128 mask,
-					       int mo)
+static inline _odp_u128_t __lockfree_fetch_and_16(_odp_u128_t *var,
+						  _odp_u128_t mask, int mo)
 {
-	register __int128 old;
+	register _odp_u128_t old;
 	int ll_mo = LL_MO(mo);
 	int sc_mo = SC_MO(mo);
 
@@ -97,10 +93,10 @@ static inline __int128 __lockfree_fetch_and_16(__int128 *var, __int128 mask,
 	return old;
 }
 
-static inline __int128 __lockfree_fetch_or_16(__int128 *var, __int128 mask,
-					      int mo)
+static inline _odp_u128_t __lockfree_fetch_or_16(_odp_u128_t *var,
+						 _odp_u128_t mask, int mo)
 {
-	register __int128 old;
+	register _odp_u128_t old;
 	int ll_mo = LL_MO(mo);
 	int sc_mo = SC_MO(mo);
 
@@ -114,8 +110,8 @@ static inline __int128 __lockfree_fetch_or_16(__int128 *var, __int128 mask,
 
 #else
 
-static inline __int128_t cas_u128(__int128_t *ptr, __int128_t old_val,
-				  __int128_t new_val, int mo)
+static inline _odp_u128_t cas_u128(_odp_u128_t *ptr, _odp_u128_t old_val,
+				   _odp_u128_t new_val, int mo)
 {
 	/* CASP instructions require that the first register number is paired */
 	register uint64_t old0 __asm__ ("x0");
@@ -152,18 +148,18 @@ static inline __int128_t cas_u128(__int128_t *ptr, __int128_t old_val,
 		abort();
 	}
 
-	return ((__int128)old0) | (((__int128)old1) << 64);
+	return ((_odp_u128_t)old0) | (((_odp_u128_t)old1) << 64);
 }
 
 static inline bool
-__lockfree_compare_exchange_16(register __int128 *var, __int128 *exp,
-			       register __int128 neu, bool weak, int mo_success,
+__lockfree_compare_exchange_16(register _odp_u128_t *var, _odp_u128_t *exp,
+			       register _odp_u128_t neu, bool weak, int mo_success,
 			       int mo_failure)
 {
 	(void)weak;
 	(void)mo_failure;
-	__int128 old;
-	__int128 expected;
+	_odp_u128_t old;
+	_odp_u128_t expected;
 
 	expected = *exp;
 	old = cas_u128(var, expected, neu, mo_success);
@@ -171,11 +167,11 @@ __lockfree_compare_exchange_16(register __int128 *var, __int128 *exp,
 	return old == expected;
 }
 
-static inline __int128 __lockfree_exchange_16(__int128 *var, __int128 neu,
-					      int mo)
+static inline _odp_u128_t __lockfree_exchange_16(_odp_u128_t *var,
+						 _odp_u128_t neu, int mo)
 {
-	__int128 old;
-	__int128 expected;
+	_odp_u128_t old;
+	_odp_u128_t expected;
 
 	do {
 		expected = *var;
@@ -184,11 +180,11 @@ static inline __int128 __lockfree_exchange_16(__int128 *var, __int128 neu,
 	return old;
 }
 
-static inline __int128 __lockfree_fetch_and_16(__int128 *var, __int128 mask,
-					       int mo)
+static inline _odp_u128_t __lockfree_fetch_and_16(_odp_u128_t *var,
+						  _odp_u128_t mask, int mo)
 {
-	__int128 old;
-	__int128 expected;
+	_odp_u128_t old;
+	_odp_u128_t expected;
 
 	do {
 		expected = *var;
@@ -197,11 +193,11 @@ static inline __int128 __lockfree_fetch_and_16(__int128 *var, __int128 mask,
 	return old;
 }
 
-static inline __int128 __lockfree_fetch_or_16(__int128 *var, __int128 mask,
-					      int mo)
+static inline _odp_u128_t __lockfree_fetch_or_16(_odp_u128_t *var,
+						 _odp_u128_t mask, int mo)
 {
-	__int128 old;
-	__int128 expected;
+	_odp_u128_t old;
+	_odp_u128_t expected;
 
 	do {
 		expected = *var;
@@ -212,9 +208,9 @@ static inline __int128 __lockfree_fetch_or_16(__int128 *var, __int128 mask,
 
 #endif  /* __ARM_FEATURE_QRDMX */
 
-static inline __int128 __lockfree_load_16(__int128 *var, int mo)
+static inline _odp_u128_t __lockfree_load_16(_odp_u128_t *var, int mo)
 {
-	__int128 old = *var; /* Possibly torn read */
+	_odp_u128_t old = *var; /* Possibly torn read */
 
 	/* Do CAS to ensure atomicity
 	 * Either CAS succeeds (writing back the same value)
@@ -226,15 +222,15 @@ static inline __int128 __lockfree_load_16(__int128 *var, int mo)
 
 static inline _odp_u128_t lockfree_load_u128(_odp_u128_t *atomic)
 {
-	return __lockfree_load_16((__int128 *)atomic, __ATOMIC_RELAXED);
+	return __lockfree_load_16((_odp_u128_t *)atomic, __ATOMIC_RELAXED);
 }
 
 static inline int lockfree_cas_acq_rel_u128(_odp_u128_t *atomic,
 					    _odp_u128_t old_val,
 					    _odp_u128_t new_val)
 {
-	return __lockfree_compare_exchange_16((__int128 *)atomic,
-					      (__int128 *)&old_val,
+	return __lockfree_compare_exchange_16((_odp_u128_t *)atomic,
+					      (_odp_u128_t *)&old_val,
 					      new_val,
 					      0,
 					      __ATOMIC_ACQ_REL,
@@ -291,10 +287,8 @@ static inline bitset_t bitset_mask(uint32_t bit)
 	if (bit < 64)
 		return 1ULL << bit;
 	else
-		return (unsigned __int128)(1ULL << (bit - 64)) << 64;
+		return (_odp_u128_t)(1ULL << (bit - 64)) << 64;
 }
-
-#pragma GCC diagnostic pop
 
 #else
 #error Unsupported size of bit sets (ATOM_BITSET_SIZE)

--- a/platform/linux-generic/arch/aarch64/odp_atomic.h
+++ b/platform/linux-generic/arch/aarch64/odp_atomic.h
@@ -12,6 +12,7 @@
 #error This file should not be included directly, please include odp_cpu.h
 #endif
 
+#include <odp_types_internal.h>
 #include <limits.h>
 
 #ifdef CONFIG_DMBSTR
@@ -223,16 +224,14 @@ static inline __int128 __lockfree_load_16(__int128 *var, int mo)
 	return old;
 }
 
-__extension__ typedef unsigned __int128 _u128_t;
-
-static inline _u128_t lockfree_load_u128(_u128_t *atomic)
+static inline _odp_u128_t lockfree_load_u128(_odp_u128_t *atomic)
 {
 	return __lockfree_load_16((__int128 *)atomic, __ATOMIC_RELAXED);
 }
 
-static inline int lockfree_cas_acq_rel_u128(_u128_t *atomic,
-					    _u128_t old_val,
-					    _u128_t new_val)
+static inline int lockfree_cas_acq_rel_u128(_odp_u128_t *atomic,
+					    _odp_u128_t old_val,
+					    _odp_u128_t new_val)
 {
 	return __lockfree_compare_exchange_16((__int128 *)atomic,
 					      (__int128 *)&old_val,
@@ -249,7 +248,7 @@ static inline int lockfree_check_u128(void)
 
 /** Atomic bit set operations with memory ordering */
 #if defined(__SIZEOF_INT128__) && __SIZEOF_INT128__ == 16
-typedef __int128 bitset_t;
+typedef _odp_u128_t bitset_t;
 #define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_INT128__)
 
 #elif __GCC_ATOMIC_LLONG_LOCK_FREE == 2 && \

--- a/platform/linux-generic/arch/aarch64/odp_llsc.h
+++ b/platform/linux-generic/arch/aarch64/odp_llsc.h
@@ -13,6 +13,8 @@
 #error This file should not be included directly, please include odp_cpu.h
 #endif
 
+#include <odp_types_internal.h>
+
 static inline uint16_t ll8(uint8_t *var, int mm)
 {
 	uint16_t old;
@@ -115,11 +117,11 @@ static inline uint32_t sc(uint64_t *var, uint64_t neu, int mm)
 #define sc64(a, b, c) sc((a), (b), (c))
 
 union i128 {
-	__extension__ __int128 i128;
+	_odp_u128_t i128;
 	int64_t  i64[2];
 };
 
-__extension__ static inline __int128 lld(__int128 *var, int mm)
+static inline _odp_u128_t lld(_odp_u128_t *var, int mm)
 {
 	union i128 old;
 
@@ -139,7 +141,7 @@ __extension__ static inline __int128 lld(__int128 *var, int mm)
 }
 
 /* Return 0 on success, 1 on failure */
-__extension__ static inline uint32_t scd(__int128 *var, __int128 neu, int mm)
+static inline uint32_t scd(_odp_u128_t *var, _odp_u128_t neu, int mm)
 {
 	uint32_t ret;
 

--- a/platform/linux-generic/arch/arm/odp_atomic.h
+++ b/platform/linux-generic/arch/arm/odp_atomic.h
@@ -12,6 +12,7 @@
 #error This file should not be included directly, please include odp_cpu.h
 #endif
 
+#include <odp_types_internal.h>
 #include <limits.h>
 
 #ifdef CONFIG_DMBSTR
@@ -70,7 +71,7 @@ static inline bitset_t bitset_mask(uint32_t bit)
 	if (bit < 64)
 		return 1ULL << bit;
 	else
-		return (unsigned __int128)(1ULL << (bit - 64)) << 64;
+		return (_odp_u128_t)(1ULL << (bit - 64)) << 64;
 }
 
 #else

--- a/platform/linux-generic/arch/default/odp_atomic.h
+++ b/platform/linux-generic/arch/default/odp_atomic.h
@@ -76,7 +76,7 @@ static inline bitset_t bitset_mask(uint32_t bit)
 	if (bit < 64)
 		return 1ULL << bit;
 	else
-		return (unsigned __int128)(1ULL << (bit - 64)) << 64;
+		return (_odp_u128_t)(1ULL << (bit - 64)) << 64;
 }
 
 #else

--- a/platform/linux-generic/arch/default/odp_atomic.h
+++ b/platform/linux-generic/arch/default/odp_atomic.h
@@ -7,18 +7,18 @@
 #ifndef ODP_DEFAULT_ATOMIC_H_
 #define ODP_DEFAULT_ATOMIC_H_
 
+#include <odp_types_internal.h>
+
 #ifdef __SIZEOF_INT128__
 
-__extension__ typedef unsigned __int128 _u128_t;
-
-static inline _u128_t lockfree_load_u128(_u128_t *atomic)
+static inline _odp_u128_t lockfree_load_u128(_odp_u128_t *atomic)
 {
 	return __atomic_load_n(atomic, __ATOMIC_RELAXED);
 }
 
-static inline int lockfree_cas_acq_rel_u128(_u128_t *atomic,
-					    _u128_t old_val,
-					    _u128_t new_val)
+static inline int lockfree_cas_acq_rel_u128(_odp_u128_t *atomic,
+					    _odp_u128_t old_val,
+					    _odp_u128_t new_val)
 {
 	return __atomic_compare_exchange_n(atomic, &old_val, new_val,
 					   0 /* strong */,

--- a/platform/linux-generic/include/odp_atomic_internal.h
+++ b/platform/linux-generic/include/odp_atomic_internal.h
@@ -20,6 +20,7 @@
 #include <odp/api/align.h>
 #include <odp/api/hints.h>
 #include <odp/api/atomic.h>
+#include <odp_types_internal.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus
@@ -137,12 +138,10 @@ static inline void _odp_atomic_flag_clear(_odp_atomic_flag_t *flag)
 #endif
 
 #ifdef ODP_ATOMIC_U128
-/** An unsigned 128-bit (16-byte) scalar type */
-__extension__ typedef __int128 _uint128_t;
 
 /** Atomic 128-bit type */
 typedef struct ODP_ALIGNED(16) {
-	_uint128_t v; /**< Actual storage for the atomic variable */
+	_odp_u128_t v; /**< Actual storage for the atomic variable */
 } _odp_atomic_u128_t;
 
 /**
@@ -154,8 +153,8 @@ typedef struct ODP_ALIGNED(16) {
  * @param       mmodel Memory model associated with the exchange operation
  */
 static inline void _odp_atomic_u128_xchg_mm(_odp_atomic_u128_t *ptr,
-					    _uint128_t *val,
-		_uint128_t *old,
+					    _odp_u128_t *val,
+		_odp_u128_t *old,
 		_odp_memmodel_t mm)
 {
 	__atomic_exchange(&ptr->v, val, old, mm);
@@ -177,8 +176,8 @@ static inline void _odp_atomic_u128_xchg_mm(_odp_atomic_u128_t *ptr,
  * @retval 0 exchange failed and '*exp' updated with current value
  */
 static inline int _odp_atomic_u128_cmp_xchg_mm(_odp_atomic_u128_t *ptr,
-					       _uint128_t *exp,
-					       _uint128_t *val,
+					       _odp_u128_t *exp,
+					       _odp_u128_t *val,
 					       _odp_memmodel_t succ,
 					       _odp_memmodel_t fail)
 {

--- a/platform/linux-generic/include/odp_llqueue.h
+++ b/platform/linux-generic/include/odp_llqueue.h
@@ -15,6 +15,7 @@
 
 #include <odp_config_internal.h>
 #include <odp_debug_internal.h>
+#include <odp_types_internal.h>
 #include <odp_cpu.h>
 
 #include <stdint.h>
@@ -49,7 +50,7 @@ static odp_bool_t llq_on_queue(struct llnode *node);
 typedef uint64_t dintptr_t;
 #endif
 #if __SIZEOF_PTRDIFF_T__ == 8
-__extension__ typedef __int128 dintptr_t;
+typedef _odp_u128_t dintptr_t;
 #endif
 
 struct llnode {

--- a/platform/linux-generic/include/odp_types_internal.h
+++ b/platform/linux-generic/include/odp_types_internal.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:	BSD-3-Clause
+ */
+
+#ifndef ODP_TYPES_INTERNAL_H_
+#define ODP_TYPES_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __SIZEOF_INT128__
+
+__extension__ typedef unsigned __int128 _odp_u128_t;
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/odp_queue_lf.c
+++ b/platform/linux-generic/odp_queue_lf.c
@@ -13,6 +13,7 @@
 #include <odp_debug_internal.h>
 #include <odp_event_internal.h>
 #include <odp_queue_basic_internal.h>
+#include <odp_types_internal.h>
 
 #include <string.h>
 #include <stdio.h>
@@ -24,9 +25,7 @@
 
 #ifdef __SIZEOF_INT128__
 
-__extension__ typedef unsigned __int128 u128_t;
-
-static inline void lockfree_zero_u128(u128_t *atomic)
+static inline void lockfree_zero_u128(_odp_u128_t *atomic)
 {
 	__atomic_store_n(atomic, 0, __ATOMIC_RELAXED);
 }
@@ -40,21 +39,21 @@ static inline void lockfree_zero_u128(u128_t *atomic)
  * So, these are never actually used. */
 typedef struct ODP_ALIGNED(16) {
 	uint64_t u64[2];
-} u128_t;
+} _odp_u128_t;
 
-static inline u128_t lockfree_load_u128(u128_t *atomic)
+static inline _odp_u128_t lockfree_load_u128(_odp_u128_t *atomic)
 {
 	return *atomic;
 }
 
-static inline void lockfree_zero_u128(u128_t *atomic)
+static inline void lockfree_zero_u128(_odp_u128_t *atomic)
 {
 	atomic->u64[0] = 0;
 	atomic->u64[1] = 0;
 }
 
-static inline int lockfree_cas_acq_rel_u128(u128_t *atomic, u128_t old_val,
-					    u128_t new_val)
+static inline int lockfree_cas_acq_rel_u128(_odp_u128_t *atomic, _odp_u128_t old_val,
+					    _odp_u128_t new_val)
 {
 	if (atomic->u64[0] == old_val.u64[0] &&
 	    atomic->u64[1] == old_val.u64[1]) {
@@ -75,7 +74,7 @@ static inline int lockfree_check_u128(void)
 
 /* Node in lock-free ring */
 typedef union {
-	u128_t u128;
+	_odp_u128_t u128;
 
 	struct {
 		/* Data with lowest counter value is the head. Empty node has

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -53,6 +53,7 @@
 #include <odp/api/plat/queue_inlines.h>
 #include <odp_global_data.h>
 #include <odp_event_internal.h>
+#include <odp_types_internal.h>
 
 /* Inlined API functions */
 #include <odp/api/plat/event_inlines.h>
@@ -689,7 +690,7 @@ static bool timer_reset(uint32_t idx, uint64_t abs_tck, odp_event_t *tmo_event,
 			/* Atomic CAS will fail if we experienced torn reads,
 			 * retry update sequence until CAS succeeds */
 		} while (!_odp_atomic_u128_cmp_xchg_mm((_odp_atomic_u128_t *)tb,
-						       (_uint128_t *)&old, (_uint128_t *)&new,
+						       (_odp_u128_t *)&old, (_odp_u128_t *)&new,
 						       _ODP_MEMMODEL_RLS, _ODP_MEMMODEL_RLX));
 #elif __GCC_ATOMIC_LLONG_LOCK_FREE >= 2 && \
 	defined __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8
@@ -760,8 +761,8 @@ static bool timer_reset(uint32_t idx, uint64_t abs_tck, odp_event_t *tmo_event,
 		/* We are releasing the new timeout event to some other
 		 * thread */
 		_odp_atomic_u128_xchg_mm((_odp_atomic_u128_t *)tb,
-					 (_uint128_t *)&new,
-					 (_uint128_t *)&old,
+					 (_odp_u128_t *)&new,
+					 (_odp_u128_t *)&old,
 					 _ODP_MEMMODEL_ACQ_RLS);
 		old_event = old.tmo_event;
 #else
@@ -804,7 +805,7 @@ static odp_event_t timer_set_unused(timer_pool_t *tp, uint32_t idx)
 	new.tmo_event = ODP_EVENT_INVALID;
 
 	_odp_atomic_u128_xchg_mm((_odp_atomic_u128_t *)tb,
-				 (_uint128_t *)&new, (_uint128_t *)&old,
+				 (_odp_u128_t *)&new, (_odp_u128_t *)&old,
 				 _ODP_MEMMODEL_RLX);
 	old_event = old.tmo_event;
 #else
@@ -858,8 +859,8 @@ static odp_event_t timer_cancel(timer_pool_t *tp, uint32_t idx)
 		/* Atomic CAS will fail if we experienced torn reads,
 		 * retry update sequence until CAS succeeds */
 	} while (!_odp_atomic_u128_cmp_xchg_mm((_odp_atomic_u128_t *)tb,
-					       (_uint128_t *)&old,
-					       (_uint128_t *)&new,
+					       (_odp_u128_t *)&old,
+					       (_odp_u128_t *)&new,
 					       _ODP_MEMMODEL_RLS,
 					       _ODP_MEMMODEL_RLX));
 	old_event = old.tmo_event;
@@ -916,7 +917,7 @@ static inline void timer_expire(timer_pool_t *tp, uint32_t idx, uint64_t tick)
 		new.tmo_event = ODP_EVENT_INVALID;
 
 		int succ = _odp_atomic_u128_cmp_xchg_mm((_odp_atomic_u128_t *)tb,
-							(_uint128_t *)&old, (_uint128_t *)&new,
+							(_odp_u128_t *)&old, (_odp_u128_t *)&new,
 							_ODP_MEMMODEL_RLS, _ODP_MEMMODEL_RLX);
 		if (succ)
 			tmo_event = old.tmo_event;


### PR DESCRIPTION
```
linux-gen: define a 128-bit integer type
    
    Define a 128-bit unsigned integer type _odp_u128_t in a new header
    file odp_types_internal.h.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

linux-gen: use new 128-bit integer type
    
    Use _odp_u128_t instead of various ad hoc typedefs.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

linux-gen: use _odp_u128_t instead of __int128
    
    Replace usage of __int128 and __int128_t with _odp_u128_t.
    
    Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```

v2:
- Matias' comment.
- Rebase.
- Add review tags.
