### PR TITLE
[PATCH v2] linux-gen: packet: remove unused defines

### DIFF
--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -46,12 +46,6 @@ ODP_STATIC_ASSERT(sizeof(_odp_packet_input_flags_t) == sizeof(uint64_t),
 ODP_STATIC_ASSERT(sizeof(_odp_packet_flags_t) == sizeof(uint32_t),
 		  "PACKET_FLAGS_SIZE_ERROR");
 
-/* Packet extra data length */
-#define PKT_EXTRA_LEN 128
-
-/* Packet extra data types */
-#define PKT_EXTRA_TYPE_DPDK 1
-
 /* Maximum number of segments per packet */
 #define PKT_MAX_SEGS 255
 


### PR DESCRIPTION
`PKT_EXTRA_LEN` and `PKT_EXTRA_TYPE_DPDK` seems to have become unused
when DPDK zero copy implementation was improved a while ago. Remove
them.

v2:
- Rebase
- Add reviewed-by tag