### PR TITLE
[PATCH v3] validation: test default value setting by init functions better

### DIFF
--- a/test/validation/api/classification/odp_classification_basic.c
+++ b/test/validation/api/classification/odp_classification_basic.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:	BSD-3-Clause
@@ -10,21 +11,27 @@
 
 #define PMR_SET_NUM	5
 
-static void classification_test_default_values(void)
+static void test_defaults(uint8_t fill)
 {
 	odp_cls_cos_param_t cos_param;
 	odp_pmr_param_t pmr_param;
 
-	memset(&cos_param, 0x55, sizeof(cos_param));
+	memset(&cos_param, fill, sizeof(cos_param));
 	odp_cls_cos_param_init(&cos_param);
 	CU_ASSERT_EQUAL(cos_param.num_queue, 1);
 	CU_ASSERT_EQUAL(cos_param.red.enable, false);
 	CU_ASSERT_EQUAL(cos_param.bp.enable, false);
 	CU_ASSERT_EQUAL(cos_param.vector.enable, false);
 
-	memset(&pmr_param, 0x55, sizeof(pmr_param));
+	memset(&pmr_param, fill, sizeof(pmr_param));
 	odp_cls_pmr_param_init(&pmr_param);
 	CU_ASSERT_EQUAL(pmr_param.range_term, false);
+}
+
+static void classification_test_default_values(void)
+{
+	test_defaults(0);
+	test_defaults(0xff);
 }
 
 static void classification_test_create_cos(void)

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -28,11 +28,11 @@ struct suite_context_s {
 
 static struct suite_context_s suite_context;
 
-static void test_default_values(void)
+static void test_defaults(uint8_t fill)
 {
 	odp_crypto_session_param_t param;
 
-	memset(&param, 0x55, sizeof(param));
+	memset(&param, fill, sizeof(param));
 	odp_crypto_session_param_init(&param);
 
 	CU_ASSERT_EQUAL(param.op, ODP_CRYPTO_OP_ENCODE);
@@ -53,6 +53,12 @@ static void test_default_values(void)
 	CU_ASSERT_EQUAL(param.auth_iv.data, NULL);
 	CU_ASSERT_EQUAL(param.auth_iv.length, 0);
 #endif
+}
+
+static void test_default_values(void)
+{
+	test_defaults(0);
+	test_defaults(0xff);
 }
 
 static int packet_cmp_mem_bits(odp_packet_t pkt, uint32_t offset,
@@ -1182,7 +1188,7 @@ static int create_hash_test_reference(odp_auth_alg_t auth,
 				      const odp_crypto_auth_capability_t *capa,
 				      crypto_test_reference_t *ref,
 				      uint32_t digest_offset,
-				      uint8_t digest_fill_byte)
+				      uint8_t digest_fill)
 {
 	odp_crypto_session_t session;
 	int rc;
@@ -1210,7 +1216,7 @@ static int create_hash_test_reference(odp_auth_alg_t auth,
 	fill_with_pattern(ref->auth_iv, ref->auth_iv_length);
 	fill_with_pattern(ref->plaintext, auth_bytes);
 
-	memset(ref->plaintext + digest_offset, digest_fill_byte, ref->digest_length);
+	memset(ref->plaintext + digest_offset, digest_fill, ref->digest_length);
 
 	pkt = odp_packet_alloc(suite_context.pool, auth_bytes + ref->digest_length);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);

--- a/test/validation/api/dma/dma.c
+++ b/test/validation/api/dma/dma.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, Nokia
+/* Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -199,31 +199,41 @@ static void test_dma_capability(void)
 	}
 }
 
-static void test_dma_param(void)
+static void test_dma_param(uint8_t fill)
 {
 	odp_dma_param_t dma_param;
 	odp_dma_transfer_param_t trs_param;
 	odp_dma_compl_param_t compl_param;
 	odp_dma_pool_param_t dma_pool_param;
 
+	memset(&dma_param, fill, sizeof(dma_param));
 	odp_dma_param_init(&dma_param);
 	CU_ASSERT(dma_param.direction == ODP_DMA_MAIN_TO_MAIN);
 	CU_ASSERT(dma_param.type == ODP_DMA_TYPE_COPY);
 	CU_ASSERT(dma_param.mt_mode == ODP_DMA_MT_SAFE);
 	CU_ASSERT(dma_param.order == ODP_DMA_ORDER_NONE);
 
+	memset(&trs_param, fill, sizeof(trs_param));
 	odp_dma_transfer_param_init(&trs_param);
 	CU_ASSERT(trs_param.src_format == ODP_DMA_FORMAT_ADDR);
 	CU_ASSERT(trs_param.dst_format == ODP_DMA_FORMAT_ADDR);
 	CU_ASSERT(trs_param.num_src == 1);
 	CU_ASSERT(trs_param.num_dst == 1);
 
+	memset(&compl_param, fill, sizeof(compl_param));
 	odp_dma_compl_param_init(&compl_param);
 	CU_ASSERT(compl_param.user_ptr == NULL);
 
+	memset(&dma_pool_param, fill, sizeof(dma_pool_param));
 	odp_dma_pool_param_init(&dma_pool_param);
 	CU_ASSERT(dma_pool_param.cache_size <= global.dma_capa.pool.max_cache_size);
 	CU_ASSERT(dma_pool_param.cache_size >= global.dma_capa.pool.min_cache_size);
+}
+
+static void test_dma_param_init(void)
+{
+	test_dma_param(0);
+	test_dma_param(0xff);
 }
 
 static void test_dma_debug(void)
@@ -1139,7 +1149,7 @@ static void test_dma_multi_pkt_to_pkt_event(void)
 
 odp_testinfo_t dma_suite[] = {
 	ODP_TEST_INFO(test_dma_capability),
-	ODP_TEST_INFO_CONDITIONAL(test_dma_param, check_sync),
+	ODP_TEST_INFO_CONDITIONAL(test_dma_param_init, check_sync),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_debug, check_sync),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_compl_pool, check_event),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_addr_to_addr_sync, check_sync),

--- a/test/validation/api/init/init_main.c
+++ b/test/validation/api/init/init_main.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2019-2021, Nokia
+ * Copyright (c) 2019-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -46,6 +46,22 @@ static int my_log_thread_func(odp_log_level_t level, const char *fmt, ...)
 	my_log_thread_func_count++;
 
 	return 0;
+}
+
+static void test_param_init(uint8_t fill)
+{
+	odp_init_t param;
+
+	memset(&param, fill, sizeof(param));
+	odp_init_param_init(&param);
+	CU_ASSERT(param.mem_model == ODP_MEM_MODEL_THREAD);
+	CU_ASSERT(param.shm.max_memory == 0);
+}
+
+static void init_test_param_init(void)
+{
+	test_param_init(0);
+	test_param_init(0xff);
 }
 
 static void init_test_defaults(void)
@@ -226,6 +242,7 @@ static void init_test_feature_disabled(void)
 }
 
 odp_testinfo_t testinfo[] = {
+	ODP_TEST_INFO(init_test_param_init),
 	ODP_TEST_INFO(init_test_defaults),
 	ODP_TEST_INFO(init_test_abort),
 	ODP_TEST_INFO(init_test_log),

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 2017-2018, Linaro Limited
  * Copyright (c) 2020, Marvell
- * Copyright (c) 2020-2021, Nokia
+ * Copyright (c) 2020-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -1598,14 +1598,12 @@ static void ipsec_test_capability(void)
 	CU_ASSERT(odp_ipsec_capability(&capa) == 0);
 }
 
-static void ipsec_test_default_values(void)
+static void test_defaults(uint8_t fill)
 {
 	odp_ipsec_config_t config;
 	odp_ipsec_sa_param_t sa_param;
 
-	memset(&config, 0x55, sizeof(config));
-	memset(&sa_param, 0x55, sizeof(sa_param));
-
+	memset(&config, fill, sizeof(config));
 	odp_ipsec_config_init(&config);
 	CU_ASSERT(config.inbound.lookup.min_spi == 0);
 	CU_ASSERT(config.inbound.lookup.max_spi == UINT32_MAX);
@@ -1623,6 +1621,7 @@ static void ipsec_test_default_values(void)
 	CU_ASSERT(!config.stats_en);
 	CU_ASSERT(!config.vector.enable);
 
+	memset(&sa_param, fill, sizeof(sa_param));
 	odp_ipsec_sa_param_init(&sa_param);
 	CU_ASSERT(sa_param.proto == ODP_IPSEC_ESP);
 	CU_ASSERT(sa_param.crypto.cipher_alg == ODP_CIPHER_ALG_NULL);
@@ -1652,6 +1651,12 @@ static void ipsec_test_default_values(void)
 	CU_ASSERT(sa_param.outbound.tunnel.ipv6.dscp == 0);
 	CU_ASSERT(sa_param.outbound.tunnel.ipv6.hlimit == 255);
 	CU_ASSERT(sa_param.outbound.frag_mode == ODP_IPSEC_FRAG_DISABLED);
+}
+
+static void ipsec_test_default_values(void)
+{
+	test_defaults(0);
+	test_defaults(0xff);
 }
 
 static void test_ipsec_stats(void)

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1578,19 +1578,19 @@ static void pktio_test_mac(void)
 	CU_ASSERT(0 == ret);
 }
 
-static void pktio_test_default_values(void)
+static void test_defaults(uint8_t fill)
 {
 	odp_pktio_param_t pktio_p;
 	odp_pktin_queue_param_t qp_in;
 	odp_pktout_queue_param_t qp_out;
 	odp_pktio_config_t pktio_conf;
 
-	memset(&pktio_p, 0x55, sizeof(pktio_p));
+	memset(&pktio_p, fill, sizeof(pktio_p));
 	odp_pktio_param_init(&pktio_p);
 	CU_ASSERT_EQUAL(pktio_p.in_mode, ODP_PKTIN_MODE_DIRECT);
 	CU_ASSERT_EQUAL(pktio_p.out_mode, ODP_PKTOUT_MODE_DIRECT);
 
-	memset(&qp_in, 0x55, sizeof(qp_in));
+	memset(&qp_in, fill, sizeof(qp_in));
 	odp_pktin_queue_param_init(&qp_in);
 	CU_ASSERT_EQUAL(qp_in.op_mode, ODP_PKTIO_OP_MT);
 	CU_ASSERT_EQUAL(qp_in.classifier_enable, 0);
@@ -1609,13 +1609,13 @@ static void pktio_test_default_values(void)
 	CU_ASSERT_EQUAL(qp_in.queue_param_ovr, NULL);
 	CU_ASSERT_EQUAL(qp_in.vector.enable, false);
 
-	memset(&qp_out, 0x55, sizeof(qp_out));
+	memset(&qp_out, fill, sizeof(qp_out));
 	odp_pktout_queue_param_init(&qp_out);
 	CU_ASSERT_EQUAL(qp_out.op_mode, ODP_PKTIO_OP_MT);
 	CU_ASSERT_EQUAL(qp_out.num_queues, 1);
 	CU_ASSERT_EQUAL(qp_out.queue_size[0], 0);
 
-	memset(&pktio_conf, 0x55, sizeof(pktio_conf));
+	memset(&pktio_conf, fill, sizeof(pktio_conf));
 	odp_pktio_config_init(&pktio_conf);
 	CU_ASSERT_EQUAL(pktio_conf.pktin.all_bits, 0);
 	CU_ASSERT_EQUAL(pktio_conf.pktout.all_bits, 0);
@@ -1628,6 +1628,12 @@ static void pktio_test_default_values(void)
 	CU_ASSERT_EQUAL(pktio_conf.reassembly.en_ipv6, false);
 	CU_ASSERT_EQUAL(pktio_conf.reassembly.max_wait_time, 0);
 	CU_ASSERT_EQUAL(pktio_conf.reassembly.max_num_frags, 2);
+}
+
+static void pktio_test_default_values(void)
+{
+	test_defaults(0);
+	test_defaults(0xff);
 }
 
 static void pktio_test_open(void)

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -42,10 +42,11 @@ static odp_pool_capability_t global_pool_capa;
 static odp_pool_param_t default_pool_param;
 static odp_pool_ext_capability_t global_pool_ext_capa;
 
-static void pool_test_param_init(void)
+static void test_param_init(uint8_t fill)
 {
 	odp_pool_param_t param;
 
+	memset(&param, fill, sizeof(param));
 	odp_pool_param_init(&param);
 
 	CU_ASSERT(param.buf.cache_size >= global_pool_capa.buf.min_cache_size &&
@@ -61,6 +62,12 @@ static void pool_test_param_init(void)
 
 	CU_ASSERT(param.vector.cache_size >= global_pool_capa.vector.min_cache_size &&
 		  param.vector.cache_size <= global_pool_capa.vector.max_cache_size);
+}
+
+static void pool_test_param_init(void)
+{
+	test_param_init(0);
+	test_param_init(0xff);
 }
 
 static void pool_create_destroy(odp_pool_param_t *param)
@@ -1293,10 +1300,11 @@ static void test_packet_pool_ext_capa(void)
 	CU_ASSERT(capa.pkt.max_segs_per_pkt > 0);
 }
 
-static void test_packet_pool_ext_param_init(void)
+static void test_ext_param_init(uint8_t fill)
 {
 	odp_pool_ext_param_t param;
 
+	memset(&param, fill, sizeof(param));
 	odp_pool_ext_param_init(ODP_POOL_PACKET, &param);
 
 	CU_ASSERT(param.type == ODP_POOL_PACKET);
@@ -1305,6 +1313,12 @@ static void test_packet_pool_ext_param_init(void)
 	CU_ASSERT(param.stats.all == 0);
 	CU_ASSERT(param.pkt.app_header_size == 0);
 	CU_ASSERT(param.pkt.uarea_size == 0);
+}
+
+static void test_packet_pool_ext_param_init(void)
+{
+	test_ext_param_init(0);
+	test_ext_param_init(0xff);
 }
 
 static void test_packet_pool_ext_create(void)

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
+ * Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -132,6 +132,32 @@ static void queue_test_capa(void)
 	CU_ASSERT(capa.max_queues >= capa.plain.max_num);
 	CU_ASSERT(capa.max_queues >= capa.plain.lockfree.max_num);
 	CU_ASSERT(capa.max_queues >= capa.plain.waitfree.max_num);
+}
+
+static void test_defaults(uint8_t fill)
+{
+	odp_queue_param_t param;
+
+	memset(&param, fill, sizeof(param));
+	odp_queue_param_init(&param);
+	CU_ASSERT(param.type == ODP_QUEUE_TYPE_PLAIN);
+	CU_ASSERT(param.enq_mode == ODP_QUEUE_OP_MT);
+	CU_ASSERT(param.deq_mode == ODP_QUEUE_OP_MT);
+	CU_ASSERT(param.sched.prio == odp_schedule_default_prio());
+	CU_ASSERT(param.sched.sync == ODP_SCHED_SYNC_PARALLEL);
+	CU_ASSERT(param.sched.group == ODP_SCHED_GROUP_ALL);
+	CU_ASSERT(param.sched.lock_count == 0);
+	CU_ASSERT(param.order == ODP_QUEUE_ORDER_KEEP);
+	CU_ASSERT(param.nonblocking == ODP_BLOCKING);
+	CU_ASSERT(param.context == NULL);
+	CU_ASSERT(param.context_len == 0);
+	CU_ASSERT(param.size == 0);
+}
+
+static void queue_test_param_init(void)
+{
+	test_defaults(0);
+	test_defaults(0xff);
 }
 
 static void queue_test_max_plain(void)
@@ -607,20 +633,7 @@ static void queue_test_param(void)
 	odp_queue_param_t qparams;
 	odp_buffer_t enbuf;
 
-	/* Defaults */
 	odp_queue_param_init(&qparams);
-	CU_ASSERT(qparams.type == ODP_QUEUE_TYPE_PLAIN);
-	CU_ASSERT(qparams.enq_mode == ODP_QUEUE_OP_MT);
-	CU_ASSERT(qparams.deq_mode == ODP_QUEUE_OP_MT);
-	CU_ASSERT(qparams.sched.prio == odp_schedule_default_prio());
-	CU_ASSERT(qparams.sched.sync == ODP_SCHED_SYNC_PARALLEL);
-	CU_ASSERT(qparams.sched.group == ODP_SCHED_GROUP_ALL);
-	CU_ASSERT(qparams.sched.lock_count == 0);
-	CU_ASSERT(qparams.order == ODP_QUEUE_ORDER_KEEP);
-	CU_ASSERT(qparams.nonblocking == ODP_BLOCKING);
-	CU_ASSERT(qparams.context == NULL);
-	CU_ASSERT(qparams.context_len == 0);
-	CU_ASSERT(qparams.size == 0);
 
 	/* Schedule type queue */
 	qparams.type       = ODP_QUEUE_TYPE_SCHED;
@@ -985,6 +998,7 @@ static void queue_test_mt_plain_nonblock_lf(void)
 
 odp_testinfo_t queue_suite[] = {
 	ODP_TEST_INFO(queue_test_capa),
+	ODP_TEST_INFO(queue_test_param_init),
 	ODP_TEST_INFO(queue_test_mode),
 	ODP_TEST_INFO(queue_test_max_plain),
 	ODP_TEST_INFO(queue_test_burst),

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -145,10 +145,11 @@ static void release_context(odp_schedule_sync_t sync)
 		odp_schedule_release_ordered();
 }
 
-static void scheduler_test_init(void)
+static void test_init(uint8_t fill)
 {
 	odp_schedule_config_t default_config;
 
+	memset(&default_config, fill, sizeof(default_config));
 	odp_schedule_config_init(&default_config);
 
 	CU_ASSERT(default_config.max_flow_id == 0);
@@ -156,6 +157,12 @@ static void scheduler_test_init(void)
 	CU_ASSERT(default_config.sched_group.all);
 	CU_ASSERT(default_config.sched_group.control);
 	CU_ASSERT(default_config.sched_group.worker);
+}
+
+static void scheduler_test_init(void)
+{
+	test_init(0);
+	test_init(0xff);
 }
 
 static void scheduler_test_capa(void)

--- a/test/validation/api/stash/stash.c
+++ b/test/validation/api/stash/stash.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Nokia
+/* Copyright (c) 2020-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -129,16 +129,22 @@ static void stash_capability(void)
 	}
 }
 
-static void stash_param_defaults(void)
+static void param_defaults(uint8_t fill)
 {
 	odp_stash_param_t param;
 
-	memset(&param, 0xff, sizeof(odp_stash_param_t));
+	memset(&param, fill, sizeof(param));
 	odp_stash_param_init(&param);
 	CU_ASSERT(param.type == ODP_STASH_TYPE_DEFAULT);
 	CU_ASSERT(param.put_mode == ODP_STASH_OP_MT);
 	CU_ASSERT(param.get_mode == ODP_STASH_OP_MT);
 	CU_ASSERT(param.cache_size == 0);
+}
+
+static void stash_param_defaults(void)
+{
+	param_defaults(0);
+	param_defaults(0xff);
 }
 
 static void stash_create_u64(void)

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -331,11 +331,11 @@ static void timer_test_capa(void)
 	}
 }
 
-static void timer_test_param_init(void)
+static void test_param_init(uint8_t fill)
 {
 	odp_timer_pool_param_t tp_param;
 
-	memset(&tp_param, 0x55, sizeof(odp_timer_pool_param_t));
+	memset(&tp_param, fill, sizeof(tp_param));
 
 	odp_timer_pool_param_init(&tp_param);
 	CU_ASSERT(tp_param.res_ns == 0);
@@ -348,6 +348,12 @@ static void timer_test_param_init(void)
 	CU_ASSERT(tp_param.periodic.base_freq_hz.integer == 0);
 	CU_ASSERT(tp_param.periodic.base_freq_hz.numer == 0);
 	CU_ASSERT(tp_param.periodic.base_freq_hz.denom == 0);
+}
+
+static void timer_test_param_init(void)
+{
+	test_param_init(0);
+	test_param_init(0xff);
 }
 
 static void timer_test_timeout_pool_alloc(void)

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -4451,7 +4451,7 @@ static void test_packet_aging(uint64_t tmo_ns, uint32_t pkt_len, odp_bool_t is_d
 	CU_ASSERT(odp_tm_is_idle(odp_tm_systems[0]));
 }
 
-static void traffic_mngr_test_default_values(void)
+static void test_defaults(uint8_t fill)
 {
 	odp_tm_requirements_t req;
 	odp_tm_shaper_params_t shaper;
@@ -4462,7 +4462,7 @@ static void traffic_mngr_test_default_values(void)
 	odp_tm_queue_params_t queue;
 	int n;
 
-	memset(&req, 0xff, sizeof(req));
+	memset(&req, fill, sizeof(req));
 	odp_tm_requirements_init(&req);
 	CU_ASSERT_EQUAL(req.num_levels, 0);
 	CU_ASSERT(!req.tm_queue_shaper_needed);
@@ -4486,7 +4486,7 @@ static void traffic_mngr_test_default_values(void)
 		CU_ASSERT(!l_req->tm_node_threshold_needed);
 	}
 
-	memset(&shaper, 0xff, sizeof(shaper));
+	memset(&shaper, fill, sizeof(shaper));
 	odp_tm_shaper_params_init(&shaper);
 	CU_ASSERT_EQUAL(shaper.shaper_len_adjust, 0);
 	CU_ASSERT(!shaper.dual_rate);
@@ -4497,24 +4497,24 @@ static void traffic_mngr_test_default_values(void)
 	for (n = 0; n < ODP_TM_MAX_PRIORITIES; n++)
 		CU_ASSERT_EQUAL(sched.sched_modes[n], ODP_TM_BYTE_BASED_WEIGHTS);
 
-	memset(&threshold, 0xff, sizeof(threshold));
+	memset(&threshold, fill, sizeof(threshold));
 	odp_tm_threshold_params_init(&threshold);
 	CU_ASSERT(!threshold.enable_max_pkts);
 	CU_ASSERT(!threshold.enable_max_bytes);
 
-	memset(&wred, 0xff, sizeof(wred));
+	memset(&wred, fill, sizeof(wred));
 	odp_tm_wred_params_init(&wred);
 	CU_ASSERT(!wred.enable_wred);
 	CU_ASSERT(!wred.use_byte_fullness);
 
-	memset(&node, 0xff, sizeof(node));
+	memset(&node, fill, sizeof(node));
 	odp_tm_node_params_init(&node);
 	CU_ASSERT_EQUAL(node.shaper_profile, ODP_TM_INVALID);
 	CU_ASSERT_EQUAL(node.threshold_profile, ODP_TM_INVALID);
 	for (n = 0; n < ODP_NUM_PACKET_COLORS; n++)
 		CU_ASSERT_EQUAL(node.wred_profile[n], ODP_TM_INVALID);
 
-	memset(&queue, 0xff, sizeof(queue));
+	memset(&queue, fill, sizeof(queue));
 	odp_tm_queue_params_init(&queue);
 	CU_ASSERT_EQUAL(queue.shaper_profile, ODP_TM_INVALID);
 	CU_ASSERT_EQUAL(queue.threshold_profile, ODP_TM_INVALID);
@@ -4522,10 +4522,12 @@ static void traffic_mngr_test_default_values(void)
 		CU_ASSERT_EQUAL(queue.wred_profile[n], ODP_TM_INVALID);
 	CU_ASSERT_EQUAL(queue.priority, 0);
 	CU_ASSERT(queue.ordered_enqueue);
-	/* re-check ordered_enqueue to notice if it is not set at all */
-	memset(&queue, 0, sizeof(queue));
-	odp_tm_queue_params_init(&queue);
-	CU_ASSERT(queue.ordered_enqueue);
+}
+
+static void traffic_mngr_test_default_values(void)
+{
+	test_defaults(0);
+	test_defaults(0xff);
 }
 
 static void traffic_mngr_test_capabilities(void)


### PR DESCRIPTION
    validation: improve testing of default values set by init functions

    Improve testing of the default values set by various init functions by
    checking the defaults twice: once after memsetting the to-be-initialized
    structure to zero before the init call and once after memsetting to 0xff.
    This way missing initialization can always be detected.


    validation: init: test default value setting by odp_init_param_init()

    Test that odp_init_param_init() initializes parameters to the specified
    default values.
