### PR TITLE
[PATCH v3] linux-gen: disable TM and most of openssl crypto in process mode

### DIFF
--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2603,6 +2603,9 @@ static int tm_capabilities(odp_tm_capabilities_t capabilities[],
 	cap_ptr = &capabilities[0];
 	memset(cap_ptr, 0, sizeof(odp_tm_capabilities_t));
 
+	if (odp_global_ro.init_param.mem_model == ODP_MEM_MODEL_PROCESS)
+		return 1;
+
 	cap_ptr->max_tm_queues                 = ODP_TM_MAX_TM_QUEUES;
 	cap_ptr->max_levels                    = ODP_TM_MAX_LEVELS;
 	cap_ptr->tm_queue_shaper_supported     = true;
@@ -3057,6 +3060,11 @@ odp_tm_t odp_tm_create(const char            *name,
 
 	if (odp_global_ro.disable.traffic_mngr) {
 		ODP_ERR("TM has been disabled\n");
+		return ODP_TM_INVALID;
+	}
+
+	if (odp_global_ro.init_param.mem_model == ODP_MEM_MODEL_PROCESS) {
+		ODP_ERR("TM is not supported in process mode\n");
 		return ODP_TM_INVALID;
 	}
 

--- a/platform/linux-generic/test/example/ipsec_api/pktio_env
+++ b/platform/linux-generic/test/example/ipsec_api/pktio_env
@@ -35,6 +35,11 @@ if [ -n "$WITH_OPENSSL_CRYPTO" ] && [ ${WITH_OPENSSL_CRYPTO} -eq 0 ]; then
 	exit 77
 fi
 
+if [ ${ODPH_PROC_MODE} -eq 1 ]; then
+	echo "Process mode not supported. Skipping."
+	exit 77
+fi
+
 # Skip live and router mode tests.
 if [ ${IPSEC_APP_MODE} -eq 1 ] || [ ${IPSEC_APP_MODE} -eq 2 ]; then
 	echo "IPsec Live / Router mode test. Skipping."

--- a/platform/linux-generic/test/example/ipsec_crypto/pktio_env
+++ b/platform/linux-generic/test/example/ipsec_crypto/pktio_env
@@ -35,6 +35,11 @@ if [ -n "$WITH_OPENSSL_CRYPTO" ] && [ ${WITH_OPENSSL_CRYPTO} -eq 0 ]; then
 	exit 77
 fi
 
+if [ ${ODPH_PROC_MODE} -eq 1 ]; then
+	echo "Process mode not supported. Skipping."
+	exit 77
+fi
+
 # Skip live and router mode tests.
 if [ ${IPSEC_APP_MODE} -eq 1 ] || [ ${IPSEC_APP_MODE} -eq 2 ]; then
 	echo "Live / Router mode test. Skipping."


### PR DESCRIPTION
TM and openssl crypto are not compatible with process mode, so disable TM and libssl based crypto algorithms in process mode.