### PR TITLE
[PATCH v2] configure: remove some unneeded checks from configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,16 +90,6 @@ AM_PROG_LIBTOOL
 
 PKG_PROG_PKG_CONFIG
 
-# Checks for typedefs, structures, and compiler characteristics.
-AC_C_INLINE
-AC_TYPE_SIZE_T
-AC_TYPE_SSIZE_T
-AC_TYPE_UINT8_T
-AC_TYPE_UINT16_T
-AC_TYPE_INT32_T
-AC_TYPE_UINT32_T
-AC_TYPE_UINT64_T
-
 ##########################################################################
 # Default warning setup
 ##########################################################################

--- a/configure.ac
+++ b/configure.ac
@@ -90,48 +90,7 @@ AM_PROG_LIBTOOL
 
 PKG_PROG_PKG_CONFIG
 
-# Checks for library functions.
-dnl breaks cross-compilation and malloc(0) behaviour is not that important
-dnl AC_FUNC_MALLOC
-AC_FUNC_MMAP
-AC_CHECK_FUNCS(m4_normalize([
-	bzero
-	clock_gettime
-	gethostbyname
-	getpagesize
-	gettimeofday
-	malloc
-	memset
-	munmap
-	socket
-	strchr
-	strerror
-	strrchr
-	strstr
-	strtoull
-]))
-
-# Checks for header files.
-AC_HEADER_RESOLV
-AC_CHECK_HEADERS(m4_normalize([
-	arpa/inet.h
-	fcntl.h
-	inttypes.h
-	limits.h
-	netdb.h
-	netinet/in.h
-	stddef.h
-	stdint.h
-	stdlib.h
-	string.h
-	sys/ioctl.h
-	sys/socket.h
-	sys/time.h
-	unistd.h
-]))
-
 # Checks for typedefs, structures, and compiler characteristics.
-AC_HEADER_STDBOOL
 AC_C_INLINE
 AC_TYPE_SIZE_T
 AC_TYPE_SSIZE_T


### PR DESCRIPTION
configure: remove fallbacks for standard int types and inline

    Remove checking whether the compilation environment supports the inline
    keyword and the standard fixed-width integer types. This also removes
    the fallback preprocessor macros that autoconf would create if the
    keyword or some of the types were not supported. The checking and the
    fallback mechanism is unnecessary since ODP requires C11 and stdint.h.

configure: remove unused function and header checks

    Remove checks for the existence of a set of function and header files.
    The HAVE_ macros resulting from the checks are not used for anything.
