### PR TITLE
[PATCH v4] linux-gen: dpdk: add support for DPDK 21.11

### DIFF
--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -214,3 +214,17 @@ jobs:
       - name: Failure log
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+
+  Run_dpdk-21_11:
+    if: ${{ github.repository == 'OpenDataPlane/odp' }}
+    runs-on: [self-hosted, ARM64]
+    env:
+      OS: ubuntu_20.04
+    steps:
+      - uses: AutoModality/action-clean@v1.1.0
+      - uses: actions/checkout@v2
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
+               -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native-dpdk_21.11 /odp/scripts/ci/check.sh
+      - name: Failure log
+        if: ${{ failure() }}
+        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -351,6 +351,18 @@ jobs:
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
 
+  Run_dpdk-21_11:
+    runs-on: ubuntu-18.04
+    env:
+      OS: ubuntu_20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
+               -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-dpdk_21.11 /odp/scripts/ci/check.sh
+      - name: Failure log
+        if: ${{ failure() }}
+        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+
   Run_netmap:
     runs-on: ubuntu-18.04
     env:

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -206,8 +206,8 @@ Prerequisites for building the OpenDataPlane (ODP) API
 
 3.5 DPDK packet I/O support (optional)
 
-   Use DPDK for ODP packet I/O. Currently supported DPDK versions are v19.11
-   (recommended) and v20.11.
+   Use DPDK for ODP packet I/O. Currently supported DPDK versions are v19.11,
+   v20.11 (recommended), v21.11.
 
    Note: only packet I/O is accelerated with DPDK. See
         https://github.com/OpenDataPlane/odp-dpdk.git
@@ -244,8 +244,8 @@ Prerequisites for building the OpenDataPlane (ODP) API
    # Configure ODP
    $ ./configure --with-dpdk-path=<dpdk-dir>
 
-3.5.4 Build DPDK v20.11 from source
-   $ git clone https://dpdk.org/git/dpdk-stable --branch 20.11 --depth 1 ./<dpdk-dir>
+3.5.4 Build DPDK v20.11 and onwards from source
+   $ git clone https://dpdk.org/git/dpdk-stable --branch <version, e.g. 21.11> --depth 1 ./<dpdk-dir>
 
    # Prepare the build directory
    $ cd <dpdk-dir>

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -1777,7 +1777,11 @@ static int dpdk_open(odp_pktio_t id ODP_UNUSED,
 	}
 
 	memset(&dev_info, 0, sizeof(struct rte_eth_dev_info));
-	rte_eth_dev_info_get(pkt_dpdk->port_id, &dev_info);
+	ret = rte_eth_dev_info_get(pkt_dpdk->port_id, &dev_info);
+	if (ret) {
+		ODP_ERR("Failed to read device info: %d\n", ret);
+		return -1;
+	}
 
 	/* Initialize runtime options */
 	if (init_options(pktio_entry, &dev_info)) {


### PR DESCRIPTION
Main impacts:

  - A few macro name deprecations, new names taken into use, old names
    mapped to the new names with older versions.
  - rte_eth_dev_set_mtu() is now forbidden to be used before device is
    configured (rte_eth_dev_configure()), so "MTU-settability" checking
    becomes less complete: support can still be inferred based on return
    codes but proper error checking cannot be done due to the pre-config
    condition.

v2:
- Update instructions in DEPENDENCIES

v3:
- Change MTU-settability support handling
- Handle `rte_eth_dev_info_get()` return value in `dpdk_open()`

v4:
- Add Github CI items for DPDK 21.11