### PR TITLE
[PATCH v10] api: crypto: deprecate odp_crypto_operation()

### DIFF
--- a/doc/users-guide/users-guide-crypto.adoc
+++ b/doc/users-guide/users-guide-crypto.adoc
@@ -13,11 +13,6 @@ ODP provides APIs for following cryptographic services:
 * Random number generation
 * Crypto capability inquiries
 
-Ciphering and authentication services are accessible via two complementary
-sets of related APIs. The original ODP crypto APIs, and a newer
-_packet-oriented_ set of crypto APIs that are designed to be consistent with
-the protocol-aware cryptographic services offered by the IPsec API set.
-
 === Crypto Sessions
 
 To apply a cryptographic operation to a packet a session must be created. All
@@ -49,112 +44,35 @@ with an `odp_crypto_session_t`.
 === Crypto operations
 
 After session creation, a cryptographic operation can be applied to a packet
-in one of two ways.
-
-==== Parameter-based Crypto Operations
-This is the original ODP support for cryptographic operations. The
-`odp_crypto_operation()` API takes an input `odp_crypto_op_param_t` struct
-that describes the cryptographic operation to be performed. This struct
-contains the session to use as well as the input packet the operation is to be
-performed on. The caller may either specify an output packet to receive the
-operation results or may request that the ODP implementation allocate a new
-packet to receive these results from the output pool associated with the
-`odp_crypto_session_t`. If the input packet is also used as the output packet,
-then an "in place" operation is requested.
-
-When using the `odp_crypto_operation()` API. Applications may indicate a
-preference for synchronous or asynchronous processing in the session's
-`pref_mode` parameter.  However crypto operations may complete synchronously
-even if an asynchronous preference is indicated, and applications must examine
-the `posted` output parameter from `odp_crypto_operation()` to determine
-whether the operation has completed or if an `ODP_EVENT_CRYPTO_COMPL`
-notification is expected. In the case of an async operation, the `posted`
-output parameter will be set to true.
-
-The operation arguments specify for each packet the areas that are to be
-encrypted or decrypted and authenticated. The parameters include also
-pointers to cipher and authentication initialization vectors as needed,
-depending on the initialization vector lengths specified at session creation.
-
-An operation can be executed in in-place, out-of-place or new buffer mode.
-In in-place mode output packet is same as the input packet.
-In case of out-of-place mode output packet is different from input packet as
-specified by the application, while in new buffer mode implementation allocates
-a new output buffer from the session’s output pool.
-
-The application can also specify a context associated with a given operation
-that will be retained during async operation and can be retrieved via the
-completion event.
-
-Results of an asynchronous session will be posted as completion events to the
-session’s completion queue, which can be accessed directly or via the ODP
-scheduler. The completion event contains the status of the operation and the
-result. The application has the responsibility to free the completion event.
-
-Upon receipt of an `ODP_EVENT_CRYPTO_COMPL` event, the
-`odp_crypto_compl_result()` API is used to retrieve the
-`odp_crypto_op_result_t` associated with the event. This result struct in turn
-contains:
-
-* An indication of the success or failure of the crypto operation
-* The user context associated with the event
-* The output `odp_packet_t`.
-* The `odp_crypto_op_status_t` for the requested cipher operation
-* The `odp_crypto_op_status_t` for the requested authentication operation
-
-==== Packet-based Crypto Operations
-To simplify the original cryptographic operation request API, as well as to
-be more flexible and consistent with the protocol-aware APIs introduced for
-IPsec support, a newer packet-oriented set of cryptographic operation
-APIs is also provided. Applications may use either API set, but going forward
-it is expected that these newer APIs will be the focus of continued
-development.
-
-Instead of a single `odp_crypto_operation()` API, the packet-based form
-provides two APIs: `odp_crypto_op()` is the synchronous form while
-`odp_crypto_op_enq()` is the asynchronous form. To check which of these are
-supported by the ODP implementation, examine the `sync_mode` and `async_mode`
-fields in the `odp_crypto_capability_t` struct returned by the
+synchronously or asynchronously. `odp_crypto_op()` is the synchronous API
+while `odp_crypto_op_enq()` is the asynchronous API. To check which of these
+are supported by the ODP implementation, examine the `sync_mode` and
+`async_mode` fields in the `odp_crypto_capability_t` struct returned by the
 `odp_crypto_capability()` API.
 
 Both forms take an input array of packets, an optional output array of packets
 to receive the results, and an array of `odp_crypto_packet_op_param_t` structs
-that describe the operation to be performed on each input packet. As with the
-original APIs, the output array may be the same packets to request in-place
-operation, or may be specified as `ODP_PACKET_INVALID` to request that ODP
-allocate output packets from the pool associated with the
-`odp_crypto_session_t` being used.
+that describe the operation to be performed on each input packet. The output
+array may be the same packets to request in-place operation, or may be
+specified as `ODP_PACKET_INVALID` to request that ODP allocate output packets
+from the pool associated with the `odp_crypto_session_t` being used.
 
-The key differences between the `odp_crypto_op_param_t` used by the original
-APIs and the `odp_crypto_packet_op_param_t` used by the new APIs are:
+The op_mode field of `odp_crypto_session_t` indicates whether asynchronous
+or synchronous operations are used with the session. If `op_mode` is set
+to `ODP_CRYPTO_SYNC` then the synchronous API must be used and if `op_mode`
+is set to `ODP_CRYPTO_ASYNC` then the asynchronous API must be used. It is
+an error to use a form of the API that does not match the mode of the crypto
+session.
 
-* The original API takes a single `odp_crypto_op_param_t` since it operates on
-a single packet whereas the new forms take an array of
-`odp_crypto_packet_op_param_t` structs, one for each input packet.
+The output of a crypto operation is an `odp_packet_t` (one for each input
+packet) that is returned either synchronously or asynchronously. Asynchronous
+return is in the form of `ODP_EVENT_PACKET` events that have event subtype
+`ODP_EVENT_PACKET_CRYPTO`. The packet associated with such events is obtained
+via the `odp_crypto_packet_from_event()` API. The `odp_crypto_result()` API,
+in turn, retrieves the `odp_crypto_packet_result_t` from this `odp_packet_t`
+that contains:
 
-* The `odp_crypto_packet_op_param_t` does not contain any packet information
-since the input and output packets are supplied as API parameters rather than
-being encoded in this struct.
-
-* The `odp_crypto_packet_op_param_t` does not contain a user context field.
-
-In addition, the `odp_crypto_session_t` field `op_mode` is used instead of
-the `pref_mode` field when the packet-oriented APIs are used. If the
-`op_mode` is set to `ODP_CRYPTO_SYNC` then the synchronous form of the API
-must be used and if `op_mode` is set to `ODP_CRYPTO_ASYNC` then the
-asynchronous form of the API must be used. It is an error to attempt to use
-a form of the API not properly matched to the mode of the crypto session.
-
-The output of a packet-based crypto operation is an `odp_packet_t` (one for
-each input packet) that is returned either synchronously or
-asynchronously. Asynchronous return is in the form of `ODP_EVENT_PACKET`
-events that have event subtype `ODP_EVENT_PACKET_CRYPTO`. The packet
-associated with such events is obtained via the
-`odp_crypto_packet_from_event()` API. The `odp_crypto_result()` API, in turn,
-retrieves the `odp_crypto_packet_result_t` from this `odp_packet_t` that
-contains:
-
-* An indication of whether the crypto packet operation was successful or not
+* An indication of whether the crypto operation was successful or not
 * The `odp_crypto_op_status_t` for the requested cipher operation
 * The `odp_crypto_op_status_t` for the requested authentication operation
 

--- a/include/odp/api/abi-default/event_types.h
+++ b/include/odp/api/abi-default/event_types.h
@@ -13,6 +13,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <odp/api/deprecated.h>
 
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_event_t;
@@ -29,7 +30,9 @@ typedef enum {
 	ODP_EVENT_BUFFER = 1,
 	ODP_EVENT_PACKET = 2,
 	ODP_EVENT_TIMEOUT = 3,
+#if ODP_DEPRECATED_API
 	ODP_EVENT_CRYPTO_COMPL = 4,
+#endif
 	ODP_EVENT_IPSEC_STATUS = 5,
 	ODP_EVENT_PACKET_VECTOR = 6,
 	ODP_EVENT_PACKET_TX_COMPL = 7,

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -41,7 +41,7 @@ extern "C" {
 
 /**
  * @typedef odp_crypto_compl_t
-* Crypto API completion event (platform dependent).
+*  @deprecated Crypto API completion event (platform dependent).
 */
 
 /**
@@ -558,8 +558,10 @@ typedef struct odp_crypto_session_param_t {
 	/** Preferred sync vs. async for odp_crypto_operation()
 	 *
 	 *  The default value is ODP_CRYPTO_SYNC.
+	 *
+	 *  @deprecated Used only with deprecated odp_crypto_operation()
 	 */
-	odp_crypto_op_mode_t pref_mode;
+	odp_crypto_op_mode_t ODP_DEPRECATE(pref_mode);
 
 	/** Operation mode when using packet interface: sync or async
 	 *
@@ -671,8 +673,8 @@ typedef struct odp_crypto_session_param_t {
 	/** Async mode completion event queue
 	 *
 	 *  The completion queue is used to return completions from
-	 *  odp_crypto_operation() or odp_crypto_op_enq() results to the
-	 *  application.
+	 *  odp_crypto_op_enq() (and the deprecated odp_crypto_operation())
+	 *  to the application.
 	 */
 	odp_queue_t compl_queue;
 
@@ -688,6 +690,8 @@ typedef struct odp_crypto_session_param_t {
 
 /**
  * Crypto API per packet operation parameters
+ *
+ * @deprecated Use odp_crypto_packet_op_param_t instead.
  */
 typedef struct odp_crypto_op_param_t {
 	/** Session handle from creation */
@@ -759,7 +763,7 @@ typedef struct odp_crypto_op_param_t {
 	 */
 	odp_packet_data_range_t auth_range;
 
-} odp_crypto_op_param_t;
+} ODP_DEPRECATE(odp_crypto_op_param_t);
 
 /**
  * Crypto packet API per packet operation parameters
@@ -894,6 +898,8 @@ typedef struct odp_crypto_op_status {
 
 /**
  * Crypto API operation result
+ *
+ * @deprecated Use odp_crypto_packet_result_t instead.
  */
 typedef struct odp_crypto_op_result {
 	/** Request completed successfully */
@@ -911,7 +917,7 @@ typedef struct odp_crypto_op_result {
 	/** Authentication status */
 	odp_crypto_op_status_t auth_status;
 
-} odp_crypto_op_result_t;
+} ODP_DEPRECATE(odp_crypto_op_result_t);
 
 /**
  * Crypto packet API operation result
@@ -1140,8 +1146,12 @@ int odp_crypto_session_create(const odp_crypto_session_param_t *param,
  */
 int odp_crypto_session_destroy(odp_crypto_session_t session);
 
+#if ODP_DEPRECATED_API
+
 /**
  * Return crypto completion handle that is associated with event
+ *
+ * @deprecated Used only with the deprecated odp_crypto_operation()
  *
  * Note: any invalid parameters will cause undefined behavior and may cause
  * the application to abort or crash.
@@ -1155,6 +1165,8 @@ odp_crypto_compl_t odp_crypto_compl_from_event(odp_event_t ev);
 /**
  * Convert crypto completion handle to event handle
  *
+ * @deprecated Used only with the deprecated odp_crypto_operation()
+ *
  * @param completion_event  Completion event to convert to generic event
  *
  * @return Event handle
@@ -1164,12 +1176,16 @@ odp_event_t odp_crypto_compl_to_event(odp_crypto_compl_t completion_event);
 /**
  * Release crypto completion event
  *
+ * @deprecated Used only with the deprecated odp_crypto_operation()
+ *
  * @param completion_event  Completion event we are done accessing
  */
 void odp_crypto_compl_free(odp_crypto_compl_t completion_event);
 
 /**
  * Crypto per packet operation
+ *
+ * @deprecated Use odp_crypto_op() or odp_crypto_op_enq() instead.
  *
  * Performs the cryptographic operations specified during session creation
  * on the packet.  If the operation is performed synchronously, "posted"
@@ -1191,11 +1207,15 @@ int odp_crypto_operation(odp_crypto_op_param_t *param,
 /**
  * Crypto per packet operation query result from completion event
  *
+ * @deprecated Used only with the deprecated odp_crypto_operation()
+ *
  * @param completion_event  Event containing operation results
  * @param result            Pointer to result structure
  */
 void odp_crypto_compl_result(odp_crypto_compl_t completion_event,
 			     odp_crypto_op_result_t *result);
+
+#endif /* ODP_DEPRECATED_API */
 
 /**
  * Get printable value for an odp_crypto_session_t
@@ -1210,8 +1230,11 @@ void odp_crypto_compl_result(odp_crypto_compl_t completion_event,
  */
 uint64_t odp_crypto_session_to_u64(odp_crypto_session_t hdl);
 
+#if ODP_DEPRECATED_API
 /**
  * Get printable value for an odp_crypto_compl_t
+ *
+ * @deprecated Used only with the deprecated odp_crypto_operation()
  *
  * @param hdl  odp_crypto_compl_t handle to be printed
  * @return     uint64_t value that can be used to print/display this
@@ -1222,6 +1245,7 @@ uint64_t odp_crypto_session_to_u64(odp_crypto_session_t hdl);
  * an odp_crypto_compl_t handle.
  */
 uint64_t odp_crypto_compl_to_u64(odp_crypto_compl_t hdl);
+#endif
 
 /**
  * Initialize crypto session parameters

--- a/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
+++ b/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
@@ -694,9 +694,7 @@ int odp_crypto_session_destroy(odp_crypto_session_t session)
 	return 0;
 }
 
-/*
- * Shim function around packet operation, can be used by other implementations.
- */
+#if ODP_DEPRECATED_API
 int
 odp_crypto_operation(odp_crypto_op_param_t *param,
 		     odp_bool_t *posted,
@@ -751,6 +749,7 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 
 	return 0;
 }
+#endif
 
 int _odp_crypto_init_global(void)
 {
@@ -831,6 +830,7 @@ int _odp_crypto_term_local(void)
 	return 0;
 }
 
+#if ODP_DEPRECATED_API
 odp_crypto_compl_t odp_crypto_compl_from_event(odp_event_t ev)
 {
 	/* This check not mandated by the API specification */
@@ -867,6 +867,7 @@ uint64_t odp_crypto_compl_to_u64(odp_crypto_compl_t hdl)
 {
 	return _odp_pri(hdl);
 }
+#endif /* ODP_DEPRECATED_API */
 
 void odp_crypto_session_param_init(odp_crypto_session_param_t *param)
 {

--- a/platform/linux-generic/include-abi/odp/api/abi/event_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/event_types.h
@@ -19,6 +19,7 @@ extern "C" {
 #endif
 
 #include <odp/api/plat/strong_types.h>
+#include <odp/api/deprecated.h>
 
 /** @ingroup odp_event
  *  @{
@@ -32,7 +33,9 @@ typedef enum odp_event_type_t {
 	ODP_EVENT_BUFFER = 1,
 	ODP_EVENT_PACKET = 2,
 	ODP_EVENT_TIMEOUT = 3,
+#if ODP_DEPRECATED_API
 	ODP_EVENT_CRYPTO_COMPL = 4,
+#endif
 	ODP_EVENT_IPSEC_STATUS = 5,
 	ODP_EVENT_PACKET_VECTOR = 6,
 	ODP_EVENT_PACKET_TX_COMPL = 7,

--- a/platform/linux-generic/odp_crypto_null.c
+++ b/platform/linux-generic/odp_crypto_null.c
@@ -269,9 +269,7 @@ int odp_crypto_session_destroy(odp_crypto_session_t session)
 	return 0;
 }
 
-/*
- * Shim function around packet operation, can be used by other implementations.
- */
+#if ODP_DEPRECATED_API
 int
 odp_crypto_operation(odp_crypto_op_param_t *param,
 		     odp_bool_t *posted,
@@ -326,6 +324,7 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 
 	return 0;
 }
+#endif
 
 int
 _odp_crypto_init_global(void)
@@ -402,6 +401,7 @@ int _odp_crypto_term_local(void)
 	return 0;
 }
 
+#if ODP_DEPRECATED_API
 odp_crypto_compl_t odp_crypto_compl_from_event(odp_event_t ev)
 {
 	/* This check not mandated by the API specification */
@@ -438,6 +438,7 @@ uint64_t odp_crypto_compl_to_u64(odp_crypto_compl_t hdl)
 {
 	return _odp_pri(hdl);
 }
+#endif
 
 void odp_crypto_session_param_init(odp_crypto_session_param_t *param)
 {

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -2501,6 +2501,7 @@ int odp_crypto_session_destroy(odp_crypto_session_t session)
 /*
  * Shim function around packet operation, can be used by other implementations.
  */
+#if ODP_DEPRECATED_API
 int
 odp_crypto_operation(odp_crypto_op_param_t *param,
 		     odp_bool_t *posted,
@@ -2555,6 +2556,7 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 
 	return 0;
 }
+#endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 static void ODP_UNUSED openssl_thread_id(CRYPTO_THREADID ODP_UNUSED *id)
@@ -2711,6 +2713,7 @@ int _odp_crypto_term_local(void)
 	return 0;
 }
 
+#if ODP_DEPRECATED_API
 odp_crypto_compl_t odp_crypto_compl_from_event(odp_event_t ev)
 {
 	/* This check not mandated by the API specification */
@@ -2747,6 +2750,7 @@ uint64_t odp_crypto_compl_to_u64(odp_crypto_compl_t hdl)
 {
 	return _odp_pri(hdl);
 }
+#endif /* ODP_DEPRECATED_API */
 
 void odp_crypto_session_param_init(odp_crypto_session_param_t *param)
 {

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -71,9 +71,11 @@ void odp_event_free(odp_event_t event)
 	case ODP_EVENT_TIMEOUT:
 		odp_timeout_free(odp_timeout_from_event(event));
 		break;
+#if ODP_DEPRECATED_API
 	case ODP_EVENT_CRYPTO_COMPL:
 		odp_crypto_compl_free(odp_crypto_compl_from_event(event));
 		break;
+#endif
 	case ODP_EVENT_IPSEC_STATUS:
 		_odp_ipsec_status_free(_odp_ipsec_status_from_event(event));
 		break;
@@ -121,8 +123,10 @@ int odp_event_is_valid(odp_event_t event)
 		/* Fall through */
 	case ODP_EVENT_TIMEOUT:
 		/* Fall through */
+#if ODP_DEPRECATED_API
 	case ODP_EVENT_CRYPTO_COMPL:
 		/* Fall through */
+#endif
 	case ODP_EVENT_IPSEC_STATUS:
 		/* Fall through */
 	case ODP_EVENT_PACKET_VECTOR:

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -610,7 +610,6 @@ create_session_from_config(odp_crypto_session_t *session,
 	odp_crypto_session_param_init(&params);
 	memcpy(&params, &config->session, sizeof(odp_crypto_session_param_t));
 	params.op = ODP_CRYPTO_OP_ENCODE;
-	params.pref_mode   = ODP_CRYPTO_SYNC;
 
 	/* Lookup the packet pool */
 	pkt_pool = odp_pool_lookup("packet_pool");

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -37,7 +37,9 @@ static void test_default_values(void)
 
 	CU_ASSERT_EQUAL(param.op, ODP_CRYPTO_OP_ENCODE);
 	CU_ASSERT_EQUAL(param.auth_cipher_text, false);
+#if ODP_DEPRECATED_API
 	CU_ASSERT_EQUAL(param.pref_mode, ODP_CRYPTO_SYNC);
+#endif
 	CU_ASSERT_EQUAL(param.op_mode, ODP_CRYPTO_SYNC);
 	CU_ASSERT_EQUAL(param.cipher_alg, ODP_CIPHER_ALG_NULL);
 	CU_ASSERT_EQUAL(param.cipher_iv_len, 0);
@@ -194,6 +196,7 @@ static const char *cipher_alg_name(odp_cipher_alg_t cipher)
 	}
 }
 
+#if ODP_DEPRECATED_API
 static int alg_op(odp_packet_t pkt,
 		  odp_bool_t *ok,
 		  odp_crypto_session_t session,
@@ -273,6 +276,7 @@ static int alg_op(odp_packet_t pkt,
 
 	return 0;
 }
+#endif
 
 static int alg_packet_op(odp_packet_t pkt,
 			 odp_bool_t *ok,
@@ -370,10 +374,14 @@ static int crypto_op(odp_packet_t pkt,
 	int rc;
 
 	if (!suite_context.packet)
+#if ODP_DEPRECATED_API
 		rc = alg_op(pkt, ok, session,
 			    cipher_iv, auth_iv,
 			    cipher_range, auth_range,
 			    aad, hash_result_offset);
+#else
+		rc = -1;
+#endif
 	else
 		rc = alg_packet_op(pkt, ok, session,
 				   cipher_iv, auth_iv,
@@ -657,7 +665,9 @@ static odp_crypto_session_t session_create(odp_crypto_op_t op,
 	ses_params.op = op;
 	ses_params.auth_cipher_text = false;
 	ses_params.op_mode = suite_context.op_mode;
+#if ODP_DEPRECATED_API
 	ses_params.pref_mode = suite_context.pref_mode;
+#endif
 	ses_params.cipher_alg = cipher_alg;
 	ses_params.auth_alg = auth_alg;
 	ses_params.compl_queue = suite_context.queue;
@@ -2154,6 +2164,7 @@ static odp_event_t plain_compl_queue_deq(void)
 	return odp_queue_deq(suite_context.queue);
 }
 
+#if ODP_DEPRECATED_API
 static int crypto_suite_sync_init(void)
 {
 	suite_context.pool = odp_pool_lookup("packet_pool");
@@ -2206,6 +2217,7 @@ static int crypto_suite_async_sched_init(void)
 
 	return 0;
 }
+#endif
 
 static int crypto_suite_packet_sync_init(void)
 {
@@ -2422,12 +2434,14 @@ odp_testinfo_t crypto_suite[] = {
 };
 
 odp_suiteinfo_t crypto_suites[] = {
+#if ODP_DEPRECATED_API
 	{"odp_crypto_sync_inp", crypto_suite_sync_init,
 	 NULL, crypto_suite},
 	{"odp_crypto_async_plain_inp", crypto_suite_async_plain_init,
 	 crypto_suite_term, crypto_suite},
 	{"odp_crypto_async_sched_inp", crypto_suite_async_sched_init,
 	 crypto_suite_term, crypto_suite},
+#endif
 	{"odp_crypto_packet_sync_inp", crypto_suite_packet_sync_init,
 	 NULL, crypto_suite},
 	{"odp_crypto_packet_async_plain_inp",


### PR DESCRIPTION
Depracate odp_crypto_operation() and the associated data structures and the completion event.

The odp_crypto_operation() function is a bit problematic since it can be synchronous or asynchronous on per-packet basis without application having control on it. Uncontrolled sync versus async behaviour can have adverse effects on packet ordering and application design in general. The function is also somewhat redundant with the newer odp_crypto_op() and odp_crypto_op_enq() functions that provide explicit control on the crypto operation completion behavior.
