### PR TITLE
[PATCH v2] linux-gen: event: fix conversion build error

### DIFF
--- a/platform/linux-generic/include/odp/api/plat/event_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/event_inlines.h
@@ -91,7 +91,7 @@ _ODP_INLINE void odp_event_flow_id_set(odp_event_t event, uint32_t id)
 {
 	uint8_t *flow_id = _odp_event_hdr_ptr(event, uint8_t, flow_id);
 
-	*flow_id = id;
+	*flow_id = (uint8_t)id;
 }
 
 /** @endcond */


### PR DESCRIPTION
Fix 'conversion' build error: conversion to uint8_t from uint32_t may alter
value.

Signed-off-by: Matias Elo <matias.elo@nokia.com>