### PR TITLE
[PATCH v4] linux-gen: sched: add configuration options for per queue type burst sizes

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.21"
+config_file_version = "0.1.22"
 
 # System options
 system: {
@@ -210,6 +210,16 @@ sched_basic: {
 	# caused by a burst of lower priority events.
 	burst_size_default = [ 32,  32,  32,  32,  32, 16,  8, 4]
 	burst_size_max     = [255, 255, 255, 255, 255, 16, 16, 8]
+
+	# Burst size configuration per priority for each scheduled queue type.
+	# Overrides default values set in 'burst_size_default' and
+	# 'burst_size_max' if != 0.
+	burst_size_parallel     = [0, 0, 0, 0, 0, 0, 0, 0]
+	burst_size_max_parallel = [0, 0, 0, 0, 0, 0, 0, 0]
+	burst_size_atomic       = [0, 0, 0, 0, 0, 0, 0, 0]
+	burst_size_max_atomic   = [0, 0, 0, 0, 0, 0, 0, 0]
+	burst_size_ordered      = [0, 0, 0, 0, 0, 0, 0, 0]
+	burst_size_max_ordered  = [0, 0, 0, 0, 0, 0, 0, 0]
 
 	# Automatically updated schedule groups
 	#

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -3,7 +3,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [21])
+m4_define([_odp_config_version_minor], [22])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.21"
+config_file_version = "0.1.22"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/packet_align.conf
+++ b/platform/linux-generic/test/packet_align.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.21"
+config_file_version = "0.1.22"
 
 pool: {
 	pkt: {

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.21"
+config_file_version = "0.1.22"
 
 # Shared memory options
 shm: {

--- a/platform/linux-generic/test/sched-basic.conf
+++ b/platform/linux-generic/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.21"
+config_file_version = "0.1.22"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {


### PR DESCRIPTION

Add new configuration file options for adjusting scheduler burst sizes per
scheduled queue type. Use 32-bit fast path variables for improved
arithmetic operation performance.

Signed-off-by: Matias Elo <matias.elo@nokia.com>