### PR TITLE
[PATCH v5] validation: init: create binary for init_test_param_init test

### DIFF
--- a/test/validation/api/Makefile.am
+++ b/test/validation/api/Makefile.am
@@ -53,6 +53,7 @@ TESTS = \
 	init/init_num_thr$(EXEEXT) \
 	init/init_feature_enabled$(EXEEXT) \
 	init/init_feature_disabled$(EXEEXT) \
+	init/init_test_param_init$(EXEEXT) \
 	ipsec/ipsec_sync$(EXEEXT) \
 	ipsec/ipsec_async$(EXEEXT) \
 	ipsec/ipsec_inline_in$(EXEEXT) \

--- a/test/validation/api/init/.gitignore
+++ b/test/validation/api/init/.gitignore
@@ -5,3 +5,4 @@ init_log_thread
 init_num_thr
 init_feature_enabled
 init_feature_disabled
+init_test_parama_init

--- a/test/validation/api/init/Makefile.am
+++ b/test/validation/api/init/Makefile.am
@@ -3,7 +3,8 @@ include ../Makefile.inc
 # Keep init test cases in separate binaries. Some implementations may not allow
 # the same application process to call odp_init_global() multiple times.
 test_PROGRAMS = init_defaults init_abort init_log init_num_thr \
-		init_feature_enabled init_feature_disabled init_log_thread
+		init_feature_enabled init_feature_disabled init_log_thread \
+		init_test_param_init
 
 init_defaults_CPPFLAGS = -DINIT_TEST=0 $(AM_CPPFLAGS)
 init_abort_CPPFLAGS    = -DINIT_TEST=1 $(AM_CPPFLAGS)
@@ -12,6 +13,7 @@ init_num_thr_CPPFLAGS  = -DINIT_TEST=3 $(AM_CPPFLAGS)
 init_feature_enabled_CPPFLAGS = -DINIT_TEST=4 $(AM_CPPFLAGS)
 init_feature_disabled_CPPFLAGS = -DINIT_TEST=5 $(AM_CPPFLAGS)
 init_log_thread_CPPFLAGS = -DINIT_TEST=6 $(AM_CPPFLAGS)
+init_test_param_init_CPPFLAGS = -DINIT_TEST=7 $(AM_CPPFLAGS)
 
 init_defaults_SOURCES = init_main.c
 init_abort_SOURCES = init_main.c
@@ -20,3 +22,4 @@ init_num_thr_SOURCES = init_main.c
 init_feature_enabled_SOURCES = init_main.c
 init_feature_disabled_SOURCES = init_main.c
 init_log_thread_SOURCES = init_main.c
+init_test_param_init_SOURCES = init_main.c

--- a/test/validation/api/init/init_main.c
+++ b/test/validation/api/init/init_main.c
@@ -242,7 +242,6 @@ static void init_test_feature_disabled(void)
 }
 
 odp_testinfo_t testinfo[] = {
-	ODP_TEST_INFO(init_test_param_init),
 	ODP_TEST_INFO(init_test_defaults),
 	ODP_TEST_INFO(init_test_abort),
 	ODP_TEST_INFO(init_test_log),
@@ -250,6 +249,7 @@ odp_testinfo_t testinfo[] = {
 	ODP_TEST_INFO(init_test_feature_enabled),
 	ODP_TEST_INFO(init_test_feature_disabled),
 	ODP_TEST_INFO(init_test_log_thread),
+	ODP_TEST_INFO(init_test_param_init),
 };
 
 odp_testinfo_t init_suite[] = {


### PR DESCRIPTION
At present, test binary for init_test_param_init is not created.
This patch creates it appropriately from init_main.c.

Signed-off-by: Gowrishankar Muthukrishnan <gmuthukrishn@marvell.com>