### PR TITLE
[PATCH v2] api: event: split header file

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -26,6 +26,7 @@ odpapiinclude_HEADERS = \
 	odp/api/dma_types.h \
 	odp/api/errno.h \
 	odp/api/event.h \
+	odp/api/event_types.h \
 	odp/api/hash.h \
 	odp/api/hints.h \
 	odp/api/init.h \
@@ -86,6 +87,7 @@ odpapispecinclude_HEADERS = \
 		  odp/api/spec/dma_types.h \
 		  odp/api/spec/errno.h \
 		  odp/api/spec/event.h \
+		  odp/api/spec/event_types.h \
 		  odp/api/spec/hash.h \
 		  odp/api/spec/hints.h \
 		  odp/api/spec/init.h \
@@ -148,6 +150,7 @@ odpapiabidefaultinclude_HEADERS = \
 	odp/api/abi-default/dma_types.h \
 	odp/api/abi-default/errno.h \
 	odp/api/abi-default/event.h \
+	odp/api/abi-default/event_types.h \
 	odp/api/abi-default/hash.h \
 	odp/api/abi-default/init.h \
 	odp/api/abi-default/ipsec.h \
@@ -202,6 +205,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm32-linux/odp/api/abi/dma_types.h \
 	odp/arch/arm32-linux/odp/api/abi/errno.h \
 	odp/arch/arm32-linux/odp/api/abi/event.h \
+	odp/arch/arm32-linux/odp/api/abi/event_types.h \
 	odp/arch/arm32-linux/odp/api/abi/hash.h \
 	odp/arch/arm32-linux/odp/api/abi/init.h \
 	odp/arch/arm32-linux/odp/api/abi/ipsec.h \
@@ -252,6 +256,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm64-linux/odp/api/abi/dma_types.h \
 	odp/arch/arm64-linux/odp/api/abi/errno.h \
 	odp/arch/arm64-linux/odp/api/abi/event.h \
+	odp/arch/arm64-linux/odp/api/abi/event_types.h \
 	odp/arch/arm64-linux/odp/api/abi/hash.h \
 	odp/arch/arm64-linux/odp/api/abi/init.h \
 	odp/arch/arm64-linux/odp/api/abi/ipsec.h \
@@ -302,6 +307,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/default-linux/odp/api/abi/dma_types.h \
 	odp/arch/default-linux/odp/api/abi/errno.h \
 	odp/arch/default-linux/odp/api/abi/event.h \
+	odp/arch/default-linux/odp/api/abi/event_types.h \
 	odp/arch/default-linux/odp/api/abi/hash.h \
 	odp/arch/default-linux/odp/api/abi/init.h \
 	odp/arch/default-linux/odp/api/abi/ipsec.h \
@@ -352,6 +358,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/power64-linux/odp/api/abi/dma_types.h \
 	odp/arch/power64-linux/odp/api/abi/errno.h \
 	odp/arch/power64-linux/odp/api/abi/event.h \
+	odp/arch/power64-linux/odp/api/abi/event_types.h \
 	odp/arch/power64-linux/odp/api/abi/hash.h \
 	odp/arch/power64-linux/odp/api/abi/init.h \
 	odp/arch/power64-linux/odp/api/abi/ipsec.h \
@@ -402,6 +409,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_32-linux/odp/api/abi/dma_types.h \
 	odp/arch/x86_32-linux/odp/api/abi/errno.h \
 	odp/arch/x86_32-linux/odp/api/abi/event.h \
+	odp/arch/x86_32-linux/odp/api/abi/event_types.h \
 	odp/arch/x86_32-linux/odp/api/abi/hash.h \
 	odp/arch/x86_32-linux/odp/api/abi/init.h \
 	odp/arch/x86_32-linux/odp/api/abi/ipsec.h \
@@ -452,6 +460,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_64-linux/odp/api/abi/dma_types.h \
 	odp/arch/x86_64-linux/odp/api/abi/errno.h \
 	odp/arch/x86_64-linux/odp/api/abi/event.h \
+	odp/arch/x86_64-linux/odp/api/abi/event_types.h \
 	odp/arch/x86_64-linux/odp/api/abi/hash.h \
 	odp/arch/x86_64-linux/odp/api/abi/init.h \
 	odp/arch/x86_64-linux/odp/api/abi/ipsec.h \

--- a/include/odp/api/abi-default/event.h
+++ b/include/odp/api/abi-default/event.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017-2018, Linaro Limited
+/* Copyright (c) 2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -11,41 +11,7 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
-
-/** @internal Dummy type for strong typing */
-typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_event_t;
-
-/** @ingroup odp_event
- *  @{
- */
-
-typedef _odp_abi_event_t *odp_event_t;
-
-#define ODP_EVENT_INVALID  ((odp_event_t)0)
-
-typedef enum {
-	ODP_EVENT_BUFFER = 1,
-	ODP_EVENT_PACKET = 2,
-	ODP_EVENT_TIMEOUT = 3,
-	ODP_EVENT_CRYPTO_COMPL = 4,
-	ODP_EVENT_IPSEC_STATUS = 5,
-	ODP_EVENT_PACKET_VECTOR = 6,
-	ODP_EVENT_PACKET_TX_COMPL = 7,
-	ODP_EVENT_DMA_COMPL = 8,
-} odp_event_type_t;
-
-typedef enum {
-	ODP_EVENT_NO_SUBTYPE = 0,
-	ODP_EVENT_PACKET_BASIC = 1,
-	ODP_EVENT_PACKET_CRYPTO = 2,
-	ODP_EVENT_PACKET_IPSEC = 3,
-	ODP_EVENT_PACKET_COMP = 4
-} odp_event_subtype_t;
-
-/**
- * @}
- */
+/* Empty header required due to the inline functions */
 
 #ifdef __cplusplus
 }

--- a/include/odp/api/abi-default/event_types.h
+++ b/include/odp/api/abi-default/event_types.h
@@ -1,0 +1,55 @@
+/* Copyright (c) 2017-2018, Linaro Limited
+ * Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_ABI_EVENT_TYPES_H_
+#define ODP_ABI_EVENT_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/** @internal Dummy type for strong typing */
+typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_event_t;
+
+/** @ingroup odp_event
+ *  @{
+ */
+
+typedef _odp_abi_event_t *odp_event_t;
+
+#define ODP_EVENT_INVALID  ((odp_event_t)0)
+
+typedef enum {
+	ODP_EVENT_BUFFER = 1,
+	ODP_EVENT_PACKET = 2,
+	ODP_EVENT_TIMEOUT = 3,
+	ODP_EVENT_CRYPTO_COMPL = 4,
+	ODP_EVENT_IPSEC_STATUS = 5,
+	ODP_EVENT_PACKET_VECTOR = 6,
+	ODP_EVENT_PACKET_TX_COMPL = 7,
+	ODP_EVENT_DMA_COMPL = 8,
+} odp_event_type_t;
+
+typedef enum {
+	ODP_EVENT_NO_SUBTYPE = 0,
+	ODP_EVENT_PACKET_BASIC = 1,
+	ODP_EVENT_PACKET_CRYPTO = 2,
+	ODP_EVENT_PACKET_IPSEC = 3,
+	ODP_EVENT_PACKET_COMP = 4
+} odp_event_subtype_t;
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/api/buffer.h
+++ b/include/odp/api/buffer.h
@@ -17,8 +17,6 @@
 extern "C" {
 #endif
 
-#include <odp/api/std_types.h>
-#include <odp/api/abi/event.h>
 #include <odp/api/abi/buffer.h>
 
 #include <odp/api/spec/buffer.h>

--- a/include/odp/api/comp.h
+++ b/include/odp/api/comp.h
@@ -18,8 +18,6 @@ extern "C" {
 #endif
 
 #include <odp/api/abi/comp.h>
-#include <odp/api/abi/event.h>
-#include <odp/api/abi/queue_types.h>
 
 #include <odp/api/spec/comp.h>
 

--- a/include/odp/api/dma_types.h
+++ b/include/odp/api/dma_types.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Nokia
+/* Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -17,7 +17,6 @@
 extern "C" {
 #endif
 
-#include <odp/api/abi/event.h>
 #include <odp/api/abi/dma_types.h>
 
 #include <odp/api/spec/dma_types.h>

--- a/include/odp/api/event_types.h
+++ b/include/odp/api/event_types.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP event API type definitions
+ */
+
+#ifndef ODP_API_EVENT_TYPES_H_
+#define ODP_API_EVENT_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/abi/event_types.h>
+
+#include <odp/api/spec/event_types.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/api/packet.h
+++ b/include/odp/api/packet.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -17,12 +18,7 @@
 extern "C" {
 #endif
 
-#include <odp/api/std_types.h>
-#include <odp/api/abi/event.h>
-#include <odp/api/abi/packet_io_types.h>
-#include <odp/api/abi/packet_types.h>
 #include <odp/api/abi/packet.h>
-#include <odp/api/abi/buffer.h>
 
 #include <odp/api/spec/packet.h>
 

--- a/include/odp/api/queue.h
+++ b/include/odp/api/queue.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -17,11 +18,7 @@
 extern "C" {
 #endif
 
-#include <odp/api/std_types.h>
-#include <odp/api/abi/event.h>
-#include <odp/api/abi/queue_types.h>
 #include <odp/api/abi/queue.h>
-#include <odp/api/abi/buffer.h>
 
 #include <odp/api/spec/queue.h>
 

--- a/include/odp/api/spec/buffer.h
+++ b/include/odp/api/spec/buffer.h
@@ -18,7 +18,9 @@
 extern "C" {
 #endif
 
+#include <odp/api/event_types.h>
 #include <odp/api/pool_types.h>
+#include <odp/api/std_types.h>
 
 /** @defgroup odp_buffer ODP BUFFER
  *  Buffer event metadata and operations.

--- a/include/odp/api/spec/comp.h
+++ b/include/odp/api/spec/comp.h
@@ -14,8 +14,11 @@
 #define ODP_API_SPEC_COMP_H_
 
 #include <odp/visibility_begin.h>
+
+#include <odp/api/event_types.h>
+#include <odp/api/packet_types.h>
+#include <odp/api/queue_types.h>
 #include <odp/api/std_types.h>
-#include <odp/api/packet.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -16,14 +16,13 @@
 #include <odp/visibility_begin.h>
 
 #include <odp/api/deprecated.h>
+#include <odp/api/packet_types.h>
 #include <odp/api/pool_types.h>
 #include <odp/api/std_types.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/packet.h>
 
 /** @defgroup odp_crypto ODP CRYPTO
  *  Data ciphering and authentication.

--- a/include/odp/api/spec/dma_types.h
+++ b/include/odp/api/spec/dma_types.h
@@ -18,7 +18,9 @@
 extern "C" {
 #endif
 
+#include <odp/api/event_types.h>
 #include <odp/api/packet_types.h>
+#include <odp/api/queue_types.h>
 #include <odp/api/std_types.h>
 
 /** @defgroup odp_dma ODP DMA

--- a/include/odp/api/spec/event.h
+++ b/include/odp/api/spec/event.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -18,86 +19,12 @@
 extern "C" {
 #endif
 
-#include <odp/api/packet.h>
+#include <odp/api/event_types.h>
+#include <odp/api/packet_types.h>
 
 /** @defgroup odp_event ODP EVENT
  *  Generic event metadata and operations.
  *  @{
- */
-
-/**
- * @typedef odp_event_t
- * ODP event
- */
-
-/**
- * @def ODP_EVENT_INVALID
- * Invalid event
- */
-
-/**
- * @typedef odp_event_type_t
- * Event type
- *
- * Event type specifies purpose and general format of an event. It can be
- * checked with odp_event_type() or odp_event_types(). Each event type has
- * functions (e.g. odp_buffer_from_event()) to convert between the generic event
- * handle (odp_event_t) and the type specific handle (e.g. odp_buffer_t).
- * Results are undefined, if conversion function of a wrong event type is used.
- * Application cannot change event type by chaining conversion functions.
- *
- * List of event types:
- * - ODP_EVENT_BUFFER
- *     - Buffer event (odp_buffer_t) for simple data storage and message passing
- * - ODP_EVENT_PACKET
- *     - Packet event (odp_packet_t) containing packet data and plenty of
- *       packet processing related metadata
- * - ODP_EVENT_TIMEOUT
- *     - Timeout event (odp_timeout_t) from a timer
- * - ODP_EVENT_CRYPTO_COMPL
- *     - Crypto completion event (odp_crypto_compl_t)
- * - ODP_EVENT_IPSEC_STATUS
- *     - IPSEC status update event (odp_ipsec_status_t)
- * - ODP_EVENT_PACKET_VECTOR
- *     - Vector of packet events (odp_packet_t) as odp_packet_vector_t
- * - ODP_EVENT_PACKET_TX_COMPL
- *     - Packet Tx completion event (odp_packet_tx_compl_t) generated as a result of a Packet Tx
- *       completion.
- * - ODP_EVENT_DMA_COMPL
- *     - DMA completion event (odp_dma_compl_t) indicates that a DMA transfer has finished
- */
-
-/**
- * @typedef odp_event_subtype_t
- * Event subtype
- *
- * Event subtype expands event type specification by providing more detailed
- * purpose and format of an event. It can be checked with odp_event_subtype() or
- * odp_event_types(). Each event subtype may define specific functions
- * (e.g. odp_ipsec_packet_from_event()) to convert between the generic event
- * handle (odp_event_t) and event type specific handle (e.g. odp_packet_t). When
- * subtype is known, these subtype specific functions should be preferred over
- * the event type general function (e.g. odp_packet_from_event()). Results are
- * undefined, if conversion function of a wrong event subtype is used.
- * Application cannot change event subtype by chaining conversion functions.
- *
- *  List of event subtypes:
- * - ODP_EVENT_PACKET_BASIC
- *     - Packet event (odp_packet_t) with basic packet metadata
- * - ODP_EVENT_PACKET_COMP
- *     - Packet event (odp_packet_t) generated as a result of a compression/
- *       decompression operation. It contains compression specific metadata in
- *       addition to the basic packet metadata.
- * - ODP_EVENT_PACKET_CRYPTO
- *     - Packet event (odp_packet_t) generated as a result of a Crypto
- *       operation. It contains crypto specific metadata in addition to the
- *       basic packet metadata.
- * - ODP_EVENT_PACKET_IPSEC
- *     - Packet event (odp_packet_t) generated as a result of an IPsec
- *       operation. It contains IPSEC specific metadata in addition to the basic
- *       packet metadata.
- * - ODP_EVENT_NO_SUBTYPE
- *     - An event type does not have any subtypes defined
  */
 
 /**

--- a/include/odp/api/spec/event_types.h
+++ b/include/odp/api/spec/event_types.h
@@ -1,0 +1,110 @@
+/* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP event API type definitions
+ */
+
+#ifndef ODP_API_SPEC_EVENT_TYPES_H_
+#define ODP_API_SPEC_EVENT_TYPES_H_
+#include <odp/visibility_begin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup odp_event
+ *  @{
+ */
+
+/**
+ * @typedef odp_event_t
+ * ODP event
+ */
+
+/**
+ * @def ODP_EVENT_INVALID
+ * Invalid event
+ */
+
+/**
+ * @typedef odp_event_type_t
+ * Event type
+ *
+ * Event type specifies purpose and general format of an event. It can be
+ * checked with odp_event_type() or odp_event_types(). Each event type has
+ * functions (e.g. odp_buffer_from_event()) to convert between the generic event
+ * handle (odp_event_t) and the type specific handle (e.g. odp_buffer_t).
+ * Results are undefined, if conversion function of a wrong event type is used.
+ * Application cannot change event type by chaining conversion functions.
+ *
+ * List of event types:
+ * - ODP_EVENT_BUFFER
+ *     - Buffer event (odp_buffer_t) for simple data storage and message passing
+ * - ODP_EVENT_PACKET
+ *     - Packet event (odp_packet_t) containing packet data and plenty of
+ *       packet processing related metadata
+ * - ODP_EVENT_TIMEOUT
+ *     - Timeout event (odp_timeout_t) from a timer
+ * - ODP_EVENT_CRYPTO_COMPL
+ *     - Crypto completion event (odp_crypto_compl_t)
+ * - ODP_EVENT_IPSEC_STATUS
+ *     - IPSEC status update event (odp_ipsec_status_t)
+ * - ODP_EVENT_PACKET_VECTOR
+ *     - Vector of packet events (odp_packet_t) as odp_packet_vector_t
+ * - ODP_EVENT_PACKET_TX_COMPL
+ *     - Packet Tx completion event (odp_packet_tx_compl_t) generated as a result of a Packet Tx
+ *       completion.
+ * - ODP_EVENT_DMA_COMPL
+ *     - DMA completion event (odp_dma_compl_t) indicates that a DMA transfer has finished
+ */
+
+/**
+ * @typedef odp_event_subtype_t
+ * Event subtype
+ *
+ * Event subtype expands event type specification by providing more detailed
+ * purpose and format of an event. It can be checked with odp_event_subtype() or
+ * odp_event_types(). Each event subtype may define specific functions
+ * (e.g. odp_ipsec_packet_from_event()) to convert between the generic event
+ * handle (odp_event_t) and event type specific handle (e.g. odp_packet_t). When
+ * subtype is known, these subtype specific functions should be preferred over
+ * the event type general function (e.g. odp_packet_from_event()). Results are
+ * undefined, if conversion function of a wrong event subtype is used.
+ * Application cannot change event subtype by chaining conversion functions.
+ *
+ *  List of event subtypes:
+ * - ODP_EVENT_PACKET_BASIC
+ *     - Packet event (odp_packet_t) with basic packet metadata
+ * - ODP_EVENT_PACKET_COMP
+ *     - Packet event (odp_packet_t) generated as a result of a compression/
+ *       decompression operation. It contains compression specific metadata in
+ *       addition to the basic packet metadata.
+ * - ODP_EVENT_PACKET_CRYPTO
+ *     - Packet event (odp_packet_t) generated as a result of a Crypto
+ *       operation. It contains crypto specific metadata in addition to the
+ *       basic packet metadata.
+ * - ODP_EVENT_PACKET_IPSEC
+ *     - Packet event (odp_packet_t) generated as a result of an IPsec
+ *       operation. It contains IPSEC specific metadata in addition to the basic
+ *       packet metadata.
+ * - ODP_EVENT_NO_SUBTYPE
+ *     - An event type does not have any subtypes defined
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <odp/visibility_end.h>
+#endif

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -19,10 +19,13 @@
 extern "C" {
 #endif
 
-#include <odp/api/proto_stats_types.h>
-#include <odp/api/time.h>
+#include <odp/api/event_types.h>
 #include <odp/api/packet_types.h>
+#include <odp/api/packet_io_types.h>
 #include <odp/api/pool_types.h>
+#include <odp/api/proto_stats_types.h>
+#include <odp/api/std_types.h>
+#include <odp/api/time.h>
 
 /** @defgroup odp_packet ODP PACKET
  *  Packet event metadata and operations.

--- a/include/odp/api/spec/packet_flags.h
+++ b/include/odp/api/spec/packet_flags.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif
 
 #include <odp/api/std_types.h>
-#include <odp/api/packet.h>
+#include <odp/api/packet_types.h>
 
 /** @addtogroup odp_packet
  *  Operations on packet metadata flags.

--- a/include/odp/api/spec/queue.h
+++ b/include/odp/api/spec/queue.h
@@ -18,8 +18,9 @@
 extern "C" {
 #endif
 
-#include <odp/api/event.h>
+#include <odp/api/event_types.h>
 #include <odp/api/queue_types.h>
+#include <odp/api/std_types.h>
 
 /** @defgroup odp_queue ODP QUEUE
  *  Queues for event passing and scheduling.

--- a/include/odp/api/spec/schedule.h
+++ b/include/odp/api/spec/schedule.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif
 
 #include <odp/api/std_types.h>
-#include <odp/api/event.h>
+#include <odp/api/event_types.h>
 #include <odp/api/queue_types.h>
 #include <odp/api/schedule_types.h>
 #include <odp/api/thrmask.h>

--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -21,7 +21,7 @@ extern "C" {
 #endif
 
 #include <odp/api/timer_types.h>
-#include <odp/api/event.h>
+#include <odp/api/event_types.h>
 #include <odp/api/pool_types.h>
 #include <odp/api/queue_types.h>
 

--- a/include/odp/api/spec/timer_types.h
+++ b/include/odp/api/spec/timer_types.h
@@ -21,7 +21,7 @@ extern "C" {
 #endif
 
 #include <odp/api/std_types.h>
-#include <odp/api/event.h>
+#include <odp/api/event_types.h>
 
 /** @defgroup odp_timer ODP TIMER
  *  Timer generating timeout events.

--- a/include/odp/arch/arm32-linux/odp/api/abi/event_types.h
+++ b/include/odp/arch/arm32-linux/odp/api/abi/event_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/event_types.h>

--- a/include/odp/arch/arm64-linux/odp/api/abi/event_types.h
+++ b/include/odp/arch/arm64-linux/odp/api/abi/event_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/event_types.h>

--- a/include/odp/arch/default-linux/odp/api/abi/event_types.h
+++ b/include/odp/arch/default-linux/odp/api/abi/event_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/event_types.h>

--- a/include/odp/arch/power64-linux/odp/api/abi/event_types.h
+++ b/include/odp/arch/power64-linux/odp/api/abi/event_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/event_types.h>

--- a/include/odp/arch/x86_32-linux/odp/api/abi/event_types.h
+++ b/include/odp/arch/x86_32-linux/odp/api/abi/event_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/event_types.h>

--- a/include/odp/arch/x86_64-linux/odp/api/abi/event_types.h
+++ b/include/odp/arch/x86_64-linux/odp/api/abi/event_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/event_types.h>

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -65,6 +65,7 @@ odpapiabiarchinclude_HEADERS += \
 		  include-abi/odp/api/abi/dma_types.h \
 		  include-abi/odp/api/abi/errno.h \
 		  include-abi/odp/api/abi/event.h \
+		  include-abi/odp/api/abi/event_types.h \
 		  include-abi/odp/api/abi/hash.h \
 		  include-abi/odp/api/abi/init.h \
 		  include-abi/odp/api/abi/ipsec.h \

--- a/platform/linux-generic/include-abi/odp/api/abi/event.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/event.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -18,41 +19,8 @@
 extern "C" {
 #endif
 
-#include <odp/api/plat/strong_types.h>
-
-/** @ingroup odp_event
- *  @{
- */
-
-typedef ODP_HANDLE_T(odp_event_t);
-
-#define ODP_EVENT_INVALID _odp_cast_scalar(odp_event_t, 0)
-
-typedef enum odp_event_type_t {
-	ODP_EVENT_BUFFER = 1,
-	ODP_EVENT_PACKET = 2,
-	ODP_EVENT_TIMEOUT = 3,
-	ODP_EVENT_CRYPTO_COMPL = 4,
-	ODP_EVENT_IPSEC_STATUS = 5,
-	ODP_EVENT_PACKET_VECTOR = 6,
-	ODP_EVENT_PACKET_TX_COMPL = 7,
-	ODP_EVENT_DMA_COMPL = 8,
-} odp_event_type_t;
-
-typedef enum odp_event_subtype_t {
-	ODP_EVENT_NO_SUBTYPE   = 0,
-	ODP_EVENT_PACKET_BASIC = 1,
-	ODP_EVENT_PACKET_CRYPTO = 2,
-	ODP_EVENT_PACKET_IPSEC = 3,
-	ODP_EVENT_PACKET_COMP = 4
-} odp_event_subtype_t;
-
 /* Inlined functions for non-ABI compat mode */
 #include <odp/api/plat/event_inlines.h>
-
-/**
- * @}
- */
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include-abi/odp/api/abi/event_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/event_types.h
@@ -1,0 +1,58 @@
+/* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP event type definitions
+ */
+
+#ifndef ODP_API_ABI_EVENT_TYPES_H_
+#define ODP_API_ABI_EVENT_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/plat/strong_types.h>
+
+/** @ingroup odp_event
+ *  @{
+ */
+
+typedef ODP_HANDLE_T(odp_event_t);
+
+#define ODP_EVENT_INVALID _odp_cast_scalar(odp_event_t, 0)
+
+typedef enum odp_event_type_t {
+	ODP_EVENT_BUFFER = 1,
+	ODP_EVENT_PACKET = 2,
+	ODP_EVENT_TIMEOUT = 3,
+	ODP_EVENT_CRYPTO_COMPL = 4,
+	ODP_EVENT_IPSEC_STATUS = 5,
+	ODP_EVENT_PACKET_VECTOR = 6,
+	ODP_EVENT_PACKET_TX_COMPL = 7,
+	ODP_EVENT_DMA_COMPL = 8,
+} odp_event_type_t;
+
+typedef enum odp_event_subtype_t {
+	ODP_EVENT_NO_SUBTYPE   = 0,
+	ODP_EVENT_PACKET_BASIC = 1,
+	ODP_EVENT_PACKET_CRYPTO = 2,
+	ODP_EVENT_PACKET_IPSEC = 3,
+	ODP_EVENT_PACKET_COMP = 4
+} odp_event_subtype_t;
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp/api/plat/buffer_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/buffer_inlines.h
@@ -8,7 +8,7 @@
 #define ODP_PLAT_BUFFER_INLINES_H_
 
 #include <odp/api/abi/buffer.h>
-#include <odp/api/abi/event.h>
+#include <odp/api/abi/event_types.h>
 
 #include <odp/api/plat/buffer_inline_types.h>
 

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -20,7 +20,7 @@
 #include <odp/api/time.h>
 
 #include <odp/api/abi/buffer.h>
-#include <odp/api/abi/event.h>
+#include <odp/api/abi/event_types.h>
 #include <odp/api/abi/packet.h>
 #include <odp/api/abi/packet_io.h>
 

--- a/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
@@ -14,7 +14,7 @@
 #ifndef _ODP_PLAT_PACKET_VECTOR_INLINES_H_
 #define _ODP_PLAT_PACKET_VECTOR_INLINES_H_
 
-#include <odp/api/abi/event.h>
+#include <odp/api/abi/event_types.h>
 #include <odp/api/abi/packet_types.h>
 #include <odp/api/abi/pool_types.h>
 

--- a/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
-#include <odp/api/event.h>
+#include <odp/api/event_types.h>
 #include <odp/api/queue_types.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */

--- a/platform/linux-generic/odp_dma.c
+++ b/platform/linux-generic/odp_dma.c
@@ -10,6 +10,7 @@
 #include <odp/api/align.h>
 #include <odp/api/buffer.h>
 #include <odp/api/stash.h>
+#include <odp/api/packet.h>
 #include <odp/api/pool.h>
 #include <odp/api/queue.h>
 

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -13,6 +13,7 @@
 #pragma GCC diagnostic ignored "-Wzero-length-bounds"
 #endif
 
+#include <odp/api/packet.h>
 #include <odp/api/ticketlock.h>
 #include <odp/api/thread.h>
 #include <odp/api/plat/thread_inlines.h>


### PR DESCRIPTION
Split event.h API file into separate files for types and functions. No API spec change.
