### PR TITLE
[PATCH v3] helper: threads: fix synchronized thread start in process mode

### DIFF
--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2021, Nokia
+ * Copyright (c) 2019-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -83,8 +83,11 @@ typedef struct {
 /** Helper internal thread start arguments. Used both in process and thread
  *  mode */
 typedef struct {
-	/** Atomic variable to sync status */
-	odp_atomic_u32_t status;
+	/** Thread status */
+	uint32_t status;
+
+	/** Socket for updating thread status */
+	int sockfd;
 
 	/** Process or thread */
 	odp_mem_model_t mem_model;


### PR DESCRIPTION
Memory for odph_thread_create() output thread table is given by
application, so there is no guarantee that the memory can be used to
synchronize child process startup. Use socketpair() instead.

Signed-off-by: Matias Elo <matias.elo@nokia.com>