### PR TITLE
[PATCH v2] linux-gen: promiscuous mode fixes

### DIFF
--- a/example/ping/ping_run.sh
+++ b/example/ping/ping_run.sh
@@ -16,8 +16,9 @@ fi
 
 setup_interfaces
 
-# Ping test with 100 ICMP echo request packets (verbose mode)
-./odp_ping${EXEEXT} -v -n 100 -i $IF0
+# Ping test with 100 ICMP echo request packets. Timeout 5 sec.
+# Promiscuous and verbose mode enabled.
+./odp_ping${EXEEXT} -v -p -t 5 -n 100 -i $IF0
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -48,7 +48,6 @@
 
 typedef struct {
 	odp_queue_t loopq;		/**< loopback queue for "loop" device */
-	odp_bool_t promisc;		/**< promiscuous mode state */
 	uint16_t mtu;			/**< link MTU */
 	uint8_t idx;			/**< index of "loop" device */
 } pkt_loop_t;
@@ -477,7 +476,7 @@ static int loopback_init_capability(pktio_entry_t *pktio_entry)
 
 	capa->max_input_queues  = 1;
 	capa->max_output_queues = 1;
-	capa->set_op.op.promisc_mode = 1;
+	capa->set_op.op.promisc_mode = 0;
 	capa->set_op.op.maxlen = 1;
 
 	capa->maxlen.equal = true;
@@ -539,16 +538,9 @@ static int loopback_capability(pktio_entry_t *pktio_entry, odp_pktio_capability_
 	return 0;
 }
 
-static int loopback_promisc_mode_set(pktio_entry_t *pktio_entry,
-				     odp_bool_t enable)
+static int loopback_promisc_mode_get(pktio_entry_t *pktio_entry ODP_UNUSED)
 {
-	pkt_priv(pktio_entry)->promisc = enable;
-	return 0;
-}
-
-static int loopback_promisc_mode_get(pktio_entry_t *pktio_entry)
-{
-	return pkt_priv(pktio_entry)->promisc ? 1 : 0;
+	return 1;
 }
 
 static int loopback_stats(pktio_entry_t *pktio_entry,
@@ -609,7 +601,7 @@ const pktio_if_ops_t _odp_loopback_pktio_ops = {
 	.send = loopback_send,
 	.maxlen_get = loopback_mtu_get,
 	.maxlen_set = loopback_mtu_set,
-	.promisc_mode_set = loopback_promisc_mode_set,
+	.promisc_mode_set = NULL,
 	.promisc_mode_get = loopback_promisc_mode_get,
 	.mac_get = loopback_mac_addr_get,
 	.mac_set = NULL,

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -435,8 +435,7 @@ static int loopback_mtu_set(pktio_entry_t *pktio_entry, uint32_t maxlen_input,
 	return 0;
 }
 
-static int loopback_mac_addr_get(pktio_entry_t *pktio_entry ODP_UNUSED,
-				 void *mac_addr)
+static int loopback_mac_addr_get(pktio_entry_t *pktio_entry, void *mac_addr)
 {
 	memcpy(mac_addr, pktio_loop_mac, ETH_ALEN);
 	((uint8_t *)mac_addr)[ETH_ALEN - 1] += pkt_priv(pktio_entry)->idx;
@@ -534,8 +533,7 @@ static int loopback_init_capability(pktio_entry_t *pktio_entry)
 	return 0;
 }
 
-static int loopback_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
-			       odp_pktio_capability_t *capa)
+static int loopback_capability(pktio_entry_t *pktio_entry, odp_pktio_capability_t *capa)
 {
 	*capa = pktio_entry->capa;
 	return 0;
@@ -560,7 +558,7 @@ static int loopback_stats(pktio_entry_t *pktio_entry,
 	return 0;
 }
 
-static int loopback_stats_reset(pktio_entry_t *pktio_entry ODP_UNUSED)
+static int loopback_stats_reset(pktio_entry_t *pktio_entry)
 {
 	memset(&pktio_entry->stats, 0, sizeof(odp_pktio_stats_t));
 	return 0;


### PR DESCRIPTION
Remove incomplete and unnecessary support of promiscuous mode set operation from loop and null interfaces.

Use promiscuous mode in ping example testing with pcap, since pcap file of the test case has different dest MAC address than the interface.