### PR TITLE
[PATCH v6] linux-gen: sched: print full lines

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -135,6 +135,7 @@ noinst_HEADERS = \
 		  include/odp_packet_internal.h \
 		  include/odp_packet_io_internal.h \
 		  include/odp_parse_internal.h \
+		  include/odp_print_internal.h \
 		  include/odp_socket_common.h \
 		  include/odp_packet_io_stats_common.h \
 		  include/odp_packet_io_stats.h \
@@ -213,6 +214,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_packet_io.c \
 			   odp_parse.c \
 			   odp_pkt_queue.c \
+			   odp_print.c \
 			   odp_pool.c \
 			   odp_pool_mem_src_ops.c \
 			   odp_queue_basic.c \

--- a/platform/linux-generic/include/odp_print_internal.h
+++ b/platform/linux-generic/include/odp_print_internal.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_PRINT_INTERNAL_H_
+#define ODP_PRINT_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+int _odp_snprint(char *str, size_t size, const char *format, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/odp_print.c
+++ b/platform/linux-generic/odp_print.c
@@ -1,0 +1,47 @@
+/* Copyright (c) 2022, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/hints.h>
+#include <odp_print_internal.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+/* Helps with snprintf() return value checking
+ *
+ * Otherwise like snprintf(), but returns always the number of characters
+ * printed (without the end mark) or zero on error. Terminates the string
+ * always with the end mark. */
+ODP_PRINTF_FORMAT(3, 4)
+int _odp_snprint(char *str, size_t size, const char *format, ...)
+{
+	va_list args;
+	int len;
+
+	/* No space to print new characters */
+	if (size < 1)
+		return 0;
+
+	if (size < 2) {
+		str[0] = 0;
+		return 0;
+	}
+
+	va_start(args, format);
+	len = vsnprintf(str, size, format, args);
+	va_end(args);
+
+	/* Error. Ensure that string has the end mark */
+	if (len < 0) {
+		str[0] = 0;
+		return 0;
+	}
+
+	/* Print would have been longer. Return the number of characters printed. */
+	if (len >= (int)size)
+		return (int)size - 1;
+
+	return len;
+}


### PR DESCRIPTION
Print full lines from odp_schedule_print() call, so that log remain readable also when other threads print into it simultaneously.