### PR TITLE
[PATCH v3] validation: test pool and queues with same name

### DIFF
--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -118,6 +118,10 @@ static int queue_init(queue_entry_t *queue, const char *name,
 		ring[ring_idx] = NULL;
 
 	queue->s.type = queue->s.param.type;
+
+	if (queue->s.type == ODP_QUEUE_TYPE_SCHED)
+		queue->s.param.deq_mode = ODP_QUEUE_OP_DISABLED;
+
 	odp_atomic_init_u64(&queue->s.num_timers, 0);
 
 	queue->s.enqueue = _queue_enq;

--- a/test/validation/api/dma/dma.c
+++ b/test/validation/api/dma/dma.c
@@ -294,6 +294,30 @@ static void test_dma_compl_pool(void)
 	odp_dma_compl_free(compl);
 }
 
+static void test_dma_compl_pool_same_name(void)
+{
+	odp_dma_pool_param_t dma_pool_param;
+	odp_pool_t pool, pool_a, pool_b;
+	const char *name = COMPL_POOL_NAME;
+
+	pool_a = global.compl_pool;
+
+	pool = odp_pool_lookup(name);
+	CU_ASSERT(pool == pool_a);
+
+	odp_dma_pool_param_init(&dma_pool_param);
+	dma_pool_param.num = NUM_COMPL;
+
+	/* Second pool with the same name */
+	pool_b = odp_dma_pool_create(name, &dma_pool_param);
+	CU_ASSERT_FATAL(pool_b != ODP_POOL_INVALID);
+
+	pool = odp_pool_lookup(name);
+	CU_ASSERT(pool == pool_a || pool == pool_b);
+
+	CU_ASSERT_FATAL(odp_pool_destroy(pool_b) == 0);
+}
+
 static void init_source(uint8_t *src, uint32_t len)
 {
 	uint32_t i;
@@ -1152,6 +1176,7 @@ odp_testinfo_t dma_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(test_dma_param_init, check_sync),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_debug, check_sync),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_compl_pool, check_event),
+	ODP_TEST_INFO_CONDITIONAL(test_dma_compl_pool_same_name, check_event),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_addr_to_addr_sync, check_sync),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_addr_to_addr_sync_mtrs, check_sync),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_addr_to_addr_sync_mseg, check_sync),

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -173,6 +173,79 @@ static void pool_test_lookup_info_print(void)
 	CU_ASSERT(odp_pool_destroy(pool) == 0);
 }
 
+static void pool_test_same_name(const odp_pool_param_t *param)
+{
+	odp_pool_t pool, pool_a, pool_b;
+	const char *name = "same_name";
+
+	pool_a = odp_pool_create(name, param);
+	CU_ASSERT_FATAL(pool_a != ODP_POOL_INVALID);
+
+	pool = odp_pool_lookup(name);
+	CU_ASSERT(pool == pool_a);
+
+	/* Second pool with the same name */
+	pool_b = odp_pool_create(name, param);
+	CU_ASSERT_FATAL(pool_b != ODP_POOL_INVALID);
+
+	pool = odp_pool_lookup(name);
+	CU_ASSERT(pool == pool_a || pool == pool_b);
+
+	CU_ASSERT(odp_pool_destroy(pool_a) == 0);
+	CU_ASSERT(odp_pool_destroy(pool_b) == 0);
+}
+
+static void pool_test_same_name_buf(void)
+{
+	odp_pool_param_t param;
+
+	odp_pool_param_init(&param);
+
+	param.type     = ODP_POOL_BUFFER;
+	param.buf.size = BUF_SIZE;
+	param.buf.num  = BUF_NUM;
+
+	pool_test_same_name(&param);
+}
+
+static void pool_test_same_name_pkt(void)
+{
+	odp_pool_param_t param;
+
+	odp_pool_param_init(&param);
+
+	param.type    = ODP_POOL_PACKET;
+	param.pkt.len = PKT_LEN;
+	param.pkt.num = PKT_NUM;
+
+	pool_test_same_name(&param);
+}
+
+static void pool_test_same_name_tmo(void)
+{
+	odp_pool_param_t param;
+
+	odp_pool_param_init(&param);
+
+	param.type    = ODP_POOL_TIMEOUT;
+	param.tmo.num = TMO_NUM;
+
+	pool_test_same_name(&param);
+}
+
+static void pool_test_same_name_vec(void)
+{
+	odp_pool_param_t param;
+
+	odp_pool_param_init(&param);
+
+	param.type            = ODP_POOL_VECTOR;
+	param.vector.num      = 10;
+	param.vector.max_size = 2;
+
+	pool_test_same_name(&param);
+}
+
 static void alloc_buffer(uint32_t cache_size)
 {
 	odp_pool_t pool;
@@ -1776,6 +1849,11 @@ odp_testinfo_t pool_suite[] = {
 	ODP_TEST_INFO(pool_test_create_destroy_packet),
 	ODP_TEST_INFO(pool_test_create_destroy_timeout),
 	ODP_TEST_INFO(pool_test_create_destroy_vector),
+	ODP_TEST_INFO(pool_test_lookup_info_print),
+	ODP_TEST_INFO(pool_test_same_name_buf),
+	ODP_TEST_INFO(pool_test_same_name_pkt),
+	ODP_TEST_INFO(pool_test_same_name_tmo),
+	ODP_TEST_INFO(pool_test_same_name_vec),
 	ODP_TEST_INFO(pool_test_alloc_buffer),
 	ODP_TEST_INFO(pool_test_alloc_buffer_min_cache),
 	ODP_TEST_INFO(pool_test_alloc_buffer_max_cache),
@@ -1790,7 +1868,6 @@ odp_testinfo_t pool_suite[] = {
 	ODP_TEST_INFO(pool_test_alloc_timeout_min_cache),
 	ODP_TEST_INFO(pool_test_alloc_timeout_max_cache),
 	ODP_TEST_INFO(pool_test_info_packet),
-	ODP_TEST_INFO(pool_test_lookup_info_print),
 	ODP_TEST_INFO(pool_test_info_data_range),
 	ODP_TEST_INFO(pool_test_buf_max_num),
 	ODP_TEST_INFO(pool_test_pkt_max_num),

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -807,6 +807,10 @@ static void queue_test_info(void)
 	CU_ASSERT(strcmp(nq_plain, info.name) == 0);
 	CU_ASSERT(info.param.type == ODP_QUEUE_TYPE_PLAIN);
 	CU_ASSERT(info.param.type == odp_queue_type(q_plain));
+	CU_ASSERT(info.param.enq_mode == ODP_QUEUE_OP_MT);
+	CU_ASSERT(info.param.deq_mode == ODP_QUEUE_OP_MT);
+	CU_ASSERT(info.param.order == ODP_QUEUE_ORDER_KEEP);
+	CU_ASSERT(info.param.nonblocking == ODP_BLOCKING);
 	ctx = info.param.context; /* 'char' context ptr */
 	CU_ASSERT(ctx == q_plain_ctx);
 	CU_ASSERT(info.param.context == odp_queue_context(q_plain));
@@ -817,6 +821,10 @@ static void queue_test_info(void)
 	CU_ASSERT(strcmp(nq_order, info.name) == 0);
 	CU_ASSERT(info.param.type == ODP_QUEUE_TYPE_SCHED);
 	CU_ASSERT(info.param.type == odp_queue_type(q_order));
+	CU_ASSERT(info.param.enq_mode == ODP_QUEUE_OP_MT);
+	CU_ASSERT(info.param.deq_mode == ODP_QUEUE_OP_DISABLED);
+	CU_ASSERT(info.param.order == ODP_QUEUE_ORDER_KEEP);
+	CU_ASSERT(info.param.nonblocking == ODP_BLOCKING);
 	ctx = info.param.context; /* 'char' context ptr */
 	CU_ASSERT(ctx == q_order_ctx);
 	CU_ASSERT(info.param.context == odp_queue_context(q_order));

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -727,6 +727,44 @@ static void queue_test_param(void)
 	CU_ASSERT(odp_queue_destroy(queue) == 0);
 }
 
+static void queue_test_same_name(int sched)
+{
+	odp_queue_t queue, queue_a, queue_b;
+	odp_queue_param_t param;
+	const char *name = "same_name";
+
+	odp_queue_param_init(&param);
+
+	if (sched)
+		param.type = ODP_QUEUE_TYPE_SCHED;
+
+	queue_a = odp_queue_create(name, &param);
+	CU_ASSERT_FATAL(queue_a != ODP_QUEUE_INVALID);
+
+	queue = odp_queue_lookup(name);
+	CU_ASSERT(queue == queue_a);
+
+	/* Second queue with the same name */
+	queue_b = odp_queue_create(name, &param);
+	CU_ASSERT_FATAL(queue_b != ODP_QUEUE_INVALID);
+
+	queue = odp_queue_lookup(name);
+	CU_ASSERT(queue == queue_a || queue == queue_b);
+
+	CU_ASSERT_FATAL(odp_queue_destroy(queue_a) == 0);
+	CU_ASSERT_FATAL(odp_queue_destroy(queue_b) == 0);
+}
+
+static void queue_test_same_name_plain(void)
+{
+	queue_test_same_name(0);
+}
+
+static void queue_test_same_name_sched(void)
+{
+	queue_test_same_name(1);
+}
+
 static void queue_test_info(void)
 {
 	odp_queue_t q_plain, q_order;
@@ -1018,6 +1056,8 @@ odp_testinfo_t queue_suite[] = {
 	ODP_TEST_INFO(queue_test_pair_lf_mpsc),
 	ODP_TEST_INFO(queue_test_pair_lf_spsc),
 	ODP_TEST_INFO(queue_test_param),
+	ODP_TEST_INFO(queue_test_same_name_plain),
+	ODP_TEST_INFO(queue_test_same_name_sched),
 	ODP_TEST_INFO(queue_test_info),
 	ODP_TEST_INFO(queue_test_mt_plain_block),
 	ODP_TEST_INFO(queue_test_mt_plain_nonblock_lf),


### PR DESCRIPTION
Added test cases to check that pools and queue can be created with the same name as API promises. Added also missing default value checks when queue param is NULL.