### PR TITLE
[PATCH v5] linux-gen: event: add event validation support

### DIFF
--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -147,7 +147,8 @@ jobs:
         cc: [gcc, clang]
         conf: ['', '--enable-abi-compat', '--enable-deprecated --enable-helper-deprecated --enable-debug=full',
                '--enable-dpdk-zero-copy --disable-static-applications',
-               '--disable-host-optimization', '--disable-host-optimization --enable-abi-compat',
+               '--disable-host-optimization --enable-event-validation=warn',
+               '--disable-host-optimization --enable-abi-compat',
                '--without-openssl --without-pcap', '--with-crypto=armv8crypto', '--with-crypto=ipsecmb']
     steps:
       - uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -334,7 +334,8 @@ jobs:
         cc: [gcc, clang]
         conf: ['', '--enable-abi-compat', '--enable-deprecated --enable-helper-deprecated --enable-debug=full',
                '--enable-dpdk-zero-copy --disable-static-applications',
-               '--disable-host-optimization', '--disable-host-optimization --enable-abi-compat',
+               '--disable-host-optimization --enable-event-validation=warn',
+               '--disable-host-optimization --enable-abi-compat',
                '--without-openssl --without-pcap']
     steps:
       - uses: actions/checkout@v3

--- a/include/odp/autoheader_external.h.in
+++ b/include/odp/autoheader_external.h.in
@@ -11,4 +11,7 @@
 /* Define cache line size */
 #undef _ODP_CACHE_LINE_SIZE
 
+/* Define to 1 or 2 to enable event validation */
+#undef _ODP_EVENT_VALIDATION
+
 #endif

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -38,6 +38,7 @@ odpapiplatinclude_HEADERS = \
 		  include/odp/api/plat/debug_inlines.h \
 		  include/odp/api/plat/event_inlines.h \
 		  include/odp/api/plat/event_inline_types.h \
+		  include/odp/api/plat/event_validation_external.h \
 		  include/odp/api/plat/event_vector_inline_types.h \
 		  include/odp/api/plat/hash_inlines.h \
 		  include/odp/api/plat/ipsec_inlines.h \
@@ -131,6 +132,7 @@ noinst_HEADERS = \
 		  include/odp_debug_internal.h \
 		  include/odp_errno_define.h \
 		  include/odp_event_internal.h \
+		  include/odp_event_validation_internal.h \
 		  include/odp_fdserver_internal.h \
 		  include/odp_forward_typedefs_internal.h \
 		  include/odp_global_data.h \
@@ -207,6 +209,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_dma.c \
 			   odp_errno.c \
 			   odp_event.c \
+			   odp_event_validation.c \
 			   odp_fdserver.c \
 			   odp_hash_crc_gen.c \
 			   odp_impl.c \

--- a/platform/linux-generic/README
+++ b/platform/linux-generic/README
@@ -1,5 +1,5 @@
 Copyright (c) 2014-2018, Linaro Limited
-Copyright (c) 2019, Nokia
+Copyright (c) 2019-2023, Nokia
 All rights reserved.
 
 SPDX-License-Identifier:        BSD-3-Clause
@@ -52,7 +52,29 @@ SPDX-License-Identifier:        BSD-3-Clause
     Note that there may be issues with the quality or security of rdrand and
     rdseed. [2]
 
-6. References
+6. Event validation
+    ODP linux-generic implementation supports additional fast path event
+    validity checks which are disabled by default to minimize overhead. These
+    checks can be enabled with --enable-event-validation [abort/warn] or
+    --enabled-debug=full configuration options.
+
+    Event validation adds additional endmark data to ODP buffers and packets,
+    which is used to detect data writes outside allowed areas. Endmarks are
+    checked by the implementation each time application calls one the following
+    API functions:
+        - odp_buffer_free() / odp_buffer_free_multi()
+        - odp_buffer_is_valid()
+        - odp_event_free() / odp_event_free_multi() / odp_event_free_sp()
+        - odp_event_is_valid()
+        - odp_packet_free() / odp_packet_free_multi() / odp_packet_free_sp()
+        - odp_packet_is_valid()
+        - odp_queue_enq() / odp_queue_enq_multi()
+
+    Event validation can function in two modes: abort (default) and warn. In
+    abort mode the application is terminated immediately if an event validity
+    check fails. In warn mode only an error log message is printed.
+
+7. References
     [1] Intel Digital Random Number Generator (DRNG) Software Implementation
         Guide. John P Mechalas, 17 October 2018.
         https://www.intel.com/content/www/us/en/developer/articles/guide/intel-digital-random-number-generator-drng-software-implementation-guide.html

--- a/platform/linux-generic/include/odp/api/plat/event_validation_external.h
+++ b/platform/linux-generic/include/odp/api/plat/event_validation_external.h
@@ -1,0 +1,93 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP event validation
+ *
+ * @warning These definitions are not part of ODP API, they are for
+ * implementation internal use only.
+ */
+
+#ifndef ODP_EVENT_VALIDATION_EXTERNAL_H_
+#define ODP_EVENT_VALIDATION_EXTERNAL_H_
+
+#include <odp/autoheader_external.h>
+
+#include <odp/api/buffer.h>
+#include <odp/api/event_types.h>
+#include <odp/api/hints.h>
+#include <odp/api/packet_types.h>
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Enumerations for identifying ODP API functions */
+typedef enum {
+	_ODP_EV_BUFFER_FREE = 0,
+	_ODP_EV_BUFFER_FREE_MULTI,
+	_ODP_EV_BUFFER_IS_VALID,
+	_ODP_EV_EVENT_FREE,
+	_ODP_EV_EVENT_FREE_MULTI,
+	_ODP_EV_EVENT_FREE_SP,
+	_ODP_EV_EVENT_IS_VALID,
+	_ODP_EV_PACKET_FREE,
+	_ODP_EV_PACKET_FREE_MULTI,
+	_ODP_EV_PACKET_FREE_SP,
+	_ODP_EV_PACKET_IS_VALID,
+	_ODP_EV_MAX
+} _odp_ev_id_t;
+
+/* Implementation internal event validation functions */
+#if _ODP_EVENT_VALIDATION
+
+int _odp_buffer_validate(odp_buffer_t buf, _odp_ev_id_t ev_id);
+
+int _odp_buffer_validate_multi(const odp_buffer_t buf[], int num, _odp_ev_id_t ev_id);
+
+int _odp_packet_validate(odp_packet_t pkt, _odp_ev_id_t ev_id);
+
+int _odp_packet_validate_multi(const odp_packet_t pkt[], int num, _odp_ev_id_t ev_id);
+
+#else
+
+static inline int _odp_buffer_validate(odp_buffer_t buf ODP_UNUSED, _odp_ev_id_t ev_id ODP_UNUSED)
+{
+	return 0;
+}
+
+static inline int _odp_buffer_validate_multi(const odp_buffer_t buf[] ODP_UNUSED,
+					     int num ODP_UNUSED,
+					     _odp_ev_id_t ev_id ODP_UNUSED)
+{
+	return 0;
+}
+
+static inline int _odp_packet_validate(odp_packet_t pkt ODP_UNUSED, _odp_ev_id_t ev_id ODP_UNUSED)
+{
+	return 0;
+}
+
+static inline int _odp_packet_validate_multi(const odp_packet_t pkt[] ODP_UNUSED,
+					     int num ODP_UNUSED,
+					     _odp_ev_id_t ev_id ODP_UNUSED)
+{
+	return 0;
+}
+
+#endif /* _ODP_EVENT_VALIDATION */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @endcond */
+
+#endif

--- a/platform/linux-generic/include/odp/api/plat/event_validation_external.h
+++ b/platform/linux-generic/include/odp/api/plat/event_validation_external.h
@@ -42,11 +42,17 @@ typedef enum {
 	_ODP_EV_PACKET_FREE_MULTI,
 	_ODP_EV_PACKET_FREE_SP,
 	_ODP_EV_PACKET_IS_VALID,
+	_ODP_EV_QUEUE_ENQ,
+	_ODP_EV_QUEUE_ENQ_MULTI,
 	_ODP_EV_MAX
 } _odp_ev_id_t;
 
 /* Implementation internal event validation functions */
 #if _ODP_EVENT_VALIDATION
+
+int _odp_event_validate(odp_event_t event, _odp_ev_id_t id);
+
+int _odp_event_validate_multi(const odp_event_t event[], int num, _odp_ev_id_t id);
 
 int _odp_buffer_validate(odp_buffer_t buf, _odp_ev_id_t ev_id);
 
@@ -57,6 +63,18 @@ int _odp_packet_validate(odp_packet_t pkt, _odp_ev_id_t ev_id);
 int _odp_packet_validate_multi(const odp_packet_t pkt[], int num, _odp_ev_id_t ev_id);
 
 #else
+
+static inline int _odp_event_validate(odp_event_t event ODP_UNUSED, _odp_ev_id_t ev_id ODP_UNUSED)
+{
+	return 0;
+}
+
+static inline int _odp_event_validate_multi(const odp_event_t event[] ODP_UNUSED,
+					    int num ODP_UNUSED,
+					    _odp_ev_id_t ev_id ODP_UNUSED)
+{
+	return 0;
+}
 
 static inline int _odp_buffer_validate(odp_buffer_t buf ODP_UNUSED, _odp_ev_id_t ev_id ODP_UNUSED)
 {

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -632,7 +632,8 @@ _ODP_INLINE uint32_t odp_packet_buf_size(odp_packet_buf_t pkt_buf)
 	odp_pool_t pool = _odp_pkt_get(pkt_buf, odp_pool_t, pool);
 
 	return _odp_pool_get(pool, uint32_t, ext_pkt_buf_size) -
-			_odp_pool_get(pool, uint32_t, ext_head_offset);
+			_odp_pool_get(pool, uint32_t, ext_head_offset) -
+			_odp_pool_get(pool, uint32_t, trailer_size);
 }
 
 _ODP_INLINE void *odp_packet_buf_head(odp_packet_buf_t pkt_buf)

--- a/platform/linux-generic/include/odp/api/plat/pool_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/pool_inline_types.h
@@ -30,6 +30,7 @@ typedef struct _odp_pool_inline_offset_t {
 	uint16_t index;
 	uint16_t seg_len;
 	uint16_t uarea_size;
+	uint16_t trailer_size;
 	uint16_t ext_head_offset;
 	uint16_t ext_pkt_buf_size;
 

--- a/platform/linux-generic/include/odp/api/plat/queue_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/queue_inlines.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2018, Linaro Limited
+ * Copyright (c) 2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -7,6 +8,9 @@
 #ifndef ODP_PLAT_QUEUE_INLINES_H_
 #define ODP_PLAT_QUEUE_INLINES_H_
 
+#include <odp/api/hints.h>
+
+#include <odp/api/plat/event_validation_external.h>
 #include <odp/api/plat/queue_inline_types.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
@@ -37,12 +41,18 @@ _ODP_INLINE void *odp_queue_context(odp_queue_t handle)
 
 _ODP_INLINE int odp_queue_enq(odp_queue_t queue, odp_event_t ev)
 {
+	if (odp_unlikely(_odp_event_validate(ev, _ODP_EV_QUEUE_ENQ)))
+		return -1;
+
 	return _odp_queue_api->queue_enq(queue, ev);
 }
 
 _ODP_INLINE int odp_queue_enq_multi(odp_queue_t queue,
 				    const odp_event_t events[], int num)
 {
+	if (odp_unlikely(_odp_event_validate_multi(events, num, _ODP_EV_QUEUE_ENQ_MULTI)))
+		return -1;
+
 	return _odp_queue_api->queue_enq_multi(queue, events, num);
 }
 

--- a/platform/linux-generic/include/odp_event_internal.h
+++ b/platform/linux-generic/include/odp_event_internal.h
@@ -53,7 +53,7 @@ typedef struct _odp_event_hdr_t {
 
 	/* --- Mostly read only data --- */
 
-	/* Initial buffer tail pointer */
+	/* Initial buffer tail pointer and endmark location (if enabled) */
 	uint8_t  *buf_end;
 
 	/* Combined pool and event index */
@@ -83,6 +83,11 @@ static inline _odp_event_hdr_t *_odp_event_hdr(odp_event_t event)
 static inline void _odp_event_type_set(odp_event_t event, int ev)
 {
 	_odp_event_hdr(event)->event_type = ev;
+}
+
+static inline uint64_t *_odp_event_endmark_get_ptr(odp_event_t event)
+{
+	return (uint64_t *)(uintptr_t)_odp_event_hdr(event)->buf_end;
 }
 
 #ifdef __cplusplus

--- a/platform/linux-generic/include/odp_event_validation_internal.h
+++ b/platform/linux-generic/include/odp_event_validation_internal.h
@@ -1,0 +1,52 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_EVENT_VALIDATION_INTERNAL_H_
+#define ODP_EVENT_VALIDATION_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/autoheader_external.h>
+
+#include <odp/api/event.h>
+#include <odp/api/hints.h>
+
+#include <odp/api/plat/event_validation_external.h>
+
+#include <odp_event_internal.h>
+
+#include <stdint.h>
+
+#if _ODP_EVENT_VALIDATION
+
+#define _ODP_EV_ENDMARK_VAL  0xDEADBEEFDEADBEEF
+#define _ODP_EV_ENDMARK_SIZE (sizeof(uint64_t))
+
+static inline void _odp_event_endmark_set(odp_event_t event)
+{
+	uint64_t *endmark_ptr;
+
+	endmark_ptr = _odp_event_endmark_get_ptr(event);
+	*endmark_ptr = _ODP_EV_ENDMARK_VAL;
+}
+
+#else
+
+#define _ODP_EV_ENDMARK_VAL  0
+#define _ODP_EV_ENDMARK_SIZE 0
+
+static inline void _odp_event_endmark_set(odp_event_t event ODP_UNUSED)
+{
+}
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/platform/linux-generic/include/odp_init_internal.h
+++ b/platform/linux-generic/include/odp_init_internal.h
@@ -33,6 +33,9 @@ int _odp_pool_init_local(void);
 int _odp_pool_term_global(void);
 int _odp_pool_term_local(void);
 
+int _odp_event_validation_init_global(void);
+int _odp_event_validation_term_global(void);
+
 int _odp_queue_init_global(void);
 int _odp_queue_term_global(void);
 

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -87,6 +87,7 @@ typedef struct pool_t {
 	uint32_t         block_size;
 	uint32_t         block_offset;
 	uint32_t         num_populated;
+	uint32_t         trailer_size;
 	uint8_t         *base_addr;
 	uint8_t         *max_addr;
 	uint8_t         *uarea_base_addr;

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -7,6 +7,7 @@ ODP_ATOMIC
 ODP_PTHREAD
 ODP_TIMER
 m4_include([platform/linux-generic/m4/odp_cpu.m4])
+m4_include([platform/linux-generic/m4/odp_event_validation.m4])
 m4_include([platform/linux-generic/m4/odp_pcap.m4])
 m4_include([platform/linux-generic/m4/odp_scheduler.m4])
 
@@ -30,6 +31,7 @@ m4_include([platform/linux-generic/m4/odp_pcapng.m4])
 m4_include([platform/linux-generic/m4/odp_netmap.m4])
 m4_include([platform/linux-generic/m4/odp_dpdk.m4])
 m4_include([platform/linux-generic/m4/odp_xdp.m4])
+ODP_EVENT_VALIDATION
 ODP_SCHEDULER
 
 AS_VAR_APPEND([PLAT_DEP_LIBS], ["${ATOMIC_LIBS} ${AARCH64CRYPTO_LIBS} ${LIBCONFIG_LIBS} ${OPENSSL_LIBS} ${IPSEC_MB_LIBS} ${DPDK_LIBS_LT} ${LIBCLI_LIBS} ${LIBXDP_LIBS}"])
@@ -37,6 +39,7 @@ AS_VAR_APPEND([PLAT_DEP_LIBS], ["${ATOMIC_LIBS} ${AARCH64CRYPTO_LIBS} ${LIBCONFI
 # Add text to the end of configure with platform specific settings.
 # Make sure it's aligned same as other lines in configure.ac.
 AS_VAR_APPEND([PLAT_CFG_TEXT], ["
+	event_validation:       ${enable_event_validation}
 	openssl:                ${with_openssl}
 	openssl_rand:           ${openssl_rand}
 	crypto:                 ${with_crypto}

--- a/platform/linux-generic/m4/odp_event_validation.m4
+++ b/platform/linux-generic/m4/odp_event_validation.m4
@@ -1,0 +1,23 @@
+# ODP_EVENT_VALIDATION
+# --------------------
+# Select event validation level
+AC_DEFUN([ODP_EVENT_VALIDATION], [dnl
+AC_ARG_ENABLE([event-validation],
+	      [AS_HELP_STRING([--enable-event-validation],
+			      [enable event validation (warn/abort)
+			      [default=disabled] (linux-generic)])],
+	      [], [AS_IF([test "x$enable_debug" = "xfull"],
+	      		 [enable_event_validation=yes], [enable_event_validation=no])])
+
+# Default to abort mode if validation is enabled
+AS_IF([test "x$enable_event_validation" = "xyes"],
+      [enable_event_validation="abort"])
+
+validation_level=0
+AS_IF([test "x$enable_event_validation" = "xwarn"], [validation_level=1])
+AS_IF([test "x$enable_event_validation" = "xyes" -o "x$enable_event_validation" = "xabort"],
+      [validation_level=2])
+
+AC_DEFINE_UNQUOTED([_ODP_EVENT_VALIDATION], [$validation_level],
+		   [Define to 1 or 2 to enable event validation])
+]) # ODP_EVENT_VALIDATION

--- a/platform/linux-generic/odp_event_validation.c
+++ b/platform/linux-generic/odp_event_validation.c
@@ -1,0 +1,234 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/atomic.h>
+#include <odp/api/buffer.h>
+#include <odp/api/debug.h>
+#include <odp/api/event.h>
+#include <odp/api/hints.h>
+#include <odp/api/packet.h>
+#include <odp/api/shared_memory.h>
+
+#include <odp_buffer_internal.h>
+#include <odp_debug_internal.h>
+#include <odp_event_internal.h>
+#include <odp_event_validation_internal.h>
+#include <odp_global_data.h>
+#include <odp_init_internal.h>
+#include <odp_libconfig_internal.h>
+#include <odp_macros_internal.h>
+#include <odp_print_internal.h>
+
+#include <inttypes.h>
+#include <string.h>
+
+#define EVENT_VALIDATION_NONE  0
+#define EVENT_VALIDATION_WARN  1
+#define EVENT_VALIDATION_ABORT 2
+
+#define EVENT_DATA_PRINT_MAX_LEN 128
+
+typedef struct {
+	odp_atomic_u64_t err_count[_ODP_EV_MAX];
+	odp_shm_t shm;
+
+} event_validation_global_t;
+
+typedef struct {
+	const char *str;
+} _odp_ev_info_t;
+
+static event_validation_global_t *_odp_ev_glb;
+
+#if _ODP_EVENT_VALIDATION
+
+/* Table for mapping function IDs to API function names */
+static const _odp_ev_info_t ev_info_tbl[] = {
+	[_ODP_EV_BUFFER_FREE]       = {.str = "odp_buffer_free()"},
+	[_ODP_EV_BUFFER_FREE_MULTI] = {.str = "odp_buffer_free_multi()"},
+	[_ODP_EV_BUFFER_IS_VALID]   = {.str = "odp_buffer_is_valid()"},
+	[_ODP_EV_EVENT_FREE]        = {.str = "odp_event_free()"},
+	[_ODP_EV_EVENT_FREE_MULTI]  = {.str = "odp_event_free_multi()"},
+	[_ODP_EV_EVENT_FREE_SP]     = {.str = "odp_event_free()_sp"},
+	[_ODP_EV_EVENT_IS_VALID]    = {.str = "odp_event_is_valid()"},
+	[_ODP_EV_PACKET_FREE]       = {.str = "odp_packet_free()"},
+	[_ODP_EV_PACKET_FREE_MULTI] = {.str = "odp_packet_free_multi()"},
+	[_ODP_EV_PACKET_FREE_SP]    = {.str = "odp_packet_free_sp()"},
+	[_ODP_EV_PACKET_IS_VALID]   = {.str = "odp_packet_is_valid()"}
+};
+
+ODP_STATIC_ASSERT(_ODP_ARRAY_SIZE(ev_info_tbl) == _ODP_EV_MAX, "ev_info_tbl missing entries");
+
+static void print_event_data(odp_event_t event, odp_event_type_t type)
+{
+	const char *type_str;
+	const uint32_t bytes_per_row = 16;
+	uint32_t byte_len;
+	int num_rows, max_len, n;
+	int len = 0;
+	uint8_t *data;
+
+	if (type == ODP_EVENT_PACKET) {
+		odp_packet_t pkt = odp_packet_from_event(event);
+
+		data = odp_packet_data(pkt);
+		byte_len = odp_packet_seg_len(pkt);
+		type_str = "Packet";
+	} else {
+		odp_buffer_t buf = odp_buffer_from_event(event);
+
+		data = odp_buffer_addr(buf);
+		byte_len = odp_buffer_size(buf);
+		type_str = "Buffer";
+	}
+
+	if (byte_len > EVENT_DATA_PRINT_MAX_LEN)
+		byte_len = EVENT_DATA_PRINT_MAX_LEN;
+
+	num_rows = (byte_len + bytes_per_row - 1) / bytes_per_row;
+	max_len = 256 + (3 * byte_len) + (3 * num_rows);
+	n = max_len - 1;
+
+	char str[max_len];
+
+	len += _odp_snprint(&str[len], n - len, "%s %p data %p:\n", type_str, event, data);
+	while (byte_len) {
+		uint32_t row_len = byte_len > bytes_per_row ? bytes_per_row : byte_len;
+
+		len += _odp_snprint(&str[len], n - len, " ");
+
+		for (uint32_t i = 0; i < row_len; i++)
+			len += _odp_snprint(&str[len], n - len, " %02x", data[i]);
+
+		len += _odp_snprint(&str[len], n - len, "\n");
+
+		byte_len -= row_len;
+		data += row_len;
+	}
+
+	_ODP_PRINT("%s\n", str);
+}
+
+static inline int validate_event_endmark(odp_event_t event, _odp_ev_id_t id, odp_event_type_t type)
+{
+	uint64_t err_count;
+	uint64_t *endmark_ptr = _odp_event_endmark_get_ptr(event);
+
+	if (odp_likely(*endmark_ptr == _ODP_EV_ENDMARK_VAL))
+		return 0;
+
+	err_count = odp_atomic_fetch_inc_u64(&_odp_ev_glb->err_count[id]) + 1;
+
+	_ODP_ERR("Event %p endmark mismatch in %s: endmark=0x%" PRIx64 " (expected 0x%" PRIx64 ") "
+		 "err_count=%" PRIu64 "\n", event, ev_info_tbl[id].str, *endmark_ptr,
+		 _ODP_EV_ENDMARK_VAL, err_count);
+
+	print_event_data(event, type);
+
+	if (_ODP_EVENT_VALIDATION == EVENT_VALIDATION_ABORT)
+		_ODP_ABORT("Abort due to event %p endmark mismatch\n", event);
+
+	/* Fix endmark value */
+	_odp_event_endmark_set(event);
+
+	return -1;
+}
+
+static inline int buffer_validate(odp_buffer_t buf, _odp_ev_id_t id)
+{
+	return validate_event_endmark(odp_buffer_to_event(buf), id, ODP_EVENT_BUFFER);
+}
+
+static inline int packet_validate(odp_packet_t pkt, _odp_ev_id_t id)
+{
+	return validate_event_endmark(odp_packet_to_event(pkt), id, ODP_EVENT_PACKET);
+}
+
+/* Enable usage from API inline files */
+#include <odp/visibility_begin.h>
+
+int _odp_buffer_validate(odp_buffer_t buf, _odp_ev_id_t id)
+{
+	return buffer_validate(buf, id);
+}
+
+int _odp_buffer_validate_multi(const odp_buffer_t buf[], int num,
+			       _odp_ev_id_t id)
+{
+	for (int i = 0; i < num; i++) {
+		if (odp_unlikely(buffer_validate(buf[i], id)))
+			return -1;
+	}
+	return 0;
+}
+
+int _odp_packet_validate(odp_packet_t pkt, _odp_ev_id_t id)
+{
+	return packet_validate(pkt, id);
+}
+
+int _odp_packet_validate_multi(const odp_packet_t pkt[], int num,
+			       _odp_ev_id_t id)
+{
+	for (int i = 0; i < num; i++) {
+		if (odp_unlikely(packet_validate(pkt[i], id)))
+			return -1;
+	}
+	return 0;
+}
+
+#include <odp/visibility_end.h>
+
+#endif /* _ODP_EVENT_VALIDATION */
+
+int _odp_event_validation_init_global(void)
+{
+	odp_shm_t shm;
+
+	_ODP_PRINT("\nEvent validation mode: %s\n\n",
+		   _ODP_EVENT_VALIDATION == EVENT_VALIDATION_NONE ? "none" :
+		   _ODP_EVENT_VALIDATION == EVENT_VALIDATION_WARN ? "warn" : "abort");
+
+	if (_ODP_EVENT_VALIDATION == EVENT_VALIDATION_NONE)
+		return 0;
+
+	shm = odp_shm_reserve("_odp_event_validation_global",
+			      sizeof(event_validation_global_t),
+			      ODP_CACHE_LINE_SIZE, ODP_SHM_EXPORT);
+	if (shm == ODP_SHM_INVALID)
+		return -1;
+
+	_odp_ev_glb = odp_shm_addr(shm);
+	if (_odp_ev_glb == NULL)
+		return -1;
+
+	memset(_odp_ev_glb, 0, sizeof(event_validation_global_t));
+	_odp_ev_glb->shm = shm;
+
+	for (int i = 0; i < _ODP_EV_MAX; i++)
+		odp_atomic_init_u64(&_odp_ev_glb->err_count[i], 0);
+
+	return 0;
+}
+
+int _odp_event_validation_term_global(void)
+{
+	int ret;
+
+	if (_ODP_EVENT_VALIDATION == EVENT_VALIDATION_NONE)
+		return 0;
+
+	if (_odp_ev_glb == NULL)
+		return 0;
+
+	ret = odp_shm_free(_odp_ev_glb->shm);
+	if (ret) {
+		_ODP_ERR("SHM free failed: %d\n", ret);
+		return -1;
+	}
+
+	return 0;
+}

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
+ * Copyright (c) 2021-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -35,6 +35,7 @@ enum init_stage {
 	HASH_INIT,
 	THREAD_INIT,
 	POOL_INIT,
+	EVENT_VALIDATION_INIT,
 	STASH_INIT,
 	QUEUE_INIT,
 	SCHED_INIT,
@@ -242,6 +243,13 @@ static int term_global(enum init_stage stage)
 		}
 		/* Fall through */
 
+	case EVENT_VALIDATION_INIT:
+		if (_odp_event_validation_term_global()) {
+			_ODP_ERR("ODP event validation term failed.\n");
+			rc = -1;
+		}
+		/* Fall through */
+
 	case POOL_INIT:
 		if (_odp_pool_term_global()) {
 			_ODP_ERR("ODP buffer pool term failed.\n");
@@ -411,6 +419,12 @@ int odp_init_global(odp_instance_t *instance,
 		goto init_failed;
 	}
 	stage = POOL_INIT;
+
+	if (_odp_event_validation_init_global()) {
+		_ODP_ERR("ODP event validation init failed.\n");
+		goto init_failed;
+	}
+	stage = EVENT_VALIDATION_INIT;
 
 	if (_odp_stash_init_global()) {
 		_ODP_ERR("ODP stash init failed.\n");

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -5,38 +5,41 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
+#include <odp/api/align.h>
+#include <odp/api/hints.h>
+#include <odp/api/packet_io.h>
 #include <odp/api/queue.h>
+#include <odp/api/schedule.h>
+#include <odp/api/shared_memory.h>
+#include <odp/api/std_types.h>
+#include <odp/api/sync.h>
+#include <odp/api/ticketlock.h>
+#include <odp/api/traffic_mngr.h>
+
+#include <odp/api/plat/queue_inline_types.h>
+#include <odp/api/plat/sync_inlines.h>
+#include <odp/api/plat/ticketlock_inlines.h>
+
+#include <odp_config_internal.h>
+#include <odp_debug_internal.h>
+#include <odp_event_internal.h>
+#include <odp_global_data.h>
+#include <odp_init_internal.h>
+#include <odp_libconfig_internal.h>
+#include <odp_macros_internal.h>
+#include <odp_packet_io_internal.h>
+#include <odp_pool_internal.h>
 #include <odp_queue_basic_internal.h>
 #include <odp_queue_if.h>
-#include <odp/api/std_types.h>
-#include <odp/api/align.h>
-#include <odp_pool_internal.h>
-#include <odp_init_internal.h>
-#include <odp_timer_internal.h>
-#include <odp/api/shared_memory.h>
-#include <odp/api/schedule.h>
 #include <odp_schedule_if.h>
-#include <odp_config_internal.h>
-#include <odp_packet_io_internal.h>
-#include <odp_debug_internal.h>
-#include <odp/api/hints.h>
-#include <odp/api/sync.h>
-#include <odp/api/plat/sync_inlines.h>
-#include <odp/api/traffic_mngr.h>
-#include <odp_libconfig_internal.h>
-#include <odp/api/plat/queue_inline_types.h>
-#include <odp_global_data.h>
-#include <odp_queue_basic_internal.h>
-#include <odp_event_internal.h>
-#include <odp_macros_internal.h>
+#include <odp_timer_internal.h>
 
-#include <odp/api/plat/ticketlock_inlines.h>
+#include <inttypes.h>
+#include <string.h>
+
 #define LOCK(queue_ptr)      odp_ticketlock_lock(&((queue_ptr)->lock))
 #define UNLOCK(queue_ptr)    odp_ticketlock_unlock(&((queue_ptr)->lock))
 #define LOCK_INIT(queue_ptr) odp_ticketlock_init(&((queue_ptr)->lock))
-
-#include <string.h>
-#include <inttypes.h>
 
 #define MIN_QUEUE_SIZE 32
 #define MAX_QUEUE_SIZE (1 * 1024 * 1024)

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -862,7 +862,7 @@ run_measure_one_async(ipsec_args_t *cargs,
 			packets_sent += rc;
 		} else {
 			odp_packet_t pkt_out[max_in_flight];
-			uint32_t i = 0;
+			int i = 0;
 
 			/*
 			 * Dequeue packets until we can enqueue the next burst
@@ -895,7 +895,7 @@ run_measure_one_async(ipsec_args_t *cargs,
 			}
 			debug_packets(debug, pkt_out, i);
 
-			if (i)
+			if (i > 0)
 				odp_packet_free_sp(pkt_out, i);
 		}
 	}

--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -173,7 +173,7 @@ static inline void send_packets(test_global_t *test_global,
 
 	drop = num_pkt - sent;
 
-	if (odp_unlikely(drop))
+	if (odp_unlikely(drop > 0))
 		odp_packet_free_multi(&pkt[sent], drop);
 
 	if (odp_unlikely(test_global->opt.collect_stat)) {


### PR DESCRIPTION
Add support for runtime event validation (initially buffer endmark
checking). Event validation can be enabled during configure with
'--enable-event-validation' [warn/abort] or  with --enabled-debug=full.

When event validation is enabled, endmarks are checked in:
- odp_buffer_free() / odp_buffer_free_multi()
- odp_buffer_is_valid()
- odp_event_free() / odp_event_free_multi() / odp_event_free_sp()
- odp_event_is_valid()
- odp_packet_free() / odp_packet_free_multi() /odp_packet_free_sp()
- odp_packet_is_valid()