### PR TITLE
[PATCH v10] api: pool: user area in buffer, timeout and vector events

### DIFF
--- a/include/odp/api/spec/buffer.h
+++ b/include/odp/api/spec/buffer.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -76,6 +77,19 @@ void *odp_buffer_addr(odp_buffer_t buf);
  * @return Buffer maximum data size
  */
 uint32_t odp_buffer_size(odp_buffer_t buf);
+
+/**
+ * Buffer user area
+ *
+ * Returns pointer to the user area associated with the buffer. Size of the area is fixed
+ * and defined in buffer pool parameters.
+ *
+ * @param buf      Buffer handle
+ *
+ * @return       Pointer to the user area of the buffer
+ * @retval NULL  The buffer does not have user area
+ */
+void *odp_buffer_user_area(odp_buffer_t buf);
 
 /**
  * Check that buffer is valid

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1492,6 +1492,31 @@ void *odp_packet_user_area(odp_packet_t pkt);
 uint32_t odp_packet_user_area_size(odp_packet_t pkt);
 
 /**
+ * Check user flag
+ *
+ * Implementation clears user flag during new packet creation (e.g. alloc and packet input)
+ * and reset. User may set the flag with odp_packet_user_flag_set(). Implementation never
+ * sets the flag, only clears it. The flag may be useful e.g. to mark when the user area
+ * content is valid.
+ *
+ * @param pkt   Packet handle
+ *
+ * @retval 0    User flag is clear
+ * @retval !0   User flag is set
+ */
+int odp_packet_user_flag(odp_packet_t pkt);
+
+/**
+ * Set user flag
+ *
+ * Set (or clear) the user flag.
+ *
+ * @param pkt   Packet handle
+ * @param val   New value for the flag. Zero clears the flag, other values set the flag.
+ */
+void odp_packet_user_flag_set(odp_packet_t pkt, int val);
+
+/**
  * Layer 2 start pointer
  *
  * Returns pointer to the start of layer 2. Optionally, outputs number of data
@@ -2224,6 +2249,31 @@ void odp_packet_vector_size_set(odp_packet_vector_t pktv, uint32_t size);
  * @retval NULL  The packet vector does not have user area
  */
 void *odp_packet_vector_user_area(odp_packet_vector_t pktv);
+
+/**
+ * Check user flag
+ *
+ * Implementation clears user flag during new packet vector creation (e.g. alloc and packet input)
+ * and reset. User may set the flag with odp_packet_vector_user_flag_set(). Implementation never
+ * sets the flag, only clears it. The flag may be useful e.g. to mark when the user area
+ * content is valid.
+ *
+ * @param pktv  Packet vector handle
+ *
+ * @retval 0    User flag is clear
+ * @retval !0   User flag is set
+ */
+int odp_packet_vector_user_flag(odp_packet_vector_t pktv);
+
+/**
+ * Set user flag
+ *
+ * Set (or clear) the user flag.
+ *
+ * @param pktv  Packet vector handle
+ * @param val   New value for the flag. Zero clears the flag, other values set the flag.
+ */
+void odp_packet_vector_user_flag_set(odp_packet_vector_t pktv, int val);
 
 /**
  * Check that packet vector is valid

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -2213,6 +2213,19 @@ uint32_t odp_packet_vector_size(odp_packet_vector_t pktv);
 void odp_packet_vector_size_set(odp_packet_vector_t pktv, uint32_t size);
 
 /**
+ * Packet vector user area
+ *
+ * Returns pointer to the user area associated with the packet vector. Size of the area is fixed
+ * and defined in vector pool parameters.
+ *
+ * @param  pktv  Packet vector handle
+ *
+ * @return       Pointer to the user area of the packet vector
+ * @retval NULL  The packet vector does not have user area
+ */
+void *odp_packet_vector_user_area(odp_packet_vector_t pktv);
+
+/**
  * Check that packet vector is valid
  *
  * This function can be used for debugging purposes to check if a packet vector handle represents

--- a/include/odp/api/spec/pool_types.h
+++ b/include/odp/api/spec/pool_types.h
@@ -250,10 +250,7 @@ typedef struct odp_pool_capability_t {
 		 * memory size for the pool. */
 		uint32_t max_seg_len;
 
-		/** Maximum user area size in bytes
-		 *
-		 * The value of zero means that limited only by the available
-		 * memory size for the pool. */
+		/** Maximum user area size in bytes */
 		uint32_t max_uarea_size;
 
 		/** Maximum number of subparameters
@@ -454,9 +451,9 @@ typedef struct odp_pool_param_t {
 		 */
 		uint32_t seg_len;
 
-		/** User area size in bytes. The maximum value is defined by
+		/** Minimum user area size in bytes. The maximum value is defined by
 		 *  pool capability pkt.max_uarea_size. Specify as 0 if no user
-		 *  area is needed.
+		 *  area is needed. The default value is 0.
 		 */
 		uint32_t uarea_size;
 

--- a/include/odp/api/spec/pool_types.h
+++ b/include/odp/api/spec/pool_types.h
@@ -304,7 +304,7 @@ typedef struct odp_pool_capability_t {
 		 * memory size for the pool. */
 		uint32_t max_num;
 
-		/** Maximum number of general types, such as odp_packet_t, in a vector. */
+		/** Maximum number of handles (such as odp_packet_t) in a vector. */
 		uint32_t max_size;
 
 		/** Minimum size of thread local cache */
@@ -344,10 +344,10 @@ typedef enum odp_pool_type_t {
 	/** Timeout pool */
 	ODP_POOL_TIMEOUT = ODP_EVENT_TIMEOUT,
 
-	/** Vector pool
+	/** Vector event pool
 	 *
-	 * The pool to hold a vector of general type such as odp_packet_t.
-	 * Each vector holds an array of generic types of the same type.
+	 * Each vector event holds an array of handles. All handles of a vector
+	 * are the same type (such as odp_packet_t).
 	 * @see ODP_EVENT_PACKET_VECTOR
 	 */
 	ODP_POOL_VECTOR,
@@ -515,7 +515,7 @@ typedef struct odp_pool_param_t {
 		/** Number of vectors in the pool */
 		uint32_t num;
 
-		/** Maximum number of general types, such as odp_packet_t, in a vector. */
+		/** Maximum number of handles (such as odp_packet_t) in a vector. */
 		uint32_t max_size;
 
 		/** Maximum number of vectors cached locally per thread

--- a/include/odp/api/spec/pool_types.h
+++ b/include/odp/api/spec/pool_types.h
@@ -174,6 +174,9 @@ typedef struct odp_pool_capability_t {
 		 * memory size for the pool. */
 		uint32_t max_num;
 
+		/** Maximum user area size in bytes */
+		uint32_t max_uarea_size;
+
 		/** Minimum size of thread local cache */
 		uint32_t min_cache_size;
 
@@ -280,6 +283,9 @@ typedef struct odp_pool_capability_t {
 		 * memory size for the pool. */
 		uint32_t max_num;
 
+		/** Maximum user area size in bytes */
+		uint32_t max_uarea_size;
+
 		/** Minimum size of thread local cache */
 		uint32_t min_cache_size;
 
@@ -303,6 +309,9 @@ typedef struct odp_pool_capability_t {
 
 		/** Maximum number of handles (such as odp_packet_t) in a vector. */
 		uint32_t max_size;
+
+		/** Maximum user area size in bytes */
+		uint32_t max_uarea_size;
 
 		/** Minimum size of thread local cache */
 		uint32_t min_cache_size;
@@ -376,6 +385,12 @@ typedef struct odp_pool_param_t {
 		 *  Default will always be a multiple of 8.
 		 */
 		uint32_t align;
+
+		/** Minimum user area size in bytes. The maximum value is defined by
+		 *  pool capability buf.max_uarea_size. Specify as 0 if no user
+		 *  area is needed. The default value is 0.
+		 */
+		uint32_t uarea_size;
 
 		/** Maximum number of buffers cached locally per thread
 		 *
@@ -500,6 +515,12 @@ typedef struct odp_pool_param_t {
 		/** Number of timeouts in the pool */
 		uint32_t num;
 
+		/** Minimum user area size in bytes. The maximum value is defined by
+		 *  pool capability tmo.max_uarea_size. Specify as 0 if no user
+		 *  area is needed. The default value is 0.
+		 */
+		uint32_t uarea_size;
+
 		/** Maximum number of timeouts cached locally per thread
 		 *
 		 *  See buf.cache_size documentation for details.
@@ -514,6 +535,12 @@ typedef struct odp_pool_param_t {
 
 		/** Maximum number of handles (such as odp_packet_t) in a vector. */
 		uint32_t max_size;
+
+		/** Minimum user area size in bytes. The maximum value is defined by
+		 *  pool capability vector.max_uarea_size. Specify as 0 if no user
+		 *  area is needed. The default value is 0.
+		 */
+		uint32_t uarea_size;
 
 		/** Maximum number of vectors cached locally per thread
 		 *

--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -505,6 +505,19 @@ uint64_t odp_timeout_tick(odp_timeout_t tmo);
 void *odp_timeout_user_ptr(odp_timeout_t tmo);
 
 /**
+ * Timeout user area
+ *
+ * Returns pointer to the user area associated with the timeout. Size of the area is fixed
+ * and defined in timeout pool parameters.
+ *
+ * @param tmo    Timeout handle
+ *
+ * @return       Pointer to the user area of the timeout
+ * @retval NULL  The timeout does not have user area
+ */
+void *odp_timeout_user_area(odp_timeout_t tmo);
+
+/**
  * Timeout alloc
  *
  * Allocates timeout from pool. Pool must be created with ODP_POOL_TIMEOUT type.

--- a/platform/linux-generic/include/odp/api/plat/event_vector_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/event_vector_inline_types.h
@@ -15,6 +15,15 @@ extern "C" {
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
+typedef union {
+	uint32_t all_flags;
+
+	struct {
+		uint32_t user_flag : 1;
+	};
+
+} _odp_event_vector_flags_t;
+
 /* Event vector field accessors */
 #define _odp_event_vect_get(vect, cast, field) \
 	(*(cast *)(uintptr_t)((uint8_t *)vect + _odp_event_vector_inline.field))
@@ -27,6 +36,7 @@ typedef struct _odp_event_vector_inline_offset_t {
 	uint16_t pool;
 	uint16_t size;
 	uint16_t uarea_addr;
+	uint16_t flags;
 
 } _odp_event_vector_inline_offset_t;
 

--- a/platform/linux-generic/include/odp/api/plat/event_vector_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/event_vector_inline_types.h
@@ -26,6 +26,8 @@ typedef struct _odp_event_vector_inline_offset_t {
 	uint16_t packet;
 	uint16_t pool;
 	uint16_t size;
+	uint16_t uarea_addr;
+
 } _odp_event_vector_inline_offset_t;
 
 /** @endcond */

--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -118,12 +118,13 @@ typedef union {
 	uint32_t all_flags;
 
 	struct {
-		uint32_t reserved1:      7;
+		uint32_t reserved1:      6;
 
 	/*
 	 * Init flags
 	 */
 		uint32_t user_ptr_set:   1; /* User has set a non-NULL value */
+		uint32_t user_flag:      1;
 
 	/*
 	 * Packet output flags
@@ -153,8 +154,8 @@ typedef union {
 
 	/* Flag groups */
 	struct {
-		uint32_t reserved2:      7;
-		uint32_t other:         18; /* All other flags */
+		uint32_t reserved2:      6;
+		uint32_t other:         19; /* All other flags */
 		uint32_t error:          7; /* All error flags */
 	} all;
 

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -50,6 +50,8 @@
 	#define odp_packet_user_ptr __odp_packet_user_ptr
 	#define odp_packet_user_area __odp_packet_user_area
 	#define odp_packet_user_area_size __odp_packet_user_area_size
+	#define odp_packet_user_flag __odp_packet_user_flag
+	#define odp_packet_user_flag_set __odp_packet_user_flag_set
 	#define odp_packet_l2_offset __odp_packet_l2_offset
 	#define odp_packet_l3_offset __odp_packet_l3_offset
 	#define odp_packet_l4_offset __odp_packet_l4_offset
@@ -184,6 +186,22 @@ _ODP_INLINE uint32_t odp_packet_user_area_size(odp_packet_t pkt)
 	void *pool = _odp_pkt_get(pkt, void *, pool);
 
 	return _odp_pool_get(pool, uint32_t, uarea_size);
+}
+
+_ODP_INLINE int odp_packet_user_flag(odp_packet_t pkt)
+{
+	_odp_packet_flags_t flags;
+
+	flags.all_flags = _odp_pkt_get(pkt, uint32_t, flags);
+
+	return flags.user_flag;
+}
+
+_ODP_INLINE void odp_packet_user_flag_set(odp_packet_t pkt, int val)
+{
+	_odp_packet_flags_t *flags = _odp_pkt_get_ptr(pkt, _odp_packet_flags_t, flags);
+
+	flags->user_flag = !!val;
 }
 
 _ODP_INLINE uint32_t odp_packet_l2_offset(odp_packet_t pkt)

--- a/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
@@ -34,6 +34,8 @@
 	#define odp_packet_vector_size __odp_packet_vector_size
 	#define odp_packet_vector_size_set __odp_packet_vector_size_set
 	#define odp_packet_vector_user_area __odp_packet_vector_user_area
+	#define odp_packet_vector_user_flag __odp_packet_vector_user_flag
+	#define odp_packet_vector_user_flag_set __odp_packet_vector_user_flag_set
 #else
 	#undef _ODP_INLINE
 	#define _ODP_INLINE
@@ -78,6 +80,23 @@ _ODP_INLINE void odp_packet_vector_size_set(odp_packet_vector_t pktv, uint32_t s
 _ODP_INLINE void *odp_packet_vector_user_area(odp_packet_vector_t pktv)
 {
 	return _odp_event_vect_get(pktv, void *, uarea_addr);
+}
+
+_ODP_INLINE int odp_packet_vector_user_flag(odp_packet_vector_t pktv)
+{
+	_odp_event_vector_flags_t flags;
+
+	flags.all_flags = _odp_event_vect_get(pktv, uint32_t, flags);
+
+	return flags.user_flag;
+}
+
+_ODP_INLINE void odp_packet_vector_user_flag_set(odp_packet_vector_t pktv, int val)
+{
+	_odp_event_vector_flags_t *flags = _odp_event_vect_get_ptr(pktv, _odp_event_vector_flags_t,
+								   flags);
+
+	flags->user_flag = !!val;
 }
 
 /** @endcond */

--- a/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
@@ -33,6 +33,7 @@
 	#define odp_packet_vector_pool __odp_packet_vector_pool
 	#define odp_packet_vector_size __odp_packet_vector_size
 	#define odp_packet_vector_size_set __odp_packet_vector_size_set
+	#define odp_packet_vector_user_area __odp_packet_vector_user_area
 #else
 	#undef _ODP_INLINE
 	#define _ODP_INLINE
@@ -72,6 +73,11 @@ _ODP_INLINE void odp_packet_vector_size_set(odp_packet_vector_t pktv, uint32_t s
 	uint32_t *vector_size = _odp_event_vect_get_ptr(pktv, uint32_t, size);
 
 	*vector_size = size;
+}
+
+_ODP_INLINE void *odp_packet_vector_user_area(odp_packet_vector_t pktv)
+{
+	return _odp_event_vect_get(pktv, void *, uarea_addr);
 }
 
 /** @endcond */

--- a/platform/linux-generic/include/odp/api/plat/timer_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/timer_inline_types.h
@@ -25,6 +25,7 @@ typedef struct _odp_timeout_inline_offset_t {
 	uint16_t expiration;
 	uint16_t timer;
 	uint16_t user_ptr;
+	uint16_t uarea_addr;
 
 } _odp_timeout_inline_offset_t;
 

--- a/platform/linux-generic/include/odp/api/plat/timer_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/timer_inlines.h
@@ -24,6 +24,7 @@ extern const _odp_timeout_inline_offset_t _odp_timeout_inline_offset;
 	#define odp_timeout_timer __odp_timeout_timer
 	#define odp_timeout_tick __odp_timeout_tick
 	#define odp_timeout_user_ptr __odp_timeout_user_ptr
+	#define odp_timeout_user_area __odp_timeout_user_area
 	#define odp_timer_tick_to_ns __odp_timer_tick_to_ns
 	#define odp_timer_ns_to_tick __odp_timer_ns_to_tick
 	#define odp_timeout_from_event __odp_timeout_from_event
@@ -45,6 +46,11 @@ _ODP_INLINE uint64_t odp_timeout_tick(odp_timeout_t tmo)
 _ODP_INLINE void *odp_timeout_user_ptr(odp_timeout_t tmo)
 {
 	return _odp_timeout_hdr_field(tmo, void *, user_ptr);
+}
+
+_ODP_INLINE void *odp_timeout_user_area(odp_timeout_t tmo)
+{
+	return _odp_timeout_hdr_field(tmo, void *, uarea_addr);
 }
 
 _ODP_INLINE uint64_t odp_timer_tick_to_ns(odp_timer_pool_t tp, uint64_t ticks)

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -36,6 +36,9 @@ typedef struct ODP_ALIGNED_CACHE odp_buffer_hdr_t {
 	/* Common event header */
 	_odp_event_hdr_t event_hdr;
 
+	/* User area pointer */
+	void *uarea_addr;
+
 	/* Data */
 	uint8_t data[];
 } odp_buffer_hdr_t;

--- a/platform/linux-generic/include/odp_event_vector_internal.h
+++ b/platform/linux-generic/include/odp_event_vector_internal.h
@@ -28,6 +28,9 @@ typedef struct ODP_ALIGNED_CACHE odp_event_vector_hdr_t {
 	/* Common event header */
 	_odp_event_hdr_t event_hdr;
 
+	/* User area pointer */
+	void *uarea_addr;
+
 	/* Event vector size */
 	uint32_t size;
 

--- a/platform/linux-generic/include/odp_event_vector_internal.h
+++ b/platform/linux-generic/include/odp_event_vector_internal.h
@@ -17,6 +17,8 @@
 #include <odp/api/debug.h>
 #include <odp/api/packet.h>
 
+#include <odp/api/plat/event_vector_inline_types.h>
+
 #include <odp_event_internal.h>
 
 #include <stdint.h>
@@ -33,6 +35,9 @@ typedef struct ODP_ALIGNED_CACHE odp_event_vector_hdr_t {
 
 	/* Event vector size */
 	uint32_t size;
+
+	/* Flags */
+	_odp_event_vector_flags_t flags;
 
 	/* Vector of packet handles */
 	odp_packet_t packet[];

--- a/platform/linux-generic/include/odp_timer_internal.h
+++ b/platform/linux-generic/include/odp_timer_internal.h
@@ -35,6 +35,9 @@ typedef struct ODP_ALIGNED_CACHE odp_timeout_hdr_t {
 	/* User ptr inherited from parent timer */
 	const void *user_ptr;
 
+	/* User area pointer */
+	void *uarea_addr;
+
 	/* Parent timer */
 	odp_timer_t timer;
 

--- a/platform/linux-generic/odp_buffer.c
+++ b/platform/linux-generic/odp_buffer.c
@@ -23,6 +23,13 @@ uint32_t odp_buffer_size(odp_buffer_t buf)
 	return pool->seg_len;
 }
 
+void *odp_buffer_user_area(odp_buffer_t buf)
+{
+	odp_buffer_hdr_t *hdr = _odp_buf_hdr(buf);
+
+	return hdr->uarea_addr;
+}
+
 void odp_buffer_print(odp_buffer_t buf)
 {
 	odp_buffer_hdr_t *hdr;

--- a/platform/linux-generic/odp_packet_vector.c
+++ b/platform/linux-generic/odp_packet_vector.c
@@ -25,7 +25,8 @@ const _odp_event_vector_inline_offset_t _odp_event_vector_inline ODP_ALIGNED_CAC
 	.packet    = offsetof(odp_event_vector_hdr_t, packet),
 	.pool      = offsetof(odp_event_vector_hdr_t, event_hdr.pool),
 	.size      = offsetof(odp_event_vector_hdr_t, size),
-	.uarea_addr = offsetof(odp_event_vector_hdr_t, uarea_addr)
+	.uarea_addr = offsetof(odp_event_vector_hdr_t, uarea_addr),
+	.flags     = offsetof(odp_event_vector_hdr_t, flags)
 };
 
 #include <odp/visibility_end.h>
@@ -60,6 +61,7 @@ void odp_packet_vector_free(odp_packet_vector_t pktv)
 	odp_event_vector_hdr_t *pktv_hdr = _odp_packet_vector_hdr(pktv);
 
 	pktv_hdr->size = 0;
+	pktv_hdr->flags.all_flags = 0;
 
 	_odp_event_free(odp_packet_vector_to_event(pktv));
 }

--- a/platform/linux-generic/odp_packet_vector.c
+++ b/platform/linux-generic/odp_packet_vector.c
@@ -24,7 +24,8 @@
 const _odp_event_vector_inline_offset_t _odp_event_vector_inline ODP_ALIGNED_CACHE = {
 	.packet    = offsetof(odp_event_vector_hdr_t, packet),
 	.pool      = offsetof(odp_event_vector_hdr_t, event_hdr.pool),
-	.size      = offsetof(odp_event_vector_hdr_t, size)
+	.size      = offsetof(odp_event_vector_hdr_t, size),
+	.uarea_addr = offsetof(odp_event_vector_hdr_t, uarea_addr)
 };
 
 #include <odp/visibility_end.h>

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -442,14 +442,26 @@ static pool_t *reserve_pool(uint32_t shmflags, uint8_t pool_ext, uint32_t num)
 }
 
 static void init_event_hdr(pool_t *pool, _odp_event_hdr_t *event_hdr, uint32_t event_index,
-			   uint32_t hdr_len, uint8_t *data_ptr, void *uarea)
+			   uint8_t *data_ptr, void *uarea)
 {
+	uint32_t hdr_len;
 	odp_pool_type_t type = pool->type;
 
+	if (type == ODP_POOL_BUFFER)
+		hdr_len = sizeof(odp_buffer_hdr_t);
+	else if (type == ODP_POOL_PACKET)
+		hdr_len = sizeof(odp_packet_hdr_t);
+	else if (type == ODP_POOL_VECTOR)
+		hdr_len = sizeof(odp_event_vector_hdr_t);
+	else if (type == ODP_POOL_TIMEOUT)
+		hdr_len = sizeof(odp_timeout_hdr_t);
+	else
+		hdr_len = sizeof(_odp_event_hdr_t);
+
+	/* Zero all event and type specific header fields */
 	memset(event_hdr, 0, hdr_len);
 
 	/* Initialize common event metadata */
-	event_hdr->index.u32    = 0;
 	event_hdr->index.pool   = pool->pool_idx;
 	event_hdr->index.event  = event_index;
 	event_hdr->type         = type;
@@ -460,6 +472,12 @@ static void init_event_hdr(pool_t *pool, _odp_event_hdr_t *event_hdr, uint32_t e
 	if (type == ODP_POOL_BUFFER || type == ODP_POOL_PACKET) {
 		event_hdr->base_data = data_ptr;
 		event_hdr->buf_end   = data_ptr + pool->seg_len + pool->tailroom;
+	}
+
+	if (type == ODP_POOL_BUFFER) {
+		odp_buffer_hdr_t *buf_hdr = (void *)event_hdr;
+
+		buf_hdr->uarea_addr = uarea;
 	}
 
 	/* Initialize segmentation metadata */
@@ -480,8 +498,15 @@ static void init_event_hdr(pool_t *pool, _odp_event_hdr_t *event_hdr, uint32_t e
 	if (type == ODP_POOL_VECTOR) {
 		odp_event_vector_hdr_t *vect_hdr = (void *)event_hdr;
 
-		vect_hdr->size = 0;
 		event_hdr->event_type = ODP_EVENT_PACKET_VECTOR;
+		vect_hdr->uarea_addr = uarea;
+	}
+
+	/* Initialize timeout metadata */
+	if (type == ODP_POOL_TIMEOUT) {
+		odp_timeout_hdr_t *tmo_hdr = (void *)event_hdr;
+
+		tmo_hdr->uarea_addr = uarea;
 	}
 }
 
@@ -496,7 +521,7 @@ static void init_buffers(pool_t *pool)
 	void *uarea = NULL;
 	uint8_t *data = NULL;
 	uint8_t *data_ptr = NULL;
-	uint32_t offset, hdr_len;
+	uint32_t offset;
 	ring_ptr_t *ring;
 	uint32_t mask;
 	odp_pool_type_t type;
@@ -554,16 +579,10 @@ static void init_buffers(pool_t *pool)
 			while (((uintptr_t)&data[offset]) % pool->align != 0)
 				offset++;
 
-			hdr_len = (uintptr_t)data - (uintptr_t)event_hdr;
 			data_ptr = &data[offset];
-		} else {
-			if (type == ODP_POOL_TIMEOUT)
-				hdr_len = sizeof(odp_timeout_hdr_t);
-			else
-				hdr_len = sizeof(odp_event_vector_hdr_t);
 		}
 
-		init_event_hdr(pool, event_hdr, i, hdr_len, data_ptr, uarea);
+		init_event_hdr(pool, event_hdr, i, data_ptr, uarea);
 
 		/* Store buffer into the global pool */
 		if (!skip)
@@ -731,6 +750,7 @@ odp_pool_t _odp_pool_create(const char *name, const odp_pool_param_t *params,
 	case ODP_POOL_BUFFER:
 		num  = params->buf.num;
 		seg_len = params->buf.size;
+		uarea_size = params->buf.uarea_size;
 		cache_size = params->buf.cache_size;
 		break;
 
@@ -782,11 +802,13 @@ odp_pool_t _odp_pool_create(const char *name, const odp_pool_param_t *params,
 
 	case ODP_POOL_TIMEOUT:
 		num = params->tmo.num;
+		uarea_size = params->tmo.uarea_size;
 		cache_size = params->tmo.cache_size;
 		break;
 
 	case ODP_POOL_VECTOR:
 		num = params->vector.num;
+		uarea_size = params->vector.uarea_size;
 		cache_size = params->vector.cache_size;
 		seg_len = params->vector.max_size * sizeof(odp_packet_t);
 		break;
@@ -973,6 +995,11 @@ static int check_params(const odp_pool_param_t *params)
 			return -1;
 		}
 
+		if (params->buf.uarea_size > capa.buf.max_uarea_size) {
+			ODP_ERR("buf.uarea_size too large %u\n", params->buf.uarea_size);
+			return -1;
+		}
+
 		if (params->stats.all & ~capa.buf.stats.all) {
 			ODP_ERR("Unsupported pool statistics counter\n");
 			return -1;
@@ -1040,6 +1067,11 @@ static int check_params(const odp_pool_param_t *params)
 			return -1;
 		}
 
+		if (params->tmo.uarea_size > capa.tmo.max_uarea_size) {
+			ODP_ERR("tmo.uarea_size too large %u\n", params->tmo.uarea_size);
+			return -1;
+		}
+
 		if (params->stats.all & ~capa.tmo.stats.all) {
 			ODP_ERR("Unsupported pool statistics counter\n");
 			return -1;
@@ -1068,6 +1100,11 @@ static int check_params(const odp_pool_param_t *params)
 
 		if (params->vector.max_size > capa.vector.max_size) {
 			ODP_ERR("vector.max_size too large %u\n", params->vector.max_size);
+			return -1;
+		}
+
+		if (params->vector.uarea_size > capa.vector.max_uarea_size) {
+			ODP_ERR("vector.uarea_size too large %u\n", params->vector.uarea_size);
 			return -1;
 		}
 
@@ -1422,6 +1459,7 @@ int odp_pool_capability(odp_pool_capability_t *capa)
 	capa->buf.max_align = ODP_CONFIG_BUFFER_ALIGN_MAX;
 	capa->buf.max_size  = MAX_SIZE;
 	capa->buf.max_num   = CONFIG_POOL_MAX_NUM;
+	capa->buf.max_uarea_size = MAX_UAREA_SIZE;
 	capa->buf.min_cache_size = 0;
 	capa->buf.max_cache_size = CONFIG_POOL_CACHE_MAX_SIZE;
 	capa->buf.stats.all = supported_stats.all;
@@ -1445,6 +1483,7 @@ int odp_pool_capability(odp_pool_capability_t *capa)
 	/* Timeout pools */
 	capa->tmo.max_pools = max_pools;
 	capa->tmo.max_num   = CONFIG_POOL_MAX_NUM;
+	capa->tmo.max_uarea_size = MAX_UAREA_SIZE;
 	capa->tmo.min_cache_size = 0;
 	capa->tmo.max_cache_size = CONFIG_POOL_CACHE_MAX_SIZE;
 	capa->tmo.stats.all = supported_stats.all;
@@ -1453,6 +1492,7 @@ int odp_pool_capability(odp_pool_capability_t *capa)
 	capa->vector.max_pools = max_pools;
 	capa->vector.max_num   = CONFIG_POOL_MAX_NUM;
 	capa->vector.max_size = CONFIG_PACKET_VECTOR_MAX_SIZE;
+	capa->vector.max_uarea_size = MAX_UAREA_SIZE;
 	capa->vector.min_cache_size = 0;
 	capa->vector.max_cache_size = CONFIG_POOL_CACHE_MAX_SIZE;
 	capa->vector.stats.all = supported_stats.all;
@@ -1876,7 +1916,6 @@ int odp_pool_ext_populate(odp_pool_t pool_hdl, void *buf[], uint32_t buf_size, u
 	uint32_t i, ring_mask, buf_index, head_offset;
 	uint32_t num_populated;
 	uint8_t *data_ptr, *min_addr, *max_addr;
-	uint32_t hdr_size = sizeof(odp_packet_hdr_t);
 	void *uarea = NULL;
 
 	if (pool_hdl == ODP_POOL_INVALID) {
@@ -1944,7 +1983,7 @@ int odp_pool_ext_populate(odp_pool_t pool_hdl, void *buf[], uint32_t buf_size, u
 			uarea = &pool->uarea_base_addr[buf_index * pool->uarea_size];
 
 		data_ptr = (uint8_t *)event_hdr + head_offset + pool->headroom;
-		init_event_hdr(pool, event_hdr, buf_index, hdr_size, data_ptr, uarea);
+		init_event_hdr(pool, event_hdr, buf_index, data_ptr, uarea);
 		pool->ring->event_hdr_by_index[buf_index] = event_hdr;
 		buf_index++;
 

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -112,7 +112,8 @@ const _odp_timeout_inline_offset_t
 _odp_timeout_inline_offset ODP_ALIGNED_CACHE = {
 	.expiration = offsetof(odp_timeout_hdr_t, expiration),
 	.timer = offsetof(odp_timeout_hdr_t, timer),
-	.user_ptr = offsetof(odp_timeout_hdr_t, user_ptr)
+	.user_ptr = offsetof(odp_timeout_hdr_t, user_ptr),
+	.uarea_addr = offsetof(odp_timeout_hdr_t, uarea_addr),
 };
 
 #include <odp/visibility_end.h>

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -350,6 +350,7 @@ static void packet_set_inflags(odp_packet_t pkt, int val)
 	odp_packet_has_tcp_set(pkt, val);
 	odp_packet_has_sctp_set(pkt, val);
 	odp_packet_has_icmp_set(pkt, val);
+	odp_packet_user_flag_set(pkt, val);
 }
 
 static void packet_check_inflags(odp_packet_t pkt, int val)
@@ -375,6 +376,7 @@ static void packet_check_inflags(odp_packet_t pkt, int val)
 	CU_ASSERT(odp_packet_has_tcp(pkt) == !!val);
 	CU_ASSERT(odp_packet_has_sctp(pkt) == !!val);
 	CU_ASSERT(odp_packet_has_icmp(pkt) == !!val);
+	CU_ASSERT(odp_packet_user_flag(pkt) == !!val);
 }
 
 static void packet_test_alloc_free(void)
@@ -1396,6 +1398,7 @@ static void packet_test_in_flags(void)
 	TEST_INFLAG(pkt, has_tcp);
 	TEST_INFLAG(pkt, has_sctp);
 	TEST_INFLAG(pkt, has_icmp);
+	TEST_INFLAG(pkt, user_flag);
 
 	packet_set_inflags(pkt, 0);
 	packet_check_inflags(pkt, 0);
@@ -1541,6 +1544,7 @@ static void packet_compare_inflags(odp_packet_t pkt1, odp_packet_t pkt2)
 	COMPARE_INFLAG(pkt1, pkt2, has_tcp);
 	COMPARE_INFLAG(pkt1, pkt2, has_sctp);
 	COMPARE_INFLAG(pkt1, pkt2, has_icmp);
+	COMPARE_INFLAG(pkt1, pkt2, user_flag);
 	COMPARE_INFLAG(pkt1, pkt2, has_flow_hash);
 	COMPARE_INFLAG(pkt1, pkt2, has_ts);
 
@@ -3097,6 +3101,19 @@ static void packet_vector_test_alloc_free(void)
 	CU_ASSERT_FATAL(odp_packet_vector_valid(pktv) == 1)
 	CU_ASSERT(odp_packet_vector_to_u64(pktv) !=
 		  odp_packet_vector_to_u64(ODP_PACKET_VECTOR_INVALID));
+
+	/* User flag should be initially zero */
+	CU_ASSERT(odp_packet_vector_user_flag(pktv) == 0);
+	odp_packet_vector_user_flag_set(pktv, 1);
+	CU_ASSERT(odp_packet_vector_user_flag(pktv) != 0);
+	odp_packet_vector_user_flag_set(pktv, 0);
+	CU_ASSERT(odp_packet_vector_user_flag(pktv) == 0);
+
+	/* Free with flag still set, alloc should clear it. */
+	odp_packet_vector_user_flag_set(pktv, 1);
+	odp_packet_vector_free(pktv);
+	pktv = odp_packet_vector_alloc(pool);
+	CU_ASSERT(odp_packet_vector_user_flag(pktv) == 0);
 
 	/* Since it was only one buffer pool, more vector packets can't be
 	 * allocated.

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -327,6 +327,56 @@ static int packet_suite_term(void)
 	return 0;
 }
 
+static void packet_set_inflags(odp_packet_t pkt, int val)
+{
+	odp_packet_has_l2_set(pkt, val);
+	odp_packet_has_l3_set(pkt, val);
+	odp_packet_has_l4_set(pkt, val);
+	odp_packet_has_eth_set(pkt, val);
+	odp_packet_has_eth_bcast_set(pkt, val);
+	odp_packet_has_eth_mcast_set(pkt, val);
+	odp_packet_has_jumbo_set(pkt, val);
+	odp_packet_has_vlan_set(pkt, val);
+	odp_packet_has_vlan_qinq_set(pkt, val);
+	odp_packet_has_arp_set(pkt, val);
+	odp_packet_has_ipv4_set(pkt, val);
+	odp_packet_has_ipv6_set(pkt, val);
+	odp_packet_has_ip_bcast_set(pkt, val);
+	odp_packet_has_ip_mcast_set(pkt, val);
+	odp_packet_has_ipfrag_set(pkt, val);
+	odp_packet_has_ipopt_set(pkt, val);
+	odp_packet_has_ipsec_set(pkt, val);
+	odp_packet_has_udp_set(pkt, val);
+	odp_packet_has_tcp_set(pkt, val);
+	odp_packet_has_sctp_set(pkt, val);
+	odp_packet_has_icmp_set(pkt, val);
+}
+
+static void packet_check_inflags(odp_packet_t pkt, int val)
+{
+	CU_ASSERT(odp_packet_has_l2(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_l3(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_l4(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_eth(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_eth_bcast(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_eth_mcast(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_jumbo(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_vlan(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_vlan_qinq(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_arp(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_ipv4(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_ipv6(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_ip_bcast(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_ip_mcast(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_ipfrag(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_ipopt(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_ipsec(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_udp(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_tcp(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_sctp(pkt) == !!val);
+	CU_ASSERT(odp_packet_has_icmp(pkt) == !!val);
+}
+
 static void packet_test_alloc_free(void)
 {
 	odp_pool_t pool;
@@ -362,6 +412,9 @@ static void packet_test_alloc_free(void)
 
 	/* User pointer should be NULL after alloc */
 	CU_ASSERT(odp_packet_user_ptr(packet) == NULL);
+
+	/* Packet flags should be zero */
+	packet_check_inflags(packet, 0);
 
 	/* Pool should have only one packet */
 	CU_ASSERT_FATAL(odp_packet_alloc(pool, packet_len)
@@ -880,11 +933,10 @@ static void packet_test_reset(void)
 	CU_ASSERT(odp_packet_reset(pkt, len) == 0);
 	CU_ASSERT(odp_packet_len(pkt) == len);
 
-	CU_ASSERT(odp_packet_has_udp(pkt) == 0);
-	odp_packet_has_udp_set(pkt, 1);
-	CU_ASSERT(odp_packet_has_udp(pkt) != 0);
+	packet_set_inflags(pkt, 1);
+	packet_check_inflags(pkt, 1);
 	CU_ASSERT(odp_packet_reset(pkt, len) == 0);
-	CU_ASSERT(odp_packet_has_udp(pkt) == 0);
+	packet_check_inflags(pkt, 0);
 
 	CU_ASSERT(odp_packet_reset(pkt, len - 1) == 0);
 	CU_ASSERT(odp_packet_len(pkt) == (len - 1));
@@ -1308,37 +1360,45 @@ static void packet_test_segment_last(void)
 
 #define TEST_INFLAG(packet, flag) \
 do { \
-	odp_packet_has_##flag##_set(packet, 0);           \
-	CU_ASSERT(odp_packet_has_##flag(packet) == 0);    \
-	odp_packet_has_##flag##_set(packet, 1);           \
-	CU_ASSERT(odp_packet_has_##flag(packet) != 0);    \
+	odp_packet_##flag##_set(packet, 0);           \
+	CU_ASSERT(odp_packet_##flag(packet) == 0);    \
+	odp_packet_##flag##_set(packet, 1);           \
+	CU_ASSERT(odp_packet_##flag(packet) != 0);    \
 } while (0)
 
 static void packet_test_in_flags(void)
 {
 	odp_packet_t pkt = test_packet;
 
-	TEST_INFLAG(pkt, l2);
-	TEST_INFLAG(pkt, l3);
-	TEST_INFLAG(pkt, l4);
-	TEST_INFLAG(pkt, eth);
-	TEST_INFLAG(pkt, eth_bcast);
-	TEST_INFLAG(pkt, eth_mcast);
-	TEST_INFLAG(pkt, jumbo);
-	TEST_INFLAG(pkt, vlan);
-	TEST_INFLAG(pkt, vlan_qinq);
-	TEST_INFLAG(pkt, arp);
-	TEST_INFLAG(pkt, ipv4);
-	TEST_INFLAG(pkt, ipv6);
-	TEST_INFLAG(pkt, ip_bcast);
-	TEST_INFLAG(pkt, ip_mcast);
-	TEST_INFLAG(pkt, ipfrag);
-	TEST_INFLAG(pkt, ipopt);
-	TEST_INFLAG(pkt, ipsec);
-	TEST_INFLAG(pkt, udp);
-	TEST_INFLAG(pkt, tcp);
-	TEST_INFLAG(pkt, sctp);
-	TEST_INFLAG(pkt, icmp);
+	packet_set_inflags(pkt, 0);
+	packet_check_inflags(pkt, 0);
+	packet_set_inflags(pkt, 1);
+	packet_check_inflags(pkt, 1);
+
+	TEST_INFLAG(pkt, has_l2);
+	TEST_INFLAG(pkt, has_l3);
+	TEST_INFLAG(pkt, has_l4);
+	TEST_INFLAG(pkt, has_eth);
+	TEST_INFLAG(pkt, has_eth_bcast);
+	TEST_INFLAG(pkt, has_eth_mcast);
+	TEST_INFLAG(pkt, has_jumbo);
+	TEST_INFLAG(pkt, has_vlan);
+	TEST_INFLAG(pkt, has_vlan_qinq);
+	TEST_INFLAG(pkt, has_arp);
+	TEST_INFLAG(pkt, has_ipv4);
+	TEST_INFLAG(pkt, has_ipv6);
+	TEST_INFLAG(pkt, has_ip_bcast);
+	TEST_INFLAG(pkt, has_ip_mcast);
+	TEST_INFLAG(pkt, has_ipfrag);
+	TEST_INFLAG(pkt, has_ipopt);
+	TEST_INFLAG(pkt, has_ipsec);
+	TEST_INFLAG(pkt, has_udp);
+	TEST_INFLAG(pkt, has_tcp);
+	TEST_INFLAG(pkt, has_sctp);
+	TEST_INFLAG(pkt, has_icmp);
+
+	packet_set_inflags(pkt, 0);
+	packet_check_inflags(pkt, 0);
 }
 
 static void packet_test_error_flags(void)
@@ -1455,37 +1515,34 @@ free_packet:
 	odp_packet_free(pkt);
 }
 
-#define COMPARE_HAS_INFLAG(p1, p2, flag) \
-	CU_ASSERT(odp_packet_has_##flag(p1) == odp_packet_has_##flag(p2))
-
 #define COMPARE_INFLAG(p1, p2, flag) \
 	CU_ASSERT(odp_packet_##flag(p1) == odp_packet_##flag(p2))
 
 static void packet_compare_inflags(odp_packet_t pkt1, odp_packet_t pkt2)
 {
-	COMPARE_HAS_INFLAG(pkt1, pkt2, l2);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, l3);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, l4);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, eth);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, eth_bcast);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, eth_mcast);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, jumbo);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, vlan);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, vlan_qinq);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, arp);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, ipv4);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, ipv6);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, ip_bcast);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, ip_mcast);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, ipfrag);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, ipopt);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, ipsec);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, udp);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, tcp);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, sctp);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, icmp);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, flow_hash);
-	COMPARE_HAS_INFLAG(pkt1, pkt2, ts);
+	COMPARE_INFLAG(pkt1, pkt2, has_l2);
+	COMPARE_INFLAG(pkt1, pkt2, has_l3);
+	COMPARE_INFLAG(pkt1, pkt2, has_l4);
+	COMPARE_INFLAG(pkt1, pkt2, has_eth);
+	COMPARE_INFLAG(pkt1, pkt2, has_eth_bcast);
+	COMPARE_INFLAG(pkt1, pkt2, has_eth_mcast);
+	COMPARE_INFLAG(pkt1, pkt2, has_jumbo);
+	COMPARE_INFLAG(pkt1, pkt2, has_vlan);
+	COMPARE_INFLAG(pkt1, pkt2, has_vlan_qinq);
+	COMPARE_INFLAG(pkt1, pkt2, has_arp);
+	COMPARE_INFLAG(pkt1, pkt2, has_ipv4);
+	COMPARE_INFLAG(pkt1, pkt2, has_ipv6);
+	COMPARE_INFLAG(pkt1, pkt2, has_ip_bcast);
+	COMPARE_INFLAG(pkt1, pkt2, has_ip_mcast);
+	COMPARE_INFLAG(pkt1, pkt2, has_ipfrag);
+	COMPARE_INFLAG(pkt1, pkt2, has_ipopt);
+	COMPARE_INFLAG(pkt1, pkt2, has_ipsec);
+	COMPARE_INFLAG(pkt1, pkt2, has_udp);
+	COMPARE_INFLAG(pkt1, pkt2, has_tcp);
+	COMPARE_INFLAG(pkt1, pkt2, has_sctp);
+	COMPARE_INFLAG(pkt1, pkt2, has_icmp);
+	COMPARE_INFLAG(pkt1, pkt2, has_flow_hash);
+	COMPARE_INFLAG(pkt1, pkt2, has_ts);
 
 	COMPARE_INFLAG(pkt1, pkt2, color);
 	COMPARE_INFLAG(pkt1, pkt2, drop_eligible);
@@ -1564,53 +1621,16 @@ static void packet_test_meta_data_copy(void)
 
 	pkt = odp_packet_alloc(pool, packet_len);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
-	CU_ASSERT(odp_packet_has_l2(pkt) == 0);
-	CU_ASSERT(odp_packet_has_l3(pkt) == 0);
-	CU_ASSERT(odp_packet_has_l4(pkt) == 0);
-	CU_ASSERT(odp_packet_has_eth(pkt) == 0);
-	CU_ASSERT(odp_packet_has_eth_bcast(pkt) == 0);
-	CU_ASSERT(odp_packet_has_eth_mcast(pkt) == 0);
-	CU_ASSERT(odp_packet_has_jumbo(pkt) == 0);
-	CU_ASSERT(odp_packet_has_vlan(pkt) == 0);
-	CU_ASSERT(odp_packet_has_vlan_qinq(pkt) == 0);
-	CU_ASSERT(odp_packet_has_arp(pkt) == 0);
-	CU_ASSERT(odp_packet_has_ipv4(pkt) == 0);
-	CU_ASSERT(odp_packet_has_ipv6(pkt) == 0);
-	CU_ASSERT(odp_packet_has_ip_bcast(pkt) == 0);
-	CU_ASSERT(odp_packet_has_ip_mcast(pkt) == 0);
-	CU_ASSERT(odp_packet_has_ipfrag(pkt) == 0);
-	CU_ASSERT(odp_packet_has_ipopt(pkt) == 0);
-	CU_ASSERT(odp_packet_has_ipsec(pkt) == 0);
-	CU_ASSERT(odp_packet_has_udp(pkt) == 0);
-	CU_ASSERT(odp_packet_has_tcp(pkt) == 0);
-	CU_ASSERT(odp_packet_has_sctp(pkt) == 0);
-	CU_ASSERT(odp_packet_has_icmp(pkt) == 0);
+
+	packet_check_inflags(pkt, 0);
+
 	CU_ASSERT(odp_packet_input(pkt) == ODP_PKTIO_INVALID);
 	CU_ASSERT(odp_packet_l3_offset(pkt) == ODP_PACKET_OFFSET_INVALID);
 	CU_ASSERT(odp_packet_l4_offset(pkt) == ODP_PACKET_OFFSET_INVALID);
 	CU_ASSERT(odp_packet_payload_offset(pkt) == ODP_PACKET_OFFSET_INVALID);
 
-	odp_packet_has_l2_set(pkt, 1);
-	odp_packet_has_l3_set(pkt, 1);
-	odp_packet_has_l4_set(pkt, 1);
-	odp_packet_has_eth_set(pkt, 1);
-	odp_packet_has_eth_bcast_set(pkt, 1);
-	odp_packet_has_eth_mcast_set(pkt, 1);
-	odp_packet_has_jumbo_set(pkt, 1);
-	odp_packet_has_vlan_set(pkt, 1);
-	odp_packet_has_vlan_qinq_set(pkt, 1);
-	odp_packet_has_arp_set(pkt, 1);
-	odp_packet_has_ipv4_set(pkt, 1);
-	odp_packet_has_ipv6_set(pkt, 1);
-	odp_packet_has_ip_bcast_set(pkt, 1);
-	odp_packet_has_ip_mcast_set(pkt, 1);
-	odp_packet_has_ipfrag_set(pkt, 1);
-	odp_packet_has_ipopt_set(pkt, 1);
-	odp_packet_has_ipsec_set(pkt, 1);
-	odp_packet_has_udp_set(pkt, 1);
-	odp_packet_has_tcp_set(pkt, 1);
-	odp_packet_has_sctp_set(pkt, 1);
-	odp_packet_has_icmp_set(pkt, 1);
+	packet_set_inflags(pkt, 1);
+	packet_check_inflags(pkt, 1);
 
 	odp_packet_input_set(pkt, pktio);
 	odp_packet_user_ptr_set(pkt, (void *)(uintptr_t)0xdeadbeef);

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -695,6 +695,7 @@ static int get_packets(pktio_info_t *pktio_rx, odp_packet_t pkt_tbl[],
 
 			pktv = odp_packet_vector_from_event(evt_tbl[i]);
 			pktv_len = odp_packet_vector_tbl(pktv, &pkts);
+			CU_ASSERT(odp_packet_vector_user_flag(pktv) == 0);
 
 			/* Make sure too many packets are not received */
 			if (num_pkts + pktv_len > num) {
@@ -996,6 +997,7 @@ static void pktio_txrx_multi(pktio_info_t *pktio_info_a,
 			CU_ASSERT(odp_packet_has_udp(pkt));
 		}
 
+		CU_ASSERT(odp_packet_user_flag(pkt) == 0);
 		CU_ASSERT(odp_packet_user_ptr(pkt) == NULL);
 		CU_ASSERT(odp_packet_cls_mark(pkt) == 0);
 

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -51,17 +51,21 @@ static void test_param_init(uint8_t fill)
 	memset(&param, fill, sizeof(param));
 	odp_pool_param_init(&param);
 
+	CU_ASSERT(param.buf.uarea_size == 0);
 	CU_ASSERT(param.buf.cache_size >= global_pool_capa.buf.min_cache_size &&
 		  param.buf.cache_size <= global_pool_capa.buf.max_cache_size);
 
 	CU_ASSERT(param.pkt.max_num == 0);
 	CU_ASSERT(param.pkt.num_subparam == 0);
+	CU_ASSERT(param.pkt.uarea_size == 0);
 	CU_ASSERT(param.pkt.cache_size >= global_pool_capa.pkt.min_cache_size &&
 		  param.pkt.cache_size <= global_pool_capa.pkt.max_cache_size);
 
+	CU_ASSERT(param.tmo.uarea_size == 0);
 	CU_ASSERT(param.tmo.cache_size >= global_pool_capa.tmo.min_cache_size &&
 		  param.tmo.cache_size <= global_pool_capa.tmo.max_cache_size);
 
+	CU_ASSERT(param.vector.uarea_size == 0);
 	CU_ASSERT(param.vector.cache_size >= global_pool_capa.vector.min_cache_size &&
 		  param.vector.cache_size <= global_pool_capa.vector.max_cache_size);
 }

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -1027,7 +1027,7 @@ static void pool_test_create_max_pkt_pools(void)
 	CU_ASSERT(num_shm == shm_capa.max_blocks);
 
 	/* Create maximum number of packet pools */
-	if (global_pool_capa.pkt.max_uarea_size && global_pool_capa.pkt.max_uarea_size < uarea_size)
+	if (uarea_size > global_pool_capa.pkt.max_uarea_size)
 		uarea_size = global_pool_capa.pkt.max_uarea_size;
 
 	odp_pool_param_init(&param);
@@ -1685,7 +1685,7 @@ static void packet_pool_ext_alloc(int len_test)
 
 		if (uarea_size) {
 			CU_ASSERT(odp_packet_user_area(pkt[i]) != NULL);
-			CU_ASSERT(odp_packet_user_area_size(pkt[i]) == uarea_size);
+			CU_ASSERT(odp_packet_user_area_size(pkt[i]) >= uarea_size);
 		}
 
 		/* Check that application header content has not changed */


### PR DESCRIPTION
Packets have already user area for storing user specific metadata, which is preserved while packet is modified or stored into a queue, etc. Introduce user area to other event types (that are allocated from a pool) as well.