### PR TITLE
[PATCH v8] linux-gen: pktio and packet parse: some improvements and cleanups

### DIFF
--- a/platform/linux-generic/include/odp_packet_dpdk.h
+++ b/platform/linux-generic/include/odp_packet_dpdk.h
@@ -46,18 +46,4 @@ int _odp_dpdk_packet_parse_common(packet_parser_t *pkt_hdr,
 				  uint32_t supported_ptypes,
 				  odp_pktin_config_opt_t pktin_cfg);
 
-static inline int _odp_dpdk_packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
-					       struct rte_mbuf *mbuf,
-					       odp_proto_layer_t layer,
-					       uint32_t supported_ptypes,
-					       odp_pktin_config_opt_t pktin_cfg)
-{
-	uint32_t seg_len = pkt_hdr->seg_len;
-	void *base = pkt_hdr->seg_data;
-
-	return _odp_dpdk_packet_parse_common(&pkt_hdr->p, base,
-					     pkt_hdr->frame_len, seg_len, mbuf,
-					     layer, supported_ptypes,
-					     pktin_cfg);
-}
 #endif

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -78,6 +78,7 @@ struct pktio_entry {
 	/* These two locks together lock the whole pktio device */
 	odp_ticketlock_t rxl;		/**< RX ticketlock */
 	odp_ticketlock_t txl;		/**< TX ticketlock */
+	odp_proto_layer_t parse_layer;
 	uint16_t pktin_frame_offset;
 
 	struct {

--- a/platform/linux-generic/include/odp_parse_internal.h
+++ b/platform/linux-generic/include/odp_parse_internal.h
@@ -80,12 +80,12 @@ static inline int _odp_packet_parse_common(packet_parser_t *prs,
 					   const uint8_t *ptr,
 					   uint32_t frame_len, uint32_t seg_len,
 					   int layer,
-					   odp_proto_chksums_t chksums)
+					   odp_proto_chksums_t chksums,
+					   uint64_t *l4_part_sum)
 {
 	uint32_t offset;
 	uint16_t ethtype;
 	const uint8_t *parseptr;
-	uint64_t l4_part_sum;
 
 	parseptr = ptr;
 	offset = 0;
@@ -100,7 +100,7 @@ static inline int _odp_packet_parse_common(packet_parser_t *prs,
 
 	return _odp_packet_parse_common_l3_l4(prs, parseptr, offset, frame_len,
 					      seg_len, layer, ethtype, chksums,
-					      &l4_part_sum);
+					      l4_part_sum);
 }
 
 /* Perform packet parse up to a given protocol layer */

--- a/platform/linux-generic/include/odp_parse_internal.h
+++ b/platform/linux-generic/include/odp_parse_internal.h
@@ -103,11 +103,6 @@ static inline int _odp_packet_parse_common(packet_parser_t *prs,
 					      l4_part_sum);
 }
 
-/* Perform packet parse up to a given protocol layer */
-int _odp_packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
-			    odp_proto_layer_t layer,
-			    odp_proto_chksums_t chksums);
-
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/include/odp_parse_internal.h
+++ b/platform/linux-generic/include/odp_parse_internal.h
@@ -65,7 +65,8 @@ int _odp_packet_parse_common_l3_l4(packet_parser_t *prs,
 				   uint32_t frame_len, uint32_t seg_len,
 				   int layer, uint16_t ethtype,
 				   odp_proto_chksums_t chksums,
-				   uint64_t *l4_part_sum);
+				   uint64_t *l4_part_sum,
+				   odp_pktin_config_opt_t opt);
 
 /**
  * Parse common packet headers up to given layer
@@ -81,7 +82,8 @@ static inline int _odp_packet_parse_common(packet_parser_t *prs,
 					   uint32_t frame_len, uint32_t seg_len,
 					   int layer,
 					   odp_proto_chksums_t chksums,
-					   uint64_t *l4_part_sum)
+					   uint64_t *l4_part_sum,
+					   odp_pktin_config_opt_t opt)
 {
 	uint32_t offset;
 	uint16_t ethtype;
@@ -100,7 +102,7 @@ static inline int _odp_packet_parse_common(packet_parser_t *prs,
 
 	return _odp_packet_parse_common_l3_l4(prs, parseptr, offset, frame_len,
 					      seg_len, layer, ethtype, chksums,
-					      l4_part_sum);
+					      l4_part_sum, opt);
 }
 
 #ifdef __cplusplus

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2033,6 +2033,7 @@ int odp_packet_parse(odp_packet_t pkt, uint32_t offset,
 	uint64_t l4_part_sum = 0;
 	const uint32_t min_seglen = PARSE_ETH_BYTES + PARSE_L3_L4_BYTES;
 	uint8_t buf[min_seglen];
+	odp_pktin_config_opt_t opt;
 
 	if (proto == ODP_PROTO_NONE || layer == ODP_PROTO_LAYER_NONE)
 		return -1;
@@ -2072,10 +2073,12 @@ int odp_packet_parse(odp_packet_t pkt, uint32_t offset,
 		ethtype = 0; /* Invalid */
 	}
 
+	opt.all_bits = 0;
+
 	ret = _odp_packet_parse_common_l3_l4(&pkt_hdr->p, data, offset,
 					     packet_len, seg_len, layer,
 					     ethtype, param->chksums,
-					     &l4_part_sum);
+					     &l4_part_sum, opt);
 
 	if (ret)
 		return -1;

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -656,6 +656,9 @@ int odp_pktio_start(odp_pktio_t hdl)
 		ODP_ERR("Already started\n");
 		return -1;
 	}
+	entry->s.parse_layer = pktio_cls_enabled(entry) ?
+				       ODP_PROTO_LAYER_ALL :
+				       entry->s.config.parser.layer;
 	if (entry->s.ops->start)
 		res = entry->s.ops->start(entry);
 	if (!res)

--- a/platform/linux-generic/odp_parse.c
+++ b/platform/linux-generic/odp_parse.c
@@ -458,38 +458,3 @@ int _odp_packet_parse_common_l3_l4(packet_parser_t *prs,
 
 	return prs->flags.all.error != 0;
 }
-
-/**
- * Simple packet parser
- */
-int _odp_packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
-			    odp_proto_layer_t layer,
-			    odp_proto_chksums_t chksums)
-{
-	uint32_t seg_len = packet_first_seg_len(pkt_hdr);
-	const uint8_t *base = packet_data(pkt_hdr);
-	uint32_t offset = 0;
-	uint16_t ethtype;
-	uint64_t l4_part_sum = 0;
-	int rc;
-
-	if (odp_unlikely(layer == ODP_PROTO_LAYER_NONE))
-		return 0;
-
-	/* Assume valid L2 header, no CRC/FCS check in SW */
-	pkt_hdr->p.l2_offset = offset;
-
-	ethtype = _odp_parse_eth(&pkt_hdr->p, &base, &offset, pkt_hdr->frame_len);
-
-	rc = _odp_packet_parse_common_l3_l4(&pkt_hdr->p, base, offset,
-					    pkt_hdr->frame_len, seg_len, layer,
-					    ethtype, chksums, &l4_part_sum);
-
-	if (rc != 0)
-		return rc;
-
-	if (layer >= ODP_PROTO_LAYER_L4)
-		return _odp_packet_l4_chksum(pkt_hdr, chksums, l4_part_sum);
-	else
-		return 0;
-}

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -27,6 +27,7 @@
 #include <odp_ipsec_internal.h>
 #include <odp_packet_internal.h>
 #include <odp_packet_io_internal.h>
+#include <odp_macros_internal.h>
 #include <odp_queue_if.h>
 
 #include <protocols/eth.h>
@@ -195,10 +196,9 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			/* Make sure there is enough data for the packet
 			 * parser in the case of a segmented packet. */
 			if (odp_unlikely(seg_len < PARSE_BYTES &&
-					 pkt_len > PARSE_BYTES)) {
-				odp_packet_copy_to_mem(pkt, 0, PARSE_BYTES,
-						       buf);
-				seg_len = PARSE_BYTES;
+					 pkt_len > seg_len)) {
+				seg_len = MIN(pkt_len, PARSE_BYTES);
+				odp_packet_copy_to_mem(pkt, 0, seg_len, buf);
 				pkt_addr = buf;
 			} else {
 				pkt_addr = odp_packet_data(pkt);

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -192,6 +192,7 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			uint8_t buf[PARSE_BYTES];
 			int ret;
 			uint32_t seg_len = odp_packet_seg_len(pkt);
+			uint64_t l4_part_sum = 0;
 
 			/* Make sure there is enough data for the packet
 			 * parser in the case of a segmented packet. */
@@ -206,7 +207,8 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 			ret = _odp_packet_parse_common(&pkt_hdr->p, pkt_addr, pkt_len,
 						       seg_len, ODP_PROTO_LAYER_ALL,
-						       pktio_entry->s.in_chksums);
+						       pktio_entry->s.in_chksums,
+						       &l4_part_sum);
 			if (ret)
 				errors++;
 
@@ -235,6 +237,8 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 				pkt = new_pkt;
 				pkt_hdr = packet_hdr(new_pkt);
 			}
+
+			_odp_packet_l4_chksum(pkt_hdr, pktio_entry->s.in_chksums, l4_part_sum);
 		} else {
 			odp_packet_parse_param_t param;
 

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -164,6 +164,7 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	uint32_t octets = 0;
 	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
+	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 
 	if (odp_unlikely(num > QUEUE_MULTI_MAX))
 		num = QUEUE_MULTI_MAX;
@@ -173,8 +174,7 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	queue = pkt_priv(pktio_entry)->loopq;
 	nbr = odp_queue_deq_multi(queue, (odp_event_t *)hdr_tbl, num);
 
-	if (pktio_entry->s.config.pktin.bit.ts_all ||
-	    pktio_entry->s.config.pktin.bit.ts_ptp) {
+	if (opt.bit.ts_all || opt.bit.ts_ptp) {
 		ts_val = odp_time_global();
 		ts = &ts_val;
 	}
@@ -207,7 +207,7 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			packet_parse_reset(pkt_hdr, 1);
 			ret = _odp_packet_parse_common(&pkt_hdr->p, pkt_addr, pkt_len,
 						       seg_len, layer, chksums,
-						       &l4_part_sum);
+						       &l4_part_sum, opt);
 			if (ret)
 				errors++;
 

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -830,6 +830,7 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 	int num_rx = 0;
 	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
+	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 
 	/* Allocate maximum sized packets */
 	max_len = pkt_priv(pktio_entry)->mtu;
@@ -854,7 +855,7 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 
 		if (layer) {
 			if (_odp_packet_parse_common(&pkt_hdr->p, buf, len, len,
-						     layer, chksums, &l4_part_sum) < 0)
+						     layer, chksums, &l4_part_sum, opt) < 0)
 				continue;
 
 			if (pktio_cls_enabled(pktio_entry)) {

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -252,6 +252,7 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
 	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
+	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 
 	odp_ticketlock_lock(&pktio_entry->s.rxl);
 
@@ -259,8 +260,7 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 		odp_ticketlock_unlock(&pktio_entry->s.rxl);
 		return 0;
 	}
-	if (pktio_entry->s.config.pktin.bit.ts_all ||
-	    pktio_entry->s.config.pktin.bit.ts_ptp)
+	if (opt.bit.ts_all || opt.bit.ts_ptp)
 		ts = &ts_val;
 
 	for (i = 0; i < num; ) {
@@ -299,7 +299,7 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 			ret = _odp_packet_parse_common(&pkt_hdr->p, data, pkt_len,
 						       pkt_len, layer, chksums,
-						       &l4_part_sum);
+						       &l4_part_sum, opt);
 			if (ret < 0) {
 				odp_packet_free(pkt);
 				continue;

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -294,10 +294,12 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 		if (pktio_cls_enabled(pktio_entry)) {
 			odp_packet_t new_pkt;
+			uint64_t l4_part_sum = 0;
 
 			ret = _odp_packet_parse_common(&pkt_hdr->p, data, pkt_len,
 						       pkt_len, ODP_PROTO_LAYER_ALL,
-						       pktio_entry->s.in_chksums);
+						       pktio_entry->s.in_chksums,
+						       &l4_part_sum);
 			if (ret < 0) {
 				odp_packet_free(pkt);
 				continue;
@@ -320,6 +322,8 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 				pkt = new_pkt;
 				pkt_hdr = packet_hdr(new_pkt);
 			}
+
+			_odp_packet_l4_chksum(pkt_hdr, pktio_entry->s.in_chksums, l4_part_sum);
 		} else {
 			_odp_packet_parse_layer(pkt_hdr,
 						pktio_entry->s.config.parser.layer,

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -236,6 +236,7 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	uint32_t alloc_len = pkt_sock->mtu + frame_offset;
 	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
+	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 
 	memset(msgvec, 0, sizeof(msgvec));
 
@@ -252,8 +253,7 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	recv_msgs = recvmmsg(sockfd, msgvec, nb_pkts, MSG_DONTWAIT, NULL);
 	odp_ticketlock_unlock(&pkt_sock->rx_lock);
 
-	if (pktio_entry->s.config.pktin.bit.ts_all ||
-	    pktio_entry->s.config.pktin.bit.ts_ptp) {
+	if (opt.bit.ts_all || opt.bit.ts_ptp) {
 		ts_val = odp_time_global();
 		ts = &ts_val;
 	}
@@ -289,7 +289,7 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 			if (_odp_packet_parse_common(&pkt_hdr->p, base, pkt_len,
 						     seg_len, layer, chksums,
-						     &l4_part_sum) < 0) {
+						     &l4_part_sum, opt) < 0) {
 				odp_packet_free(pkt);
 				continue;
 			}

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -153,9 +153,9 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 	uint16_t vlan_len = 0;
 	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
+	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 
-	if (pktio_entry->s.config.pktin.bit.ts_all ||
-	    pktio_entry->s.config.pktin.bit.ts_ptp)
+	if (opt.bit.ts_all || opt.bit.ts_ptp)
 		ts = &ts_val;
 
 	ring  = &pkt_sock->rx_ring;
@@ -220,7 +220,7 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 		if (layer) {
 			if (_odp_packet_parse_common(&hdr->p, pkt_buf, pkt_len,
 						     pkt_len, layer, chksums,
-						     &l4_part_sum) < 0) {
+						     &l4_part_sum, opt) < 0) {
 				odp_packet_free(pkt);
 				tp_hdr->tp_status = TP_STATUS_KERNEL;
 				frame_num = next_frame_num;

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -291,12 +291,13 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
 	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
+	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 
 	if (layer) {
 		packet_parse_reset(&parsed_hdr, 1);
 		packet_set_len(&parsed_hdr, len);
 		if (_odp_packet_parse_common(&parsed_hdr.p, data, len, len, layer,
-					     chksums, &l4_part_sum) < 0) {
+					     chksums, &l4_part_sum, opt) < 0) {
 			return ODP_PACKET_INVALID;
 		}
 


### PR DESCRIPTION
v2 - v4:
- Only do packet_parse_reset(), etc., when needed.
- Include odp_macros_internal.h.
- Store parse layer in pktio_entry_t.

v5:
- Fix packet_init() / parse_reset() in dpdk pktio.

v6 - v7:
- Remove _odp_packet_parse_common_l3_l4_opt().
- Move pktio_entry::parse_layer.
- Add chksums temporary variable also in netmap and pcap pktio.
- Move commit `linux-gen: drop error packets according to pktin configuration`.

v8:
- Rebase.
- Add review tags.
- Petri's comment.
