### PR TITLE
[PATCH v6] linux-gen: pktio: statistics fixes and cleanups

### DIFF
--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -131,6 +131,7 @@ struct pktio_entry {
 	/* Statistics counters used also outside drivers */
 	struct {
 		odp_atomic_u64_t in_discards;
+		odp_atomic_u64_t in_errors;
 		odp_atomic_u64_t out_discards;
 	} stats_extra;
 	/* Latest Tx timestamp */

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -1687,10 +1687,9 @@ static uint32_t packet_rss_hash(odp_packet_hdr_t *pkt_hdr,
  * @param pool[out]	Packet pool
  * @param pkt_hdr[out]	Packet header
  *
- * @retval 0 on success
- * @retval -EFAULT Bug
- * @retval -EINVAL Config error
- * @retval -ENOENT Drop action
+ * @retval 0 success
+ * @retval -1 drop packet and increment in_discards
+ * @retval 1 drop packet
  *
  * @note *base is not released
  */
@@ -1706,10 +1705,10 @@ int _odp_cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 	cos = cls_select_cos(entry, base, pkt_hdr);
 
 	if (cos == NULL)
-		return -EINVAL;
+		return -1;
 
 	if (cos->s.action == ODP_COS_ACTION_DROP)
-		return -ENOENT;
+		return 1;
 
 	if (cos->s.queue == ODP_QUEUE_INVALID && cos->s.num_queue == 1)
 		goto error;
@@ -1736,7 +1735,7 @@ int _odp_cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 
 error:
 	odp_atomic_inc_u64(&cos->s.stats.discards);
-	return -EFAULT;
+	return 1;
 }
 
 static uint32_t packet_rss_hash(odp_packet_hdr_t *pkt_hdr,

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1964,6 +1964,8 @@ int _odp_packet_l4_chksum(odp_packet_hdr_t *pkt_hdr,
 			pkt_hdr->p.flags.l4_chksum_err = 1;
 			pkt_hdr->p.flags.udp_err = 1;
 			ODP_DBG("UDP chksum fail (%x)!\n", sum);
+			if (opt.bit.drop_udp_err)
+				return -1;
 		}
 	}
 
@@ -1982,6 +1984,8 @@ int _odp_packet_l4_chksum(odp_packet_hdr_t *pkt_hdr,
 			pkt_hdr->p.flags.l4_chksum_err = 1;
 			pkt_hdr->p.flags.tcp_err = 1;
 			ODP_DBG("TCP chksum fail (%x)!\n", sum);
+			if (opt.bit.drop_tcp_err)
+				return -1;
 		}
 	}
 
@@ -2013,6 +2017,8 @@ int _odp_packet_l4_chksum(odp_packet_hdr_t *pkt_hdr,
 			pkt_hdr->p.flags.sctp_err = 1;
 			ODP_DBG("SCTP chksum fail (%x/%x)!\n", sum,
 				sctp->chksum);
+			if (opt.bit.drop_sctp_err)
+				return -1;
 		}
 	}
 

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -277,6 +277,7 @@ static void init_pktio_entry(pktio_entry_t *entry)
 	entry->s.tx_compl_pool = ODP_POOL_INVALID;
 
 	odp_atomic_init_u64(&entry->s.stats_extra.in_discards, 0);
+	odp_atomic_init_u64(&entry->s.stats_extra.in_errors, 0);
 	odp_atomic_init_u64(&entry->s.stats_extra.out_discards, 0);
 	odp_atomic_init_u64(&entry->s.tx_ts, 0);
 
@@ -1851,6 +1852,7 @@ int odp_pktio_stats(odp_pktio_t pktio,
 		ret = entry->s.ops->stats(entry, stats);
 	if (odp_likely(ret == 0)) {
 		stats->in_discards += odp_atomic_load_u64(&entry->s.stats_extra.in_discards);
+		stats->in_errors += odp_atomic_load_u64(&entry->s.stats_extra.in_errors);
 		stats->out_discards += odp_atomic_load_u64(&entry->s.stats_extra.out_discards);
 	}
 	unlock_entry(entry);
@@ -1878,6 +1880,7 @@ int odp_pktio_stats_reset(odp_pktio_t pktio)
 	}
 
 	odp_atomic_store_u64(&entry->s.stats_extra.in_discards, 0);
+	odp_atomic_store_u64(&entry->s.stats_extra.in_errors, 0);
 	odp_atomic_store_u64(&entry->s.stats_extra.out_discards, 0);
 	if (entry->s.ops->stats)
 		ret = entry->s.ops->stats_reset(entry);

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -666,6 +666,7 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 					    &pkt, &pkt_hdr, new_pool))) {
 					odp_packet_free(pkt);
 					rte_pktmbuf_free(mbuf);
+					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
 					continue;
 				}
 			}
@@ -952,6 +953,7 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 				if (odp_unlikely(_odp_pktio_packet_to_pool(
 					    &pkt, &pkt_hdr, new_pool))) {
 					rte_pktmbuf_free(mbuf);
+					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
 					continue;
 				}
 			}

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -648,11 +648,15 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 			}
 
 			if (pktio_cls_enabled(pktio_entry)) {
+				int ret;
 				odp_pool_t new_pool;
 
-				if (_odp_cls_classify_packet(pktio_entry,
-							     (const uint8_t *)data,
-							     &new_pool, pkt_hdr)) {
+				ret = _odp_cls_classify_packet(pktio_entry, (const uint8_t *)data,
+							       &new_pool, pkt_hdr);
+				if (ret < 0)
+					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
+
+				if (ret) {
 					odp_packet_free(pkt);
 					rte_pktmbuf_free(mbuf);
 					continue;
@@ -932,11 +936,15 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 			}
 
 			if (pktio_cls_enabled(pktio_entry)) {
+				int ret;
 				odp_pool_t new_pool;
 
-				if (_odp_cls_classify_packet(pktio_entry,
-							     (const uint8_t *)data,
-							     &new_pool, pkt_hdr)) {
+				ret = _odp_cls_classify_packet(pktio_entry, (const uint8_t *)data,
+							       &new_pool, pkt_hdr);
+				if (ret < 0)
+					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
+
+				if (ret) {
 					rte_pktmbuf_free(mbuf);
 					continue;
 				}

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -160,7 +160,7 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	odp_time_t ts_val;
 	odp_time_t *ts = NULL;
 	int num_rx = 0;
-	int packets = 0, errors = 0;
+	int packets = 0;
 	uint32_t octets = 0;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
 	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
@@ -206,7 +206,7 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			ret = _odp_packet_parse_common(pkt_hdr, pkt_addr, pkt_len,
 						       seg_len, layer, opt);
 			if (ret)
-				errors++;
+				odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_errors);
 
 			if (ret < 0) {
 				odp_packet_free(pkt);
@@ -254,7 +254,6 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 	pktio_entry->s.stats.in_octets += octets;
 	pktio_entry->s.stats.in_packets += packets;
-	pktio_entry->s.stats.in_errors += errors;
 
 	odp_ticketlock_unlock(&pktio_entry->s.rxl);
 

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -218,6 +218,9 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 				ret = _odp_cls_classify_packet(pktio_entry, pkt_addr,
 							       &new_pool, pkt_hdr);
+				if (ret < 0)
+					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
+
 				if (ret) {
 					odp_packet_free(pkt);
 					continue;
@@ -226,9 +229,7 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 				if (odp_unlikely(_odp_pktio_packet_to_pool(
 					    &pkt, &pkt_hdr, new_pool))) {
 					odp_packet_free(pkt);
-					odp_atomic_inc_u64(
-						&pktio_entry->s.stats_extra
-							 .in_discards);
+					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
 					continue;
 				}
 			}

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -1246,11 +1246,6 @@ static int netmap_capability(pktio_entry_t *pktio_entry,
 static int netmap_stats(pktio_entry_t *pktio_entry,
 			odp_pktio_stats_t *stats)
 {
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
-		memset(stats, 0, sizeof(*stats));
-		return 0;
-	}
-
 	return _odp_sock_stats_fd(pktio_entry,
 				  stats,
 				  pkt_priv(pktio_entry)->sockfd);

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -1253,12 +1253,6 @@ static int netmap_stats(pktio_entry_t *pktio_entry,
 
 static int netmap_stats_reset(pktio_entry_t *pktio_entry)
 {
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
-		memset(&pktio_entry->s.stats, 0,
-		       sizeof(odp_pktio_stats_t));
-		return 0;
-	}
-
 	return _odp_sock_stats_reset_fd(pktio_entry,
 					pkt_priv(pktio_entry)->sockfd);
 }

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -861,14 +861,19 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 		}
 
 		if (layer) {
-			if (_odp_packet_parse_common(pkt_hdr, buf, len, len,
-						     layer, opt) < 0) {
+			int ret;
+
+			ret = _odp_packet_parse_common(pkt_hdr, buf, len, len,
+						       layer, opt);
+			if (ret)
+				odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_errors);
+
+			if (ret < 0) {
 				odp_packet_free(pkt);
 				continue;
 			}
 
 			if (pktio_cls_enabled(pktio_entry)) {
-				int ret;
 				odp_pool_t new_pool;
 
 				ret = _odp_cls_classify_packet(pktio_entry, buf,

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -248,7 +248,7 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	pkt_pcap_t *pcap = pkt_priv(pktio_entry);
 	odp_time_t ts_val;
 	odp_time_t *ts = NULL;
-	int packets = 0, errors = 0;
+	int packets = 0;
 	uint32_t octets = 0;
 	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
 	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
@@ -298,7 +298,7 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			ret = _odp_packet_parse_common(pkt_hdr, data, pkt_len,
 						       pkt_len, layer, opt);
 			if (ret)
-				errors++;
+				odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_errors);
 
 			if (ret < 0) {
 				odp_packet_free(pkt);
@@ -342,7 +342,6 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 	pktio_entry->s.stats.in_octets += octets;
 	pktio_entry->s.stats.in_packets += packets;
-	pktio_entry->s.stats.in_errors += errors;
 
 	odp_ticketlock_unlock(&pktio_entry->s.rxl);
 

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -310,6 +310,9 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 				ret = _odp_cls_classify_packet(pktio_entry, data,
 							       &new_pool, pkt_hdr);
+				if (ret < 0)
+					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
+
 				if (ret) {
 					odp_packet_free(pkt);
 					continue;
@@ -318,9 +321,7 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 				if (odp_unlikely(_odp_pktio_packet_to_pool(
 					    &pkt, &pkt_hdr, new_pool))) {
 					odp_packet_free(pkt);
-					odp_atomic_inc_u64(
-						&pktio_entry->s.stats_extra
-							 .in_discards);
+					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
 					continue;
 				}
 			}

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -586,11 +586,6 @@ static int sock_capability(pktio_entry_t *pktio_entry,
 static int sock_stats(pktio_entry_t *pktio_entry,
 		      odp_pktio_stats_t *stats)
 {
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
-		memset(stats, 0, sizeof(*stats));
-		return 0;
-	}
-
 	return _odp_sock_stats_fd(pktio_entry, stats, pkt_priv(pktio_entry)->sockfd);
 }
 

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -292,8 +292,12 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 				base = buf;
 			}
 
-			if (_odp_packet_parse_common(pkt_hdr, base, pkt_len,
-						     seg_len, layer, opt) < 0) {
+			ret = _odp_packet_parse_common(pkt_hdr, base, pkt_len,
+						       seg_len, layer, opt);
+			if (ret)
+				odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_errors);
+
+			if (ret < 0) {
 				odp_packet_free(pkt);
 				continue;
 			}

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -591,12 +591,6 @@ static int sock_stats(pktio_entry_t *pktio_entry,
 
 static int sock_stats_reset(pktio_entry_t *pktio_entry)
 {
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
-		memset(&pktio_entry->s.stats, 0,
-		       sizeof(odp_pktio_stats_t));
-		return 0;
-	}
-
 	return _odp_sock_stats_reset_fd(pktio_entry, pkt_priv(pktio_entry)->sockfd);
 }
 

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -278,8 +278,12 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 			if (pktio_cls_enabled(pktio_entry)) {
 				odp_pool_t new_pool;
 
-				if (_odp_cls_classify_packet(pktio_entry, pkt_buf,
-							     &new_pool, hdr)) {
+				ret = _odp_cls_classify_packet(pktio_entry, pkt_buf,
+							       &new_pool, hdr);
+				if (ret < 0)
+					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
+
+				if (ret) {
 					odp_packet_free(pkt);
 					tp_hdr->tp_status = TP_STATUS_KERNEL;
 					frame_num = next_frame_num;
@@ -291,9 +295,7 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 					odp_packet_free(pkt);
 					tp_hdr->tp_status = TP_STATUS_KERNEL;
 					frame_num = next_frame_num;
-					odp_atomic_inc_u64(
-						&pktio_entry->s.stats_extra
-							 .in_discards);
+					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
 					continue;
 				}
 			}

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -892,11 +892,6 @@ static int sock_mmap_capability(pktio_entry_t *pktio_entry,
 static int sock_mmap_stats(pktio_entry_t *pktio_entry,
 			   odp_pktio_stats_t *stats)
 {
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
-		memset(stats, 0, sizeof(*stats));
-		return 0;
-	}
-
 	return _odp_sock_stats_fd(pktio_entry,
 				  stats,
 				  pkt_priv(pktio_entry)->sockfd);

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -899,12 +899,6 @@ static int sock_mmap_stats(pktio_entry_t *pktio_entry,
 
 static int sock_mmap_stats_reset(pktio_entry_t *pktio_entry)
 {
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
-		memset(&pktio_entry->s.stats, 0,
-		       sizeof(odp_pktio_stats_t));
-		return 0;
-	}
-
 	return _odp_sock_stats_reset_fd(pktio_entry,
 					pkt_priv(pktio_entry)->sockfd);
 }

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -267,8 +267,12 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 		}
 
 		if (layer) {
-			if (_odp_packet_parse_common(hdr, pkt_buf, pkt_len,
-						     pkt_len, layer, opt) < 0) {
+			ret = _odp_packet_parse_common(hdr, pkt_buf, pkt_len,
+						       pkt_len, layer, opt);
+			if (ret)
+				odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_errors);
+
+			if (ret < 0) {
 				odp_packet_free(pkt);
 				tp_hdr->tp_status = TP_STATUS_KERNEL;
 				frame_num = next_frame_num;

--- a/platform/linux-generic/pktio/stats/packet_io_stats.c
+++ b/platform/linux-generic/pktio/stats/packet_io_stats.c
@@ -49,8 +49,10 @@ int _odp_sock_stats_fd(pktio_entry_t *pktio_entry,
 	odp_pktio_stats_t cur_stats;
 	int ret = 0;
 
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED)
+	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
+		memset(stats, 0, sizeof(*stats));
 		return 0;
+	}
 
 	memset(&cur_stats, 0, sizeof(odp_pktio_stats_t));
 	if (pktio_entry->s.stats_type == STATS_ETHTOOL) {

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -325,8 +325,6 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 			if (odp_unlikely(_odp_pktio_packet_to_pool(
 				    &pkt, &pkt_hdr, new_pool))) {
 				odp_packet_free(pkt);
-				odp_atomic_inc_u64(
-					&pktio_entry->s.stats_extra.in_discards);
 				return ODP_PACKET_INVALID;
 			}
 		}


### PR DESCRIPTION
This series attempts to unify statistics handling in the recv functions in different pktios.

v2:
- Add commit `linux-gen: pktio: loop: support discards counter in queue statistics`
- Add commit `linux-gen: pktio: stats: fix error handling for socket type pktio`

v3:
- _odp_sock_stats_get -> sock_stats_get
- Add review tags.

v4:
- Use atomic counters.

v5:
- Rebase.
- Remove xdp changes.
- Counter increments on one line.

v6:
- Add review tags.
