### PR TITLE
[PATCH v3] doc: include deprecated APIs in documentation

### DIFF
--- a/doc/Doxyfile_common
+++ b/doc/Doxyfile_common
@@ -38,4 +38,5 @@ PREDEFINED = __GNUC__ \
 	     __x86_64__ \
 	     ODP_PACKED \
 	     ODP_DEPRECATE(x)=x \
+	     ODP_DEPRECATED_API=1 \
 	     "ODP_HANDLE_T(type)=odp_handle_t type"

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -498,7 +498,7 @@ typedef struct odp_crypto_key {
 /**
  * Crypto API IV structure
  *
- * @deprecated
+ * @deprecated Use per-packet IV in crypto operation parameters
  */
 typedef struct odp_crypto_iv {
 	/** IV data
@@ -594,14 +594,17 @@ typedef struct odp_crypto_session_param_t {
 	 */
 	union {
 #if ODP_DEPRECATED_API
-		/** Cipher Initialization Vector (IV) */
+		/** @deprecated Cipher IV */
 		odp_crypto_iv_t ODP_DEPRECATE(cipher_iv);
 #endif
 		/** Cipher IV length */
 		struct {
 #if ODP_DEPRECATED_API
-			/** Unused padding field */
+			/** @cond
+			 *  Unused padding field
+			 */
 			uint8_t *dummy_padding_0;
+			/** @endcond */
 #endif
 			/** Length of cipher initialization vector.
 			 *  Default value is zero.
@@ -641,13 +644,17 @@ typedef struct odp_crypto_session_param_t {
 	 */
 	union {
 #if ODP_DEPRECATED_API
+		/** @deprecated Authentication IV */
 		odp_crypto_iv_t ODP_DEPRECATE(auth_iv);
 #endif
 		/** Authentication IV length */
 		struct {
 #if ODP_DEPRECATED_API
-			/** Unused padding field */
+			/** @cond
+			 *  Unused padding field
+			 */
 			uint8_t *dummy_padding_1;
+			/** @endcond */
 #endif
 			/** Length of authentication initialization vector.
 			 *  Default value is zero.

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -1059,7 +1059,7 @@ typedef struct {
 	 * not TRUE while packets per second when packet mode is TRUE.
 	 */
 	union {
-		/**< @deprecated Use commit_rate instead */
+		/** @deprecated Use commit_rate instead */
 		uint64_t ODP_DEPRECATE(commit_bps);
 		uint64_t commit_rate; /**< Commit information rate */
 	};
@@ -1070,7 +1070,7 @@ typedef struct {
 	 * This field is ignored when dual_rate is FALSE.
 	 */
 	union {
-		/**< @deprecated Use peak_rate instead */
+		/** @deprecated Use peak_rate instead */
 		uint64_t ODP_DEPRECATE(peak_bps);
 		uint64_t peak_rate; /**< Peak information rate */
 	};


### PR DESCRIPTION
Have Doxygen expand the ODP_DEPRECATED_API macro so that it includes
conditional deprecated segments of API headers in document generation
when ODP is configured with --enable-deprecated.

v2:
- Include the deprecated secions in documentation always, regardless of the --enable-deprecated option, as suggested by @psavol.
- Add an API patch (that does not modify the actual API) to improve documentation generation for various deprecated fields.