### PR TITLE
[PATCH v3] test: cunit: fix cunit asserts for multithreaded test apps

### DIFF
--- a/test/common/odp_cunit_common.c
+++ b/test/common/odp_cunit_common.c
@@ -29,6 +29,7 @@
 /* Globals */
 static int allow_skip_result;
 static odph_thread_t thread_tbl[MAX_WORKERS];
+static int threads_running;
 static odp_instance_t instance;
 static char *progname;
 
@@ -51,6 +52,12 @@ int odp_cunit_thread_create(int num, int func_ptr(void *), void *const arg[], in
 	odp_cpumask_t cpumask;
 	odph_thread_common_param_t thr_common;
 	odph_thread_param_t thr_param[num];
+
+	if (threads_running) {
+		/* thread_tbl is already in use */
+		fprintf(stderr, "error: %s: threads already running\n", __func__);
+		return -1;
+	}
 
 	odph_thread_common_param_init(&thr_common);
 
@@ -84,6 +91,8 @@ int odp_cunit_thread_create(int num, int func_ptr(void *), void *const arg[], in
 	if (ret != num)
 		fprintf(stderr, "error: odph_thread_create() failed.\n");
 
+	threads_running = (ret > 0);
+
 	return ret;
 }
 
@@ -94,6 +103,7 @@ int odp_cunit_thread_join(int num)
 		fprintf(stderr, "error: odph_thread_join() failed.\n");
 		return -1;
 	}
+	threads_running = 0;
 
 	return 0;
 }

--- a/test/common/odp_cunit_common.h
+++ b/test/common/odp_cunit_common.h
@@ -110,6 +110,9 @@ int odp_cunit_set_inactive(void);
 /* Check from CI_SKIP environment variable if the test case should be skipped by CI */
 int odp_cunit_ci_skip(const char *test_name);
 
+void odp_cu_assert(CU_BOOL value, unsigned int line,
+		   const char *condition, const char *file, CU_BOOL fatal);
+
 /*
  * Wrapper for CU_assertImplementation for the fatal asserts to show the
  * compiler and static analyzers that the function does not return if the
@@ -119,7 +122,7 @@ int odp_cunit_ci_skip(const char *test_name);
 static inline void odp_cu_assert_fatal(CU_BOOL value, unsigned int line,
 				       const char *condition, const char *file)
 {
-	CU_assertImplementation(value, line, condition, file, "", CU_TRUE);
+	odp_cu_assert(value, line, condition, file, CU_TRUE);
 
 	if (!value) {
 		/* not reached */
@@ -134,13 +137,27 @@ static inline void odp_cu_assert_fatal(CU_BOOL value, unsigned int line,
  * compatibility with CU and existing code that assumes this kind of macros.
  */
 
+#undef CU_ASSERT
+#define CU_ASSERT(value) \
+	{ odp_cu_assert((value), __LINE__, #value, __FILE__, CU_FALSE); }
+
 #undef CU_ASSERT_FATAL
 #define CU_ASSERT_FATAL(value) \
 	{ odp_cu_assert_fatal((value), __LINE__, #value, __FILE__); }
 
+#undef CU_FAIL
+#define CU_FAIL(msg) \
+	{ odp_cu_assert(CU_FALSE, __LINE__, ("CU_FAIL(" #msg ")"), __FILE__, CU_FALSE); }
+
 #undef CU_FAIL_FATAL
 #define CU_FAIL_FATAL(msg) \
 	{ odp_cu_assert_fatal(CU_FALSE, __LINE__, ("CU_FAIL_FATAL(" #msg ")"), __FILE__); }
+
+#undef CU_ASSERT_EQUAL
+#define CU_ASSERT_EQUAL(actual, expected) \
+	{ odp_cu_assert(((actual) == (expected)), __LINE__, \
+			("CU_ASSERT_EQUAL(" #actual "," #expected ")"), \
+			__FILE__, CU_FALSE); }
 
 #undef CU_ASSERT_EQUAL_FATAL
 #define CU_ASSERT_EQUAL_FATAL(actual, expected) \
@@ -148,16 +165,32 @@ static inline void odp_cu_assert_fatal(CU_BOOL value, unsigned int line,
 			      ("CU_ASSERT_EQUAL_FATAL(" #actual "," #expected ")"), \
 			      __FILE__); }
 
+#undef CU_ASSERT_NOT_EQUAL
+#define CU_ASSERT_NOT_EQUAL(actual, expected) \
+	{ odp_cu_assert(((actual) != (expected)), __LINE__, \
+			("CU_ASSERT_NOT_EQUAL(" #actual "," #expected ")"), \
+			__FILE__, CU_FALSE); }
+
 #undef CU_ASSERT_NOT_EQUAL_FATAL
 #define CU_ASSERT_NOT_EQUAL_FATAL(actual, expected) \
 	{ odp_cu_assert_fatal(((actual) != (expected)), __LINE__, \
 			      ("CU_ASSERT_NOT_EQUAL_FATAL(" #actual "," #expected ")"), \
 			      __FILE__); }
 
+#undef CU_ASSERT_PTR_NULL
+#define CU_ASSERT_PTR_NULL(value) \
+	{ odp_cu_assert((NULL == (const void *)(value)), __LINE__, \
+			("CU_ASSERT_PTR_NULL(" #value ")"), __FILE__, CU_FALSE); }
+
 #undef CU_ASSERT_PTR_NULL_FATAL
 #define CU_ASSERT_PTR_NULL_FATAL(value) \
 	{ odp_cu_assert_fatal((NULL == (const void *)(value)), __LINE__, \
 			      ("CU_ASSERT_PTR_NULL_FATAL(" #value ")"), __FILE__); }
+
+#undef CU_ASSERT_PTR_NOT_NULL
+#define CU_ASSERT_PTR_NOT_NULL(value) \
+	{ odp_cu_assert((NULL != (const void *)(value)), __LINE__, \
+			("CU_ASSERT_PTR_NOT_NULL_FATAL(" #value ")"), __FILE__, CU_FALSE); }
 
 #undef CU_ASSERT_PTR_NOT_NULL_FATAL
 #define CU_ASSERT_PTR_NOT_NULL_FATAL(value) \


### PR DESCRIPTION
    CUnit is not thread-safe and not aware of process mode, which causes
    problems when CUnit assertions are used in multithreaded tests:
    - Updating the recorded assert failures has data races
    - Assertion failures in other than the main process are lost
    - The longjmp performed at fatal assertion failure tries to jump to
      a stack frame of another thread, which is doomed to fail badly

    Fix the problems by wrapping the commonly used CUnit assertions with
    ODP macros and an ODP function that calls CUnit only if running in the
    main thread and the main process. In other threads/processes record
    failed assertions in shared memory and re-play them to CUnit within
    the main thread/process when becoming single threaded again in
    odp_cunit_thread_exit().

    This does not solve the general issue that careless use of fatal
    assertions in the middle of tests may leave the test app in a state
    from which it cannot recover.
