### PR TITLE
[PATCH v3] remove crypto error from packet error flags

### DIFF
--- a/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
+++ b/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
@@ -724,7 +724,6 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 		 * We cannot fail since odp_crypto_op() has already processed
 		 * the packet. Let's indicate error in the result instead.
 		 */
-		packet_hdr(out_pkt)->p.flags.crypto_err = 1;
 		packet_result.ok = false;
 	}
 
@@ -916,8 +915,6 @@ int crypto_int(odp_packet_t pkt_in,
 	odp_crypto_generic_session_t *session;
 	odp_bool_t allocated = false;
 	odp_packet_t out_pkt = *pkt_out;
-	odp_packet_hdr_t *pkt_hdr;
-	odp_bool_t ok;
 
 	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
 
@@ -959,11 +956,9 @@ int crypto_int(odp_packet_t pkt_in,
 	}
 
 	/* Invoke the crypto function */
-	ok = session->func(out_pkt, param, session);
+	(void)session->func(out_pkt, param, session);
 
 	packet_subtype_set(out_pkt, ODP_EVENT_PACKET_CRYPTO);
-	pkt_hdr = packet_hdr(out_pkt);
-	pkt_hdr->p.flags.crypto_err = !ok;
 
 	/* Synchronous, simply return results */
 	*pkt_out = out_pkt;

--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -115,7 +115,7 @@ typedef union {
 	uint32_t all_flags;
 
 	struct {
-		uint32_t reserved1:      6;
+		uint32_t reserved1:      7;
 
 	/*
 	 * Init flags
@@ -146,14 +146,13 @@ typedef union {
 		uint32_t udp_err:        1; /* UDP error */
 		uint32_t sctp_err:       1; /* SCTP error */
 		uint32_t l4_chksum_err:  1; /* L4 checksum error */
-		uint32_t crypto_err:     1; /* Crypto packet operation error */
 	};
 
 	/* Flag groups */
 	struct {
-		uint32_t reserved2:      6;
+		uint32_t reserved2:      7;
 		uint32_t other:         18; /* All other flags */
-		uint32_t error:          8; /* All error flags */
+		uint32_t error:          7; /* All error flags */
 	} all;
 
 } _odp_packet_flags_t;

--- a/platform/linux-generic/odp_crypto_null.c
+++ b/platform/linux-generic/odp_crypto_null.c
@@ -299,7 +299,6 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 		 * We cannot fail since odp_crypto_op() has already processed
 		 * the packet. Let's indicate error in the result instead.
 		 */
-		packet_hdr(out_pkt)->p.flags.crypto_err = 1;
 		packet_result.ok = false;
 	}
 
@@ -496,7 +495,6 @@ int crypto_int(odp_packet_t pkt_in,
 	odp_bool_t allocated = false;
 	odp_packet_t out_pkt = *pkt_out;
 	odp_crypto_packet_result_t *op_result;
-	odp_packet_hdr_t *pkt_hdr;
 
 	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
 
@@ -545,9 +543,6 @@ int crypto_int(odp_packet_t pkt_in,
 	op_result->auth_status.alg_err = ODP_CRYPTO_ALG_ERR_NONE;
 	op_result->auth_status.hw_err = ODP_CRYPTO_HW_ERR_NONE;
 	op_result->ok = true;
-
-	pkt_hdr = packet_hdr(out_pkt);
-	pkt_hdr->p.flags.crypto_err = !op_result->ok;
 
 	/* Synchronous, simply return results */
 	*pkt_out = out_pkt;

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -2531,7 +2531,6 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 		 * We cannot fail since odp_crypto_op() has already processed
 		 * the packet. Let's indicate error in the result instead.
 		 */
-		packet_hdr(out_pkt)->p.flags.crypto_err = 1;
 		packet_result.ok = false;
 	}
 
@@ -2810,7 +2809,6 @@ int crypto_int(odp_packet_t pkt_in,
 	odp_bool_t allocated = false;
 	odp_packet_t out_pkt = *pkt_out;
 	odp_crypto_packet_result_t *op_result;
-	odp_packet_hdr_t *pkt_hdr;
 
 	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
 
@@ -2872,9 +2870,6 @@ int crypto_int(odp_packet_t pkt_in,
 	op_result->ok =
 		(rc_cipher == ODP_CRYPTO_ALG_ERR_NONE) &&
 		(rc_auth == ODP_CRYPTO_ALG_ERR_NONE);
-
-	pkt_hdr = packet_hdr(out_pkt);
-	pkt_hdr->p.flags.crypto_err = !op_result->ok;
 
 	/* Synchronous, simply return results */
 	*pkt_out = out_pkt;

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -353,9 +353,6 @@ static int alg_packet_op(odp_packet_t pkt,
 		return rc;
 	}
 
-	if (!result.ok)
-		CU_ASSERT(odp_packet_has_error(pkt));
-
 	*ok = result.ok;
 
 	return 0;


### PR DESCRIPTION
validation: crypto: remove odp_packet_has_error() check after crypto error

    ODP API does not say that odp_packet_has_error() must return true after
    crypto operation errors. odp_packet_has_error() indicates various packet
    parsing errors and crypto operations are not parsing the packet.

    Remove the odp_packet_has_error() check to prevent potential test failures
    with API compliant ODP implementations.

linux_gen: remove crypto error from packet error flags

    Remove the unnecessary crypto_err parse flag from packet header.
    odp_packet_has_error() is supposed to indicate parse errors not crypto
    processing errors, which are indicated through odp_crypto_result_t.

    Remove the flag and its setting in crypto implementations as the flag
    is not needed and may cause subtle API spec violations.
