### PR TITLE
Avoid possible deadloop in llq dequeue

### DIFF
--- a/platform/linux-generic/include/odp_llqueue.h
+++ b/platform/linux-generic/include/odp_llqueue.h
@@ -41,6 +41,7 @@ static odp_bool_t llq_on_queue(struct llnode *node);
  *****************************************************************************/
 
 #define SENTINEL ((void *)~(uintptr_t)0)
+#define MAX_SPIN_COUNT 100000
 
 #ifdef CONFIG_LLDSCD
 /* Implement queue operations using double-word LL/SC */
@@ -114,6 +115,7 @@ static inline struct llnode *llq_dequeue(struct llqueue *llq)
 	(void)__atomic_load_n(&head->next, __ATOMIC_RELAXED);
 
 	do {
+restartLoop:
 		old.ui = lld(&llq->u.ui, __ATOMIC_RELAXED);
 		if (odp_unlikely(old.st.head == NULL)) {
 			/* Empty list */
@@ -125,13 +127,18 @@ static inline struct llnode *llq_dequeue(struct llqueue *llq)
 		} else {
 			/* Multi-element list, dequeue head */
 			struct llnode *next;
+			int	spinCount=0;
 			/* Wait until llq_enqueue() has written true next
 			 * pointer
 			 */
 			while ((next = __atomic_load_n(&old.st.head->next,
 						       __ATOMIC_RELAXED)) ==
 				SENTINEL)
+			{
 				odp_cpu_pause();
+				if (++spinCount >= MAX_SPIN_COUNT)
+					goto restartLoop;
+			}
 			neu.st.head = next;
 			neu.st.tail = old.st.tail;
 		}
@@ -146,6 +153,7 @@ static inline odp_bool_t llq_dequeue_cond(struct llqueue *llq,
 	union llht old, neu;
 
 	do {
+restartLoop:		
 		old.ui = lld(&llq->u.ui, __ATOMIC_ACQUIRE);
 		if (odp_unlikely(old.st.head == NULL || old.st.head != exp)) {
 			/* Empty list or wrong head */
@@ -157,13 +165,17 @@ static inline odp_bool_t llq_dequeue_cond(struct llqueue *llq,
 		} else {
 			/* Multi-element list, dequeue head */
 			struct llnode *next;
-
+			int	spinCount=0;
 			/* Wait until llq_enqueue() has written true next
 			 * pointer */
 			while ((next = __atomic_load_n(&old.st.head->next,
 						       __ATOMIC_RELAXED)) ==
 				SENTINEL)
+			{
 				odp_cpu_pause();
+				if (++spinCount >= MAX_SPIN_COUNT)
+					goto restartLoop;
+			}
 
 			neu.st.head = next;
 			neu.st.tail = old.st.tail;


### PR DESCRIPTION
The cpu_pause while loop is added to handle the case that the dequeue happens when an enqueue is in progress and the llq->u.ui.head is being updated.
 
In some corner case, however, if the old.st.head is dequeued from llq and then enqueued into another queue before the while loop starts, then the dequeue can get stuck in the while loop until the queue is scheduled again. 

Add a threshold of spin count, so we will re-check the llq head once max spin count is reached.

Signed-off-by: Hui Ling <hling@sonicwall.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>