### PR TITLE
[PATCH v2] linux-gen: system: remove redundant cpu count code

### DIFF
--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -34,7 +34,6 @@ typedef struct {
 	uint64_t default_cpu_hz;
 	uint64_t page_size;
 	int      cache_line_size;
-	int      cpu_count;
 	odp_bool_t cpu_hz_static;
 	odp_cpu_arch_t cpu_arch;
 	odp_cpu_arch_isa_t cpu_isa_sw;


### PR DESCRIPTION
Number of CPUs is stored into odp_global_ro.num_cpus_installed.
Remove code maintaining a redundant copy of the same value in
odp_global_ro.system_info.cpu_count. Rename systemcpu() to
system_cache_line(), as code remaining in the function handles
system cache line size only.
