### PR TITLE
[PATCH v5] linux-gen: cls: mark implemented capabilities enabled

### DIFF
--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -1155,17 +1155,12 @@ static inline int verify_pmr_ipsec_spi(const uint8_t *pkt_addr,
 
 	pkt_addr += pkt_hdr->p.l4_offset;
 
-	if (pkt_hdr->p.input_flags.ipsec_ah) {
-		const _odp_ahhdr_t *ahhdr = (const _odp_ahhdr_t *)pkt_addr;
-
-		spi = odp_be_to_cpu_32(ahhdr->spi);
-	} else if (pkt_hdr->p.input_flags.ipsec_esp) {
-		const _odp_esphdr_t *esphdr = (const _odp_esphdr_t *)pkt_addr;
-
-		spi = odp_be_to_cpu_32(esphdr->spi);
-	} else {
+	if (pkt_hdr->p.input_flags.ipsec_ah)
+		spi = ((const _odp_ahhdr_t *)pkt_addr)->spi;
+	else if (pkt_hdr->p.input_flags.ipsec_esp)
+		spi = ((const _odp_esphdr_t *)pkt_addr)->spi;
+	else
 		return 0;
-	}
 
 	if (term_value->match.value == (spi & term_value->match.mask))
 		return 1;

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -181,6 +181,7 @@ int odp_cls_capability(odp_cls_capability_t *capability)
 	capability->supported_terms.bit.dip_addr = 1;
 	capability->supported_terms.bit.sip6_addr = 1;
 	capability->supported_terms.bit.dip6_addr = 1;
+	capability->supported_terms.bit.ipsec_spi = 1;
 	capability->supported_terms.bit.custom_frame = 1;
 	capability->supported_terms.bit.custom_l3 = 1;
 	capability->random_early_detection = ODP_SUPPORT_NO;

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -189,6 +189,12 @@ int odp_cls_capability(odp_cls_capability_t *capability)
 	capability->threshold_red.all_bits = 0;
 	capability->threshold_bp.all_bits = 0;
 	capability->max_hash_queues = CLS_COS_QUEUE_MAX;
+	capability->hash_protocols.proto.ipv4_udp = 1;
+	capability->hash_protocols.proto.ipv4_tcp = 1;
+	capability->hash_protocols.proto.ipv4 = 1;
+	capability->hash_protocols.proto.ipv6_udp = 1;
+	capability->hash_protocols.proto.ipv6_tcp = 1;
+	capability->hash_protocols.proto.ipv6 = 1;
 	capability->max_mark = MAX_MARK;
 	capability->stats.cos.counter.discards = 1;
 	capability->stats.cos.counter.packets = 1;

--- a/test/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/validation/api/classification/odp_classification_test_pmr.c
@@ -1873,6 +1873,98 @@ static void classification_test_pmr_term_custom_l3(void)
 	test_pmr_term_custom(1);
 }
 
+static void test_pmr_term_ipsec_spi_ah(odp_bool_t is_ipv6)
+{
+	uint32_t val;
+	uint32_t mask;
+	odp_pmr_param_t pmr_param;
+	cls_packet_info_t pkt_info;
+	odp_packet_t pkt;
+	odph_ahhdr_t *ah;
+
+	val = odp_cpu_to_be_32(0x11223344);
+	mask = odp_cpu_to_be_32(0xffffffff);
+
+	odp_cls_pmr_param_init(&pmr_param);
+	pmr_param.term = ODP_PMR_IPSEC_SPI;
+	pmr_param.match.value = &val;
+	pmr_param.match.mask = &mask;
+	pmr_param.val_sz = sizeof(val);
+
+	pkt_info = default_pkt_info;
+	pkt_info.l4_type = CLS_PKT_L4_AH;
+	pkt_info.ipv6 = is_ipv6;
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	ah = (odph_ahhdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	ah->spi = val;
+
+	test_pmr(&pmr_param, pkt, MATCH);
+
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	ah = (odph_ahhdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	ah->spi = val + 1;
+
+	test_pmr(&pmr_param, pkt, NO_MATCH);
+}
+
+static void classification_test_pmr_term_ipsec_spi_ah_ipv4(void)
+{
+	test_pmr_term_ipsec_spi_ah(TEST_IPV4);
+}
+
+static void test_pmr_term_ipsec_spi_esp(odp_bool_t is_ipv6)
+{
+	uint32_t val;
+	uint32_t mask;
+	odp_pmr_param_t pmr_param;
+	cls_packet_info_t pkt_info;
+	odp_packet_t pkt;
+	odph_esphdr_t *esp;
+
+	val = odp_cpu_to_be_32(0x11223344);
+	mask = odp_cpu_to_be_32(0xffffffff);
+
+	odp_cls_pmr_param_init(&pmr_param);
+	pmr_param.term = ODP_PMR_IPSEC_SPI;
+	pmr_param.match.value = &val;
+	pmr_param.match.mask = &mask;
+	pmr_param.val_sz = sizeof(val);
+
+	pkt_info = default_pkt_info;
+	pkt_info.l4_type = CLS_PKT_L4_ESP;
+	pkt_info.ipv6 = is_ipv6;
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	esp = (odph_esphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	esp->spi = val;
+
+	test_pmr(&pmr_param, pkt, MATCH);
+
+	pkt = create_packet(pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	esp = (odph_esphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	esp->spi = val + 1;
+
+	test_pmr(&pmr_param, pkt, NO_MATCH);
+}
+
+static void classification_test_pmr_term_ipsec_spi_esp_ipv4(void)
+{
+	test_pmr_term_ipsec_spi_esp(TEST_IPV4);
+}
+
+static void classification_test_pmr_term_ipsec_spi_ah_ipv6(void)
+{
+	test_pmr_term_ipsec_spi_ah(TEST_IPV6);
+}
+
+static void classification_test_pmr_term_ipsec_spi_esp_ipv6(void)
+{
+	test_pmr_term_ipsec_spi_esp(TEST_IPV6);
+}
+
 static int check_capa_tcp_dport(void)
 {
 	return cls_capa.supported_terms.bit.tcp_dport;
@@ -1966,6 +2058,11 @@ static int check_capa_custom_frame(void)
 static int check_capa_custom_l3(void)
 {
 	return cls_capa.supported_terms.bit.custom_l3;
+}
+
+static int check_capa_ipsec_spi(void)
+{
+	return cls_capa.supported_terms.bit.ipsec_spi;
 }
 
 static int check_capa_pmr_series(void)
@@ -2088,6 +2185,14 @@ odp_testinfo_t classification_suite_pmr[] = {
 				  check_capa_custom_frame),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_custom_l3,
 				  check_capa_custom_l3),
+	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_ipsec_spi_ah_ipv4,
+				  check_capa_ipsec_spi),
+	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_ipsec_spi_esp_ipv4,
+				  check_capa_ipsec_spi),
+	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_ipsec_spi_ah_ipv6,
+				  check_capa_ipsec_spi),
+	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_term_ipsec_spi_esp_ipv6,
+				  check_capa_ipsec_spi),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_serial,
 				  check_capa_pmr_series),
 	ODP_TEST_INFO_CONDITIONAL(classification_test_pmr_parallel,

--- a/test/validation/api/classification/odp_classification_testsuites.h
+++ b/test/validation/api/classification/odp_classification_testsuites.h
@@ -19,6 +19,8 @@ typedef enum cls_packet_l4_info {
 	CLS_PKT_L4_ICMP,
 	CLS_PKT_L4_GTP,
 	CLS_PKT_L4_IGMP,
+	CLS_PKT_L4_AH,
+	CLS_PKT_L4_ESP
 } cls_packet_l4_info;
 
 typedef struct cls_packet_info {


### PR DESCRIPTION
This patchset marks implemented but missing IPsec SPI PMR and class-of-service hash protocol capabilities enabled in classification. Additionally, add validation tests for `ODP_PMR_IPSEC_SPI` variants.

v2:
- Added valid values to AH and ESP header fields when creating test packets

v3:
- Fixed AH header length usage
- Added reviewed-by tags

v4:
- Removed extra endianness swap in `verify_pmr_ipsec_spi()` and changed validation tests accordingly

v5:
- Added reviewed-by tags