### PR TITLE
[PATCH v2] api: increment ODP API version to 1.37.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+== OpenDataPlane (1.37.1.0)
+
+=== Backward compatible API changes
+==== Packet IO
+* Clarify that `odp_pktout_send_lso()` can be used also for packets that have
+payload less than `max_payload_len` bytes.
+
+==== Stash
+* Change 32-bit and 64-bit specific get/put functions' parameter names to avoid
+name conflicts.
+
+==== Traffic Manager
+* Add option to do rate limiting instead of rate shaping in TM nodes and queues.
+
 == OpenDataPlane (1.37.0.0)
 
 === Backward incompatible API changes

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.5])
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [37])
-m4_define([odpapi_minor_version], [0])
+m4_define([odpapi_minor_version], [1])
 m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])


### PR DESCRIPTION
Increment API version number to reflect the following changes:

Backward compatible:
- pktio: clarify that LSO send handles small packets
- stash: change get/put function parameter names
- tm: add rate limit mode in shapers

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reviewed-by: Petri Savolainen <petri.savolainen@nokia.com>