### PR TITLE
[PATCH v2] linux-gen: atomic: fix build error with gcc 12

### DIFF
--- a/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2021, ARM Limited
- * Copyright (c) 2021, Nokia
+ * Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -81,10 +81,13 @@ static inline void _odp_atomic_init_u128(odp_atomic_u128_t *atom, odp_u128_t val
 
 static inline odp_u128_t _odp_atomic_load_u128(odp_atomic_u128_t *atom)
 {
-	odp_u128_t val;
+	union {
+		odp_u128_t val;
+		__int128_t i;
+	} u;
 
-	*(__int128_t *)&val = __atomic_load_n((__int128_t *)&atom->v, __ATOMIC_RELAXED);
-	return val;
+	u.i = __atomic_load_n((__int128_t *)&atom->v, __ATOMIC_RELAXED);
+	return u.val;
 }
 
 static inline void _odp_atomic_store_u128(odp_atomic_u128_t *atom, odp_u128_t val)


### PR DESCRIPTION
Pointer aliasing caused by pointer casting in _odp_atomic_load_u128() seems
to confuse GCC 12.1 so that GCC issues a warning about a use of an
uninitialized variable. The generated code was anyway ok in the compiler
versions I tested.

Replace pointer casting in the problematic code by type punning through
a union, which appears to have been valid C since C99. The generated code
is not affected in various GCC and Clang versions tested.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>