### PR TITLE
[PATCH v2] ci: update LTO builds

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -251,18 +251,35 @@ jobs:
         if: ${{ failure() }}
         run: find . -name config.log -exec cat {} \;
 
-  Build_gcc:
+  Build_gcc_u20:
+    runs-on: ubuntu-18.04
+    env:
+      OS: ubuntu_20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        cc_ver: [9]
+        conf: ['', '--enable-abi-compat']
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="gcc-${{matrix.cc_ver}}" -e CXX="g++-${{matrix.cc_ver}}"
+               -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
+      - name: Failure log
+        if: ${{ failure() }}
+        run: find . -name config.log -exec cat {} \;
+
+  Build_gcc_u22:
     runs-on: ubuntu-18.04
     env:
       OS: ubuntu_22.04
     strategy:
       fail-fast: false
       matrix:
-        cc: [gcc-10, gcc-11, gcc-12]
-        conf: ['', '--enable-lto']
+        cc_ver: [10, 11, 12]
+        conf: ['', '--enable-abi-compat']
     steps:
       - uses: actions/checkout@v2
-      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="gcc-${{matrix.cc_ver}}" -e CXX="g++-${{matrix.cc_ver}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
       - name: Failure log
         if: ${{ failure() }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -82,6 +82,41 @@ jobs:
         if: ${{ failure() }}
         run: find . -name config.log -exec cat {} \;
 
+  Build_static_u20:
+    runs-on: ubuntu-18.04
+    env:
+      OS: ubuntu_20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        cc_ver: [9]
+        conf: ['--disable-shared', '--enable-lto --disable-shared']
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="gcc-${{matrix.cc_ver}}" -e CXX="g++-${{matrix.cc_ver}}"
+               -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_static_${ARCH}.sh
+      - name: Failure log
+        if: ${{ failure() }}
+        run: find . -name config.log -exec cat {} \;
+
+  Build_static_u22:
+    runs-on: ubuntu-18.04
+    env:
+      OS: ubuntu_22.04
+      CONF: "--disable-shared --without-openssl --without-pcap"
+    strategy:
+      fail-fast: false
+      matrix:
+        cc_ver: [10, 11, 12]
+        conf: ['', '--enable-lto']
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="gcc-${{matrix.cc_ver}}" -e CXX="g++-${{matrix.cc_ver}}"
+               -e CONF="${CONF} ${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_static_${ARCH}.sh
+      - name: Failure log
+        if: ${{ failure() }}
+        run: find . -name config.log -exec cat {} \;
+
   Build_arm64:
     runs-on: ubuntu-18.04
     env:

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -73,12 +73,13 @@ static void wait_for_order(ordering_mode_t mode)
  */
 static int set_ipsec_crypto_capa(odp_ipsec_capability_t *capa)
 {
-	int rc;
 	odp_crypto_capability_t crypto_capa;
 
-	rc = odp_crypto_capability(&crypto_capa);
-	if (rc < 0)
-		return rc;
+	crypto_capa.ciphers.all_bits = 0;
+	crypto_capa.auths.all_bits = 0;
+
+	if (odp_crypto_capability(&crypto_capa))
+		return -1;
 
 #define CHECK_CIPHER(field, alg) do {				\
 	if (crypto_capa.ciphers.bit.field &&			\

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -168,6 +168,8 @@ int _odp_ipsec_sad_init_global(void)
 	if (odp_global_ro.disable.ipsec)
 		return 0;
 
+	crypto_capa.max_sessions = 0;
+
 	if (odp_crypto_capability(&crypto_capa)) {
 		ODP_ERR("odp_crypto_capability() failed\n");
 		return -1;

--- a/scripts/ci/build_static_x86_64.sh
+++ b/scripts/ci/build_static_x86_64.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+CONFIG_OPT="--prefix=/opt/odp ${CONF}"
+
+cd "$(dirname "$0")"/../..
+./bootstrap
+echo "./configure $CONFIG_OPT"
+./configure $CONFIG_OPT
+
+make clean
+
+make -j $(nproc)
+
+make install
+
+# Build and run sysinfo with installed libs
+pushd ${HOME}
+
+${CC} ${CFLAGS} ${OLDPWD}/example/sysinfo/odp_sysinfo.c -static -o odp_sysinfo_inst_static `PKG_CONFIG_PATH=/opt/odp/lib/pkgconfig:${PKG_CONFIG_PATH} pkg-config --cflags --libs --static libodp-linux`
+
+./odp_sysinfo_inst_static
+
+popd

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -942,6 +942,9 @@ static int check_cipher_params(const odp_crypto_capability_t *crypto_capa,
 		return 1;
 
 	num = odp_crypto_cipher_capability(param->cipher_alg, NULL, 0);
+	if (num <= 0)
+		return 1;
+
 	odp_crypto_cipher_capability_t cipher_capa[num];
 
 	rc = odp_crypto_cipher_capability(param->cipher_alg, cipher_capa, num);
@@ -984,6 +987,9 @@ static int check_auth_params(const odp_crypto_capability_t *crypto_capa,
 		return 1;
 
 	num = odp_crypto_auth_capability(param->auth_alg, NULL, 0);
+	if (num <= 0)
+		return 1;
+
 	odp_crypto_auth_capability_t auth_capa[num];
 
 	rc = odp_crypto_auth_capability(param->auth_alg, auth_capa, num);

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -1342,12 +1342,11 @@ static void test_auth_hashes_in_auth_range(void)
 		odp_auth_alg_t auth = auth_algs[n];
 		int num;
 
-		if (check_alg_support(ODP_CIPHER_ALG_NULL, auth)
-		    == ODP_TEST_INACTIVE)
+		if (check_alg_support(ODP_CIPHER_ALG_NULL, auth) == ODP_TEST_INACTIVE)
 			continue;
 
 		num = odp_crypto_auth_capability(auth, NULL, 0);
-		CU_ASSERT(num > 0);
+		CU_ASSERT_FATAL(num > 0);
 
 		odp_crypto_auth_capability_t capa[num];
 


### PR DESCRIPTION
Add build only jobs that use static linking. Test LTO mainly with static linking since that exposes more code to LTO analysis that dynamic linking.