### PR TITLE
[PATCH v1] linux-gen: pool: properly initialize ext pool base and max addresses

### DIFF
--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -1937,5 +1937,11 @@ int odp_pool_ext_populate(odp_pool_t pool_hdl, void *buf[], uint32_t buf_size, u
 
 	pool->num_populated += num;
 
+	if (flags & ODP_POOL_POPULATE_DONE) {
+		pool->base_addr = (uint8_t *)pool->ring->event_hdr_by_index[0];
+		pool->max_addr = (uint8_t *)pool->ring->event_hdr_by_index[pool->num - 1]
+				 + buf_size - 1;
+	}
+
 	return 0;
 }

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -1656,6 +1656,8 @@ static void packet_pool_ext_alloc(int len_test)
 		if (pkt[i] == ODP_PACKET_INVALID)
 			break;
 
+		CU_ASSERT(odp_packet_is_valid(pkt[i]) == 1);
+		CU_ASSERT(odp_event_is_valid(odp_packet_to_event(pkt[i])) == 1);
 		CU_ASSERT(odp_packet_len(pkt[i]) == pkt_len);
 		CU_ASSERT(odp_packet_headroom(pkt[i]) >= headroom);
 		buf_index = find_buf(pkt[i], buf, num_buf, head_offset);


### PR DESCRIPTION
This patchset fixes `odp_packet_is_valid()` behavior with packets allocated from external memory pools. Currently the check always fails due to pool base and maximum address fields being zero. This is fixed by properly initializing the addresses utilizing the populated memory chunks.