### PR TITLE
[PATCH v5] linux-gen: timer: use new 128-bit atomic APIs for timer processing functions

### DIFF
--- a/platform/linux-generic/include/odp_atomic_internal.h
+++ b/platform/linux-generic/include/odp_atomic_internal.h
@@ -159,31 +159,6 @@ static inline void _odp_atomic_u128_xchg_mm(_odp_atomic_u128_t *ptr,
 {
 	__atomic_exchange(&ptr->v, val, old, mm);
 }
-
-/**
- * Atomic compare and exchange (swap) of 16-byte atomic variable
- * "Strong" semantics, will not fail spuriously.
- *
- * @param ptr   Pointer to a 16-byte atomic variable
- * @param exp   Pointer to expected value (updated on failure)
- * @param val   Pointer to new value to write
- * @param succ  Memory model associated with a successful compare-and-swap
- * operation
- * @param fail  Memory model associated with a failed compare-and-swap
- * operation
- *
- * @retval 1 exchange successul
- * @retval 0 exchange failed and '*exp' updated with current value
- */
-static inline int _odp_atomic_u128_cmp_xchg_mm(_odp_atomic_u128_t *ptr,
-					       _odp_u128_t *exp,
-					       _odp_u128_t *val,
-					       _odp_memmodel_t succ,
-					       _odp_memmodel_t fail)
-{
-	return __atomic_compare_exchange(&ptr->v, exp, val,
-			false/*strong*/, succ, fail);
-}
 #endif
 
 /**

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -117,24 +117,31 @@ _odp_timeout_inline_offset ODP_ALIGNED_CACHE = {
 
 #include <odp/visibility_end.h>
 
-typedef struct
+typedef union
 #if USE_128BIT_ATOMICS
 ODP_ALIGNED(16) /* 16-byte atomic operations need properly aligned addresses */
 #endif
 tick_buf_s {
-	/* Expiration tick or TMO_xxx */
-	odp_atomic_u64_t exp_tck;
-	union {
-		/* ODP_EVENT_INVALID if timer not active */
-		odp_event_t tmo_event;
+#if USE_128BIT_ATOMICS
+	odp_atomic_u128_t tb_atomic_u128;
 
-		/* Ensures that tick_buf_t is 128 bits */
-		uint64_t tmo_u64;
+	odp_u128_t tb_u128;
+#endif
+
+	struct {
+		/* Expiration tick or TMO_xxx */
+		odp_atomic_u64_t exp_tck;
+		union {
+			/* ODP_EVENT_INVALID if timer not active */
+			odp_event_t tmo_event;
+
+			/* Ensures that tick_buf_t is 128 bits */
+			uint64_t tmo_u64;
+		};
 	};
-
 } tick_buf_t;
 
-#ifndef ODP_ATOMIC_U64_LOCK
+#if USE_128BIT_ATOMICS
 ODP_STATIC_ASSERT(sizeof(tick_buf_t) == 16, "sizeof(tick_buf_t) == 16");
 #endif
 
@@ -702,9 +709,8 @@ static bool timer_reset(uint32_t idx, uint64_t abs_tck, odp_event_t *tmo_event,
 
 			/* Atomic CAS will fail if we experienced torn reads,
 			 * retry update sequence until CAS succeeds */
-		} while (!_odp_atomic_u128_cmp_xchg_mm((_odp_atomic_u128_t *)tb,
-						       (_odp_u128_t *)&old, (_odp_u128_t *)&new,
-						       _ODP_MEMMODEL_RLS, _ODP_MEMMODEL_RLX));
+		} while (!odp_atomic_cas_rel_u128(&tb->tb_atomic_u128,
+						  &old.tb_u128, new.tb_u128));
 #else
 		/* Take a related lock */
 		while (_odp_atomic_flag_tas(IDX2LOCK(tp, idx)))
@@ -847,11 +853,9 @@ static odp_event_t timer_cancel(timer_pool_t *tp, uint32_t idx)
 
 		/* Atomic CAS will fail if we experienced torn reads,
 		 * retry update sequence until CAS succeeds */
-	} while (!_odp_atomic_u128_cmp_xchg_mm((_odp_atomic_u128_t *)tb,
-					       (_odp_u128_t *)&old,
-					       (_odp_u128_t *)&new,
-					       _ODP_MEMMODEL_RLS,
-					       _ODP_MEMMODEL_RLX));
+	} while (!odp_atomic_cas_rel_u128(&tb->tb_atomic_u128, &old.tb_u128,
+					  new.tb_u128));
+
 	old_event = old.tmo_event;
 #else
 	/* Take a related lock */
@@ -905,9 +909,8 @@ static inline void timer_expire(timer_pool_t *tp, uint32_t idx, uint64_t tick)
 		new.exp_tck.v = exp_tck | TMO_INACTIVE;
 		new.tmo_event = ODP_EVENT_INVALID;
 
-		int succ = _odp_atomic_u128_cmp_xchg_mm((_odp_atomic_u128_t *)tb,
-							(_odp_u128_t *)&old, (_odp_u128_t *)&new,
-							_ODP_MEMMODEL_RLS, _ODP_MEMMODEL_RLX);
+		int succ = odp_atomic_cas_rel_u128(&tb->tb_atomic_u128,
+						   &old.tb_u128, new.tb_u128);
 		if (succ)
 			tmo_event = old.tmo_event;
 		/* Else CAS failed, something changed => skip timer


### PR DESCRIPTION
Use newer and ODP standardized 128-bit atomic APIs in the timer
processing functions. ODP timer library was the sole user of the
_odp_atomic_u128_cmp_xchg_mm() API so this can be removed as well.

The first commit is a part of PR #1610 which has been approved. It will be dropped when the PR is merged