### PR TITLE
[PATCH v2] helper: add missing odp_api.h includes

### DIFF
--- a/helper/include/odp/helper/cli.h
+++ b/helper/include/odp/helper/cli.h
@@ -21,8 +21,6 @@
 extern "C" {
 #endif
 
-#include <odp_api.h>
-#include <odp/helper/ip.h>
 #include <stdint.h>
 #include <stdarg.h>
 

--- a/helper/include/odp/helper/linux/process.h
+++ b/helper/include/odp/helper/linux/process.h
@@ -18,6 +18,7 @@
 #define ODPH_LINUX_PROCESS_H_
 
 #include <odp/helper/threads.h>
+#include <odp_api.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/helper/include/odp/helper/linux/pthread.h
+++ b/helper/include/odp/helper/linux/pthread.h
@@ -18,6 +18,7 @@
 #define ODPH_LINUX_PTHREAD_H_
 
 #include <odp/helper/threads.h>
+#include <odp_api.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -24,6 +24,7 @@ extern "C" {
 #endif
 
 #include <odp/helper/deprecated.h>
+#include <odp_api.h>
 
 #include <pthread.h>
 #include <getopt.h>


### PR DESCRIPTION
Added three missing ODP API header includes and removed one
include that was not needed.