### PR TITLE
[PATCH v3] IPsec: a few small fixes

### DIFF
--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -1803,6 +1803,7 @@ static ipsec_sa_t *ipsec_out_single(odp_packet_t pkt,
 			state.out_tunnel.ip_tos = 0;
 			state.out_tunnel.ip_df = 0;
 			state.out_tunnel.ip_flabel = 0;
+			state.ip_next_hdr = _ODP_IPPROTO_NO_NEXT;
 			rc = 0;
 		} else {
 			rc = -1;

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -2269,12 +2269,6 @@ int odp_ipsec_out_inline(const odp_packet_t pkt_in[], int num_in,
 					     ptr) < 0)
 			status.error.alg = 1;
 
-		packet_subtype_set(pkt, ODP_EVENT_PACKET_IPSEC);
-		result = ipsec_pkt_result(pkt);
-		memset(result, 0, sizeof(*result));
-		result->sa = ipsec_sa->ipsec_sa_hdl;
-		result->status = status;
-
 		if (!status.error.all) {
 			odp_pktout_queue_t pkqueue;
 

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -863,7 +863,10 @@ ipsec_sa_t *_odp_ipsec_sa_lookup(const ipsec_sa_lookup_t *lookup)
 		    lookup->proto == ipsec_sa->proto &&
 		    lookup->spi == ipsec_sa->spi &&
 		    lookup->ver == ipsec_sa->in.lookup_ver &&
-		    !memcmp(lookup->dst_addr, &ipsec_sa->in.lookup_dst_ipv4,
+		    !memcmp(lookup->dst_addr,
+			    lookup->ver == ODP_IPSEC_IPV4 ?
+				    (void *)&ipsec_sa->in.lookup_dst_ipv4 :
+				    (void *)&ipsec_sa->in.lookup_dst_ipv6,
 			    lookup->ver == ODP_IPSEC_IPV4 ?
 				    _ODP_IPV4ADDR_LEN :
 				    _ODP_IPV6ADDR_LEN)) {

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -942,9 +942,8 @@ static void verify_in(const ipsec_test_part *part,
 					  result.orig_ip_len == len);
 			}
 		}
-		ipsec_check_packet(part->out[i].pkt_res,
-				   pkto[i],
-				   false);
+		if (part->out[i].l3_type != ODP_PROTO_L3_TYPE_NONE)
+			ipsec_check_packet(part->out[i].pkt_res, pkto[i], false);
 		if (suite_context.inbound_op_mode == ODP_IPSEC_OP_MODE_INLINE)
 			expected_user_ptr = NULL;
 		CU_ASSERT(odp_packet_user_ptr(pkto[i]) == expected_user_ptr);

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -281,10 +281,6 @@ int ipsec_check_esp_chacha20_poly1305(void)
 
 int ipsec_check_test_sa_update_seq_num(void)
 {
-	odp_ipsec_capability_t capa;
-
-	odp_ipsec_capability(&capa);
-
 	if (!capa.test.sa_operations.seq_num)
 		return ODP_TEST_INACTIVE;
 


### PR DESCRIPTION
linux-gen: ipsec: remove redundant inline operation result setting
linux-gen: ipsec: access union member properly to silence a warning
linux-gen: ipsec: fix uninitialized variable access with dummy packets
validation: ipsec: relax tunnel mode dummy TFC packet checking
validation: ipsec: get rid of an unchecked odp_ipsec_capability call
