### PR TITLE
[PATCH v1] api: pktio: add VLAN strip offload in packet input

### DIFF
--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1645,6 +1645,19 @@ uint32_t odp_packet_l4_offset(odp_packet_t pkt);
 int odp_packet_l4_offset_set(odp_packet_t pkt, uint32_t offset);
 
 /**
+ * Get information on the VLAN tag stripped in packet reception.
+ *
+ * @see odp_pktin_config_opt_t::bit.vlan_strip
+ *
+ * @param      pkt  Packet handle
+ * @param[out] info Structure into which VLAN tag information will be written
+ *
+ * @retval 0  on success
+ * @retval <0 VLAN strip not done, packet does not have VLAN strip metadata
+ */
+int odp_packet_vlan_info(odp_packet_t pkt, odp_packet_vlan_info_t *info);
+
+/**
  * Layer 2 protocol type
  *
  * Returns layer 2 protocol type. Initial type value is ODP_PROTO_L2_TYPE_NONE.

--- a/include/odp/api/spec/packet_io_types.h
+++ b/include/odp/api/spec/packet_io_types.h
@@ -377,6 +377,29 @@ typedef union odp_pktin_config_opt_t {
 		  * on packet input */
 		uint64_t ts_ptp        : 1;
 
+		/** Strip VLAN tags of received packets so that the ODP
+		 *  application sees untagged packets. VLAN ID is saved
+		 *  in packet metadata and can be read using
+		 *  odp_packet_vlan_info().
+		 *
+		 *  This removes only the outermost VLAN tag and only if
+		 *  its ethertype is 0x8100.
+		 *
+		 *  VLAN stripping is done as a last step of packet input
+		 *  processing just before the application gets the packet.
+		 *  This means that packet parsing and classification is
+		 *  done with the VLAN tag still in the packet. The has_vlan
+		 *  and has_qinq packet flags are set at packet parsing
+		 *  before the stripping. Retained L2 headers in inline
+		 *  IPsec processing include the VLAN tag.
+		 *
+		 *  Support for VLAN strip offload must be checked from
+		 *  odp_pktio_capability_t::vlan_offload returned by
+		 *  odp_pktio_capability(). This flag is used only for
+		 *  configuration.
+		 */
+		uint64_t vlan_strip    : 1;
+
 		/** Check IPv4 header checksum on packet input */
 		uint64_t ipv4_chksum   : 1;
 
@@ -812,6 +835,18 @@ typedef struct odp_pktin_vector_capability_t {
 } odp_pktin_vector_capability_t;
 
 /**
+ * VLAN offload capabilities
+ */
+typedef struct odp_vlan_offload_capability_t {
+	/** Supported offloads */
+	struct {
+		/** VLAN strip in packet input */
+		uint32_t vlan_strip:1;
+	} offloads;
+
+} odp_vlan_offload_capability_t;
+
+/**
  * Packet IO capabilities
  *
  * Note that interface capabilities may differ between packet output modes. For example,
@@ -913,6 +948,9 @@ typedef struct odp_pktio_capability_t {
 
 	/** Packet input reassembly capability */
 	odp_reass_capability_t reassembly;
+
+	/** VLAN offload capability */
+	odp_vlan_offload_capability_t vlan_offload;
 
 	/** Statistics counters capabilities */
 	odp_pktio_stats_capability_t stats;

--- a/include/odp/api/spec/packet_types.h
+++ b/include/odp/api/spec/packet_types.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
+ * Copyright (c) 2021-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -303,6 +303,15 @@ typedef struct odp_packet_reass_partial_state_t {
 	/** Time, in ns, since the reception of the first received fragment */
 	uint64_t elapsed_time;
 } odp_packet_reass_partial_state_t;
+
+/**
+ * Information about a stripped VLAN header
+ */
+typedef struct odp_packet_vlan_info_t {
+	/** VLAN ID in host byte order */
+	uint16_t vlan_id;
+
+} odp_packet_vlan_info_t;
 
 /**
  * Flags to control packet data checksum checking


### PR DESCRIPTION
Add a pktin config flag that requests removal of VLAN tags of received
Ethernet frames so that the ODP application sees untagged frames. Add new
packet metadata and an associated API function for an application to query
the VLAN ID of the stripped VLAN tag.
