### PR TITLE
[PATCH v3] A couple of very small clean-ups

### DIFF
--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -151,13 +151,11 @@ typedef struct ODP_ALIGNED_CACHE odp_packet_hdr_t {
 	uint8_t lso_profile_idx;
 
 	union {
-		struct {
-			/* Result for crypto packet op */
-			odp_crypto_packet_result_t crypto_op_result;
+		/* Result for crypto packet op */
+		odp_crypto_packet_result_t crypto_op_result;
 
-			/* Context for IPsec */
-			odp_ipsec_packet_result_t ipsec_ctx;
-		};
+		/* Context for IPsec */
+		odp_ipsec_packet_result_t ipsec_ctx;
 
 		/* Result for comp packet op */
 		odp_comp_packet_result_t comp_op_result;

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2228,6 +2228,7 @@ static void tm_egress_marking(tm_system_t *tm_system, odp_packet_t odp_pkt)
 	tm_tos_marking_t  *ip_marking;
 
 	color = odp_packet_color(odp_pkt);
+	ODP_ASSERT(color < ODP_NUM_PACKET_COLORS);
 
 	if (odp_packet_has_vlan(odp_pkt)) {
 		vlan_marking = &tm_system->marking.vlan_marking[color];

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -405,20 +405,9 @@ static int loopback_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	}
 
 	for (i = 0; i < nb_tx; ++i) {
-		odp_ipsec_packet_result_t result;
-
-		if (odp_packet_subtype(pkt_tbl[i]) ==
-				ODP_EVENT_PACKET_IPSEC &&
-		    pktio_entry->s.config.outbound_ipsec) {
-
-			/* Possibly postprocessing packet */
-			odp_ipsec_result(&result, pkt_tbl[i]);
-		}
 		packet_subtype_set(pkt_tbl[i], ODP_EVENT_PACKET_BASIC);
-	}
-
-	for (i = 0; i < nb_tx; ++i)
 		loopback_fix_checksums(pkt_tbl[i], pktout_cfg, pktout_capa);
+	}
 
 	odp_ticketlock_lock(&pktio_entry->s.txl);
 

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -3078,6 +3078,7 @@ static void pktio_test_pktin_ts(void)
 	ns1 = 100;
 	ts = odp_pktio_ts_from_ns(pktio_tx, ns1);
 	ns2 = odp_time_to_ns(ts);
+	CU_ASSERT_FATAL(res != 0);
 	res_ns = ODP_TIME_SEC_IN_NS / res;
 	if (ODP_TIME_SEC_IN_NS % res)
 		res_ns++;


### PR DESCRIPTION
linux-gen: packet: put crypto and ipsec results in a union in packet hdr
linux-gen: traffic_mgr: add assert to suppress warnings
linux-gen: pktio: loop: remove unnecessary odp_ipsec_result() call
validation: pktio: trigger fatal failure before dividing by zero
