### PR TITLE
[PATCH v6] linux-gen: scheduler: improve priority scheduling

### DIFF
--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -1339,8 +1339,10 @@ static inline int schedule_grp_prio(odp_queue_t *out_queue, odp_event_t out_ev[]
 				 * packet input queue even when it is empty. */
 				ring_u32_enq(ring, ring_mask, qi);
 
-				/* Continue scheduling from the next group/priority */
-				return 0;
+				/* Continue scheduling from the next spread */
+				i++;
+				spr++;
+				continue;
 			}
 
 			/* Process packets from an atomic or parallel queue right away. */

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2021, Nokia
+ * Copyright (c) 2019-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -1063,7 +1063,7 @@ static inline int balance_spread(int grp, int prio, int cur_spr)
 	return new_spr;
 }
 
-static inline int copy_from_stash(odp_event_t out_ev[], unsigned int max)
+static inline int copy_from_stash(odp_event_t out_ev[], uint32_t max)
 {
 	int i = 0;
 
@@ -1202,8 +1202,8 @@ static inline int poll_pktin(uint32_t qi, int direct_recv,
 	return ret;
 }
 
-static inline int do_schedule_grp(odp_queue_t *out_queue, odp_event_t out_ev[],
-				  unsigned int max_num, int grp, int first_spr, int balance)
+static inline int do_schedule_grp(odp_queue_t *out_queue, odp_event_t out_ev[], uint32_t max_num,
+				  int grp, int first_spr, int balance)
 {
 	int prio, spr, new_spr, i, ret;
 	uint32_t qi;
@@ -1377,8 +1377,7 @@ static inline int do_schedule_grp(odp_queue_t *out_queue, odp_event_t out_ev[],
 /*
  * Schedule queues
  */
-static inline int do_schedule(odp_queue_t *out_queue, odp_event_t out_ev[],
-			      unsigned int max_num)
+static inline int do_schedule(odp_queue_t *out_queue, odp_event_t out_ev[], uint32_t max_num)
 {
 	int i, num_grp, ret, spr, grp_id;
 	uint32_t sched_round;
@@ -1462,8 +1461,7 @@ static inline int do_schedule(odp_queue_t *out_queue, odp_event_t out_ev[],
 	return 0;
 }
 
-static inline int schedule_run(odp_queue_t *out_queue, odp_event_t out_ev[],
-			       unsigned int max_num)
+static inline int schedule_run(odp_queue_t *out_queue, odp_event_t out_ev[], uint32_t max_num)
 {
 	timer_run(1);
 
@@ -1471,7 +1469,7 @@ static inline int schedule_run(odp_queue_t *out_queue, odp_event_t out_ev[],
 }
 
 static inline int schedule_loop(odp_queue_t *out_queue, uint64_t wait,
-				odp_event_t out_ev[], unsigned int max_num)
+				odp_event_t out_ev[], uint32_t max_num)
 {
 	odp_time_t next, wtime;
 	int first = 1;


### PR DESCRIPTION
Currently, scheduler selects group first (round robin), and then finds highest priority queue from that. This leads to bad response time to high priority events when there are multiple groups, but only few of those have high priority queues.

This PR changes scheduler to check first highest priority level on all groups. This causes more work for each schedule call. A new mask of active groups per priority is introduced to optimize the additional checking.