### PR TITLE
[PATCH v2] linux-gen: crypto: fix configure portability issue

### DIFF
--- a/platform/linux-generic/m4/odp_crypto.m4
+++ b/platform/linux-generic/m4/odp_crypto.m4
@@ -20,7 +20,9 @@ AS_IF([test "x$with_crypto" != "xopenssl" -a "x$with_crypto" != "xarmv8crypto" -
 ##########################################################################
 # OpenSSL implementation
 ##########################################################################
+AC_CONFIG_COMMANDS_PRE([dnl
 AM_CONDITIONAL([WITH_OPENSSL_CRYPTO], [test "x$with_crypto" == "xopenssl"])
+])
 
 ##########################################################################
 # ARMv8 Crypto library implementation
@@ -29,7 +31,10 @@ AS_IF([test "x$with_crypto" == "xarmv8crypto"],
       [PKG_CHECK_MODULES([AARCH64CRYPTO], [libAArch64crypto])
        AARCH64CRYPTO_PKG=", libAArch64crypto"
        AC_SUBST([AARCH64CRYPTO_PKG])])
+AC_CONFIG_COMMANDS_PRE([dnl
 AM_CONDITIONAL([WITH_ARMV8_CRYPTO], [test "x$with_crypto" == "xarmv8crypto"])
+])
+
 ##########################################################################
 # Null implementation
 ##########################################################################


### PR DESCRIPTION
OpenSSL and ARMv8 crypto implementations are platform specific, so wrap the
AM_CONDITIONALs to avoid configure failures on other platforms:
	configure: error: conditional "WITH_OPENSSL_CRYPTO" was never defined.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Suggested-by: Nithin Dabilpuram <ndabilpuram@marvell.com>