### PR TITLE
[PATCH v2] linux-gen: debug: avoid duplication of macro argument side effects

### DIFF
--- a/platform/linux-generic/include/odp_debug_internal.h
+++ b/platform/linux-generic/include/odp_debug_internal.h
@@ -37,15 +37,8 @@ extern "C" {
  * level 0 to N. */
 #define CONFIG_DEBUG_LEVEL 0
 
-ODP_PRINTF_FORMAT(1, 2)
-static inline void check_printf_format(const char *fmt, ...)
-{
-	(void)fmt;
-}
-
 #define _ODP_LOG_FN(level, fmt, ...) \
 	do { \
-		check_printf_format(fmt, ##__VA_ARGS__); \
 		if (_odp_this_thread && _odp_this_thread->log_fn) \
 			_odp_this_thread->log_fn(level, fmt, ##__VA_ARGS__); \
 		else \

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -61,7 +61,7 @@ typedef struct odp_global_data_ro_t {
 	pid_t main_pid;
 	pid_t fdserver_pid;
 	char uid[UID_MAXLEN];
-	odp_log_func_t log_fn;
+	odp_log_func_t ODP_PRINTF_FORMAT(2, 3) log_fn;
 	odp_abort_func_t abort_fn;
 	system_info_t system_info;
 	hugepage_info_t hugepage_info;


### PR DESCRIPTION
Remove the separate check_printf_format() function and move
ODP_PRINTF_FORMAT, so that the variable argument in _ODP_LOG_FN is
substituted only once, to avoid duplication of side effects.

Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

v2:
- Rebase.
- Add review tags.