### PR TITLE
[PATCH v2] validation: common: add missing guard

### DIFF
--- a/test/common/odp_cunit_common.c
+++ b/test/common/odp_cunit_common.c
@@ -6,7 +6,9 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Added guarding #ifndef to avoid re-definition of _GNU_SOURCE.
