### PR TITLE
[PATCH v2] github_ci: update checkpatch-action version

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -24,7 +24,7 @@ jobs:
       if: github.event_name == 'pull_request'
       env:
         CHECKPATCH_COMMAND: ./scripts/checkpatch.pl
-      uses: webispy/checkpatch-action@v7
+      uses: webispy/checkpatch-action@v8
 
     - name: Check push
       if: github.event_name == 'push' && github.ref != 'refs/heads/master'


### PR DESCRIPTION
Update checkpatch-action to v8 to fix failures caused by dubious ownership
in git repository.

Signed-off-by: Matias Elo <matias.elo@nokia.com>