### PR TITLE
[PATCH v2] api: increment ODP API version to 1.36.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,36 @@
+== OpenDataPlane (1.36.0.0)
+
+=== Backward incompatible API changes
+
+==== Classifier
+* Add an action parameter `odp_cos_action_t` to CoS parameters
+(`odp_cls_cos_param_t`). Action may be to enqueue or drop the packet classified
+to the CoS. The old methods of creating a drop CoS have been replaced by the
+new drop action.
+
+==== Crypto
+* Deprecate `odp_crypto_operation()`, the associated data structures, and the
+completion event. Use `odp_crypto_op()` or `odp_crypto_op_enq()` instead.
+
+==== Traffic Manager
+* Split `odp_tm_capabilities_t.tm_queue_threshold` capability into byte and
+packet modes.
+* Split `odp_tm_level_capabilities_t.tm_node_threshold` capability into byte and
+packet modes.
+
+=== Backward compatible API changes
+==== Classifier
+* Add CoS specific statistics counters (`odp_cls_cos_stats_t`) and
+matching capabilities (`odp_cls_stats_capability_t`). Statistics counters can be
+read with `odp_cls_cos_stats()`.
+
+==== Common
+* Convert `unsigned int` types to `uint32_t`.
+
+==== Traffic Manager
+* Remove unused TM shaper color enum `odp_tm_shaper_color_t` and
+`ODP_NUM_SHAPER_COLORS` define.
+
 == OpenDataPlane (1.35.0.0)
 
 === Backward incompatible API changes

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ([2.5])
 # ODP API version
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
-m4_define([odpapi_major_version], [35])
+m4_define([odpapi_major_version], [36])
 m4_define([odpapi_minor_version], [0])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],


### PR DESCRIPTION
Increment API version number to reflect the following changes:

Backward incompatible:
- cls: add action parameter odp_cos_action_t to CoS parameters
- crypto: deprecate odp_crypto_operation() and the associated data
  structures and the completion event
- tm: split odp_tm_capabilities_t.tm_queue_threshold capability into byte
  and packet modes
- tm: split odp_tm_level_capabilities_t.tm_node_threshold capability into
  byte and packet modes

Backward compatible:
- cls: add CoS specific statistics counters (odp_cls_cos_stats_t) and
  matching capabilities (odp_cls_stats_capability_t)
- common: convert 'unsigned int' types to 'uint32_t'
- tm: remove unused TM shaper color enum odp_tm_shaper_color_t and
  ODP_NUM_SHAPER_COLORS define

Signed-off-by: Matias Elo <matias.elo@nokia.com>