### PR TITLE
[PATCH v3] linux-gen: clean up and align some structs

### DIFF
--- a/platform/linux-generic/include/odp_classification_datamodel.h
+++ b/platform/linux-generic/include/odp_classification_datamodel.h
@@ -131,13 +131,13 @@ typedef struct pmr_term_value {
 /*
 Class Of Service
 */
-struct cos_s {
+typedef struct ODP_ALIGNED_CACHE cos_s {
 	odp_cos_action_t action;	/* Action */
 	odp_queue_t queue;		/* Associated Queue */
 	odp_pool_t pool;		/* Associated Buffer pool */
 	odp_pktin_vector_config_t vector;	/* Packet vector config */
 	union pmr_u *pmr[CLS_PMR_PER_COS_MAX];	/* Chained PMR */
-	union cos_u *linked_cos[CLS_PMR_PER_COS_MAX]; /* Chained CoS with PMR*/
+	struct cos_s *linked_cos[CLS_PMR_PER_COS_MAX]; /* Chained CoS with PMR*/
 	uint32_t valid;			/* validity Flag */
 	odp_cls_drop_t drop_policy;	/* Associated Drop Policy */
 	size_t headroom;		/* Headroom for this CoS */
@@ -154,11 +154,6 @@ struct cos_s {
 		odp_atomic_u64_t discards;
 		odp_atomic_u64_t packets;
 	} stats, queue_stats[CLS_COS_QUEUE_MAX];
-};
-
-typedef union cos_u {
-	struct cos_s s;
-	uint8_t pad[_ODP_ROUNDUP_CACHE_LINE(sizeof(struct cos_s))];
 } cos_t;
 
 /* Pattern Matching Rule */

--- a/platform/linux-generic/include/odp_classification_datamodel.h
+++ b/platform/linux-generic/include/odp_classification_datamodel.h
@@ -136,7 +136,7 @@ typedef struct ODP_ALIGNED_CACHE cos_s {
 	odp_queue_t queue;		/* Associated Queue */
 	odp_pool_t pool;		/* Associated Buffer pool */
 	odp_pktin_vector_config_t vector;	/* Packet vector config */
-	union pmr_u *pmr[CLS_PMR_PER_COS_MAX];	/* Chained PMR */
+	struct pmr_s *pmr[CLS_PMR_PER_COS_MAX];	/* Chained PMR */
 	struct cos_s *linked_cos[CLS_PMR_PER_COS_MAX]; /* Chained CoS with PMR*/
 	uint32_t valid;			/* validity Flag */
 	odp_cls_drop_t drop_policy;	/* Associated Drop Policy */
@@ -157,7 +157,7 @@ typedef struct ODP_ALIGNED_CACHE cos_s {
 } cos_t;
 
 /* Pattern Matching Rule */
-struct pmr_s {
+typedef struct ODP_ALIGNED_CACHE pmr_s {
 	uint32_t valid;			/* Validity Flag */
 	odp_atomic_u32_t count;		/* num of packets matching this rule */
 	uint32_t num_pmr;		/* num of PMR Term Values*/
@@ -166,11 +166,6 @@ struct pmr_s {
 	cos_t *src_cos;			/* source CoS where PMR is attached */
 	pmr_term_value_t  pmr_term_value[CLS_PMRTERM_MAX];
 			/* List of associated PMR Terms */
-};
-
-typedef union pmr_u {
-	struct pmr_s s;
-	uint8_t pad[_ODP_ROUNDUP_CACHE_LINE(sizeof(struct pmr_s))];
 } pmr_t;
 
 typedef struct _cls_queue_grp_tbl_s {

--- a/platform/linux-generic/include/odp_classification_datamodel.h
+++ b/platform/linux-generic/include/odp_classification_datamodel.h
@@ -168,13 +168,8 @@ typedef struct ODP_ALIGNED_CACHE pmr_s {
 			/* List of associated PMR Terms */
 } pmr_t;
 
-typedef struct _cls_queue_grp_tbl_s {
+typedef struct ODP_ALIGNED_CACHE {
 	odp_queue_t queue[CLS_QUEUE_GROUP_MAX];
-} _cls_queue_grp_tbl_s;
-
-typedef union _cls_queue_grp_tbl_t {
-	_cls_queue_grp_tbl_s s;
-	uint8_t pad[_ODP_ROUNDUP_CACHE_LINE(sizeof(_cls_queue_grp_tbl_s))];
 } _cls_queue_grp_tbl_t;
 
 /**

--- a/platform/linux-generic/include/odp_classification_internal.h
+++ b/platform/linux-generic/include/odp_classification_internal.h
@@ -40,14 +40,14 @@ static inline int _odp_cos_queue_idx(const cos_t *cos, odp_queue_t queue)
 	uint32_t i, tbl_idx;
 	int queue_idx = -1;
 
-	if (cos->s.num_queue == 1) {
-		if (odp_unlikely(cos->s.queue != queue))
+	if (cos->num_queue == 1) {
+		if (odp_unlikely(cos->queue != queue))
 			return -1;
 		return 0;
 	}
 
-	tbl_idx = cos->s.index * CLS_COS_QUEUE_MAX;
-	for (i = 0; i < cos->s.num_queue; i++) {
+	tbl_idx = cos->index * CLS_COS_QUEUE_MAX;
+	for (i = 0; i < cos->num_queue; i++) {
 		if (_odp_cls_global->queue_grp_tbl.s.queue[tbl_idx + i] == queue) {
 			queue_idx = i;
 			break;
@@ -67,9 +67,9 @@ static inline void _odp_cos_queue_stats_add(cos_t *cos, odp_queue_t queue,
 	}
 
 	if (packets)
-		odp_atomic_add_u64(&cos->s.queue_stats[queue_idx].packets, packets);
+		odp_atomic_add_u64(&cos->queue_stats[queue_idx].packets, packets);
 	if (discards)
-		odp_atomic_add_u64(&cos->s.queue_stats[queue_idx].discards, discards);
+		odp_atomic_add_u64(&cos->queue_stats[queue_idx].discards, discards);
 }
 
 /** Classification Internal function **/

--- a/platform/linux-generic/include/odp_classification_internal.h
+++ b/platform/linux-generic/include/odp_classification_internal.h
@@ -48,7 +48,7 @@ static inline int _odp_cos_queue_idx(const cos_t *cos, odp_queue_t queue)
 
 	tbl_idx = cos->index * CLS_COS_QUEUE_MAX;
 	for (i = 0; i < cos->num_queue; i++) {
-		if (_odp_cls_global->queue_grp_tbl.s.queue[tbl_idx + i] == queue) {
+		if (_odp_cls_global->queue_grp_tbl.queue[tbl_idx + i] == queue) {
 			queue_idx = i;
 			break;
 		}

--- a/platform/linux-generic/include/odp_forward_typedefs_internal.h
+++ b/platform/linux-generic/include/odp_forward_typedefs_internal.h
@@ -22,7 +22,7 @@
 extern "C" {
 #endif
 
-typedef union queue_entry_u queue_entry_t;
+typedef struct queue_entry_s queue_entry_t;
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -77,7 +77,7 @@ struct pktio_if_ops;
 #define PKTIO_PRIVATE_SIZE 384
 #endif
 
-struct pktio_entry {
+typedef struct ODP_ALIGNED_CACHE {
 	const struct pktio_if_ops *ops; /**< Implementation specific methods */
 	/* These two locks together lock the whole pktio device */
 	odp_ticketlock_t rxl;		/**< RX ticketlock */
@@ -173,11 +173,6 @@ struct pktio_entry {
 		} state[PKTIO_MAX_QUEUES];
 		int fd[PKTIO_MAX_QUEUES];
 	} pcapng;
-};
-
-typedef union {
-	struct pktio_entry s;
-	uint8_t pad[_ODP_ROUNDUP_CACHE_LINE(sizeof(struct pktio_entry))];
 } pktio_entry_t;
 
 typedef struct {
@@ -285,29 +280,29 @@ static inline pktio_entry_t *get_pktio_entry(odp_pktio_t pktio)
 
 static inline int pktio_cls_enabled(pktio_entry_t *entry)
 {
-	return entry->s.enabled.cls;
+	return entry->enabled.cls;
 }
 
 static inline int _odp_pktio_tx_ts_enabled(pktio_entry_t *entry)
 {
-	return entry->s.enabled.tx_ts;
+	return entry->enabled.tx_ts;
 }
 
 static inline int _odp_pktio_tx_compl_enabled(const pktio_entry_t *entry)
 {
-	return entry->s.enabled.tx_compl;
+	return entry->enabled.tx_compl;
 }
 
 static inline int _odp_pktio_tx_aging_enabled(pktio_entry_t *entry)
 {
-	return entry->s.enabled.tx_aging;
+	return entry->enabled.tx_aging;
 }
 
 static inline void _odp_pktio_tx_ts_set(pktio_entry_t *entry)
 {
 	odp_time_t ts_val = odp_time_global();
 
-	odp_atomic_store_u64(&entry->s.tx_ts, ts_val.u64);
+	odp_atomic_store_u64(&entry->tx_ts, ts_val.u64);
 }
 
 extern const pktio_if_ops_t _odp_netmap_pktio_ops;

--- a/platform/linux-generic/include/odp_queue_basic_internal.h
+++ b/platform/linux-generic/include/odp_queue_basic_internal.h
@@ -34,7 +34,7 @@ extern "C" {
 #define QUEUE_STATUS_NOTSCHED     3
 #define QUEUE_STATUS_SCHED        4
 
-struct queue_entry_s {
+typedef struct ODP_ALIGNED_CACHE queue_entry_s {
 	/* The first cache line is read only */
 	queue_enq_fn_t       enqueue ODP_ALIGNED_CACHE;
 	queue_deq_fn_t       dequeue;
@@ -65,12 +65,7 @@ struct queue_entry_s {
 	void             *queue_lf;
 	int               spsc;
 	char              name[ODP_QUEUE_NAME_LEN];
-};
-
-union queue_entry_u {
-	struct queue_entry_s s;
-	uint8_t pad[_ODP_ROUNDUP_CACHE_LINE(sizeof(struct queue_entry_s))];
-};
+} queue_entry_t;
 
 typedef struct queue_global_t {
 	queue_entry_t   queue[CONFIG_MAX_QUEUES];
@@ -94,7 +89,7 @@ static inline uint32_t queue_to_index(odp_queue_t handle)
 {
 	queue_entry_t *qentry = (queue_entry_t *)(uintptr_t)handle;
 
-	return qentry->s.index;
+	return qentry->index;
 }
 
 static inline queue_entry_t *qentry_from_index(uint32_t queue_id)

--- a/platform/linux-generic/include/odp_queue_scalable_internal.h
+++ b/platform/linux-generic/include/odp_queue_scalable_internal.h
@@ -31,7 +31,7 @@ extern "C" {
 #define QUEUE_STATUS_DESTROYED    1
 #define QUEUE_STATUS_READY        2
 
-struct queue_entry_s {
+struct ODP_ALIGNED_CACHE queue_entry_s {
 	sched_elem_t     sched_elem;
 
 	odp_ticketlock_t lock ODP_ALIGNED_CACHE;
@@ -51,11 +51,6 @@ struct queue_entry_s {
 	odp_pktin_queue_t  pktin;
 	odp_pktout_queue_t pktout;
 	char               name[ODP_QUEUE_NAME_LEN];
-};
-
-union queue_entry_u {
-	struct queue_entry_s s;
-	uint8_t pad[_ODP_ROUNDUP_CACHE_LINE(sizeof(struct queue_entry_s))];
 };
 
 int _odp_queue_deq(sched_elem_t *q, _odp_event_hdr_t *event_hdr[], int num);
@@ -79,7 +74,7 @@ static inline void *shm_pool_alloc_align(_odp_ishm_pool_t *pool, uint32_t size)
 
 static inline uint32_t queue_to_id(odp_queue_t handle)
 {
-	return _odp_qentry_from_ext(handle)->s.index;
+	return _odp_qentry_from_ext(handle)->index;
 }
 
 static inline queue_entry_t *qentry_from_int(odp_queue_t handle)
@@ -94,12 +89,12 @@ static inline odp_queue_t qentry_to_int(queue_entry_t *qentry)
 
 static inline odp_queue_t queue_get_handle(queue_entry_t *queue)
 {
-	return queue->s.handle;
+	return queue->handle;
 }
 
 static inline reorder_window_t *queue_get_rwin(queue_entry_t *queue)
 {
-	return queue->s.sched_elem.rwin;
+	return queue->sched_elem.rwin;
 }
 
 #ifdef __cplusplus

--- a/platform/linux-generic/include/odp_ring_internal.h
+++ b/platform/linux-generic/include/odp_ring_internal.h
@@ -36,13 +36,16 @@ extern "C" {
 
 struct ring_common {
 	/* Writer head and tail */
-	odp_atomic_u32_t w_head;
-	odp_atomic_u32_t w_tail;
-	uint8_t pad[ODP_CACHE_LINE_SIZE - (2 * sizeof(odp_atomic_u32_t))];
+	struct ODP_ALIGNED_CACHE {
+		odp_atomic_u32_t w_head;
+		odp_atomic_u32_t w_tail;
+	};
 
 	/* Reader head and tail */
-	odp_atomic_u32_t r_head;
-	odp_atomic_u32_t r_tail;
+	struct ODP_ALIGNED_CACHE {
+		odp_atomic_u32_t r_head;
+		odp_atomic_u32_t r_tail;
+	};
 };
 
 typedef struct ODP_ALIGNED_CACHE {

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -522,7 +522,7 @@ int odp_pktio_default_cos_set(odp_pktio_t pktio_in, odp_cos_t default_cos)
 		return -1;
 	}
 
-	entry->s.cls.default_cos = cos;
+	entry->cls.default_cos = cos;
 	return 0;
 }
 
@@ -543,7 +543,7 @@ int odp_pktio_error_cos_set(odp_pktio_t pktio_in, odp_cos_t error_cos)
 		return -1;
 	}
 
-	entry->s.cls.error_cos = cos;
+	entry->cls.error_cos = cos;
 	return 0;
 }
 
@@ -564,7 +564,7 @@ int odp_pktio_headroom_set(odp_pktio_t pktio_in, uint32_t headroom)
 		ODP_ERR("Invalid odp_pktio_t handle\n");
 		return -1;
 	}
-	entry->s.cls.headroom = headroom;
+	entry->cls.headroom = headroom;
 	return 0;
 }
 
@@ -582,7 +582,7 @@ int odp_cos_with_l2_priority(odp_pktio_t pktio_in,
 		ODP_ERR("Invalid odp_pktio_t handle\n");
 		return -1;
 	}
-	l2_cos = &entry->s.cls.l2_cos_table;
+	l2_cos = &entry->cls.l2_cos_table;
 
 	LOCK(&l2_cos->lock);
 	/* Update the L2 QoS table*/
@@ -610,8 +610,8 @@ int ODP_DEPRECATE(odp_cos_with_l3_qos)(odp_pktio_t pktio_in, uint32_t num_qos, u
 		return -1;
 	}
 
-	entry->s.cls.l3_precedence = l3_preference;
-	l3_cos = &entry->s.cls.l3_cos_table;
+	entry->cls.l3_precedence = l3_preference;
+	l3_cos = &entry->cls.l3_cos_table;
 
 	LOCK(&l3_cos->lock);
 	/* Update the L3 QoS table*/
@@ -1605,7 +1605,7 @@ int _odp_pktio_classifier_init(pktio_entry_t *entry)
 	/* classifier lock should be acquired by the calling function */
 	if (entry == NULL)
 		return -1;
-	cls = &entry->s.cls;
+	cls = &entry->cls;
 	cls->error_cos = NULL;
 	cls->default_cos = NULL;
 	cls->headroom = 0;
@@ -1639,7 +1639,7 @@ static inline cos_t *cls_select_cos(pktio_entry_t *entry,
 	uint32_t i;
 	classifier_t *cls;
 
-	cls = &entry->s.cls;
+	cls = &entry->cls;
 	default_cos = cls->default_cos;
 
 	/* Return error cos for error packet */
@@ -1700,7 +1700,7 @@ int _odp_cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 	uint32_t tbl_index;
 	uint32_t hash;
 
-	ODP_DBG_LVL(CLS_DBG, "Classify packet from %s\n", entry->s.full_name);
+	ODP_DBG_LVL(CLS_DBG, "Classify packet from %s\n", entry->full_name);
 
 	cos = cls_select_cos(entry, base, pkt_hdr);
 
@@ -1857,7 +1857,7 @@ static
 cos_t *match_qos_cos(pktio_entry_t *entry, const uint8_t *pkt_addr,
 		     odp_packet_hdr_t *hdr)
 {
-	classifier_t *cls = &entry->s.cls;
+	classifier_t *cls = &entry->cls;
 	pmr_l2_cos_t *l2_cos;
 	pmr_l3_cos_t *l3_cos;
 	cos_t *cos;

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -222,7 +222,7 @@ static void _odp_cls_update_hash_proto(cos_t *cos,
 static inline void _cls_queue_unwind(uint32_t tbl_index, uint32_t j)
 {
 	while (j > 0)
-		odp_queue_destroy(queue_grp_tbl->s.queue[tbl_index + --j]);
+		odp_queue_destroy(queue_grp_tbl->queue[tbl_index + --j]);
 }
 
 odp_cos_t odp_cls_cos_create(const char *name, const odp_cls_cos_param_t *param_in)
@@ -304,7 +304,7 @@ odp_cos_t odp_cls_cos_create(const char *name, const odp_cls_cos_param_t *param_
 						UNLOCK(&cos->lock);
 						return ODP_COS_INVALID;
 					}
-					queue_grp_tbl->s.queue[tbl_index + j] =
+					queue_grp_tbl->queue[tbl_index + j] =
 							queue;
 				}
 
@@ -475,7 +475,7 @@ uint32_t odp_cls_cos_queues(odp_cos_t cos_id, odp_queue_t queue[],
 
 	tbl_index = cos->index * CLS_COS_QUEUE_MAX;
 	for (i = 0; i < num_queues; i++)
-		queue[i] = queue_grp_tbl->s.queue[tbl_index + i];
+		queue[i] = queue_grp_tbl->queue[tbl_index + i];
 
 	return cos->num_queue;
 }
@@ -1730,7 +1730,7 @@ int _odp_cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 	hash = hash & (CLS_COS_QUEUE_MAX - 1);
 	tbl_index = (cos->index * CLS_COS_QUEUE_MAX) + (hash %
 							  cos->num_queue);
-	pkt_hdr->dst_queue = queue_grp_tbl->s.queue[tbl_index];
+	pkt_hdr->dst_queue = queue_grp_tbl->queue[tbl_index];
 	return 0;
 
 error:

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -777,8 +777,8 @@ static void packet_vector_enq_cos(odp_queue_t queue, odp_event_t events[],
 				  uint32_t num, cos_t *cos_hdr)
 {
 	odp_packet_vector_t pktv;
-	odp_pool_t pool = cos_hdr->s.vector.pool;
-	uint32_t max_size = cos_hdr->s.vector.max_size;
+	odp_pool_t pool = cos_hdr->vector.pool;
+	uint32_t max_size = cos_hdr->vector.max_size;
 	uint32_t num_enq;
 	int num_pktv = (num + max_size - 1) / max_size;
 	int ret;
@@ -967,7 +967,7 @@ static inline int pktin_recv_buf(pktio_entry_t *entry, int pktin_index,
 			/* Packets from classifier */
 			cos_hdr = _odp_cos_entry_from_idx(cos[i]);
 
-			if (cos_hdr->s.vector.enable) {
+			if (cos_hdr->vector.enable) {
 				packet_vector_enq_cos(dst[i], &ev[idx], num_enq, cos_hdr);
 				continue;
 			}

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -31,9 +31,9 @@
 #include <odp_macros_internal.h>
 
 #include <odp/api/plat/ticketlock_inlines.h>
-#define LOCK(queue_ptr)      odp_ticketlock_lock(&((queue_ptr)->s.lock))
-#define UNLOCK(queue_ptr)    odp_ticketlock_unlock(&((queue_ptr)->s.lock))
-#define LOCK_INIT(queue_ptr) odp_ticketlock_init(&((queue_ptr)->s.lock))
+#define LOCK(queue_ptr)      odp_ticketlock_lock(&((queue_ptr)->lock))
+#define UNLOCK(queue_ptr)    odp_ticketlock_unlock(&((queue_ptr)->lock))
+#define LOCK_INIT(queue_ptr) odp_ticketlock_init(&((queue_ptr)->lock))
 
 #include <string.h>
 #include <inttypes.h>
@@ -122,7 +122,7 @@ static int queue_init_global(void)
 	memset(&_odp_queue_inline_offset, 0,
 	       sizeof(_odp_queue_inline_offset_t));
 	_odp_queue_inline_offset.context = offsetof(queue_entry_t,
-						    s.param.context);
+						    param.context);
 
 	shm = odp_shm_reserve("_odp_queue_basic_global",
 			      sizeof(queue_global_t),
@@ -140,8 +140,8 @@ static int queue_init_global(void)
 		queue_entry_t *queue = qentry_from_index(i);
 
 		LOCK_INIT(queue);
-		queue->s.index  = i;
-		queue->s.handle = (odp_queue_t)queue;
+		queue->index  = i;
+		queue->handle = (odp_queue_t)queue;
 	}
 
 	if (read_config_file(_odp_queue_glb)) {
@@ -200,8 +200,8 @@ static int queue_term_global(void)
 	for (i = 0; i < CONFIG_MAX_QUEUES; i++) {
 		queue = qentry_from_index(i);
 		LOCK(queue);
-		if (queue->s.status != QUEUE_STATUS_FREE) {
-			ODP_ERR("Not destroyed queue: %s\n", queue->s.name);
+		if (queue->status != QUEUE_STATUS_FREE) {
+			ODP_ERR("Not destroyed queue: %s\n", queue->name);
 			ret = -1;
 		}
 		UNLOCK(queue);
@@ -229,30 +229,30 @@ static int queue_capability(odp_queue_capability_t *capa)
 
 static odp_queue_type_t queue_type(odp_queue_t handle)
 {
-	return qentry_from_handle(handle)->s.type;
+	return qentry_from_handle(handle)->type;
 }
 
 static odp_schedule_sync_t queue_sched_type(odp_queue_t handle)
 {
-	return qentry_from_handle(handle)->s.param.sched.sync;
+	return qentry_from_handle(handle)->param.sched.sync;
 }
 
 static odp_schedule_prio_t queue_sched_prio(odp_queue_t handle)
 {
-	return qentry_from_handle(handle)->s.param.sched.prio;
+	return qentry_from_handle(handle)->param.sched.prio;
 }
 
 static odp_schedule_group_t queue_sched_group(odp_queue_t handle)
 {
-	return qentry_from_handle(handle)->s.param.sched.group;
+	return qentry_from_handle(handle)->param.sched.group;
 }
 
 static uint32_t queue_lock_count(odp_queue_t handle)
 {
 	queue_entry_t *queue = qentry_from_handle(handle);
 
-	return queue->s.param.sched.sync == ODP_SCHED_SYNC_ORDERED ?
-		queue->s.param.sched.lock_count : 0;
+	return queue->param.sched.sync == ODP_SCHED_SYNC_ORDERED ?
+		queue->param.sched.lock_count : 0;
 }
 
 static odp_queue_t queue_create(const char *name,
@@ -309,17 +309,17 @@ static odp_queue_t queue_create(const char *name,
 	for (; i < max_idx; i++) {
 		queue = qentry_from_index(i);
 
-		if (queue->s.status != QUEUE_STATUS_FREE)
+		if (queue->status != QUEUE_STATUS_FREE)
 			continue;
 
 		LOCK(queue);
-		if (queue->s.status == QUEUE_STATUS_FREE) {
+		if (queue->status == QUEUE_STATUS_FREE) {
 			if (queue_init(queue, name, param)) {
 				UNLOCK(queue);
 				return ODP_QUEUE_INVALID;
 			}
 
-			if (!queue->s.spsc &&
+			if (!queue->spsc &&
 			    param->nonblocking == ODP_NONBLOCKING_LF) {
 				queue_lf_func_t *lf_fn;
 
@@ -331,21 +331,21 @@ static odp_queue_t queue_create(const char *name,
 					UNLOCK(queue);
 					return ODP_QUEUE_INVALID;
 				}
-				queue->s.queue_lf = queue_lf;
+				queue->queue_lf = queue_lf;
 
-				queue->s.enqueue       = lf_fn->enq;
-				queue->s.enqueue_multi = lf_fn->enq_multi;
-				queue->s.dequeue       = lf_fn->deq;
-				queue->s.dequeue_multi = lf_fn->deq_multi;
-				queue->s.orig_dequeue_multi = lf_fn->deq_multi;
+				queue->enqueue       = lf_fn->enq;
+				queue->enqueue_multi = lf_fn->enq_multi;
+				queue->dequeue       = lf_fn->deq;
+				queue->dequeue_multi = lf_fn->deq_multi;
+				queue->orig_dequeue_multi = lf_fn->deq_multi;
 			}
 
 			if (type == ODP_QUEUE_TYPE_SCHED)
-				queue->s.status = QUEUE_STATUS_NOTSCHED;
+				queue->status = QUEUE_STATUS_NOTSCHED;
 			else
-				queue->s.status = QUEUE_STATUS_READY;
+				queue->status = QUEUE_STATUS_READY;
 
-			handle = queue->s.handle;
+			handle = queue->handle;
 			UNLOCK(queue);
 			break;
 		}
@@ -356,9 +356,9 @@ static odp_queue_t queue_create(const char *name,
 		return ODP_QUEUE_INVALID;
 
 	if (type == ODP_QUEUE_TYPE_SCHED) {
-		if (_odp_sched_fn->create_queue(queue->s.index,
-						&queue->s.param.sched)) {
-			queue->s.status = QUEUE_STATUS_FREE;
+		if (_odp_sched_fn->create_queue(queue->index,
+						&queue->param.sched)) {
+			queue->status = QUEUE_STATUS_FREE;
 			ODP_ERR("schedule queue init failed\n");
 			return ODP_QUEUE_INVALID;
 		}
@@ -373,7 +373,7 @@ void _odp_sched_queue_set_status(uint32_t queue_index, int status)
 
 	LOCK(queue);
 
-	queue->s.status = status;
+	queue->status = status;
 
 	UNLOCK(queue);
 }
@@ -389,48 +389,48 @@ static int queue_destroy(odp_queue_t handle)
 		return -1;
 
 	LOCK(queue);
-	if (queue->s.status == QUEUE_STATUS_FREE) {
+	if (queue->status == QUEUE_STATUS_FREE) {
 		UNLOCK(queue);
-		ODP_ERR("queue \"%s\" already free\n", queue->s.name);
+		ODP_ERR("queue \"%s\" already free\n", queue->name);
 		return -1;
 	}
-	if (queue->s.status == QUEUE_STATUS_DESTROYED) {
+	if (queue->status == QUEUE_STATUS_DESTROYED) {
 		UNLOCK(queue);
-		ODP_ERR("queue \"%s\" already destroyed\n", queue->s.name);
+		ODP_ERR("queue \"%s\" already destroyed\n", queue->name);
 		return -1;
 	}
 
-	if (queue->s.spsc)
-		empty = ring_spsc_is_empty(&queue->s.ring_spsc);
-	else if (queue->s.type == ODP_QUEUE_TYPE_SCHED)
-		empty = ring_st_is_empty(&queue->s.ring_st);
+	if (queue->spsc)
+		empty = ring_spsc_is_empty(&queue->ring_spsc);
+	else if (queue->type == ODP_QUEUE_TYPE_SCHED)
+		empty = ring_st_is_empty(&queue->ring_st);
 	else
-		empty = ring_mpmc_is_empty(&queue->s.ring_mpmc);
+		empty = ring_mpmc_is_empty(&queue->ring_mpmc);
 
 	if (!empty) {
 		UNLOCK(queue);
-		ODP_ERR("queue \"%s\" not empty\n", queue->s.name);
+		ODP_ERR("queue \"%s\" not empty\n", queue->name);
 		return -1;
 	}
 
-	switch (queue->s.status) {
+	switch (queue->status) {
 	case QUEUE_STATUS_READY:
-		queue->s.status = QUEUE_STATUS_FREE;
+		queue->status = QUEUE_STATUS_FREE;
 		break;
 	case QUEUE_STATUS_NOTSCHED:
-		queue->s.status = QUEUE_STATUS_FREE;
-		_odp_sched_fn->destroy_queue(queue->s.index);
+		queue->status = QUEUE_STATUS_FREE;
+		_odp_sched_fn->destroy_queue(queue->index);
 		break;
 	case QUEUE_STATUS_SCHED:
 		/* Queue is still in scheduling */
-		queue->s.status = QUEUE_STATUS_DESTROYED;
+		queue->status = QUEUE_STATUS_DESTROYED;
 		break;
 	default:
 		ODP_ABORT("Unexpected queue status\n");
 	}
 
-	if (queue->s.queue_lf)
-		_odp_queue_lf_destroy(queue->s.queue_lf);
+	if (queue->queue_lf)
+		_odp_queue_lf_destroy(queue->queue_lf);
 
 	UNLOCK(queue);
 
@@ -441,7 +441,7 @@ static int queue_context_set(odp_queue_t handle, void *context,
 			     uint32_t len ODP_UNUSED)
 {
 	odp_mb_full();
-	qentry_from_handle(handle)->s.param.context = context;
+	qentry_from_handle(handle)->param.context = context;
 	odp_mb_full();
 	return 0;
 }
@@ -453,15 +453,15 @@ static odp_queue_t queue_lookup(const char *name)
 	for (i = 0; i < CONFIG_MAX_QUEUES; i++) {
 		queue_entry_t *queue = qentry_from_index(i);
 
-		if (queue->s.status == QUEUE_STATUS_FREE ||
-		    queue->s.status == QUEUE_STATUS_DESTROYED)
+		if (queue->status == QUEUE_STATUS_FREE ||
+		    queue->status == QUEUE_STATUS_DESTROYED)
 			continue;
 
 		LOCK(queue);
-		if (strcmp(name, queue->s.name) == 0) {
+		if (strcmp(name, queue->name) == 0) {
 			/* found it */
 			UNLOCK(queue);
-			return queue->s.handle;
+			return queue->handle;
 		}
 		UNLOCK(queue);
 	}
@@ -498,15 +498,15 @@ static inline int _plain_queue_enq_multi(odp_queue_t handle,
 	uint32_t event_idx[num];
 
 	queue = qentry_from_handle(handle);
-	ring_mpmc = &queue->s.ring_mpmc;
+	ring_mpmc = &queue->ring_mpmc;
 
 	if (_odp_sched_fn->ord_enq_multi(handle, (void **)event_hdr, num, &ret))
 		return ret;
 
 	event_index_from_hdr(event_idx, event_hdr, num);
 
-	num_enq = ring_mpmc_enq_multi(ring_mpmc, queue->s.ring_data,
-				      queue->s.ring_mask, event_idx, num);
+	num_enq = ring_mpmc_enq_multi(ring_mpmc, queue->ring_data,
+				      queue->ring_mask, event_idx, num);
 
 	return num_enq;
 }
@@ -520,10 +520,10 @@ static inline int _plain_queue_deq_multi(odp_queue_t handle,
 	uint32_t event_idx[num];
 
 	queue = qentry_from_handle(handle);
-	ring_mpmc = &queue->s.ring_mpmc;
+	ring_mpmc = &queue->ring_mpmc;
 
-	num_deq = ring_mpmc_deq_multi(ring_mpmc, queue->s.ring_data,
-				      queue->s.ring_mask, event_idx, num);
+	num_deq = ring_mpmc_deq_multi(ring_mpmc, queue->ring_data,
+				      queue->ring_mask, event_idx, num);
 
 	if (num_deq == 0)
 		return 0;
@@ -647,7 +647,7 @@ static int queue_info(odp_queue_t handle, odp_queue_info_t *info)
 	queue = qentry_from_index(queue_id);
 
 	LOCK(queue);
-	status = queue->s.status;
+	status = queue->status;
 
 	if (odp_unlikely(status == QUEUE_STATUS_FREE ||
 			 status == QUEUE_STATUS_DESTROYED)) {
@@ -656,8 +656,8 @@ static int queue_info(odp_queue_t handle, odp_queue_info_t *info)
 		return -1;
 	}
 
-	info->name = queue->s.name;
-	info->param = queue->s.param;
+	info->name = queue->name;
+	info->param = queue->param;
 
 	UNLOCK(queue);
 
@@ -683,7 +683,7 @@ static void queue_print(odp_queue_t handle)
 	queue = qentry_from_index(queue_id);
 
 	LOCK(queue);
-	status = queue->s.status;
+	status = queue->status;
 
 	if (odp_unlikely(status == QUEUE_STATUS_FREE ||
 			 status == QUEUE_STATUS_DESTROYED)) {
@@ -693,72 +693,72 @@ static void queue_print(odp_queue_t handle)
 	}
 	ODP_PRINT("\nQueue info\n");
 	ODP_PRINT("----------\n");
-	ODP_PRINT("  handle          %p\n", (void *)queue->s.handle);
+	ODP_PRINT("  handle          %p\n", (void *)queue->handle);
 	ODP_PRINT("  index           %" PRIu32 "\n", queue_id);
-	ODP_PRINT("  name            %s\n", queue->s.name);
+	ODP_PRINT("  name            %s\n", queue->name);
 	ODP_PRINT("  enq mode        %s\n",
-		  queue->s.param.enq_mode == ODP_QUEUE_OP_MT ? "ODP_QUEUE_OP_MT" :
-		  (queue->s.param.enq_mode == ODP_QUEUE_OP_MT_UNSAFE ? "ODP_QUEUE_OP_MT_UNSAFE" :
-		   (queue->s.param.enq_mode == ODP_QUEUE_OP_DISABLED ? "ODP_QUEUE_OP_DISABLED" :
+		  queue->param.enq_mode == ODP_QUEUE_OP_MT ? "ODP_QUEUE_OP_MT" :
+		  (queue->param.enq_mode == ODP_QUEUE_OP_MT_UNSAFE ? "ODP_QUEUE_OP_MT_UNSAFE" :
+		   (queue->param.enq_mode == ODP_QUEUE_OP_DISABLED ? "ODP_QUEUE_OP_DISABLED" :
 		    "unknown")));
 	ODP_PRINT("  deq mode        %s\n",
-		  queue->s.param.deq_mode == ODP_QUEUE_OP_MT ? "ODP_QUEUE_OP_MT" :
-		  (queue->s.param.deq_mode == ODP_QUEUE_OP_MT_UNSAFE ? "ODP_QUEUE_OP_MT_UNSAFE" :
-		   (queue->s.param.deq_mode == ODP_QUEUE_OP_DISABLED ? "ODP_QUEUE_OP_DISABLED" :
+		  queue->param.deq_mode == ODP_QUEUE_OP_MT ? "ODP_QUEUE_OP_MT" :
+		  (queue->param.deq_mode == ODP_QUEUE_OP_MT_UNSAFE ? "ODP_QUEUE_OP_MT_UNSAFE" :
+		   (queue->param.deq_mode == ODP_QUEUE_OP_DISABLED ? "ODP_QUEUE_OP_DISABLED" :
 		    "unknown")));
 	ODP_PRINT("  non-blocking    %s\n",
-		  queue->s.param.nonblocking == ODP_BLOCKING ? "ODP_BLOCKING" :
-		  (queue->s.param.nonblocking == ODP_NONBLOCKING_LF ? "ODP_NONBLOCKING_LF" :
-		   (queue->s.param.nonblocking == ODP_NONBLOCKING_WF ? "ODP_NONBLOCKING_WF" :
+		  queue->param.nonblocking == ODP_BLOCKING ? "ODP_BLOCKING" :
+		  (queue->param.nonblocking == ODP_NONBLOCKING_LF ? "ODP_NONBLOCKING_LF" :
+		   (queue->param.nonblocking == ODP_NONBLOCKING_WF ? "ODP_NONBLOCKING_WF" :
 		    "unknown")));
 	ODP_PRINT("  type            %s\n",
-		  queue->s.type == ODP_QUEUE_TYPE_PLAIN ? "ODP_QUEUE_TYPE_PLAIN" :
-		  (queue->s.type == ODP_QUEUE_TYPE_SCHED ? "ODP_QUEUE_TYPE_SCHED" : "unknown"));
-	if (queue->s.type == ODP_QUEUE_TYPE_SCHED) {
+		  queue->type == ODP_QUEUE_TYPE_PLAIN ? "ODP_QUEUE_TYPE_PLAIN" :
+		  (queue->type == ODP_QUEUE_TYPE_SCHED ? "ODP_QUEUE_TYPE_SCHED" : "unknown"));
+	if (queue->type == ODP_QUEUE_TYPE_SCHED) {
 		ODP_PRINT("    sync          %s\n",
-			  queue->s.param.sched.sync == ODP_SCHED_SYNC_PARALLEL ?
+			  queue->param.sched.sync == ODP_SCHED_SYNC_PARALLEL ?
 			  "ODP_SCHED_SYNC_PARALLEL" :
-			  (queue->s.param.sched.sync == ODP_SCHED_SYNC_ATOMIC ?
+			  (queue->param.sched.sync == ODP_SCHED_SYNC_ATOMIC ?
 			   "ODP_SCHED_SYNC_ATOMIC" :
-			   (queue->s.param.sched.sync == ODP_SCHED_SYNC_ORDERED ?
+			   (queue->param.sched.sync == ODP_SCHED_SYNC_ORDERED ?
 			    "ODP_SCHED_SYNC_ORDERED" : "unknown")));
-		prio = queue->s.param.sched.prio;
+		prio = queue->param.sched.prio;
 		ODP_PRINT("    priority      %i (%i in API)\n", max_prio - prio, prio);
-		ODP_PRINT("    group         %i\n", queue->s.param.sched.group);
+		ODP_PRINT("    group         %i\n", queue->param.sched.group);
 		if (_odp_sched_id == _ODP_SCHED_ID_BASIC)
 			ODP_PRINT("    spread        %i\n", _odp_sched_basic_get_spread(queue_id));
 	}
-	if (queue->s.pktin.pktio != ODP_PKTIO_INVALID) {
-		if (!odp_pktio_info(queue->s.pktin.pktio, &pktio_info))
+	if (queue->pktin.pktio != ODP_PKTIO_INVALID) {
+		if (!odp_pktio_info(queue->pktin.pktio, &pktio_info))
 			ODP_PRINT("  pktin           %s\n", pktio_info.name);
 	}
-	if (queue->s.pktout.pktio != ODP_PKTIO_INVALID) {
-		if (!odp_pktio_info(queue->s.pktout.pktio, &pktio_info))
+	if (queue->pktout.pktio != ODP_PKTIO_INVALID) {
+		if (!odp_pktio_info(queue->pktout.pktio, &pktio_info))
 			ODP_PRINT("  pktout          %s\n", pktio_info.name);
 	}
 	ODP_PRINT("  timers          %" PRIu64 "\n",
-		  odp_atomic_load_u64(&queue->s.num_timers));
+		  odp_atomic_load_u64(&queue->num_timers));
 	ODP_PRINT("  status          %s\n",
-		  queue->s.status == QUEUE_STATUS_READY ? "ready" :
-		  (queue->s.status == QUEUE_STATUS_NOTSCHED ? "not scheduled" :
-		   (queue->s.status == QUEUE_STATUS_SCHED ? "scheduled" : "unknown")));
-	ODP_PRINT("  param.size      %" PRIu32 "\n", queue->s.param.size);
-	if (queue->s.queue_lf) {
+		  queue->status == QUEUE_STATUS_READY ? "ready" :
+		  (queue->status == QUEUE_STATUS_NOTSCHED ? "not scheduled" :
+		   (queue->status == QUEUE_STATUS_SCHED ? "scheduled" : "unknown")));
+	ODP_PRINT("  param.size      %" PRIu32 "\n", queue->param.size);
+	if (queue->queue_lf) {
 		ODP_PRINT("  implementation  queue_lf\n");
 		ODP_PRINT("  length          %" PRIu32 "/%" PRIu32 "\n",
-			  _odp_queue_lf_length(queue->s.queue_lf), _odp_queue_lf_max_length());
-	} else if (queue->s.spsc) {
+			  _odp_queue_lf_length(queue->queue_lf), _odp_queue_lf_max_length());
+	} else if (queue->spsc) {
 		ODP_PRINT("  implementation  ring_spsc\n");
 		ODP_PRINT("  length          %" PRIu32 "/%" PRIu32 "\n",
-			  ring_spsc_length(&queue->s.ring_spsc), queue->s.ring_mask + 1);
-	} else if (queue->s.type == ODP_QUEUE_TYPE_SCHED) {
+			  ring_spsc_length(&queue->ring_spsc), queue->ring_mask + 1);
+	} else if (queue->type == ODP_QUEUE_TYPE_SCHED) {
 		ODP_PRINT("  implementation  ring_st\n");
 		ODP_PRINT("  length          %" PRIu32 "/%" PRIu32 "\n",
-			  ring_st_length(&queue->s.ring_st), queue->s.ring_mask + 1);
+			  ring_st_length(&queue->ring_st), queue->ring_mask + 1);
 	} else {
 		ODP_PRINT("  implementation  ring_mpmc\n");
 		ODP_PRINT("  length          %" PRIu32 "/%" PRIu32 "\n",
-			  ring_mpmc_length(&queue->s.ring_mpmc), queue->s.ring_mask + 1);
+			  ring_mpmc_length(&queue->ring_mpmc), queue->ring_mask + 1);
 	}
 	ODP_PRINT("\n");
 
@@ -795,37 +795,37 @@ static void queue_print_all(void)
 	for (i = 0; i < CONFIG_MAX_QUEUES; i++) {
 		queue_entry_t *queue = qentry_from_index(i);
 
-		if (queue->s.status < QUEUE_STATUS_READY)
+		if (queue->status < QUEUE_STATUS_READY)
 			continue;
 
 		LOCK(queue);
 
-		status   = queue->s.status;
-		index    = queue->s.index;
-		name     = queue->s.name;
-		type     = queue->s.type;
-		blocking = queue->s.param.nonblocking;
-		enq_mode = queue->s.param.enq_mode;
-		deq_mode = queue->s.param.deq_mode;
-		order    = queue->s.param.order;
+		status   = queue->status;
+		index    = queue->index;
+		name     = queue->name;
+		type     = queue->type;
+		blocking = queue->param.nonblocking;
+		enq_mode = queue->param.enq_mode;
+		deq_mode = queue->param.deq_mode;
+		order    = queue->param.order;
 
-		if (queue->s.queue_lf) {
-			len     = _odp_queue_lf_length(queue->s.queue_lf);
+		if (queue->queue_lf) {
+			len     = _odp_queue_lf_length(queue->queue_lf);
 			max_len = _odp_queue_lf_max_length();
-		} else if (queue->s.spsc) {
-			len     = ring_spsc_length(&queue->s.ring_spsc);
-			max_len = queue->s.ring_mask + 1;
+		} else if (queue->spsc) {
+			len     = ring_spsc_length(&queue->ring_spsc);
+			max_len = queue->ring_mask + 1;
 		} else if (type == ODP_QUEUE_TYPE_SCHED) {
-			len     = ring_st_length(&queue->s.ring_st);
-			max_len = queue->s.ring_mask + 1;
-			prio    = queue->s.param.sched.prio;
-			grp     = queue->s.param.sched.group;
-			sync    = queue->s.param.sched.sync;
+			len     = ring_st_length(&queue->ring_st);
+			max_len = queue->ring_mask + 1;
+			prio    = queue->param.sched.prio;
+			grp     = queue->param.sched.group;
+			sync    = queue->param.sched.sync;
 			if (_odp_sched_id == _ODP_SCHED_ID_BASIC)
 				spr = _odp_sched_basic_get_spread(index);
 		} else {
-			len     = ring_mpmc_length(&queue->s.ring_mpmc);
-			max_len = queue->s.ring_mask + 1;
+			len     = ring_mpmc_length(&queue->ring_mpmc);
+			max_len = queue->ring_mask + 1;
 		}
 
 		UNLOCK(queue);
@@ -882,7 +882,7 @@ static inline int _sched_queue_enq_multi(odp_queue_t handle,
 	uint32_t event_idx[num];
 
 	queue = qentry_from_handle(handle);
-	ring_st = &queue->s.ring_st;
+	ring_st = &queue->ring_st;
 
 	if (_odp_sched_fn->ord_enq_multi(handle, (void **)event_hdr, num, &ret))
 		return ret;
@@ -891,23 +891,23 @@ static inline int _sched_queue_enq_multi(odp_queue_t handle,
 
 	LOCK(queue);
 
-	num_enq = ring_st_enq_multi(ring_st, queue->s.ring_data,
-				    queue->s.ring_mask, event_idx, num);
+	num_enq = ring_st_enq_multi(ring_st, queue->ring_data,
+				    queue->ring_mask, event_idx, num);
 
 	if (odp_unlikely(num_enq == 0)) {
 		UNLOCK(queue);
 		return 0;
 	}
 
-	if (queue->s.status == QUEUE_STATUS_NOTSCHED) {
-		queue->s.status = QUEUE_STATUS_SCHED;
+	if (queue->status == QUEUE_STATUS_NOTSCHED) {
+		queue->status = QUEUE_STATUS_SCHED;
 		sched = 1;
 	}
 
 	UNLOCK(queue);
 
 	/* Add queue to scheduling */
-	if (sched && _odp_sched_fn->sched_queue(queue->s.index))
+	if (sched && _odp_sched_fn->sched_queue(queue->index))
 		ODP_ABORT("schedule_queue failed\n");
 
 	return num_enq;
@@ -921,17 +921,17 @@ int _odp_sched_queue_deq(uint32_t queue_index, odp_event_t ev[], int max_num,
 	queue_entry_t *queue = qentry_from_index(queue_index);
 	uint32_t event_idx[max_num];
 
-	ring_st = &queue->s.ring_st;
+	ring_st = &queue->ring_st;
 
 	LOCK(queue);
 
-	status = queue->s.status;
+	status = queue->status;
 
 	if (odp_unlikely(status < QUEUE_STATUS_READY)) {
 		/* Bad queue, or queue has been destroyed.
 		 * Inform scheduler about a destroyed queue. */
-		if (queue->s.status == QUEUE_STATUS_DESTROYED) {
-			queue->s.status = QUEUE_STATUS_FREE;
+		if (queue->status == QUEUE_STATUS_DESTROYED) {
+			queue->status = QUEUE_STATUS_FREE;
 			_odp_sched_fn->destroy_queue(queue_index);
 		}
 
@@ -939,13 +939,13 @@ int _odp_sched_queue_deq(uint32_t queue_index, odp_event_t ev[], int max_num,
 		return -1;
 	}
 
-	num_deq = ring_st_deq_multi(ring_st, queue->s.ring_data,
-				    queue->s.ring_mask, event_idx, max_num);
+	num_deq = ring_st_deq_multi(ring_st, queue->ring_data,
+				    queue->ring_mask, event_idx, max_num);
 
 	if (num_deq == 0) {
 		/* Already empty queue */
 		if (update_status && status == QUEUE_STATUS_SCHED)
-			queue->s.status = QUEUE_STATUS_NOTSCHED;
+			queue->status = QUEUE_STATUS_NOTSCHED;
 
 		UNLOCK(queue);
 
@@ -984,16 +984,16 @@ int _odp_sched_queue_empty(uint32_t queue_index)
 
 	LOCK(queue);
 
-	if (odp_unlikely(queue->s.status < QUEUE_STATUS_READY)) {
+	if (odp_unlikely(queue->status < QUEUE_STATUS_READY)) {
 		/* Bad queue, or queue has been destroyed. */
 		UNLOCK(queue);
 		return -1;
 	}
 
-	if (ring_st_is_empty(&queue->s.ring_st)) {
+	if (ring_st_is_empty(&queue->ring_st)) {
 		/* Already empty queue. Update status. */
-		if (queue->s.status == QUEUE_STATUS_SCHED)
-			queue->s.status = QUEUE_STATUS_NOTSCHED;
+		if (queue->status == QUEUE_STATUS_SCHED)
+			queue->status = QUEUE_STATUS_NOTSCHED;
 
 		ret = 1;
 	}
@@ -1014,23 +1014,23 @@ static int queue_init(queue_entry_t *queue, const char *name,
 	queue_type = param->type;
 
 	if (name == NULL) {
-		queue->s.name[0] = 0;
+		queue->name[0] = 0;
 	} else {
-		strncpy(queue->s.name, name, ODP_QUEUE_NAME_LEN - 1);
-		queue->s.name[ODP_QUEUE_NAME_LEN - 1] = 0;
+		strncpy(queue->name, name, ODP_QUEUE_NAME_LEN - 1);
+		queue->name[ODP_QUEUE_NAME_LEN - 1] = 0;
 	}
-	memcpy(&queue->s.param, param, sizeof(odp_queue_param_t));
-	if (queue->s.param.sched.lock_count > _odp_sched_fn->max_ordered_locks())
+	memcpy(&queue->param, param, sizeof(odp_queue_param_t));
+	if (queue->param.sched.lock_count > _odp_sched_fn->max_ordered_locks())
 		return -1;
 
 	if (queue_type == ODP_QUEUE_TYPE_SCHED)
-		queue->s.param.deq_mode = ODP_QUEUE_OP_DISABLED;
+		queue->param.deq_mode = ODP_QUEUE_OP_DISABLED;
 
-	queue->s.type = queue_type;
-	odp_atomic_init_u64(&queue->s.num_timers, 0);
+	queue->type = queue_type;
+	odp_atomic_init_u64(&queue->num_timers, 0);
 
-	queue->s.pktin = PKTIN_INVALID;
-	queue->s.pktout = PKTOUT_INVALID;
+	queue->pktin = PKTIN_INVALID;
+	queue->pktout = PKTOUT_INVALID;
 
 	queue_size = param->size;
 	if (queue_size == 0)
@@ -1047,7 +1047,7 @@ static int queue_init(queue_entry_t *queue, const char *name,
 		return -1;
 	}
 
-	offset = queue->s.index * (uint64_t)_odp_queue_glb->config.max_queue_size;
+	offset = queue->index * (uint64_t)_odp_queue_glb->config.max_queue_size;
 
 	/* Single-producer / single-consumer plain queue has simple and
 	 * lock-free implementation */
@@ -1055,37 +1055,37 @@ static int queue_init(queue_entry_t *queue, const char *name,
 	       (param->enq_mode == ODP_QUEUE_OP_MT_UNSAFE) &&
 	       (param->deq_mode == ODP_QUEUE_OP_MT_UNSAFE);
 
-	queue->s.spsc = spsc;
-	queue->s.queue_lf = NULL;
+	queue->spsc = spsc;
+	queue->queue_lf = NULL;
 
 	/* Default to error functions */
-	queue->s.enqueue            = error_enqueue;
-	queue->s.enqueue_multi      = error_enqueue_multi;
-	queue->s.dequeue            = error_dequeue;
-	queue->s.dequeue_multi      = error_dequeue_multi;
-	queue->s.orig_dequeue_multi = error_dequeue_multi;
+	queue->enqueue            = error_enqueue;
+	queue->enqueue_multi      = error_enqueue_multi;
+	queue->dequeue            = error_dequeue;
+	queue->dequeue_multi      = error_dequeue_multi;
+	queue->orig_dequeue_multi = error_dequeue_multi;
 
 	if (spsc) {
 		_odp_queue_spsc_init(queue, queue_size);
 	} else {
 		if (queue_type == ODP_QUEUE_TYPE_PLAIN) {
-			queue->s.enqueue            = plain_queue_enq;
-			queue->s.enqueue_multi      = plain_queue_enq_multi;
-			queue->s.dequeue            = plain_queue_deq;
-			queue->s.dequeue_multi      = plain_queue_deq_multi;
-			queue->s.orig_dequeue_multi = plain_queue_deq_multi;
+			queue->enqueue            = plain_queue_enq;
+			queue->enqueue_multi      = plain_queue_enq_multi;
+			queue->dequeue            = plain_queue_deq;
+			queue->dequeue_multi      = plain_queue_deq_multi;
+			queue->orig_dequeue_multi = plain_queue_deq_multi;
 
-			queue->s.ring_data = &_odp_queue_glb->ring_data[offset];
-			queue->s.ring_mask = queue_size - 1;
-			ring_mpmc_init(&queue->s.ring_mpmc);
+			queue->ring_data = &_odp_queue_glb->ring_data[offset];
+			queue->ring_mask = queue_size - 1;
+			ring_mpmc_init(&queue->ring_mpmc);
 
 		} else {
-			queue->s.enqueue            = sched_queue_enq;
-			queue->s.enqueue_multi      = sched_queue_enq_multi;
+			queue->enqueue            = sched_queue_enq;
+			queue->enqueue_multi      = sched_queue_enq_multi;
 
-			queue->s.ring_data = &_odp_queue_glb->ring_data[offset];
-			queue->s.ring_mask = queue_size - 1;
-			ring_st_init(&queue->s.ring_st);
+			queue->ring_data = &_odp_queue_glb->ring_data[offset];
+			queue->ring_mask = queue_size - 1;
+			ring_st_init(&queue->ring_st);
 		}
 	}
 
@@ -1101,30 +1101,30 @@ static odp_pktout_queue_t queue_get_pktout(odp_queue_t handle)
 {
 	queue_entry_t *qentry = qentry_from_handle(handle);
 
-	return qentry->s.pktout;
+	return qentry->pktout;
 }
 
 static void queue_set_pktout(odp_queue_t handle, odp_pktio_t pktio, int index)
 {
 	queue_entry_t *qentry = qentry_from_handle(handle);
 
-	qentry->s.pktout.pktio = pktio;
-	qentry->s.pktout.index = index;
+	qentry->pktout.pktio = pktio;
+	qentry->pktout.index = index;
 }
 
 static odp_pktin_queue_t queue_get_pktin(odp_queue_t handle)
 {
 	queue_entry_t *qentry = qentry_from_handle(handle);
 
-	return qentry->s.pktin;
+	return qentry->pktin;
 }
 
 static void queue_set_pktin(odp_queue_t handle, odp_pktio_t pktio, int index)
 {
 	queue_entry_t *qentry = qentry_from_handle(handle);
 
-	qentry->s.pktin.pktio = pktio;
-	qentry->s.pktin.index = index;
+	qentry->pktin.pktio = pktio;
+	qentry->pktin.index = index;
 }
 
 static void queue_set_enq_deq_func(odp_queue_t handle,
@@ -1136,16 +1136,16 @@ static void queue_set_enq_deq_func(odp_queue_t handle,
 	queue_entry_t *qentry = qentry_from_handle(handle);
 
 	if (enq)
-		qentry->s.enqueue = enq;
+		qentry->enqueue = enq;
 
 	if (enq_multi)
-		qentry->s.enqueue_multi = enq_multi;
+		qentry->enqueue_multi = enq_multi;
 
 	if (deq)
-		qentry->s.dequeue = deq;
+		qentry->dequeue = deq;
 
 	if (deq_multi)
-		qentry->s.dequeue_multi = deq_multi;
+		qentry->dequeue_multi = deq_multi;
 }
 
 static int queue_orig_multi(odp_queue_t handle,
@@ -1153,7 +1153,7 @@ static int queue_orig_multi(odp_queue_t handle,
 {
 	queue_entry_t *queue = qentry_from_handle(handle);
 
-	return queue->s.orig_dequeue_multi(handle, event_hdr, num);
+	return queue->orig_dequeue_multi(handle, event_hdr, num);
 }
 
 static int queue_api_enq_multi(odp_queue_t handle,
@@ -1167,7 +1167,7 @@ static int queue_api_enq_multi(odp_queue_t handle,
 	if (num > QUEUE_MULTI_MAX)
 		num = QUEUE_MULTI_MAX;
 
-	return queue->s.enqueue_multi(handle,
+	return queue->enqueue_multi(handle,
 				      (_odp_event_hdr_t **)(uintptr_t)ev, num);
 }
 
@@ -1175,21 +1175,21 @@ static void queue_timer_add(odp_queue_t handle)
 {
 	queue_entry_t *queue = qentry_from_handle(handle);
 
-	odp_atomic_inc_u64(&queue->s.num_timers);
+	odp_atomic_inc_u64(&queue->num_timers);
 }
 
 static void queue_timer_rem(odp_queue_t handle)
 {
 	queue_entry_t *queue = qentry_from_handle(handle);
 
-	odp_atomic_dec_u64(&queue->s.num_timers);
+	odp_atomic_dec_u64(&queue->num_timers);
 }
 
 static int queue_api_enq(odp_queue_t handle, odp_event_t ev)
 {
 	queue_entry_t *queue = qentry_from_handle(handle);
 
-	return queue->s.enqueue(handle,
+	return queue->enqueue(handle,
 				(_odp_event_hdr_t *)(uintptr_t)ev);
 }
 
@@ -1201,10 +1201,10 @@ static int queue_api_deq_multi(odp_queue_t handle, odp_event_t ev[], int num)
 	if (num > QUEUE_MULTI_MAX)
 		num = QUEUE_MULTI_MAX;
 
-	ret = queue->s.dequeue_multi(handle, (_odp_event_hdr_t **)ev, num);
+	ret = queue->dequeue_multi(handle, (_odp_event_hdr_t **)ev, num);
 
 	if (odp_global_rw->inline_timers &&
-	    odp_atomic_load_u64(&queue->s.num_timers))
+	    odp_atomic_load_u64(&queue->num_timers))
 		timer_run(ret ? 2 : 1);
 
 	return ret;
@@ -1213,10 +1213,10 @@ static int queue_api_deq_multi(odp_queue_t handle, odp_event_t ev[], int num)
 static odp_event_t queue_api_deq(odp_queue_t handle)
 {
 	queue_entry_t *queue = qentry_from_handle(handle);
-	odp_event_t ev = (odp_event_t)queue->s.dequeue(handle);
+	odp_event_t ev = (odp_event_t)queue->dequeue(handle);
 
 	if (odp_global_rw->inline_timers &&
-	    odp_atomic_load_u64(&queue->s.num_timers))
+	    odp_atomic_load_u64(&queue->num_timers))
 		timer_run(ev != ODP_EVENT_INVALID ? 2 : 1);
 
 	return ev;

--- a/platform/linux-generic/odp_queue_lf.c
+++ b/platform/linux-generic/odp_queue_lf.c
@@ -125,7 +125,7 @@ static int queue_lf_enq(odp_queue_t handle, _odp_event_hdr_t *event_hdr)
 	ring_lf_node_t *node;
 
 	queue    = qentry_from_handle(handle);
-	queue_lf = queue->s.queue_lf;
+	queue_lf = queue->queue_lf;
 
 	new_val.s.ptr     = (uintptr_t)event_hdr;
 	new_val.s.counter = odp_atomic_fetch_inc_u64(&queue_lf->enq_counter);
@@ -184,7 +184,7 @@ static _odp_event_hdr_t *queue_lf_deq(odp_queue_t handle)
 	_odp_event_hdr_t *event_hdr;
 
 	queue    = qentry_from_handle(handle);
-	queue_lf = queue->s.queue_lf;
+	queue_lf = queue->queue_lf;
 	new_val.s.counter = 0;
 	new_val.s.ptr     = 0;
 	old = NULL;
@@ -325,7 +325,7 @@ void *_odp_queue_lf_create(queue_entry_t *queue)
 		return NULL;
 	}
 
-	if (queue->s.type != ODP_QUEUE_TYPE_PLAIN)
+	if (queue->type != ODP_QUEUE_TYPE_PLAIN)
 		return NULL;
 
 	for (i = 0; i < QUEUE_LF_NUM; i++) {

--- a/platform/linux-generic/odp_queue_spsc.c
+++ b/platform/linux-generic/odp_queue_spsc.c
@@ -41,17 +41,17 @@ static inline int spsc_enq_multi(odp_queue_t handle,
 	uint32_t buf_idx[num];
 
 	queue = qentry_from_handle(handle);
-	ring_spsc = &queue->s.ring_spsc;
+	ring_spsc = &queue->ring_spsc;
 
 	event_index_from_hdr(buf_idx, event_hdr, num);
 
-	if (odp_unlikely(queue->s.status < QUEUE_STATUS_READY)) {
+	if (odp_unlikely(queue->status < QUEUE_STATUS_READY)) {
 		ODP_ERR("Bad queue status\n");
 		return -1;
 	}
 
-	return ring_spsc_enq_multi(ring_spsc, queue->s.ring_data,
-				   queue->s.ring_mask, buf_idx, num);
+	return ring_spsc_enq_multi(ring_spsc, queue->ring_data,
+				   queue->ring_mask, buf_idx, num);
 }
 
 static inline int spsc_deq_multi(odp_queue_t handle,
@@ -63,15 +63,15 @@ static inline int spsc_deq_multi(odp_queue_t handle,
 	uint32_t buf_idx[num];
 
 	queue = qentry_from_handle(handle);
-	ring_spsc = &queue->s.ring_spsc;
+	ring_spsc = &queue->ring_spsc;
 
-	if (odp_unlikely(queue->s.status < QUEUE_STATUS_READY)) {
+	if (odp_unlikely(queue->status < QUEUE_STATUS_READY)) {
 		/* Bad queue, or queue has been destroyed. */
 		return -1;
 	}
 
-	num_deq = ring_spsc_deq_multi(ring_spsc, queue->s.ring_data,
-				      queue->s.ring_mask, buf_idx, num);
+	num_deq = ring_spsc_deq_multi(ring_spsc, queue->ring_data,
+				      queue->ring_mask, buf_idx, num);
 
 	if (num_deq == 0)
 		return 0;
@@ -122,15 +122,15 @@ void _odp_queue_spsc_init(queue_entry_t *queue, uint32_t queue_size)
 {
 	uint64_t offset;
 
-	queue->s.enqueue = queue_spsc_enq;
-	queue->s.dequeue = queue_spsc_deq;
-	queue->s.enqueue_multi = queue_spsc_enq_multi;
-	queue->s.dequeue_multi = queue_spsc_deq_multi;
-	queue->s.orig_dequeue_multi = queue_spsc_deq_multi;
+	queue->enqueue = queue_spsc_enq;
+	queue->dequeue = queue_spsc_deq;
+	queue->enqueue_multi = queue_spsc_enq_multi;
+	queue->dequeue_multi = queue_spsc_deq_multi;
+	queue->orig_dequeue_multi = queue_spsc_deq_multi;
 
-	offset = queue->s.index * (uint64_t)_odp_queue_glb->config.max_queue_size;
+	offset = queue->index * (uint64_t)_odp_queue_glb->config.max_queue_size;
 
-	queue->s.ring_data = &_odp_queue_glb->ring_data[offset];
-	queue->s.ring_mask = queue_size - 1;
-	ring_spsc_init(&queue->s.ring_spsc);
+	queue->ring_data = &_odp_queue_glb->ring_data[offset];
+	queue->ring_mask = queue_size - 1;
+	ring_spsc_init(&queue->ring_spsc);
 }

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -1132,7 +1132,7 @@ static int schedule_ord_enq_multi(odp_queue_t dst_queue, void *event_hdr[],
 
 	dst_qentry = qentry_from_handle(dst_queue);
 
-	if (dst_qentry->s.param.order == ODP_QUEUE_ORDER_IGNORE)
+	if (dst_qentry->param.order == ODP_QUEUE_ORDER_IGNORE)
 		return 0;
 
 	src_queue  = sched_local.ordered.src_queue;
@@ -1146,7 +1146,7 @@ static int schedule_ord_enq_multi(odp_queue_t dst_queue, void *event_hdr[],
 	}
 
 	/* Pktout may drop packets, so the operation cannot be stashed. */
-	if (dst_qentry->s.pktout.pktio != ODP_PKTIO_INVALID ||
+	if (dst_qentry->pktout.pktio != ODP_PKTIO_INVALID ||
 	    odp_unlikely(stash_num >=  MAX_ORDERED_STASH)) {
 		/* If the local stash is full, wait until it is our turn and
 		 * then release the stash and do enqueue directly. */

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -718,7 +718,7 @@ static void pktio_start(int pktio_idx,
 		__atomic_fetch_add(&global->poll_count[pktio_idx], 1,
 				   __ATOMIC_RELAXED);
 		qentry = _odp_qentry_from_ext(odpq[i]);
-		elem = &qentry->s.sched_elem;
+		elem = &qentry->sched_elem;
 		elem->cons_type |= FLAG_PKTIN; /* Set pktin queue flag */
 		elem->pktio_idx = pktio_idx;
 		elem->rx_queue = rxq;
@@ -2102,7 +2102,7 @@ static int ord_enq_multi(odp_queue_t handle, void *event_hdr[], int num,
 	ts = _odp_sched_ts;
 	queue = qentry_from_int(handle);
 	if (ts && odp_unlikely(ts->out_of_order) &&
-	    (queue->s.param.order == ODP_QUEUE_ORDER_KEEP)) {
+	    (queue->param.order == ODP_QUEUE_ORDER_KEEP)) {
 		actual = _odp_rctx_save(queue, (_odp_event_hdr_t **)event_hdr, num);
 		*ret = actual;
 		return 1;

--- a/platform/linux-generic/odp_schedule_scalable_ordered.c
+++ b/platform/linux-generic/odp_schedule_scalable_ordered.c
@@ -264,7 +264,7 @@ static void blocking_enqueue(queue_entry_t *q, _odp_event_hdr_t **evts, int num)
 	/* Iterate until all events have been successfully enqueued */
 	for (;;) {
 		/* Attempt to enqueue remaining events */
-		actual = q->s.enqueue_multi(qentry_to_int(q), evts, num);
+		actual = q->enqueue_multi(qentry_to_int(q), evts, num);
 		if (odp_unlikely(actual < 0))
 			ODP_ERR("Failed to enqueue deferred events\n");
 		/* Update for potential partial success */

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2690,7 +2690,7 @@ int odp_tm_egress_capabilities(odp_tm_capabilities_t *capabilities,
 		}
 
 		/* Report not capable if pktout mode is not TM */
-		if (entry->s.param.out_mode != ODP_PKTOUT_MODE_TM)
+		if (entry->param.out_mode != ODP_PKTOUT_MODE_TM)
 			return 0;
 	}
 

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -173,7 +173,7 @@ static inline odp_packet_hdr_t *pkt_hdr_from_mbuf(struct rte_mbuf *mbuf)
 
 static inline pkt_dpdk_t *pkt_priv(pktio_entry_t *pktio_entry)
 {
-	return (pkt_dpdk_t *)(uintptr_t)(pktio_entry->s.pkt_priv);
+	return (pkt_dpdk_t *)(uintptr_t)(pktio_entry->pkt_priv);
 }
 
 static inline mem_src_data_t *mem_src_priv(uint8_t *data)
@@ -606,10 +606,10 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 	int nb_pkts = 0;
 	pkt_dpdk_t *pkt_dpdk = pkt_priv(pktio_entry);
 	odp_pool_t pool = pkt_dpdk->pool;
-	odp_pktin_config_opt_t pktin_cfg = pktio_entry->s.config.pktin;
-	odp_pktio_t input = pktio_entry->s.handle;
-	uint16_t frame_offset = pktio_entry->s.pktin_frame_offset;
-	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
+	odp_pktin_config_opt_t pktin_cfg = pktio_entry->config.pktin;
+	odp_pktio_t input = pktio_entry->handle;
+	uint16_t frame_offset = pktio_entry->pktin_frame_offset;
+	const odp_proto_layer_t layer = pktio_entry->parse_layer;
 
 	/* Allocate maximum sized packets */
 	max_len = pkt_dpdk->data_room;
@@ -644,7 +644,7 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 			ret = _odp_dpdk_packet_parse_common(pkt_hdr, data, pkt_len, pkt_len,
 							    mbuf, layer, pktin_cfg);
 			if (ret)
-				odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_errors);
+				odp_atomic_inc_u64(&pktio_entry->stats_extra.in_errors);
 
 			if (ret < 0) {
 				odp_packet_free(pkt);
@@ -658,7 +658,7 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 				ret = _odp_cls_classify_packet(pktio_entry, (const uint8_t *)data,
 							       &new_pool, pkt_hdr);
 				if (ret < 0)
-					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
+					odp_atomic_inc_u64(&pktio_entry->stats_extra.in_discards);
 
 				if (ret) {
 					odp_packet_free(pkt);
@@ -670,7 +670,7 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 					    &pkt, &pkt_hdr, new_pool))) {
 					odp_packet_free(pkt);
 					rte_pktmbuf_free(mbuf);
-					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
+					odp_atomic_inc_u64(&pktio_entry->stats_extra.in_discards);
 					continue;
 				}
 			}
@@ -826,9 +826,9 @@ static inline int pkt_to_mbuf(pktio_entry_t *pktio_entry,
 	int i, j;
 	char *data;
 	uint16_t pkt_len;
-	uint8_t chksum_enabled = pktio_entry->s.enabled.chksum_insert;
+	uint8_t chksum_enabled = pktio_entry->enabled.chksum_insert;
 	uint8_t tx_ts_enabled = _odp_pktio_tx_ts_enabled(pktio_entry);
-	odp_pktout_config_opt_t *pktout_cfg = &pktio_entry->s.config.pktout;
+	odp_pktout_config_opt_t *pktout_cfg = &pktio_entry->config.pktout;
 
 	if (odp_unlikely((rte_pktmbuf_alloc_bulk(pkt_dpdk->pkt_pool,
 						 mbuf_table, num)))) {
@@ -853,7 +853,7 @@ static inline int pkt_to_mbuf(pktio_entry_t *pktio_entry,
 
 		if (odp_unlikely(chksum_enabled)) {
 			odp_pktout_config_opt_t *pktout_capa =
-			&pktio_entry->s.capa.config.pktout;
+			&pktio_entry->capa.config.pktout;
 
 			pkt_set_ol_tx(pktout_cfg, pktout_capa, pkt_hdr,
 				      mbuf_table[i], data);
@@ -897,14 +897,14 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 	odp_pktin_config_opt_t pktin_cfg;
 	odp_pktio_t input;
 	pkt_dpdk_t *pkt_dpdk = pkt_priv(pktio_entry);
-	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
+	const odp_proto_layer_t layer = pktio_entry->parse_layer;
 
 	prefetch_pkt(mbuf_table[0]);
 
 	nb_pkts = 0;
 	set_flow_hash = pkt_dpdk->opt.set_flow_hash;
-	pktin_cfg = pktio_entry->s.config.pktin;
-	input = pktio_entry->s.handle;
+	pktin_cfg = pktio_entry->config.pktin;
+	input = pktio_entry->handle;
 
 	if (odp_likely(mbuf_num > 1))
 		prefetch_pkt(mbuf_table[1]);
@@ -938,7 +938,7 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 			ret = _odp_dpdk_packet_parse_common(pkt_hdr, data, pkt_len, pkt_len,
 							    mbuf, layer, pktin_cfg);
 			if (ret)
-				odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_errors);
+				odp_atomic_inc_u64(&pktio_entry->stats_extra.in_errors);
 
 			if (ret < 0) {
 				rte_pktmbuf_free(mbuf);
@@ -951,7 +951,7 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 				ret = _odp_cls_classify_packet(pktio_entry, (const uint8_t *)data,
 							       &new_pool, pkt_hdr);
 				if (ret < 0)
-					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
+					odp_atomic_inc_u64(&pktio_entry->stats_extra.in_discards);
 
 				if (ret) {
 					rte_pktmbuf_free(mbuf);
@@ -961,7 +961,7 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 				if (odp_unlikely(_odp_pktio_packet_to_pool(
 					    &pkt, &pkt_hdr, new_pool))) {
 					rte_pktmbuf_free(mbuf);
-					odp_atomic_inc_u64(&pktio_entry->s.stats_extra.in_discards);
+					odp_atomic_inc_u64(&pktio_entry->stats_extra.in_discards);
 					continue;
 				}
 			}
@@ -986,11 +986,11 @@ static inline int pkt_to_mbuf_zero(pktio_entry_t *pktio_entry,
 				   uint16_t *copy_count, uint16_t cpy_idx[], int *tx_ts_idx)
 {
 	pkt_dpdk_t *pkt_dpdk = pkt_priv(pktio_entry);
-	odp_pktout_config_opt_t *pktout_cfg = &pktio_entry->s.config.pktout;
+	odp_pktout_config_opt_t *pktout_cfg = &pktio_entry->config.pktout;
 	odp_pktout_config_opt_t *pktout_capa =
-		&pktio_entry->s.capa.config.pktout;
+		&pktio_entry->capa.config.pktout;
 	uint16_t mtu = pkt_dpdk->mtu;
-	uint8_t chksum_enabled = pktio_entry->s.enabled.chksum_insert;
+	uint8_t chksum_enabled = pktio_entry->enabled.chksum_insert;
 	uint8_t tx_ts_enabled = _odp_pktio_tx_ts_enabled(pktio_entry);
 	int i;
 	*copy_count = 0;
@@ -1200,38 +1200,38 @@ static int dpdk_setup_eth_dev(pktio_entry_t *pktio_entry)
 	eth_conf.rx_adv_conf.rss_conf = pkt_dpdk->rss_conf;
 
 	/* Setup RX checksum offloads */
-	if (pktio_entry->s.config.pktin.bit.ipv4_chksum)
+	if (pktio_entry->config.pktin.bit.ipv4_chksum)
 		rx_offloads |= DEV_RX_OFFLOAD_IPV4_CKSUM;
 
-	if (pktio_entry->s.config.pktin.bit.udp_chksum)
+	if (pktio_entry->config.pktin.bit.udp_chksum)
 		rx_offloads |= DEV_RX_OFFLOAD_UDP_CKSUM;
 
-	if (pktio_entry->s.config.pktin.bit.tcp_chksum)
+	if (pktio_entry->config.pktin.bit.tcp_chksum)
 		rx_offloads |= DEV_RX_OFFLOAD_TCP_CKSUM;
 
 	eth_conf.rxmode.offloads = rx_offloads;
 
 	/* Setup TX checksum offloads */
-	if (pktio_entry->s.config.pktout.bit.ipv4_chksum_ena)
+	if (pktio_entry->config.pktout.bit.ipv4_chksum_ena)
 		tx_offloads |= DEV_TX_OFFLOAD_IPV4_CKSUM;
 
-	if (pktio_entry->s.config.pktout.bit.udp_chksum_ena)
+	if (pktio_entry->config.pktout.bit.udp_chksum_ena)
 		tx_offloads |= DEV_TX_OFFLOAD_UDP_CKSUM;
 
-	if (pktio_entry->s.config.pktout.bit.tcp_chksum_ena)
+	if (pktio_entry->config.pktout.bit.tcp_chksum_ena)
 		tx_offloads |= DEV_TX_OFFLOAD_TCP_CKSUM;
 
-	if (pktio_entry->s.config.pktout.bit.sctp_chksum_ena)
+	if (pktio_entry->config.pktout.bit.sctp_chksum_ena)
 		tx_offloads |= DEV_TX_OFFLOAD_SCTP_CKSUM;
 
 	eth_conf.txmode.offloads = tx_offloads;
 
 	if (tx_offloads)
-		pktio_entry->s.enabled.chksum_insert = 1;
+		pktio_entry->enabled.chksum_insert = 1;
 
 	ret = rte_eth_dev_configure(pkt_dpdk->port_id,
-				    pktio_entry->s.num_in_queue,
-				    pktio_entry->s.num_out_queue, &eth_conf);
+				    pktio_entry->num_in_queue,
+				    pktio_entry->num_out_queue, &eth_conf);
 	if (ret < 0) {
 		ODP_ERR("Failed to setup device: err=%d, port=%" PRIu8 "\n",
 			ret, pkt_dpdk->port_id);
@@ -1476,7 +1476,7 @@ static void prepare_rss_conf(pktio_entry_t *pktio_entry,
 static int dpdk_input_queues_config(pktio_entry_t *pktio_entry,
 				    const odp_pktin_queue_param_t *p)
 {
-	odp_pktin_mode_t mode = pktio_entry->s.param.in_mode;
+	odp_pktin_mode_t mode = pktio_entry->param.in_mode;
 	uint8_t lockless;
 
 	prepare_rss_conf(pktio_entry, p);
@@ -1543,7 +1543,7 @@ static int dpdk_init_capability(pktio_entry_t *pktio_entry,
 				const struct rte_eth_dev_info *dev_info)
 {
 	pkt_dpdk_t *pkt_dpdk = pkt_priv(pktio_entry);
-	odp_pktio_capability_t *capa = &pktio_entry->s.capa;
+	odp_pktio_capability_t *capa = &pktio_entry->capa;
 	struct rte_ether_addr mac_addr;
 	int ptype_cnt;
 	int ptype_l3_ipv4 = 0;
@@ -1813,7 +1813,7 @@ static int dpdk_open(odp_pktio_t id ODP_UNUSED,
 	pkt_dpdk->data_room = RTE_MIN(pool_entry->seg_len, data_room);
 
 	/* Reserve room for packet input offset */
-	pkt_dpdk->data_room -= pktio_entry->s.pktin_frame_offset;
+	pkt_dpdk->data_room -= pktio_entry->pktin_frame_offset;
 
 	/* Mbuf chaining not yet supported */
 	pkt_dpdk->mtu = RTE_MIN(pkt_dpdk->mtu, pkt_dpdk->data_room);
@@ -1842,7 +1842,7 @@ static int dpdk_setup_eth_tx(pktio_entry_t *pktio_entry,
 	int ret;
 	uint16_t port_id = pkt_dpdk->port_id;
 
-	for (i = 0; i < pktio_entry->s.num_out_queue; i++) {
+	for (i = 0; i < pktio_entry->num_out_queue; i++) {
 		ret = rte_eth_tx_queue_setup(port_id, i,
 					     pkt_dpdk->num_tx_desc[i],
 					     rte_eth_dev_socket_id(port_id),
@@ -1856,7 +1856,7 @@ static int dpdk_setup_eth_tx(pktio_entry_t *pktio_entry,
 
 	/* Set per queue statistics mappings. Not supported by all PMDs, so
 	 * ignore the return value. */
-	for (i = 0; i < pktio_entry->s.num_out_queue && i < RTE_ETHDEV_QUEUE_STAT_CNTRS; i++) {
+	for (i = 0; i < pktio_entry->num_out_queue && i < RTE_ETHDEV_QUEUE_STAT_CNTRS; i++) {
 		ret = rte_eth_dev_set_tx_queue_stats_mapping(port_id, i, i);
 		if (ret) {
 			ODP_DBG("Mapping per TX queue statistics not supported: %d\n", ret);
@@ -1881,7 +1881,7 @@ static int dpdk_setup_eth_rx(const pktio_entry_t *pktio_entry,
 
 	rxconf.rx_drop_en = pkt_dpdk->opt.rx_drop_en;
 
-	for (i = 0; i < pktio_entry->s.num_in_queue; i++) {
+	for (i = 0; i < pktio_entry->num_in_queue; i++) {
 		ret = rte_eth_rx_queue_setup(port_id, i,
 					     pkt_dpdk->opt.num_rx_desc,
 					     rte_eth_dev_socket_id(port_id),
@@ -1895,7 +1895,7 @@ static int dpdk_setup_eth_rx(const pktio_entry_t *pktio_entry,
 
 	/* Set per queue statistics mappings. Not supported by all PMDs, so
 	 * ignore the return value. */
-	for (i = 0; i < pktio_entry->s.num_in_queue && i < RTE_ETHDEV_QUEUE_STAT_CNTRS; i++) {
+	for (i = 0; i < pktio_entry->num_in_queue && i < RTE_ETHDEV_QUEUE_STAT_CNTRS; i++) {
 		ret = rte_eth_dev_set_rx_queue_stats_mapping(port_id, i, i);
 		if (ret) {
 			ODP_DBG("Mapping per RX queue statistics not supported: %d\n", ret);
@@ -1915,10 +1915,10 @@ static int dpdk_start(pktio_entry_t *pktio_entry)
 	int ret;
 
 	/* DPDK doesn't support nb_rx_q/nb_tx_q being 0 */
-	if (!pktio_entry->s.num_in_queue)
-		pktio_entry->s.num_in_queue = 1;
-	if (!pktio_entry->s.num_out_queue)
-		pktio_entry->s.num_out_queue = 1;
+	if (!pktio_entry->num_in_queue)
+		pktio_entry->num_in_queue = 1;
+	if (!pktio_entry->num_out_queue)
+		pktio_entry->num_out_queue = 1;
 
 	rte_eth_dev_info_get(port_id, &dev_info);
 
@@ -1937,7 +1937,7 @@ static int dpdk_start(pktio_entry_t *pktio_entry)
 		return -1;
 
 	/* Restore MTU value resetted by dpdk_setup_eth_rx() */
-	if (pkt_dpdk->mtu_set && pktio_entry->s.capa.set_op.op.maxlen) {
+	if (pkt_dpdk->mtu_set && pktio_entry->capa.set_op.op.maxlen) {
 		ret = dpdk_maxlen_set(pktio_entry, pkt_dpdk->mtu, 0);
 		if (ret) {
 			ODP_ERR("Restoring device MTU failed: err=%d, port=%" PRIu8 "\n",
@@ -2018,8 +2018,8 @@ static int dpdk_recv(pktio_entry_t *pktio_entry, int index,
 		odp_ticketlock_unlock(&pkt_dpdk->rx_lock[index]);
 
 	if (nb_rx > 0) {
-		if (pktio_entry->s.config.pktin.bit.ts_all ||
-		    pktio_entry->s.config.pktin.bit.ts_ptp) {
+		if (pktio_entry->config.pktin.bit.ts_all ||
+		    pktio_entry->config.pktin.bit.ts_ptp) {
 			ts_val = odp_time_global();
 			ts = &ts_val;
 		}
@@ -2141,7 +2141,7 @@ static int dpdk_promisc_mode_get(pktio_entry_t *pktio_entry)
 static int dpdk_capability(pktio_entry_t *pktio_entry,
 			   odp_pktio_capability_t *capa)
 {
-	*capa = pktio_entry->s.capa;
+	*capa = pktio_entry->capa;
 	return 0;
 }
 

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -106,7 +106,7 @@ ODP_STATIC_ASSERT(PKTIO_PRIVATE_SIZE >= sizeof(pkt_ipc_t),
 
 static inline pkt_ipc_t *pkt_priv(pktio_entry_t *pktio_entry)
 {
-	return (pkt_ipc_t *)(uintptr_t)(pktio_entry->s.pkt_priv);
+	return (pkt_ipc_t *)(uintptr_t)(pktio_entry->pkt_priv);
 }
 
 /* MAC address for the "ipc" interface */
@@ -220,7 +220,7 @@ static int _ipc_master_start(pktio_entry_t *pktio_entry)
 
 	odp_atomic_store_u32(&pktio_ipc->ready, 1);
 
-	ODP_DBG_LVL(IPC_DBG, "%s started.\n",  pktio_entry->s.name);
+	ODP_DBG_LVL(IPC_DBG, "%s started.\n",  pktio_entry->name);
 	return 0;
 }
 
@@ -440,7 +440,7 @@ static int _ipc_slave_start(pktio_entry_t *pktio_entry)
 	int pid;
 	uint32_t ring_mask = pktio_ipc->ring_mask;
 
-	if (sscanf(pktio_entry->s.name, "ipc:%d:%s", &pid, tail) != 2) {
+	if (sscanf(pktio_entry->name, "ipc:%d:%s", &pid, tail) != 2) {
 		ODP_ERR("wrong pktio name\n");
 		return -1;
 	}
@@ -505,7 +505,7 @@ static int _ipc_slave_start(pktio_entry_t *pktio_entry)
 	odp_atomic_store_u32(&pktio_ipc->ready, 1);
 	pinfo->slave.init_done = 1;
 
-	ODP_DBG("%s started.\n",  pktio_entry->s.name);
+	ODP_DBG("%s started.\n",  pktio_entry->name);
 	return 0;
 
 free_s_prod:
@@ -753,11 +753,11 @@ static int ipc_pktio_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 {
 	int ret;
 
-	odp_ticketlock_lock(&pktio_entry->s.rxl);
+	odp_ticketlock_lock(&pktio_entry->rxl);
 
 	ret = ipc_pktio_recv_lockless(pktio_entry, pkt_table, num);
 
-	odp_ticketlock_unlock(&pktio_entry->s.rxl);
+	odp_ticketlock_unlock(&pktio_entry->rxl);
 
 	return ret;
 }
@@ -841,11 +841,11 @@ static int ipc_pktio_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 {
 	int ret;
 
-	odp_ticketlock_lock(&pktio_entry->s.txl);
+	odp_ticketlock_lock(&pktio_entry->txl);
 
 	ret = ipc_pktio_send_lockless(pktio_entry, pkt_table, num);
 
-	odp_ticketlock_unlock(&pktio_entry->s.txl);
+	odp_ticketlock_unlock(&pktio_entry->txl);
 
 	return ret;
 }
@@ -869,7 +869,7 @@ static int ipc_start(pktio_entry_t *pktio_entry)
 	uint32_t ready = odp_atomic_load_u32(&pktio_ipc->ready);
 
 	if (ready) {
-		ODP_ABORT("%s Already started\n", pktio_entry->s.name);
+		ODP_ABORT("%s Already started\n", pktio_entry->name);
 		return -1;
 	}
 
@@ -932,7 +932,7 @@ static int ipc_close(pktio_entry_t *pktio_entry)
 {
 	pkt_ipc_t *pktio_ipc = pkt_priv(pktio_entry);
 	char ipc_shm_name[ODP_POOL_NAME_LEN + sizeof("_m_prod")];
-	char *dev = pktio_entry->s.name;
+	char *dev = pktio_entry->name;
 	char name[ODP_POOL_NAME_LEN];
 	char tail[ODP_POOL_NAME_LEN];
 	int pid = 0;

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -238,14 +238,14 @@ done:
  * @param num_rings      Number of matching netmap rings
  */
 static inline void map_netmap_rings(netmap_ring_t *rings,
-				    unsigned num_queues, unsigned num_rings)
+				    unsigned int num_queues, unsigned int num_rings)
 {
 	struct netmap_ring_t *desc_ring;
-	unsigned rings_per_queue;
-	unsigned remainder;
-	unsigned mapped_rings;
-	unsigned i;
-	unsigned desc_id = 0;
+	unsigned int rings_per_queue;
+	unsigned int remainder;
+	unsigned int mapped_rings;
+	unsigned int i;
+	unsigned int desc_id = 0;
 
 	rings_per_queue = num_rings / num_queues;
 	remainder = num_rings % num_queues;
@@ -274,7 +274,7 @@ static int netmap_input_queues_config(pktio_entry_t *pktio_entry,
 {
 	pkt_netmap_t *pkt_nm = pkt_priv(pktio_entry);
 	odp_pktin_mode_t mode = pktio_entry->param.in_mode;
-	unsigned num_queues = p->num_queues;
+	unsigned int num_queues = p->num_queues;
 	odp_bool_t lockless;
 
 	/* Scheduler synchronizes input queue polls. Only single thread
@@ -590,7 +590,7 @@ static int netmap_open(odp_pktio_t id ODP_UNUSED, pktio_entry_t *pktio_entry,
 	}
 
 	if (pkt_nm->is_virtual) {
-		static unsigned mac;
+		static unsigned int mac;
 		uint32_t tid = syscall(SYS_gettid);
 
 		if ((int)tid == -1)
@@ -655,9 +655,9 @@ static int netmap_start(pktio_entry_t *pktio_entry)
 	pkt_netmap_t *pkt_nm = pkt_priv(pktio_entry);
 	netmap_ring_t *desc_ring;
 	struct nm_desc *desc_ptr;
-	unsigned i;
-	unsigned j;
-	unsigned num_rx_desc = 0;
+	unsigned int i;
+	unsigned int j;
+	unsigned int num_rx_desc = 0;
 	uint64_t flags;
 	odp_pktin_mode_t in_mode = pktio_entry->param.in_mode;
 	odp_pktout_mode_t out_mode = pktio_entry->param.out_mode;
@@ -962,9 +962,9 @@ static int netmap_fd_set(pktio_entry_t *pktio_entry, int index, fd_set *readfds)
 {
 	struct nm_desc *desc;
 	pkt_netmap_t *pkt_nm = pkt_priv(pktio_entry);
-	unsigned first_desc_id = pkt_nm->rx_desc_ring[index].s.first;
-	unsigned last_desc_id = pkt_nm->rx_desc_ring[index].s.last;
-	unsigned desc_id;
+	unsigned int first_desc_id = pkt_nm->rx_desc_ring[index].s.first;
+	unsigned int last_desc_id = pkt_nm->rx_desc_ring[index].s.last;
+	unsigned int desc_id;
 	int num_desc = pkt_nm->rx_desc_ring[index].s.num;
 	int i;
 	int max_fd = 0;
@@ -998,9 +998,9 @@ static int netmap_recv(pktio_entry_t *pktio_entry, int index,
 {
 	struct nm_desc *desc;
 	pkt_netmap_t *pkt_nm = pkt_priv(pktio_entry);
-	unsigned first_desc_id = pkt_nm->rx_desc_ring[index].s.first;
-	unsigned last_desc_id = pkt_nm->rx_desc_ring[index].s.last;
-	unsigned desc_id;
+	unsigned int first_desc_id = pkt_nm->rx_desc_ring[index].s.first;
+	unsigned int last_desc_id = pkt_nm->rx_desc_ring[index].s.last;
+	unsigned int desc_id;
 	int num_desc = pkt_nm->rx_desc_ring[index].s.num;
 	int i;
 	int num_rx = 0;
@@ -1128,7 +1128,7 @@ static int netmap_send(pktio_entry_t *pktio_entry, int index,
 	uint8_t tx_ts_enabled = _odp_pktio_tx_ts_enabled(pktio_entry);
 	odp_packet_t pkt;
 	uint32_t pkt_len;
-	unsigned slot_id;
+	unsigned int slot_id;
 	char *buf;
 
 	/* Only one netmap tx ring per pktout queue */

--- a/platform/linux-generic/pktio/null.c
+++ b/platform/linux-generic/pktio/null.c
@@ -21,7 +21,7 @@ ODP_STATIC_ASSERT(PKTIO_PRIVATE_SIZE >= sizeof(pkt_null_t),
 
 static inline pkt_null_t *pkt_priv(pktio_entry_t *pktio_entry)
 {
-	return (pkt_null_t *)(uintptr_t)(pktio_entry->s.pkt_priv);
+	return (pkt_null_t *)(uintptr_t)(pktio_entry->pkt_priv);
 }
 
 static int null_close(pktio_entry_t *pktio_entry ODP_UNUSED)

--- a/platform/linux-generic/pktio/pktio_common.c
+++ b/platform/linux-generic/pktio/pktio_common.c
@@ -21,7 +21,7 @@ static int sock_recv_mq_tmo_select(pktio_entry_t * const *entry,
 	int ret;
 
 	for (i = 0; i < num_q; i++) {
-		ret = entry[i]->s.ops->recv(entry[i], index[i], packets, num);
+		ret = entry[i]->ops->recv(entry[i], index[i], packets, num);
 
 		if (ret > 0 && from)
 			*from = i;
@@ -37,7 +37,7 @@ static int sock_recv_mq_tmo_select(pktio_entry_t * const *entry,
 		return 0;
 
 	for (i = 0; i < num_q; i++) {
-		ret = entry[i]->s.ops->recv(entry[i], index[i], packets, num);
+		ret = entry[i]->ops->recv(entry[i], index[i], packets, num);
 
 		if (ret > 0 && from)
 			*from = i;
@@ -78,21 +78,21 @@ int _odp_sock_recv_mq_tmo_try_int_driven(const struct odp_pktin_queue_t queues[]
 			return -1;
 		}
 
-		if (odp_unlikely(entry[i]->s.state != PKTIO_STATE_STARTED)) {
+		if (odp_unlikely(entry[i]->state != PKTIO_STATE_STARTED)) {
 			*trial_successful = 0;
 			return 0;
 		}
 
-		if (entry[i]->s.ops->recv_mq_tmo == NULL &&
-		    entry[i]->s.ops->fd_set == NULL) {
+		if (entry[i]->ops->recv_mq_tmo == NULL &&
+		    entry[i]->ops->fd_set == NULL) {
 			*trial_successful = 0;
 			return 0;
 		}
 		if (!impl_set) {
-			impl = entry[i]->s.ops->recv_mq_tmo;
+			impl = entry[i]->ops->recv_mq_tmo;
 			impl_set = 1;
 		} else {
-			if (impl != entry[i]->s.ops->recv_mq_tmo)
+			if (impl != entry[i]->ops->recv_mq_tmo)
 				impl = NULL;
 		}
 	}
@@ -107,11 +107,10 @@ int _odp_sock_recv_mq_tmo_try_int_driven(const struct odp_pktin_queue_t queues[]
 	   fails. */
 	FD_ZERO(&readfds);
 	for (i = 0; i < num_q; i++) {
-		if (entry[i]->s.ops->fd_set) {
+		if (entry[i]->ops->fd_set) {
 			int maxfd2;
 
-			maxfd2 = entry[i]->s.ops->fd_set(
-				entry[i], queues[i].index, &readfds);
+			maxfd2 = entry[i]->ops->fd_set(entry[i], queues[i].index, &readfds);
 			if (maxfd2 < 0) {
 				maxfd = -1;
 				break;

--- a/platform/linux-generic/pktio/socket_xdp.c
+++ b/platform/linux-generic/pktio/socket_xdp.c
@@ -133,7 +133,7 @@ static int sock_xdp_init_global(void)
 
 static inline xdp_sock_info_t *pkt_priv(pktio_entry_t *pktio_entry)
 {
-	return (xdp_sock_info_t *)(uintptr_t)(pktio_entry->s.pkt_priv);
+	return (xdp_sock_info_t *)(uintptr_t)(pktio_entry->pkt_priv);
 }
 
 static void parse_options(xdp_umem_info_t *umem_info)
@@ -279,9 +279,9 @@ static int sock_xdp_open(odp_pktio_t pktio, pktio_entry_t *pktio_entry, const ch
 		odp_ticketlock_init(&priv->qs[i].tx_lock);
 	}
 
-	priv->bind_q = get_bind_queue_index(pktio_entry->s.name);
+	priv->bind_q = get_bind_queue_index(pktio_entry->name);
 
-	ODP_DBG("Socket xdp interface (%s):\n", pktio_entry->s.name);
+	ODP_DBG("Socket xdp interface (%s):\n", pktio_entry->name);
 	ODP_DBG("  num_rx_desc: %d\n", priv->umem_info->num_rx_desc);
 	ODP_DBG("  num_tx_desc: %d\n", priv->umem_info->num_tx_desc);
 	ODP_DBG("  starting bind queue: %u\n", priv->bind_q);
@@ -499,11 +499,11 @@ static uint32_t process_received(pktio_entry_t *pktio_entry, xdp_sock_t *sock, p
 	struct xsk_ring_cons *rx = &sock->rx;
 	uint8_t *base_addr = pool->base_addr;
 	pkt_data_t pkt_data;
-	const odp_proto_layer_t layer = pktio_entry->s.parse_layer;
+	const odp_proto_layer_t layer = pktio_entry->parse_layer;
 	int ret;
-	const odp_pktin_config_opt_t opt = pktio_entry->s.config.pktin;
+	const odp_pktin_config_opt_t opt = pktio_entry->config.pktin;
 	uint64_t errors = 0U, octets = 0U;
-	odp_pktio_t pktio_hdl = pktio_entry->s.handle;
+	odp_pktio_t pktio_hdl = pktio_entry->handle;
 	uint32_t num_rx = 0U;
 
 	for (int i = 0; i < num; ++i) {
@@ -790,7 +790,7 @@ static int sock_xdp_mtu_set(pktio_entry_t *pktio_entry, uint32_t maxlen_input,
 	xdp_sock_info_t *priv = pkt_priv(pktio_entry);
 	int ret;
 
-	ret = _odp_mtu_set_fd(priv->helper_sock, pktio_entry->s.name, maxlen_input);
+	ret = _odp_mtu_set_fd(priv->helper_sock, pktio_entry->name, maxlen_input);
 	if (ret)
 		return ret;
 
@@ -802,31 +802,31 @@ static int sock_xdp_mtu_set(pktio_entry_t *pktio_entry, uint32_t maxlen_input,
 static int sock_xdp_promisc_mode_set(pktio_entry_t *pktio_entry,  int enable)
 {
 	return _odp_promisc_mode_set_fd(pkt_priv(pktio_entry)->helper_sock,
-					pktio_entry->s.name, enable);
+					pktio_entry->name, enable);
 }
 
 static int sock_xdp_promisc_mode_get(pktio_entry_t *pktio_entry)
 {
 	return _odp_promisc_mode_get_fd(pkt_priv(pktio_entry)->helper_sock,
-					pktio_entry->s.name);
+					pktio_entry->name);
 }
 
 static int sock_xdp_mac_addr_get(pktio_entry_t *pktio_entry ODP_UNUSED, void *mac_addr)
 {
 	return _odp_mac_addr_get_fd(pkt_priv(pktio_entry)->helper_sock,
-				    pktio_entry->s.name, mac_addr) ? -1 : ETH_ALEN;
+				    pktio_entry->name, mac_addr) ? -1 : ETH_ALEN;
 }
 
 static int sock_xdp_link_status(pktio_entry_t *pktio_entry)
 {
 	return _odp_link_status_fd(pkt_priv(pktio_entry)->helper_sock,
-				   pktio_entry->s.name);
+				   pktio_entry->name);
 }
 
 static int sock_xdp_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *info)
 {
 	return _odp_link_info_fd(pkt_priv(pktio_entry)->helper_sock,
-				 pktio_entry->s.name, info);
+				 pktio_entry->name, info);
 }
 
 static int set_queue_capability(int fd, const char *devname, odp_pktio_capability_t *capa)
@@ -864,7 +864,7 @@ static int sock_xdp_capability(pktio_entry_t *pktio_entry, odp_pktio_capability_
 
 	memset(capa, 0, sizeof(odp_pktio_capability_t));
 
-	if (set_queue_capability(priv->helper_sock, pktio_entry->s.name, capa))
+	if (set_queue_capability(priv->helper_sock, pktio_entry->name, capa))
 		return -1;
 
 	capa->set_op.op.promisc_mode = 1U;
@@ -902,7 +902,7 @@ static int sock_xdp_input_queues_config(pktio_entry_t *pktio_entry,
 {
 	xdp_sock_info_t *priv = pkt_priv(pktio_entry);
 
-	priv->lockless_rx = pktio_entry->s.param.in_mode == ODP_PKTIN_MODE_SCHED ||
+	priv->lockless_rx = pktio_entry->param.in_mode == ODP_PKTIN_MODE_SCHED ||
 			    param->op_mode == ODP_PKTIO_OP_MT_UNSAFE;
 
 	return 0;
@@ -922,7 +922,7 @@ static int sock_xdp_output_queues_config(pktio_entry_t *pktio_entry,
 {
 	xdp_sock_info_t *priv = pkt_priv(pktio_entry);
 	struct xsk_socket_config config;
-	const char *devname = pktio_entry->s.name;
+	const char *devname = pktio_entry->name;
 	uint32_t bind_q, i;
 	struct xsk_umem *umem;
 	xdp_sock_t *sock;

--- a/platform/linux-generic/pktio/stats/packet_io_stats.c
+++ b/platform/linux-generic/pktio/stats/packet_io_stats.c
@@ -18,9 +18,9 @@ static int sock_stats_get(pktio_entry_t *e, odp_pktio_stats_t *stats, int fd)
 
 	memset(stats, 0, sizeof(*stats));
 
-	if (e->s.stats_type == STATS_ETHTOOL)
-		ret = _odp_ethtool_stats_get_fd(fd, e->s.name, stats);
-	else if (e->s.stats_type == STATS_SYSFS)
+	if (e->stats_type == STATS_ETHTOOL)
+		ret = _odp_ethtool_stats_get_fd(fd, e->name, stats);
+	else if (e->stats_type == STATS_SYSFS)
 		ret = _odp_sysfs_stats(e, stats);
 
 	if (ret)
@@ -34,8 +34,8 @@ int _odp_sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd)
 	odp_pktio_stats_t cur_stats;
 	int ret;
 
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
-		memset(&pktio_entry->s.stats, 0,
+	if (pktio_entry->stats_type == STATS_UNSUPPORTED) {
+		memset(&pktio_entry->stats, 0,
 		       sizeof(odp_pktio_stats_t));
 		return 0;
 	}
@@ -43,7 +43,7 @@ int _odp_sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd)
 	ret = sock_stats_get(pktio_entry, &cur_stats, fd);
 
 	if (!ret)
-		memcpy(&pktio_entry->s.stats, &cur_stats,
+		memcpy(&pktio_entry->stats, &cur_stats,
 		       sizeof(odp_pktio_stats_t));
 
 	return ret;
@@ -55,7 +55,7 @@ int _odp_sock_stats_fd(pktio_entry_t *pktio_entry,
 {
 	odp_pktio_stats_t cur_stats;
 
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
+	if (pktio_entry->stats_type == STATS_UNSUPPORTED) {
 		memset(stats, 0, sizeof(*stats));
 		return 0;
 	}
@@ -64,37 +64,37 @@ int _odp_sock_stats_fd(pktio_entry_t *pktio_entry,
 		return -1;
 
 	stats->in_octets = cur_stats.in_octets -
-				pktio_entry->s.stats.in_octets;
+				pktio_entry->stats.in_octets;
 	stats->in_packets = cur_stats.in_packets -
-				pktio_entry->s.stats.in_packets;
+				pktio_entry->stats.in_packets;
 	stats->in_ucast_pkts = cur_stats.in_ucast_pkts -
-				pktio_entry->s.stats.in_ucast_pkts;
+				pktio_entry->stats.in_ucast_pkts;
 	stats->in_bcast_pkts = cur_stats.in_bcast_pkts -
-				pktio_entry->s.stats.in_bcast_pkts;
+				pktio_entry->stats.in_bcast_pkts;
 	stats->in_mcast_pkts = cur_stats.in_mcast_pkts -
-				pktio_entry->s.stats.in_mcast_pkts;
+				pktio_entry->stats.in_mcast_pkts;
 	stats->in_discards = cur_stats.in_discards -
-				pktio_entry->s.stats.in_discards;
+				pktio_entry->stats.in_discards;
 	stats->in_errors = cur_stats.in_errors -
-				pktio_entry->s.stats.in_errors;
+				pktio_entry->stats.in_errors;
 #if ODP_DEPRECATED_API
 	stats->in_unknown_protos = cur_stats.in_unknown_protos -
-				pktio_entry->s.stats.in_unknown_protos;
+				pktio_entry->stats.in_unknown_protos;
 #endif
 	stats->out_octets = cur_stats.out_octets -
-				pktio_entry->s.stats.out_octets;
+				pktio_entry->stats.out_octets;
 	stats->out_packets = cur_stats.out_packets -
-				pktio_entry->s.stats.out_packets;
+				pktio_entry->stats.out_packets;
 	stats->out_ucast_pkts = cur_stats.out_ucast_pkts -
-				pktio_entry->s.stats.out_ucast_pkts;
+				pktio_entry->stats.out_ucast_pkts;
 	stats->out_bcast_pkts = cur_stats.out_bcast_pkts -
-				pktio_entry->s.stats.out_bcast_pkts;
+				pktio_entry->stats.out_bcast_pkts;
 	stats->out_mcast_pkts = cur_stats.out_mcast_pkts -
-				pktio_entry->s.stats.out_mcast_pkts;
+				pktio_entry->stats.out_mcast_pkts;
 	stats->out_discards = cur_stats.out_discards -
-				pktio_entry->s.stats.out_discards;
+				pktio_entry->stats.out_discards;
 	stats->out_errors = cur_stats.out_errors -
-				pktio_entry->s.stats.out_errors;
+				pktio_entry->stats.out_errors;
 
 	return 0;
 }
@@ -103,13 +103,13 @@ int _odp_sock_extra_stat_info(pktio_entry_t *pktio_entry,
 			      odp_pktio_extra_stat_info_t info[], int num,
 			      int fd)
 {
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED)
+	if (pktio_entry->stats_type == STATS_UNSUPPORTED)
 		return 0;
 
-	if (pktio_entry->s.stats_type == STATS_ETHTOOL)
-		return _odp_ethtool_extra_stat_info(fd, pktio_entry->s.name,
+	if (pktio_entry->stats_type == STATS_ETHTOOL)
+		return _odp_ethtool_extra_stat_info(fd, pktio_entry->name,
 						    info, num);
-	else if (pktio_entry->s.stats_type == STATS_SYSFS)
+	else if (pktio_entry->stats_type == STATS_SYSFS)
 		return _odp_sysfs_extra_stat_info(pktio_entry, info, num);
 
 	return 0;
@@ -118,13 +118,13 @@ int _odp_sock_extra_stat_info(pktio_entry_t *pktio_entry,
 int _odp_sock_extra_stats(pktio_entry_t *pktio_entry, uint64_t stats[], int num,
 			  int fd)
 {
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED)
+	if (pktio_entry->stats_type == STATS_UNSUPPORTED)
 		return 0;
 
-	if (pktio_entry->s.stats_type == STATS_ETHTOOL)
-		return _odp_ethtool_extra_stats(fd, pktio_entry->s.name,
+	if (pktio_entry->stats_type == STATS_ETHTOOL)
+		return _odp_ethtool_extra_stats(fd, pktio_entry->name,
 						stats, num);
-	else if (pktio_entry->s.stats_type == STATS_SYSFS)
+	else if (pktio_entry->stats_type == STATS_SYSFS)
 		return _odp_sysfs_extra_stats(pktio_entry, stats, num);
 
 	return 0;
@@ -133,13 +133,13 @@ int _odp_sock_extra_stats(pktio_entry_t *pktio_entry, uint64_t stats[], int num,
 int _odp_sock_extra_stat_counter(pktio_entry_t *pktio_entry, uint32_t id,
 				 uint64_t *stat, int fd)
 {
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED)
+	if (pktio_entry->stats_type == STATS_UNSUPPORTED)
 		return -1;
 
-	if (pktio_entry->s.stats_type == STATS_ETHTOOL) {
-		return _odp_ethtool_extra_stat_counter(fd, pktio_entry->s.name,
+	if (pktio_entry->stats_type == STATS_ETHTOOL) {
+		return _odp_ethtool_extra_stat_counter(fd, pktio_entry->name,
 						       id, stat);
-	} else if (pktio_entry->s.stats_type == STATS_SYSFS) {
+	} else if (pktio_entry->stats_type == STATS_SYSFS) {
 		return _odp_sysfs_extra_stat_counter(pktio_entry, id, stat);
 	}
 
@@ -150,7 +150,7 @@ pktio_stats_type_t _odp_sock_stats_type_fd(pktio_entry_t *pktio_entry, int fd)
 {
 	odp_pktio_stats_t cur_stats;
 
-	if (!_odp_ethtool_stats_get_fd(fd, pktio_entry->s.name, &cur_stats))
+	if (!_odp_ethtool_stats_get_fd(fd, pktio_entry->name, &cur_stats))
 		return STATS_ETHTOOL;
 
 	if (!_odp_sysfs_stats(pktio_entry, &cur_stats))
@@ -166,7 +166,7 @@ void _odp_sock_stats_capa(pktio_entry_t *pktio_entry,
 	capa->stats.pktin_queue.all_counters = 0;
 	capa->stats.pktout_queue.all_counters = 0;
 
-	if (pktio_entry->s.stats_type == STATS_SYSFS) {
+	if (pktio_entry->stats_type == STATS_SYSFS) {
 		capa->stats.pktio.counter.in_octets = 1;
 		capa->stats.pktio.counter.in_packets = 1;
 		capa->stats.pktio.counter.in_ucast_pkts = 1;
@@ -178,7 +178,7 @@ void _odp_sock_stats_capa(pktio_entry_t *pktio_entry,
 		capa->stats.pktio.counter.out_ucast_pkts = 1;
 		capa->stats.pktio.counter.out_discards = 1;
 		capa->stats.pktio.counter.out_errors = 1;
-	} else if (pktio_entry->s.stats_type == STATS_ETHTOOL) {
+	} else if (pktio_entry->stats_type == STATS_ETHTOOL) {
 		capa->stats.pktio.counter.in_octets = 1;
 		capa->stats.pktio.counter.in_packets = 1;
 		capa->stats.pktio.counter.in_ucast_pkts = 1;

--- a/platform/linux-generic/pktio/stats/sysfs_stats.c
+++ b/platform/linux-generic/pktio/stats/sysfs_stats.c
@@ -53,7 +53,7 @@ int _odp_sysfs_stats(pktio_entry_t *pktio_entry,
 		     odp_pktio_stats_t *stats)
 {
 	char fname[256];
-	const char *dev = pktio_entry->s.name;
+	const char *dev = pktio_entry->name;
 	int ret = 0;
 
 	sprintf(fname, "/sys/class/net/%s/statistics/rx_bytes", dev);
@@ -100,7 +100,7 @@ int _odp_sysfs_extra_stat_info(pktio_entry_t *pktio_entry,
 	char sysfs_dir[PATH_MAX];
 	int counters = 0;
 
-	snprintf(sysfs_dir, PATH_MAX, SYSFS_DIR, pktio_entry->s.name);
+	snprintf(sysfs_dir, PATH_MAX, SYSFS_DIR, pktio_entry->name);
 	dir = opendir(sysfs_dir);
 	if (!dir) {
 		ODP_ERR("Failed to open sysfs dir: %s\n", sysfs_dir);
@@ -132,7 +132,7 @@ int _odp_sysfs_extra_stats(pktio_entry_t *pktio_entry, uint64_t stats[],
 	char file_path[PATH_MAX];
 	int counters = 0;
 
-	snprintf(sysfs_dir, PATH_MAX, SYSFS_DIR, pktio_entry->s.name);
+	snprintf(sysfs_dir, PATH_MAX, SYSFS_DIR, pktio_entry->name);
 	dir = opendir(sysfs_dir);
 	if (!dir) {
 		ODP_ERR("Failed to open dir: %s\n", sysfs_dir);
@@ -173,7 +173,7 @@ int _odp_sysfs_extra_stat_counter(pktio_entry_t *pktio_entry, uint32_t id,
 	uint32_t counters = 0;
 	int ret = -1;
 
-	snprintf(sysfs_dir, PATH_MAX, SYSFS_DIR, pktio_entry->s.name);
+	snprintf(sysfs_dir, PATH_MAX, SYSFS_DIR, pktio_entry->name);
 	dir = opendir(sysfs_dir);
 	if (!dir) {
 		ODP_ERR("Failed to open dir: %s\n", sysfs_dir);

--- a/test/performance/odp_sched_latency.c
+++ b/test/performance/odp_sched_latency.c
@@ -106,10 +106,8 @@ typedef struct {
 } test_stat_t;
 
 /** Performance test statistics (per core) */
-typedef union ODP_ALIGNED_CACHE {
+typedef struct ODP_ALIGNED_CACHE {
 	test_stat_t prio[NUM_PRIOS]; /**< Test statistics per priority */
-
-	uint8_t pad[CACHE_ALIGN_ROUNDUP(NUM_PRIOS * sizeof(test_stat_t))];
 } core_stat_t;
 
 /** Test global variables */

--- a/test/performance/odp_scheduling.c
+++ b/test/performance/odp_scheduling.c
@@ -53,9 +53,6 @@ typedef struct {
 
 typedef struct ODP_ALIGNED_CACHE {
 	uint64_t num_ev;
-
-	/* Round up the struct size to cache line size */
-	uint8_t pad[ODP_CACHE_LINE_SIZE - sizeof(uint64_t)];
 } queue_context_t;
 
 /** Test global variables */


### PR DESCRIPTION
Clean up and align some structs:
- Remove unnecessary pad[] members.
- Remove an extra level of hierarchy by removing the unions that are not needed after removing pad[] members.
- Cache line align.

v2:
- Rebase.

v3:
- Rebase on master.
- Add review tags.
