### PR TITLE
[PATCH v3] examples: avoid buffering of output

### DIFF
--- a/example/generator/generator_run.sh
+++ b/example/generator/generator_run.sh
@@ -16,7 +16,13 @@ fi
 
 setup_interfaces
 
-./odp_generator${EXEEXT} -w 1 -n 1 -I $IF0 -m u
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
+$STDBUF ./odp_generator${EXEEXT} -w 1 -n 1 -I $IF0 -m u
 STATUS=$?
 
 if [ "$STATUS" -ne 0 ]; then

--- a/example/l2fwd_simple/l2fwd_simple_run.sh
+++ b/example/l2fwd_simple/l2fwd_simple_run.sh
@@ -16,7 +16,13 @@ fi
 
 setup_interfaces
 
-./odp_l2fwd_simple${EXEEXT} $IF0 $IF1 02:00:00:00:00:01 02:00:00:00:00:02 -t 2
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
+$STDBUF ./odp_l2fwd_simple${EXEEXT} $IF0 $IF1 02:00:00:00:00:01 02:00:00:00:00:02 -t 2
 STATUS=$?
 
 if [ "$STATUS" -ne 0 ]; then

--- a/example/l3fwd/odp_l3fwd_run.sh
+++ b/example/l3fwd/odp_l3fwd_run.sh
@@ -16,7 +16,13 @@ fi
 
 setup_interfaces
 
-./odp_l3fwd${EXEEXT} -i $IF0,$IF1 -r "10.0.0.0/24,$IF1" -d 1
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
+$STDBUF ./odp_l3fwd${EXEEXT} -i $IF0,$IF1 -r "10.0.0.0/24,$IF1" -d 1
 
 STATUS=$?
 

--- a/example/packet/packet_dump_run.sh
+++ b/example/packet/packet_dump_run.sh
@@ -16,7 +16,13 @@ fi
 
 setup_interfaces
 
-./odp_packet_dump${EXEEXT} -i $IF0 -n 10 -o 0 -l 64
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
+$STDBUF ./odp_packet_dump${EXEEXT} -i $IF0 -n 10 -o 0 -l 64
 STATUS=$?
 if [ "$STATUS" -ne 0 ]; then
   echo "Error: status was: $STATUS, expected 0"

--- a/example/packet/pktio_run.sh
+++ b/example/packet/pktio_run.sh
@@ -27,8 +27,14 @@ fi
 validate_result
 echo "Pass -m 0: status ${STATUS}"
 
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
 # queue mode
-./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 1
+$STDBUF ./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 1
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then
@@ -40,7 +46,7 @@ validate_result
 echo "Pass -m 1: status ${STATUS}"
 
 # sched/queue mode
-./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 2
+$STDBUF ./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 2
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then
@@ -52,7 +58,7 @@ validate_result
 echo "Pass -m 2: status ${STATUS}"
 
 # cpu number option test 1
-./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 0 -c 1
+$STDBUF ./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 0 -c 1
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then

--- a/example/ping/ping_run.sh
+++ b/example/ping/ping_run.sh
@@ -16,9 +16,15 @@ fi
 
 setup_interfaces
 
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
 # Ping test with 100 ICMP echo request packets. Timeout 5 sec.
 # Promiscuous and verbose mode enabled.
-./odp_ping${EXEEXT} -v -p -t 5 -n 100 -i $IF0
+$STDBUF ./odp_ping${EXEEXT} -v -p -t 5 -n 100 -i $IF0
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then

--- a/example/simple_pipeline/simple_pipeline_run.sh
+++ b/example/simple_pipeline/simple_pipeline_run.sh
@@ -24,7 +24,13 @@ fi
 
 setup_interfaces
 
-./odp_simple_pipeline${EXEEXT} -i $IF0,$IF1 -e -t 1 -a 1
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
+$STDBUF ./odp_simple_pipeline${EXEEXT} -i $IF0,$IF1 -e -t 1 -a 1
 STATUS=$?
 
 if [ "$STATUS" -ne 0 ]; then

--- a/example/switch/switch_run.sh
+++ b/example/switch/switch_run.sh
@@ -18,7 +18,13 @@ fi
 
 setup_interfaces
 
-./odp_switch${EXEEXT} -i $IF0,$IF1,$IF2,$IF3 -t 1 -a 1
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
+$STDBUF ./odp_switch${EXEEXT} -i $IF0,$IF1,$IF2,$IF3 -t 1 -a 1
 STATUS=$?
 if [ "$STATUS" -ne 0 ]; then
   echo "Error: status was: $STATUS, expected 0"

--- a/test/performance/odp_packet_gen_run.sh
+++ b/test/performance/odp_packet_gen_run.sh
@@ -49,8 +49,14 @@ run_packet_gen()
 	# Runs 500 * 10ms = 5 sec
 	# Sends 500 packets through both interfaces => total 1000 packets
 
+	if [ "$(which stdbuf)" != "" ]; then
+		STDBUF="stdbuf -o 0"
+	else
+		STDBUF=
+	fi
+
 	# Static packet length
-	odp_packet_gen${EXEEXT} -i $IF0,$IF1 -b 1 -g 10000000 -q 500 -w 10
+	$STDBUF odp_packet_gen${EXEEXT} -i $IF0,$IF1 -b 1 -g 10000000 -q 500 -w 10
 	ret=$?
 
 	if [ $ret -eq 2 ]; then
@@ -63,7 +69,7 @@ run_packet_gen()
 	fi
 
 	# Random packet length
-	odp_packet_gen${EXEEXT} -i $IF0,$IF1 -b 1 -g 10000000 -q 500 -L 60,1514,10 -w 10
+	$STDBUF odp_packet_gen${EXEEXT} -i $IF0,$IF1 -b 1 -g 10000000 -q 500 -L 60,1514,10 -w 10
 	ret=$?
 
 	if [ $ret -eq 2 ]; then

--- a/test/performance/odp_sched_latency_run.sh
+++ b/test/performance/odp_sched_latency_run.sh
@@ -16,10 +16,16 @@ run()
 	echo odp_sched_latency_run starts requesting $1 worker threads
 	echo =========================================================
 
+	if [ "$(which stdbuf)" != "" ]; then
+		STDBUF="stdbuf -o 0"
+	else
+		STDBUF=
+	fi
+
 	if [ $(nproc) -lt $1 ]; then
 		echo "Not enough CPU cores. Skipping test."
 	else
-		$TEST_DIR/odp_sched_latency${EXEEXT} -c $1 || exit $?
+		$STDBUF $TEST_DIR/odp_sched_latency${EXEEXT} -c $1 || exit $?
 	fi
 }
 

--- a/test/performance/odp_sched_pktio_run.sh
+++ b/test/performance/odp_sched_pktio_run.sh
@@ -54,8 +54,14 @@ run_sched_pktio()
 		exit 1
 	fi
 
+	if [ "$(which stdbuf)" != "" ]; then
+		STDBUF="stdbuf -o 0"
+	else
+		STDBUF=
+	fi
+
 	# 1 worker
-	odp_sched_pktio${EXEEXT} -i $IF1,$IF2 -c 1 -s &
+	$STDBUF odp_sched_pktio${EXEEXT} -i $IF1,$IF2 -c 1 -s &
 
 	TEST_PID=$!
 

--- a/test/performance/odp_scheduling_run.sh
+++ b/test/performance/odp_scheduling_run.sh
@@ -16,10 +16,16 @@ run()
 	echo odp_scheduling_run starts requesting $1 worker threads
 	echo ======================================================
 
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
 	if [ $(nproc) -lt $1 ]; then
 		echo "Not enough CPU cores. Skipping test."
 	else
-		$TEST_DIR/odp_scheduling${EXEEXT} -c $1
+		$STDBUF $TEST_DIR/odp_scheduling${EXEEXT} -c $1
 		RET_VAL=$?
 		if [ $RET_VAL -ne 0 ]; then
 			echo odp_scheduling FAILED


### PR DESCRIPTION
Currently some of the tests redirect the output to
a file and dumps the file contents at the end of the
test. Avoid this and tee the output to a file. And
whenever stdbuf utility is available, use it turn off
output buffering so that logs are displayed real time.

Also, dump generator logs at the end of the tests only in
case of error exits. And don't do cleanup if it is a
successful exit as cleanup would have been already done
for these cases.

Signed-off-by: Sunil Kumar Kori <skori@marvell.com>