### PR TITLE
[PATCH v3] api: cpumask: default mask pointer may be NULL

### DIFF
--- a/include/odp/api/spec/cpumask.h
+++ b/include/odp/api/spec/cpumask.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -208,26 +209,36 @@ int odp_cpumask_last(const odp_cpumask_t *mask);
 int odp_cpumask_next(const odp_cpumask_t *mask, int cpu);
 
 /**
- * Default cpumask for worker threads
+ * Default CPU mask for worker threads
  *
- * Initializes cpumask with CPUs available for worker threads. Sets up to 'num'
- * CPUs and returns the count actually set. Use zero for all available CPUs.
+ * Initializes CPU mask with the default set of CPUs available for worker threads. It's system
+ * specific if other CPUs may be used for worker threads as well. Parameter 'num' defines
+ * the maximum number of CPUs to be returned. Use zero for all available CPUs. The mask pointer
+ * may be set to NULL when CPU mask is not required.
+ *
+ * Returns the number of CPUs selected and written into the CPU mask (when not NULL).
  *
  * @param[out] mask      CPU mask to initialize
- * @param      num       Number of worker threads, zero for all available CPUs
- * @return Actual number of CPUs used to create the mask
+ * @param      num       Maximum number of CPUs to return. Use zero for all available CPUs.
+ *
+ * @return Number of selected CPUs
  */
 int odp_cpumask_default_worker(odp_cpumask_t *mask, int num);
 
 /**
- * Default cpumask for control threads
+ * Default CPU mask for control threads
  *
- * Initializes cpumask with CPUs available for control threads. Sets up to 'num'
- * CPUs and returns the count actually set. Use zero for all available CPUs.
+ * Initializes CPU mask with the default set of CPUs available for control threads. It's system
+ * specific if other CPUs may be used for control threads as well. Parameter 'num' defines
+ * the maximum number of CPUs to be returned. Use zero for all available CPUs. The mask pointer
+ * may be set to NULL when CPU mask is not required.
+ *
+ * Returns the number of CPUs selected and written into the CPU mask (when not NULL).
  *
  * @param[out] mask      CPU mask to initialize
- * @param      num       Number of control threads, zero for all available CPUs
- * @return Actual number of CPUs used to create the mask
+ * @param      num       Maximum number of CPUs to return. Use zero for all available CPUs.
+ *
+ * @return Number of selected CPUs
  */
 int odp_cpumask_default_control(odp_cpumask_t *mask, int num);
 

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -65,6 +65,7 @@ typedef struct odp_global_data_ro_t {
 	odp_abort_func_t abort_fn;
 	system_info_t system_info;
 	hugepage_info_t hugepage_info;
+	odp_cpumask_t all_cpus;
 	odp_cpumask_t control_cpus;
 	odp_cpumask_t worker_cpus;
 	int num_cpus_installed;

--- a/platform/linux-generic/odp_cpumask_task.c
+++ b/platform/linux-generic/odp_cpumask_task.c
@@ -78,8 +78,7 @@ int odp_cpumask_default_control(odp_cpumask_t *mask, int max_num)
 
 int odp_cpumask_all_available(odp_cpumask_t *mask)
 {
-	odp_cpumask_or(mask, &odp_global_ro.worker_cpus,
-		       &odp_global_ro.control_cpus);
+	odp_cpumask_copy(mask, &odp_global_ro.all_cpus);
 
-	return odp_cpumask_count(mask);
+	return odp_global_ro.num_cpus_installed;
 }

--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -969,7 +969,6 @@ static int atomic_init(odp_instance_t *inst)
 {
 	uint32_t workers_count, max_threads;
 	int ret = 0;
-	odp_cpumask_t mask;
 	odp_init_t init_param;
 	odph_helper_options_t helper_options;
 
@@ -1002,7 +1001,7 @@ static int atomic_init(odp_instance_t *inst)
 
 	global_mem->g_num_threads = MAX_WORKERS;
 
-	workers_count = odp_cpumask_default_worker(&mask, 0);
+	workers_count = odp_cpumask_default_worker(NULL, 0);
 
 	max_threads = (workers_count >= MAX_WORKERS) ?
 			MAX_WORKERS : workers_count;

--- a/test/validation/api/barrier/barrier.c
+++ b/test/validation/api/barrier/barrier.c
@@ -301,7 +301,6 @@ static int barrier_init(odp_instance_t *inst)
 {
 	uint32_t workers_count, max_threads;
 	int ret = 0;
-	odp_cpumask_t mask;
 	odp_init_t init_param;
 	odph_helper_options_t helper_options;
 
@@ -336,7 +335,7 @@ static int barrier_init(odp_instance_t *inst)
 	global_mem->g_iterations = MAX_ITERATIONS;
 	global_mem->g_verbose = VERBOSE;
 
-	workers_count = odp_cpumask_default_worker(&mask, 0);
+	workers_count = odp_cpumask_default_worker(NULL, 0);
 
 	max_threads = (workers_count >= MAX_WORKERS) ?
 			MAX_WORKERS : workers_count;

--- a/test/validation/api/cpumask/cpumask.c
+++ b/test/validation/api/cpumask/cpumask.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
+ * Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -10,82 +10,150 @@
 #include "odp_cunit_common.h"
 #include "mask_common.h"
 
-/* default worker parameter to get all that may be available */
-#define ALL_AVAILABLE 0
+static int cpumask_max_count(void)
+{
+	odp_cpumask_t mask;
+
+	odp_cpumask_setall(&mask);
+
+	return odp_cpumask_count(&mask);
+}
 
 static void cpumask_test_odp_cpumask_def_control(void)
 {
-	unsigned int num, max_num;
-	unsigned int mask_count;
-	unsigned int max_cpus = mask_capacity();
 	odp_cpumask_t mask;
+	int num, count, all;
+	int max = cpumask_max_count();
+	int request = 7;
 
-	num = odp_cpumask_default_control(&mask, ALL_AVAILABLE);
-	mask_count = odp_cpumask_count(&mask);
+	CU_ASSERT_FATAL(max > 1);
 
-	CU_ASSERT(mask_count == num);
+	if (request > max)
+		request = max - 1;
+
+	all = odp_cpumask_default_control(&mask, 0);
+	num = all;
+	count = odp_cpumask_count(&mask);
+
 	CU_ASSERT(num > 0);
-	CU_ASSERT(num <= max_cpus);
+	CU_ASSERT(num == count);
+	CU_ASSERT(num <= max);
 
-	max_num = odp_cpumask_default_control(&mask, max_cpus);
-	mask_count = odp_cpumask_count(&mask);
+	num = odp_cpumask_default_control(&mask, max);
+	count = odp_cpumask_count(&mask);
 
-	CU_ASSERT(max_num > 0);
-	CU_ASSERT(max_num == mask_count);
-	CU_ASSERT(max_num <= max_cpus);
-	CU_ASSERT(max_num <= num);
+	CU_ASSERT(num > 0);
+	CU_ASSERT(num == count);
+	CU_ASSERT(num <= max);
+	CU_ASSERT(num == all);
+
+	num = odp_cpumask_default_control(&mask, 1);
+	count = odp_cpumask_count(&mask);
+
+	CU_ASSERT(num == 1);
+	CU_ASSERT(num == count);
+
+	num = odp_cpumask_default_control(&mask, request);
+	count = odp_cpumask_count(&mask);
+
+	CU_ASSERT(num > 0);
+	CU_ASSERT(num <= request);
+	CU_ASSERT(num == count);
+
+	CU_ASSERT(odp_cpumask_default_control(NULL, request) == num);
+	CU_ASSERT(odp_cpumask_default_control(NULL, 0) == all);
+	CU_ASSERT(odp_cpumask_default_control(NULL, 1) == 1);
 }
 
 static void cpumask_test_odp_cpumask_def_worker(void)
 {
-	unsigned int num, max_num;
-	unsigned int mask_count;
-	unsigned int max_cpus = mask_capacity();
 	odp_cpumask_t mask;
+	int num, count, all;
+	int max = cpumask_max_count();
+	int request = 7;
 
-	num = odp_cpumask_default_worker(&mask, ALL_AVAILABLE);
-	mask_count = odp_cpumask_count(&mask);
+	CU_ASSERT_FATAL(max > 1);
 
-	CU_ASSERT(mask_count == num);
+	if (request > max)
+		request = max - 1;
+
+	all = odp_cpumask_default_worker(&mask, 0);
+	num = all;
+	count = odp_cpumask_count(&mask);
+
 	CU_ASSERT(num > 0);
-	CU_ASSERT(num <= max_cpus);
+	CU_ASSERT(num == count);
+	CU_ASSERT(num <= max);
 
-	max_num = odp_cpumask_default_worker(&mask, max_cpus);
-	mask_count = odp_cpumask_count(&mask);
+	num = odp_cpumask_default_worker(&mask, max);
+	count = odp_cpumask_count(&mask);
 
-	CU_ASSERT(max_num > 0);
-	CU_ASSERT(max_num == mask_count);
-	CU_ASSERT(max_num <= max_cpus);
-	CU_ASSERT(max_num <= num);
+	CU_ASSERT(num > 0);
+	CU_ASSERT(num == count);
+	CU_ASSERT(num <= max);
+	CU_ASSERT(num == all);
+
+	num = odp_cpumask_default_worker(&mask, 1);
+	count = odp_cpumask_count(&mask);
+
+	CU_ASSERT(num == 1);
+	CU_ASSERT(num == count);
+
+	num = odp_cpumask_default_worker(&mask, request);
+	count = odp_cpumask_count(&mask);
+
+	CU_ASSERT(num > 0);
+	CU_ASSERT(num <= request);
+	CU_ASSERT(num == count);
+
+	CU_ASSERT(odp_cpumask_default_worker(NULL, request) == num);
+	CU_ASSERT(odp_cpumask_default_worker(NULL, 0) == all);
+	CU_ASSERT(odp_cpumask_default_worker(NULL, 1) == 1);
 }
 
 static void cpumask_test_odp_cpumask_def(void)
 {
-	unsigned mask_count;
-	unsigned num_worker;
-	unsigned num_control;
-	unsigned max_cpus = mask_capacity();
-	unsigned available_cpus = odp_cpu_count();
-	unsigned requested_cpus;
-	odp_cpumask_t mask;
+	odp_cpumask_t mask, all_mask, overlap;
+	int count, all, num_worker, num_control, request;
+	int max = cpumask_max_count();
+	int cpu_count = odp_cpu_count();
 
-	CU_ASSERT(available_cpus <= max_cpus);
+	all = odp_cpumask_all_available(&all_mask);
+	count = odp_cpumask_count(&all_mask);
 
-	if (available_cpus > 1)
-		requested_cpus = available_cpus - 1;
-	else
-		requested_cpus = available_cpus;
-	num_worker = odp_cpumask_default_worker(&mask, requested_cpus);
-	mask_count = odp_cpumask_count(&mask);
-	CU_ASSERT(mask_count == num_worker);
+	CU_ASSERT_FATAL(cpu_count > 0);
+	CU_ASSERT_FATAL(all > 0);
+	CU_ASSERT(all == cpu_count);
+	CU_ASSERT(all <= max);
+	CU_ASSERT(all == count);
+
+	request = all - 1;
+	if (request == 0)
+		request = 1;
+
+	num_worker = odp_cpumask_default_worker(&mask, request);
+	count = odp_cpumask_count(&mask);
+	CU_ASSERT(num_worker > 0);
+	CU_ASSERT(num_worker <= request);
+	CU_ASSERT(num_worker == count);
+
+	/* Check that CPUs are in the all CPUs mask */
+	odp_cpumask_zero(&overlap);
+	odp_cpumask_and(&overlap, &mask, &all_mask);
+	CU_ASSERT(odp_cpumask_count(&overlap) == num_worker);
 
 	num_control = odp_cpumask_default_control(&mask, 1);
-	mask_count = odp_cpumask_count(&mask);
-	CU_ASSERT(mask_count == num_control);
+	count = odp_cpumask_count(&mask);
+	CU_ASSERT(num_control == 1);
+	CU_ASSERT(num_control == count);
 
-	CU_ASSERT(num_control >= 1);
-	CU_ASSERT(num_worker <= available_cpus);
-	CU_ASSERT(num_worker > 0);
+	odp_cpumask_zero(&overlap);
+	odp_cpumask_and(&overlap, &mask, &all_mask);
+	CU_ASSERT(odp_cpumask_count(&overlap) == num_control);
+
+	CU_ASSERT(odp_cpumask_default_worker(NULL, request) == num_worker);
+	CU_ASSERT(odp_cpumask_default_worker(NULL, 0) <= all);
+	CU_ASSERT(odp_cpumask_default_control(NULL, 0) <= all);
 }
 
 odp_testinfo_t cpumask_suite[] = {

--- a/test/validation/api/lock/lock.c
+++ b/test/validation/api/lock/lock.c
@@ -1149,7 +1149,6 @@ static int lock_init(odp_instance_t *inst)
 {
 	uint32_t workers_count, max_threads;
 	int ret = 0;
-	odp_cpumask_t mask;
 	odp_init_t init_param;
 	odph_helper_options_t helper_options;
 
@@ -1184,7 +1183,7 @@ static int lock_init(odp_instance_t *inst)
 	global_mem->g_iterations = 0; /* tuned by first test */
 	global_mem->g_verbose = VERBOSE;
 
-	workers_count = odp_cpumask_default_worker(&mask, 0);
+	workers_count = odp_cpumask_default_worker(NULL, 0);
 
 	max_threads = (workers_count >= MAX_WORKERS) ?
 			MAX_WORKERS : workers_count;

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -895,7 +895,6 @@ static int run_pool_test_create_after_fork(void *arg ODP_UNUSED)
 static void pool_test_create_after_fork(void)
 {
 	odp_shm_t shm;
-	odp_cpumask_t unused;
 	int num;
 
 	/* No single VA required since reserve is done before fork */
@@ -904,7 +903,7 @@ static void pool_test_create_after_fork(void)
 	global_mem = odp_shm_addr(shm);
 	CU_ASSERT_PTR_NOT_NULL_FATAL(global_mem);
 
-	num = odp_cpumask_default_worker(&unused, 0);
+	num = odp_cpumask_default_worker(NULL, 0);
 	if (num > MAX_WORKERS)
 		num = MAX_WORKERS;
 

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -59,7 +59,6 @@ static int queue_suite_init(void)
 	test_globals_t *globals;
 	odp_pool_param_t params;
 	int num_workers;
-	odp_cpumask_t mask;
 
 	shm = odp_shm_reserve(GLOBALS_NAME, sizeof(test_globals_t),
 			      ODP_CACHE_LINE_SIZE, 0);
@@ -72,7 +71,7 @@ static int queue_suite_init(void)
 	globals = odp_shm_addr(shm);
 	memset(globals, 0, sizeof(test_globals_t));
 
-	num_workers = odp_cpumask_default_worker(&mask, 0);
+	num_workers = odp_cpumask_default_worker(NULL, 0);
 
 	if (num_workers > MAX_WORKERS)
 		num_workers = MAX_WORKERS;

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -3509,7 +3509,6 @@ static void scheduler_test_mq_mt_prio_a_print(void)
 
 static int scheduler_test_global_init(void)
 {
-	odp_cpumask_t mask;
 	odp_shm_t shm;
 	thread_args_t *args;
 	odp_pool_t pool;
@@ -3536,7 +3535,7 @@ static int scheduler_test_global_init(void)
 	memset(globals, 0, sizeof(test_globals_t));
 	globals->shm_glb = shm;
 
-	globals->num_workers = odp_cpumask_default_worker(&mask, 0);
+	globals->num_workers = odp_cpumask_default_worker(NULL, 0);
 	if (globals->num_workers > MAX_WORKERS)
 		globals->num_workers = MAX_WORKERS;
 

--- a/test/validation/api/shmem/shmem.c
+++ b/test/validation/api/shmem/shmem.c
@@ -138,7 +138,6 @@ static void shmem_test_multi_thread(void)
 	odp_shm_t shm;
 	odp_shm_t shm2;
 	shared_test_data_t *shared_test_data;
-	odp_cpumask_t unused;
 	int i, num;
 	char max_name[ODP_SHM_NAME_LEN];
 
@@ -201,7 +200,7 @@ static void shmem_test_multi_thread(void)
 	shared_test_data->foo = TEST_SHARE_FOO;
 	shared_test_data->bar = TEST_SHARE_BAR;
 
-	num = odp_cpumask_default_worker(&unused, 0);
+	num = odp_cpumask_default_worker(NULL, 0);
 
 	if (num > MAX_WORKERS)
 		num = MAX_WORKERS;
@@ -543,7 +542,6 @@ static void shmem_test_reserve_after_fork(void)
 	odp_shm_t shm;
 	odp_shm_t thr_shm;
 	shared_test_data_t *glob_data;
-	odp_cpumask_t unused;
 	int thr_index, i, num;
 	shared_test_data_small_t  *pattern_small;
 	shared_test_data_medium_t *pattern_medium;
@@ -554,7 +552,7 @@ static void shmem_test_reserve_after_fork(void)
 	glob_data = odp_shm_addr(shm);
 	CU_ASSERT_PTR_NOT_NULL(glob_data);
 
-	num = odp_cpumask_default_worker(&unused, 0);
+	num = odp_cpumask_default_worker(NULL, 0);
 	if (num > MAX_WORKERS)
 		num = MAX_WORKERS;
 
@@ -734,7 +732,6 @@ static void shmem_test_singleva_after_fork(void)
 	odp_shm_t shm;
 	odp_shm_t thr_shm;
 	shared_test_data_t *glob_data;
-	odp_cpumask_t unused;
 	int thr_index, i, num;
 	void *address;
 	shared_test_data_small_t  *pattern_small;
@@ -747,7 +744,7 @@ static void shmem_test_singleva_after_fork(void)
 	glob_data = odp_shm_addr(shm);
 	CU_ASSERT_PTR_NOT_NULL(glob_data);
 
-	num = odp_cpumask_default_worker(&unused, 3);
+	num = odp_cpumask_default_worker(NULL, 3);
 	if (num > MAX_WORKERS)
 		num = MAX_WORKERS;
 
@@ -974,7 +971,6 @@ static void shmem_test_stress(void)
 	odp_shm_t shm;
 	odp_shm_t globshm;
 	shared_test_data_t *glob_data;
-	odp_cpumask_t unused;
 	uint32_t i;
 	int num;
 
@@ -984,7 +980,7 @@ static void shmem_test_stress(void)
 	glob_data = odp_shm_addr(globshm);
 	CU_ASSERT_PTR_NOT_NULL(glob_data);
 
-	num = odp_cpumask_default_worker(&unused, 0);
+	num = odp_cpumask_default_worker(NULL, 0);
 	if (num > MAX_WORKERS)
 		num = MAX_WORKERS;
 

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -2071,7 +2071,6 @@ static void timer_test_all(odp_queue_type_t queue_type)
 	int rc;
 	odp_pool_param_t params;
 	odp_timer_pool_param_t tparam;
-	odp_cpumask_t unused;
 	odp_timer_pool_info_t tpinfo;
 	uint64_t ns, tick, ns2;
 	uint64_t res_ns, min_tmo, max_tmo;
@@ -2089,7 +2088,7 @@ static void timer_test_all(odp_queue_type_t queue_type)
 	/* Reserve at least one core for running other processes so the timer
 	 * test hopefully can run undisturbed and thus get better timing
 	 * results. */
-	num_workers = odp_cpumask_default_worker(&unused, 0);
+	num_workers = odp_cpumask_default_worker(NULL, 0);
 
 	/* force to max CPU count */
 	if (num_workers > MAX_WORKERS)


### PR DESCRIPTION
Improved default worker/control mask API documentation. Allow application to use NULL as mask pointer, when it is only interested about number of worker/control CPUs.