### PR TITLE
[PATCH v3] validation: pool: allow zero max user area size for external pools

### DIFF
--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -1291,7 +1291,6 @@ static void test_packet_pool_ext_capa(void)
 	CU_ASSERT(capa.pkt.max_headroom_size > 0);
 	CU_ASSERT(capa.pkt.max_headroom_size >= capa.pkt.max_headroom);
 	CU_ASSERT(capa.pkt.max_segs_per_pkt > 0);
-	CU_ASSERT(capa.pkt.max_uarea_size > 0);
 }
 
 static void test_packet_pool_ext_param_init(void)


### PR DESCRIPTION
External pool spec does not limit the max user area size to be non-zero.
So remove the check for non-zero max user area size for external pools
in pool_main test case.

Signed-off-by: Ashwin Sekhar T K <asekhar@marvell.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>