### PR TITLE
[PATCH v9] linux-gen: pktio: a couple of parse and classification related fixes

### DIFF
--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -478,7 +478,7 @@ int _odp_packet_udp_chksum_insert(odp_packet_t pkt);
 int _odp_packet_sctp_chksum_insert(odp_packet_t pkt);
 
 int _odp_packet_l4_chksum(odp_packet_hdr_t *pkt_hdr,
-			  odp_proto_chksums_t chksums, uint64_t l4_part_sum);
+			  odp_pktin_config_opt_t opt, uint64_t l4_part_sum);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -361,6 +361,27 @@ int _odp_lso_create_packets(odp_packet_t packet, const odp_packet_lso_opt_t *lso
 void _odp_pktio_allocate_and_send_tx_compl_events(const pktio_entry_t *entry,
 						  const odp_packet_t packets[], int num);
 
+static inline int _odp_pktio_packet_to_pool(odp_packet_t *pkt,
+					    odp_packet_hdr_t **pkt_hdr,
+					    odp_pool_t new_pool)
+{
+	odp_packet_t new_pkt;
+
+	if (odp_likely(new_pool == odp_packet_pool(*pkt)))
+		return 0;
+
+	new_pkt = odp_packet_copy(*pkt, new_pool);
+
+	if (odp_unlikely(new_pkt == ODP_PACKET_INVALID))
+		return 1;
+
+	odp_packet_free(*pkt);
+	*pkt = new_pkt;
+	*pkt_hdr = packet_hdr(new_pkt);
+
+	return 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -135,7 +135,6 @@ struct pktio_entry {
 	} stats_extra;
 	/* Latest Tx timestamp */
 	odp_atomic_u64_t tx_ts;
-	odp_proto_chksums_t in_chksums; /**< Checksums validation settings */
 	pktio_stats_type_t stats_type;
 	char name[PKTIO_NAME_LEN];	/**< name of pktio provided to
 					     internal pktio_open() calls */

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -128,7 +128,7 @@ struct pktio_entry {
 	classifier_t cls;		/**< classifier linked with this pktio*/
 	/* Driver level statistics counters */
 	odp_pktio_stats_t stats;
-	/* Statistics counters used outside drivers */
+	/* Statistics counters used also outside drivers */
 	struct {
 		odp_atomic_u64_t in_discards;
 		odp_atomic_u64_t out_discards;

--- a/platform/linux-generic/include/odp_parse_internal.h
+++ b/platform/linux-generic/include/odp_parse_internal.h
@@ -64,7 +64,6 @@ int _odp_packet_parse_common_l3_l4(packet_parser_t *prs,
 				   const uint8_t *parseptr, uint32_t offset,
 				   uint32_t frame_len, uint32_t seg_len,
 				   int layer, uint16_t ethtype,
-				   odp_proto_chksums_t chksums,
 				   uint64_t *l4_part_sum,
 				   odp_pktin_config_opt_t opt);
 
@@ -81,7 +80,6 @@ static inline int _odp_packet_parse_common(odp_packet_hdr_t *pkt_hdr,
 					   const uint8_t *ptr,
 					   uint32_t frame_len, uint32_t seg_len,
 					   int layer,
-					   odp_proto_chksums_t chksums,
 					   odp_pktin_config_opt_t opt)
 {
 	int r;
@@ -103,11 +101,11 @@ static inline int _odp_packet_parse_common(odp_packet_hdr_t *pkt_hdr,
 	ethtype = _odp_parse_eth(prs, &parseptr, &offset, frame_len);
 
 	r = _odp_packet_parse_common_l3_l4(prs, parseptr, offset, frame_len,
-					   seg_len, layer, ethtype, chksums,
+					   seg_len, layer, ethtype,
 					   &l4_part_sum, opt);
 
 	if (!r && layer >= ODP_PROTO_LAYER_L4)
-		r = _odp_packet_l4_chksum(pkt_hdr, chksums, l4_part_sum);
+		r = _odp_packet_l4_chksum(pkt_hdr, opt, l4_part_sum);
 
 	return r;
 }

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -612,12 +612,6 @@ int odp_pktio_config(odp_pktio_t hdl, const odp_pktio_config_t *config)
 
 	entry->s.config = *config;
 
-	entry->s.in_chksums.all_chksum = 0;
-	entry->s.in_chksums.chksum.ipv4 = config->pktin.bit.ipv4_chksum;
-	entry->s.in_chksums.chksum.tcp = config->pktin.bit.tcp_chksum;
-	entry->s.in_chksums.chksum.udp = config->pktin.bit.udp_chksum;
-	entry->s.in_chksums.chksum.sctp = config->pktin.bit.sctp_chksum;
-
 	entry->s.enabled.tx_ts = config->pktout.bit.ts_ena;
 	entry->s.enabled.tx_compl = config->pktout.bit.tx_compl_ena;
 

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -612,6 +612,7 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 	odp_pktio_t input = pktio_entry->s.handle;
 	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
+	const uint32_t supported_ptypes = pkt_dpdk->supported_ptypes;
 
 	/* Allocate maximum sized packets */
 	max_len = pkt_dpdk->data_room;
@@ -640,8 +641,6 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 		pkt_hdr = packet_hdr(pkt);
 
 		if (layer) {
-			uint32_t supported_ptypes = pkt_dpdk->supported_ptypes;
-
 			packet_parse_reset(pkt_hdr, 1);
 			if (_odp_dpdk_packet_parse_common(&pkt_hdr->p, data,
 							  pkt_len, pkt_len, mbuf,
@@ -892,12 +891,12 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 	int i, nb_pkts;
 	odp_pktin_config_opt_t pktin_cfg;
 	odp_pktio_t input;
-	pkt_dpdk_t *pkt_dpdk;
+	pkt_dpdk_t *pkt_dpdk = pkt_priv(pktio_entry);
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
+	const uint32_t supported_ptypes = pkt_dpdk->supported_ptypes;
 
 	prefetch_pkt(mbuf_table[0]);
 
-	pkt_dpdk = pkt_priv(pktio_entry);
 	nb_pkts = 0;
 	set_flow_hash = pkt_dpdk->opt.set_flow_hash;
 	pktin_cfg = pktio_entry->s.config.pktin;
@@ -930,8 +929,6 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 		pkt_hdr->seg_data = data;
 
 		if (layer) {
-			uint32_t supported_ptypes = pkt_dpdk->supported_ptypes;
-
 			if (_odp_dpdk_packet_parse_common(&pkt_hdr->p, data,
 							  pkt_len, pkt_len, mbuf,
 							  layer, supported_ptypes,

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -647,16 +647,25 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 							  pkt_len, pkt_len, mbuf,
 							  layer, supported_ptypes,
 							  pktin_cfg)) {
-				odp_packet_free(pkt_table[i]);
+				odp_packet_free(pkt);
 				rte_pktmbuf_free(mbuf);
 				continue;
 			}
 
 			if (pktio_cls_enabled(pktio_entry)) {
+				odp_pool_t new_pool;
+
 				if (_odp_cls_classify_packet(pktio_entry,
 							     (const uint8_t *)data,
-							     &pool, pkt_hdr)) {
-					odp_packet_free(pkt_table[i]);
+							     &new_pool, pkt_hdr)) {
+					odp_packet_free(pkt);
+					rte_pktmbuf_free(mbuf);
+					continue;
+				}
+
+				if (odp_unlikely(_odp_pktio_packet_to_pool(
+					    &pkt, &pkt_hdr, new_pool))) {
+					odp_packet_free(pkt);
 					rte_pktmbuf_free(mbuf);
 					continue;
 				}
@@ -881,7 +890,6 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 	struct rte_mbuf *mbuf;
 	void *data;
 	int i, nb_pkts;
-	odp_pool_t pool;
 	odp_pktin_config_opt_t pktin_cfg;
 	odp_pktio_t input;
 	pkt_dpdk_t *pkt_dpdk;
@@ -891,7 +899,6 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 
 	pkt_dpdk = pkt_priv(pktio_entry);
 	nb_pkts = 0;
-	pool = pkt_dpdk->pool;
 	set_flow_hash = pkt_dpdk->opt.set_flow_hash;
 	pktin_cfg = pktio_entry->s.config.pktin;
 	input = pktio_entry->s.handle;
@@ -900,6 +907,8 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 		prefetch_pkt(mbuf_table[1]);
 
 	for (i = 0; i < mbuf_num; i++) {
+		odp_packet_t pkt;
+
 		if (odp_likely((i + 2) < mbuf_num))
 			prefetch_pkt(mbuf_table[i + 2]);
 
@@ -913,7 +922,12 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 		data = rte_pktmbuf_mtod(mbuf, char *);
 		pkt_len = rte_pktmbuf_pkt_len(mbuf);
 		pkt_hdr = pkt_hdr_from_mbuf(mbuf);
+		pkt = packet_handle(pkt_hdr);
 		packet_init(pkt_hdr, pkt_len);
+
+		/* Init buffer segments. Currently, only single segment packets
+		 * are supported. */
+		pkt_hdr->seg_data = data;
 
 		if (layer) {
 			uint32_t supported_ptypes = pkt_dpdk->supported_ptypes;
@@ -927,18 +941,22 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 			}
 
 			if (pktio_cls_enabled(pktio_entry)) {
+				odp_pool_t new_pool;
+
 				if (_odp_cls_classify_packet(pktio_entry,
 							     (const uint8_t *)data,
-							     &pool, pkt_hdr)) {
+							     &new_pool, pkt_hdr)) {
+					rte_pktmbuf_free(mbuf);
+					continue;
+				}
+
+				if (odp_unlikely(_odp_pktio_packet_to_pool(
+					    &pkt, &pkt_hdr, new_pool))) {
 					rte_pktmbuf_free(mbuf);
 					continue;
 				}
 			}
 		}
-
-		/* Init buffer segments. Currently, only single segment packets
-		 * are supported. */
-		pkt_hdr->seg_data = data;
 
 		pkt_hdr->input = input;
 
@@ -947,7 +965,7 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 
 		packet_set_ts(pkt_hdr, ts);
 
-		pkt_table[nb_pkts++] = packet_handle(pkt_hdr);
+		pkt_table[nb_pkts++] = pkt;
 	}
 
 	return nb_pkts;

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -162,7 +162,6 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	int num_rx = 0;
 	int packets = 0, errors = 0;
 	uint32_t octets = 0;
-	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
 	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 
@@ -204,9 +203,8 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			}
 
 			packet_parse_reset(pkt_hdr, 1);
-			ret = _odp_packet_parse_common(pkt_hdr, pkt_addr,
-						       pkt_len, seg_len, layer,
-						       chksums, opt);
+			ret = _odp_packet_parse_common(pkt_hdr, pkt_addr, pkt_len,
+						       seg_len, layer, opt);
 			if (ret)
 				errors++;
 

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -191,7 +191,6 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			uint8_t buf[PARSE_BYTES];
 			int ret;
 			uint32_t seg_len = odp_packet_seg_len(pkt);
-			uint64_t l4_part_sum = 0;
 
 			/* Make sure there is enough data for the packet
 			 * parser in the case of a segmented packet. */
@@ -205,9 +204,9 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			}
 
 			packet_parse_reset(pkt_hdr, 1);
-			ret = _odp_packet_parse_common(&pkt_hdr->p, pkt_addr, pkt_len,
-						       seg_len, layer, chksums,
-						       &l4_part_sum, opt);
+			ret = _odp_packet_parse_common(pkt_hdr, pkt_addr,
+						       pkt_len, seg_len, layer,
+						       chksums, opt);
 			if (ret)
 				errors++;
 
@@ -242,9 +241,6 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 					pkt_hdr = packet_hdr(new_pkt);
 				}
 			}
-
-			if (layer >= ODP_PROTO_LAYER_L4)
-				_odp_packet_l4_chksum(pkt_hdr, chksums, l4_part_sum);
 		}
 
 		packet_set_ts(pkt_hdr, ts);

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -233,7 +233,8 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 					odp_packet_free(pkt);
 
 					if (new_pkt == ODP_PACKET_INVALID) {
-						pktio_entry->s.stats.in_discards++;
+						odp_atomic_inc_u64(&pktio_entry->s
+								   .stats_extra.in_discards);
 						continue;
 					}
 

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -842,7 +842,6 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 		netmap_slot_t slot;
 		uint16_t len;
 		const uint8_t *buf;
-		uint64_t l4_part_sum = 0;
 
 		slot = slot_tbl[i];
 		len = slot.len;
@@ -863,8 +862,8 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 		}
 
 		if (layer) {
-			if (_odp_packet_parse_common(&pkt_hdr->p, buf, len, len,
-						     layer, chksums, &l4_part_sum, opt) < 0) {
+			if (_odp_packet_parse_common(pkt_hdr, buf, len, len,
+						     layer, chksums, opt) < 0) {
 				odp_packet_free(pkt);
 				continue;
 			}
@@ -879,11 +878,8 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 		}
 
 		pkt_hdr->input = pktio_entry->s.handle;
-
-		if (layer >= ODP_PROTO_LAYER_L4)
-			_odp_packet_l4_chksum(pkt_hdr, chksums, l4_part_sum);
-
 		packet_set_ts(pkt_hdr, ts);
+
 		pkt_tbl[num_rx++] = pkt;
 	}
 

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -853,6 +853,15 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 		pkt = pkt_tbl[i];
 		pkt_hdr = packet_hdr(pkt);
 
+		pull_tail(pkt_hdr, max_len - len);
+		if (frame_offset)
+			pull_head(pkt_hdr, frame_offset);
+
+		if (odp_packet_copy_from_mem(pkt, 0, len, slot.buf) != 0) {
+			odp_packet_free(pkt);
+			continue;
+		}
+
 		if (layer) {
 			if (_odp_packet_parse_common(&pkt_hdr->p, buf, len, len,
 						     layer, chksums, &l4_part_sum, opt) < 0) {
@@ -868,13 +877,6 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 				}
 			}
 		}
-
-		pull_tail(pkt_hdr, max_len - len);
-		if (frame_offset)
-			pull_head(pkt_hdr, frame_offset);
-
-		if (odp_packet_copy_from_mem(pkt, 0, len, slot.buf) != 0)
-			break;
 
 		pkt_hdr->input = pktio_entry->s.handle;
 

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -828,7 +828,6 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 	uint32_t max_len;
 	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
 	int num_rx = 0;
-	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
 	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 
@@ -863,7 +862,7 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 
 		if (layer) {
 			if (_odp_packet_parse_common(pkt_hdr, buf, len, len,
-						     layer, chksums, opt) < 0) {
+						     layer, opt) < 0) {
 				odp_packet_free(pkt);
 				continue;
 			}

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -251,7 +251,6 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	int packets = 0, errors = 0;
 	uint32_t octets = 0;
 	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
-	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
 	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 
@@ -297,8 +296,7 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 		if (layer) {
 			ret = _odp_packet_parse_common(pkt_hdr, data, pkt_len,
-						       pkt_len, layer, chksums,
-						       opt);
+						       pkt_len, layer, opt);
 			if (ret)
 				errors++;
 

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -297,11 +297,9 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 		}
 
 		if (layer) {
-			uint64_t l4_part_sum = 0;
-
-			ret = _odp_packet_parse_common(&pkt_hdr->p, data, pkt_len,
+			ret = _odp_packet_parse_common(pkt_hdr, data, pkt_len,
 						       pkt_len, layer, chksums,
-						       &l4_part_sum, opt);
+						       opt);
 			if (ret)
 				errors++;
 
@@ -334,9 +332,6 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 					pkt_hdr = packet_hdr(new_pkt);
 				}
 			}
-
-			if (layer >= ODP_PROTO_LAYER_L4)
-				_odp_packet_l4_chksum(pkt_hdr, chksums, l4_part_sum);
 		}
 
 		packet_set_ts(pkt_hdr, ts);

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -325,7 +325,8 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 					odp_packet_free(pkt);
 
 					if (odp_unlikely(new_pkt == ODP_PACKET_INVALID)) {
-						pktio_entry->s.stats.in_discards++;
+						odp_atomic_inc_u64(&pktio_entry->s
+								   .stats_extra.in_discards);
 						continue;
 					}
 

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -266,7 +266,6 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 		odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 		uint16_t pkt_len = msgvec[i].msg_len;
 		int ret;
-		uint64_t l4_part_sum = 0;
 
 		if (odp_unlikely(msgvec[i].msg_hdr.msg_flags & MSG_TRUNC)) {
 			odp_packet_free(pkt);
@@ -294,9 +293,9 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 				base = buf;
 			}
 
-			if (_odp_packet_parse_common(&pkt_hdr->p, base, pkt_len,
+			if (_odp_packet_parse_common(pkt_hdr, base, pkt_len,
 						     seg_len, layer, chksums,
-						     &l4_part_sum, opt) < 0) {
+						     opt) < 0) {
 				odp_packet_free(pkt);
 				continue;
 			}
@@ -318,10 +317,6 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 		}
 
 		pkt_hdr->input = pktio_entry->s.handle;
-
-		if (layer >= ODP_PROTO_LAYER_L4)
-			_odp_packet_l4_chksum(pkt_hdr, chksums, l4_part_sum);
-
 		packet_set_ts(pkt_hdr, ts);
 
 		pkt_table[nb_rx++] = pkt;

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -301,9 +301,20 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			}
 
 			if (pktio_cls_enabled(pktio_entry)) {
-				if (_odp_cls_classify_packet(pktio_entry, base, &pool,
+				odp_pool_t new_pool;
+
+				if (_odp_cls_classify_packet(pktio_entry, base, &new_pool,
 							     pkt_hdr)) {
 					odp_packet_free(pkt);
+					continue;
+				}
+
+				if (odp_unlikely(_odp_pktio_packet_to_pool(
+					    &pkt, &pkt_hdr, new_pool))) {
+					odp_packet_free(pkt);
+					odp_atomic_inc_u64(
+						&pktio_entry->s.stats_extra
+							 .in_discards);
 					continue;
 				}
 			}

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -235,7 +235,6 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	int i;
 	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
 	uint32_t alloc_len = pkt_sock->mtu + frame_offset;
-	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
 	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 
@@ -294,8 +293,7 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			}
 
 			if (_odp_packet_parse_common(pkt_hdr, base, pkt_len,
-						     seg_len, layer, chksums,
-						     opt) < 0) {
+						     seg_len, layer, opt) < 0) {
 				odp_packet_free(pkt);
 				continue;
 			}

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -218,27 +218,6 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 
 		hdr = packet_hdr(pkt);
 
-		if (layer) {
-			if (_odp_packet_parse_common(&hdr->p, pkt_buf, pkt_len,
-						     pkt_len, layer, chksums,
-						     &l4_part_sum, opt) < 0) {
-				odp_packet_free(pkt);
-				tp_hdr->tp_status = TP_STATUS_KERNEL;
-				frame_num = next_frame_num;
-				continue;
-			}
-
-			if (pktio_cls_enabled(pktio_entry)) {
-				if (_odp_cls_classify_packet(pktio_entry, pkt_buf,
-							     &pool, hdr)) {
-					odp_packet_free(pkt);
-					tp_hdr->tp_status = TP_STATUS_KERNEL;
-					frame_num = next_frame_num;
-					continue;
-				}
-			}
-		}
-
 		if (frame_offset)
 			pull_head(hdr, frame_offset);
 
@@ -287,6 +266,27 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 
 			tci   = type + 1;
 			*tci  = odp_cpu_to_be_16(tp_hdr->tp_vlan_tci);
+		}
+
+		if (layer) {
+			if (_odp_packet_parse_common(&hdr->p, pkt_buf, pkt_len,
+						     pkt_len, layer, chksums,
+						     &l4_part_sum, opt) < 0) {
+				odp_packet_free(pkt);
+				tp_hdr->tp_status = TP_STATUS_KERNEL;
+				frame_num = next_frame_num;
+				continue;
+			}
+
+			if (pktio_cls_enabled(pktio_entry)) {
+				if (_odp_cls_classify_packet(pktio_entry, pkt_buf,
+							     &pool, hdr)) {
+					odp_packet_free(pkt);
+					tp_hdr->tp_status = TP_STATUS_KERNEL;
+					frame_num = next_frame_num;
+					continue;
+				}
+			}
 		}
 
 		hdr->input = pktio_entry->s.handle;

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -168,7 +168,6 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 		odp_packet_t pkt;
 		odp_packet_hdr_t *hdr;
 		int ret;
-		uint64_t l4_part_sum = 0;
 
 		tp_hdr = (void *)next_ptr;
 
@@ -269,9 +268,9 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 		}
 
 		if (layer) {
-			if (_odp_packet_parse_common(&hdr->p, pkt_buf, pkt_len,
+			if (_odp_packet_parse_common(hdr, pkt_buf, pkt_len,
 						     pkt_len, layer, chksums,
-						     &l4_part_sum, opt) < 0) {
+						     opt) < 0) {
 				odp_packet_free(pkt);
 				tp_hdr->tp_status = TP_STATUS_KERNEL;
 				frame_num = next_frame_num;
@@ -290,10 +289,6 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 		}
 
 		hdr->input = pktio_entry->s.handle;
-
-		if (layer >= ODP_PROTO_LAYER_L4)
-			_odp_packet_l4_chksum(hdr, chksums, l4_part_sum);
-
 		packet_set_ts(hdr, ts);
 
 		tp_hdr->tp_status = TP_STATUS_KERNEL;

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -152,7 +152,6 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 	odp_pool_t pool = pkt_sock->pool;
 	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
 	uint16_t vlan_len = 0;
-	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
 	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 
@@ -269,8 +268,7 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 
 		if (layer) {
 			if (_odp_packet_parse_common(hdr, pkt_buf, pkt_len,
-						     pkt_len, layer, chksums,
-						     opt) < 0) {
+						     pkt_len, layer, opt) < 0) {
 				odp_packet_free(pkt);
 				tp_hdr->tp_status = TP_STATUS_KERNEL;
 				frame_num = next_frame_num;

--- a/platform/linux-generic/pktio/socket_xdp.c
+++ b/platform/linux-generic/pktio/socket_xdp.c
@@ -332,7 +332,6 @@ static uint32_t process_received(pktio_entry_t *pktio_entry, xdp_sock_t *sock, p
 	pkt_data_t pkt_data;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
 	int ret;
-	const odp_proto_chksums_t in_chksums = pktio_entry->s.in_chksums;
 	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 	uint64_t errors = 0U, octets = 0U;
 	odp_pktio_t pktio_hdl = pktio_entry->s.handle;
@@ -348,7 +347,7 @@ static uint32_t process_received(pktio_entry_t *pktio_entry, xdp_sock_t *sock, p
 		if (layer) {
 			ret = _odp_packet_parse_common(pkt_data.pkt_hdr, pkt_data.data,
 						       pkt_data.len, pkt_data.len,
-						       layer, in_chksums, opt);
+						       layer, opt);
 
 			if (ret)
 				++errors;

--- a/platform/linux-generic/pktio/socket_xdp.c
+++ b/platform/linux-generic/pktio/socket_xdp.c
@@ -334,7 +334,6 @@ static uint32_t process_received(pktio_entry_t *pktio_entry, xdp_sock_t *sock, p
 	int ret;
 	const odp_proto_chksums_t in_chksums = pktio_entry->s.in_chksums;
 	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
-	uint64_t l4_part_sum = 0U;
 	odp_pool_t *pool_hdl = &pool->pool_hdl;
 	uint64_t errors = 0U, octets = 0U;
 	odp_pktio_t pktio_hdl = pktio_entry->s.handle;
@@ -346,9 +345,9 @@ static uint32_t process_received(pktio_entry_t *pktio_entry, xdp_sock_t *sock, p
 		packet_init(pkt_data.pkt_hdr, pkt_data.len);
 
 		if (layer) {
-			ret = _odp_packet_parse_common(&pkt_data.pkt_hdr->p, pkt_data.data,
+			ret = _odp_packet_parse_common(pkt_data.pkt_hdr, pkt_data.data,
 						       pkt_data.len, pkt_data.len,
-						       layer, in_chksums, &l4_part_sum, opt);
+						       layer, in_chksums, opt);
 
 			if (ret)
 				++errors;

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -285,30 +285,12 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 {
 	odp_packet_t pkt;
 	odp_packet_hdr_t *pkt_hdr;
-	odp_packet_hdr_t parsed_hdr;
 	int num;
 	uint64_t l4_part_sum = 0;
 	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
 	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
 	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
-
-	if (layer) {
-		packet_parse_reset(&parsed_hdr, 1);
-		packet_set_len(&parsed_hdr, len);
-		if (_odp_packet_parse_common(&parsed_hdr.p, data, len, len, layer,
-					     chksums, &l4_part_sum, opt) < 0) {
-			return ODP_PACKET_INVALID;
-		}
-
-		if (pktio_cls_enabled(pktio_entry)) {
-			if (_odp_cls_classify_packet(pktio_entry, data,
-						     &pkt_priv(pktio_entry)->pool,
-						     &parsed_hdr)) {
-				return ODP_PACKET_INVALID;
-			}
-		}
-	}
 
 	num = _odp_packet_alloc_multi(pkt_priv(pktio_entry)->pool,
 				      len + frame_offset, &pkt, 1);
@@ -327,7 +309,20 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 	}
 
 	if (layer) {
-		_odp_packet_copy_cls_md(pkt_hdr, &parsed_hdr);
+		if (_odp_packet_parse_common(&pkt_hdr->p, data, len, len, layer,
+					     chksums, &l4_part_sum, opt) < 0) {
+			odp_packet_free(pkt);
+			return ODP_PACKET_INVALID;
+		}
+
+		if (pktio_cls_enabled(pktio_entry)) {
+			if (_odp_cls_classify_packet(pktio_entry, data,
+						     &pkt_priv(pktio_entry)->pool,
+						     pkt_hdr)) {
+				odp_packet_free(pkt);
+				return ODP_PACKET_INVALID;
+			}
+		}
 
 		if (layer >= ODP_PROTO_LAYER_L4)
 			_odp_packet_l4_chksum(pkt_hdr, chksums, l4_part_sum);

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -287,7 +287,6 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 	odp_packet_hdr_t *pkt_hdr;
 	int num;
 	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
-	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
 	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
 
@@ -309,7 +308,7 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 
 	if (layer) {
 		if (_odp_packet_parse_common(pkt_hdr, data, len, len, layer,
-					     chksums, opt) < 0) {
+					     opt) < 0) {
 			odp_packet_free(pkt);
 			return ODP_PACKET_INVALID;
 		}

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -286,7 +286,6 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 	odp_packet_t pkt;
 	odp_packet_hdr_t *pkt_hdr;
 	int num;
-	uint64_t l4_part_sum = 0;
 	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
 	const odp_proto_chksums_t chksums = pktio_entry->s.in_chksums;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
@@ -309,8 +308,8 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 	}
 
 	if (layer) {
-		if (_odp_packet_parse_common(&pkt_hdr->p, data, len, len, layer,
-					     chksums, &l4_part_sum, opt) < 0) {
+		if (_odp_packet_parse_common(pkt_hdr, data, len, len, layer,
+					     chksums, opt) < 0) {
 			odp_packet_free(pkt);
 			return ODP_PACKET_INVALID;
 		}
@@ -323,9 +322,6 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 				return ODP_PACKET_INVALID;
 			}
 		}
-
-		if (layer >= ODP_PROTO_LAYER_L4)
-			_odp_packet_l4_chksum(pkt_hdr, chksums, l4_part_sum);
 	}
 
 	packet_set_ts(pkt_hdr, ts);


### PR DESCRIPTION
v2:
- Add commit `linux-gen: pktio: remove struct pktio_entry::in_chksums`

v3:
- Rebase.
- stats_extra comment.

v4 - v6:
- Matias' comments.
- packet_to_pool() call added also to xdp.

v7:
- packet_to_pool() call added also to dpdk zero copy.

v8:
- Rebase.
- Add commit `linux-gen: pktio: dpdk: move reading pkt_dpdk_t::supported_ptypes`
- Set data pointers in pkt_hdr before packet_to_pool() in xdp.
- Add review tags. (Matias)

v9:
- Add review tags. (Tuomas)
