### PR TITLE
[PATCH v1] helper: threads: update odph_thread_create() specification

### DIFF
--- a/example/classifier/odp_classifier.c
+++ b/example/classifier/odp_classifier.c
@@ -93,6 +93,9 @@ typedef struct {
 	int shutdown_sig;
 	int verbose;
 	int promisc_mode;	/**< Promiscuous mode enabled */
+	/** Thread states for odph_thread_create() and odph_thread_join() */
+	odph_thread_t thread_tbl[MAX_WORKERS];
+
 } appl_args_t;
 
 enum packet_mode {
@@ -566,7 +569,6 @@ static void sig_handler(int signo)
 int main(int argc, char *argv[])
 {
 	odph_helper_options_t helper_options;
-	odph_thread_t thread_tbl[MAX_WORKERS];
 	odp_pool_t pool;
 	int num_workers;
 	int i;
@@ -681,7 +683,6 @@ int main(int argc, char *argv[])
 	}
 
 	/* Create and init worker threads */
-	memset(thread_tbl, 0, sizeof(thread_tbl));
 	odph_thread_common_param_init(&thr_common);
 	odph_thread_param_init(&thr_param);
 
@@ -693,7 +694,7 @@ int main(int argc, char *argv[])
 	thr_common.cpumask     = &cpumask;
 	thr_common.share_param = 1;
 
-	odph_thread_create(thread_tbl, &thr_common, &thr_param, num_workers);
+	odph_thread_create(args->thread_tbl, &thr_common, &thr_param, num_workers);
 
 	if (args->verbose == 0) {
 		print_cls_statistics(args);
@@ -710,7 +711,7 @@ int main(int argc, char *argv[])
 
 	odp_pktio_stop(pktio);
 	args->shutdown = 1;
-	odph_thread_join(thread_tbl, num_workers);
+	odph_thread_join(args->thread_tbl, num_workers);
 
 	if (check_ci_pass_count(args)) {
 		ODPH_ERR("Error: Packet count verification failed\n");

--- a/example/ipsec_api/odp_ipsec.c
+++ b/example/ipsec_api/odp_ipsec.c
@@ -97,6 +97,8 @@ typedef struct {
 	int num_polled_queues;
 	/* Stop workers if set to 1 */
 	odp_atomic_u32_t exit_threads;
+	odph_thread_t thread_tbl[MAX_WORKERS];
+
 } global_data_t;
 
 /* helper funcs */
@@ -914,7 +916,6 @@ int
 main(int argc, char *argv[])
 {
 	odph_helper_options_t helper_options;
-	odph_thread_t thread_tbl[MAX_WORKERS];
 	odph_thread_common_param_t thr_common;
 	odph_thread_param_t thr_param;
 	int num_workers;
@@ -1089,8 +1090,7 @@ main(int argc, char *argv[])
 	thr_param.arg = NULL;
 	thr_param.thr_type = ODP_THREAD_WORKER;
 
-	memset(thread_tbl, 0, sizeof(thread_tbl));
-	odph_thread_create(thread_tbl, &thr_common, &thr_param, num_workers);
+	odph_thread_create(global->thread_tbl, &thr_common, &thr_param, num_workers);
 
 	/* If there are streams attempt to verify them. Otherwise, run until
 	 * SIGINT is received. */
@@ -1104,7 +1104,7 @@ main(int argc, char *argv[])
 		printf("All received\n");
 		odp_atomic_store_u32(&global->exit_threads, 1);
 	}
-	odph_thread_join(thread_tbl, num_workers);
+	odph_thread_join(global->thread_tbl, num_workers);
 
 	/* Stop and close used pktio devices */
 	for (i = 0; i < global->appl.if_count; i++) {

--- a/example/ipsec_crypto/odp_ipsec.c
+++ b/example/ipsec_crypto/odp_ipsec.c
@@ -101,6 +101,8 @@ typedef struct {
 	/* Stop workers if set to 1 */
 	odp_atomic_u32_t exit_threads;
 	odp_crypto_capability_t crypto_capa;
+	odph_thread_t thread_tbl[MAX_WORKERS];
+
 } global_data_t;
 
 /* helper funcs */
@@ -1219,7 +1221,6 @@ int
 main(int argc, char *argv[])
 {
 	odph_helper_options_t helper_options;
-	odph_thread_t thread_tbl[MAX_WORKERS];
 	odph_thread_common_param_t thr_common;
 	odph_thread_param_t thr_param;
 	int num_workers;
@@ -1392,8 +1393,7 @@ main(int argc, char *argv[])
 	thr_param.arg = NULL;
 	thr_param.thr_type = ODP_THREAD_WORKER;
 
-	memset(thread_tbl, 0, sizeof(thread_tbl));
-	odph_thread_create(thread_tbl, &thr_common, &thr_param, num_workers);
+	odph_thread_create(global->thread_tbl, &thr_common, &thr_param, num_workers);
 
 	/* If there are streams attempt to verify them. Otherwise, run until
 	 * SIGINT is received. */
@@ -1407,7 +1407,7 @@ main(int argc, char *argv[])
 		printf("All received\n");
 		odp_atomic_store_u32(&global->exit_threads, 1);
 	}
-	odph_thread_join(thread_tbl, num_workers);
+	odph_thread_join(global->thread_tbl, num_workers);
 
 	/* Stop and close used pktio devices */
 	for (i = 0; i < global->appl.if_count; i++) {

--- a/example/l2fwd_simple/odp_l2fwd_simple.c
+++ b/example/l2fwd_simple/odp_l2fwd_simple.c
@@ -25,6 +25,8 @@ typedef struct {
 	odp_shm_t shm;
 	odp_atomic_u32_t exit_thr;
 	int wait_sec;
+	odph_thread_t thd[MAX_WORKERS];
+
 } global_data_t;
 
 static global_data_t *global;
@@ -145,7 +147,6 @@ int main(int argc, char **argv)
 	odp_pool_t pool;
 	odp_pool_param_t params;
 	odp_cpumask_t cpumask;
-	odph_thread_t thd[MAX_WORKERS];
 	odp_instance_t instance;
 	odp_init_t init_param;
 	odph_thread_common_param_t thr_common;
@@ -259,13 +260,13 @@ int main(int argc, char **argv)
 
 	signal(SIGINT, sig_handler);
 
-	if (odph_thread_create(thd, &thr_common, &thr_param, MAX_WORKERS) !=
+	if (odph_thread_create(global->thd, &thr_common, &thr_param, MAX_WORKERS) !=
 	    MAX_WORKERS) {
 		printf("Error: failed to create threads\n");
 		exit(EXIT_FAILURE);
 	}
 
-	if (odph_thread_join(thd, MAX_WORKERS) != MAX_WORKERS) {
+	if (odph_thread_join(global->thd, MAX_WORKERS) != MAX_WORKERS) {
 		printf("Error: failed to join threads\n");
 		exit(EXIT_FAILURE);
 	}

--- a/example/time/time_global_test.c
+++ b/example/time/time_global_test.c
@@ -40,6 +40,8 @@ typedef struct {
 	int thread_num;
 	log_entry_t *log;
 	int log_enries_num;
+	odph_thread_t thread_tbl[MAX_WORKERS];
+
 } test_globals_t;
 
 static void print_log(test_globals_t *gbls)
@@ -257,7 +259,6 @@ int main(int argc, char *argv[])
 	odp_shm_t shm_log = ODP_SHM_INVALID;
 	int log_size, log_enries_num;
 	odph_helper_options_t helper_options;
-	odph_thread_t thread_tbl[MAX_WORKERS];
 	odp_instance_t instance;
 	odp_init_t init_param;
 	odph_thread_common_param_t thr_common;
@@ -355,10 +356,10 @@ int main(int argc, char *argv[])
 	thr_common.share_param = 1;
 
 	/* Create and launch worker threads */
-	odph_thread_create(thread_tbl, &thr_common, &thr_param, num_workers);
+	odph_thread_create(gbls->thread_tbl, &thr_common, &thr_param, num_workers);
 
 	/* Wait for worker threads to exit */
-	odph_thread_join(thread_tbl, num_workers);
+	odph_thread_join(gbls->thread_tbl, num_workers);
 
 	print_log(gbls);
 

--- a/example/timer/odp_timer_test.c
+++ b/example/timer/odp_timer_test.c
@@ -48,6 +48,9 @@ typedef struct {
 	odp_atomic_u32_t remain;	/**< Number of timeouts to receive*/
 	struct test_timer tt[256];	/**< Array of all timer helper structs*/
 	uint32_t num_workers;		/**< Number of threads */
+	/** Thread states for odph_thread_create() and odph_thread_join() */
+	odph_thread_t thread_tbl[MAX_WORKERS];
+
 } test_globals_t;
 
 /** @private Timer set status ASCII strings */
@@ -332,7 +335,6 @@ static int parse_args(int argc, char *argv[], test_args_t *args)
 int main(int argc, char *argv[])
 {
 	odph_helper_options_t helper_options;
-	odph_thread_t thread_tbl[MAX_WORKERS];
 	odph_thread_common_param_t thr_common;
 	odph_thread_param_t thr_param;
 	int num_workers;
@@ -401,8 +403,6 @@ int main(int argc, char *argv[])
 		ODPH_ERR("Parse args failed.\n");
 		goto err;
 	}
-
-	memset(thread_tbl, 0, sizeof(thread_tbl));
 
 	num_workers = MAX_WORKERS;
 	if (gbls->args.cpu_count && gbls->args.cpu_count < MAX_WORKERS)
@@ -522,10 +522,10 @@ int main(int argc, char *argv[])
 	thr_param.arg = gbls;
 	thr_param.thr_type = ODP_THREAD_WORKER;
 
-	odph_thread_create(thread_tbl, &thr_common, &thr_param, num_workers);
+	odph_thread_create(gbls->thread_tbl, &thr_common, &thr_param, num_workers);
 
 	/* Wait for worker threads to exit */
-	odph_thread_join(thread_tbl, num_workers);
+	odph_thread_join(gbls->thread_tbl, num_workers);
 
 	/* free resources */
 	if (odp_queue_destroy(queue))

--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2021, Nokia
+ * Copyright (c) 2019-2022, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -241,9 +241,10 @@ void odph_thread_common_param_init(odph_thread_common_param_t *param);
  * Use odph_thread_common_param_init() and odph_thread_param_init() to
  * initialize parameters with default values.
  *
- * Thread table must be large enough to hold 'num' elements. Also the cpumask
+ * Thread table must be large enough to hold 'num' elements. Also, the cpumask
  * must contain 'num' CPUs. Threads are pinned to CPUs in order - the first
- * thread goes to the smallest CPU number of the mask, etc.
+ * thread goes to the smallest CPU number of the mask, etc. When creating Linux
+ * processes, memory for the output thread table must be allocated from ODP SHM.
  *
  * Launched threads may be waited for exit with odph_thread_join(), or with
  * direct Linux system calls.

--- a/test/performance/odp_bench_packet.c
+++ b/test/performance/odp_bench_packet.c
@@ -160,6 +160,9 @@ typedef struct {
 	uint8_t data_tbl[TEST_REPEAT_COUNT][TEST_MAX_PKT_SIZE];
 	/** Benchmark run failed */
 	uint8_t bench_failed;
+	/** Thread state for odph_thread_create() and odph_thread_join() */
+	odph_thread_t worker_thread;
+
 } args_t;
 
 /** Global pointer to args */
@@ -1739,7 +1742,6 @@ bench_info_t test_suite[] = {
 int main(int argc, char *argv[])
 {
 	odph_helper_options_t helper_options;
-	odph_thread_t worker_thread;
 	odph_thread_common_param_t thr_common;
 	odph_thread_param_t thr_param;
 	int cpu;
@@ -1866,8 +1868,6 @@ int main(int argc, char *argv[])
 
 	odp_pool_print(gbl_args->pool);
 
-	memset(&worker_thread, 0, sizeof(odph_thread_t));
-
 	signal(SIGINT, sig_handler);
 
 	/* Create worker threads */
@@ -1888,9 +1888,9 @@ int main(int argc, char *argv[])
 	thr_param.arg = gbl_args;
 	thr_param.thr_type = ODP_THREAD_WORKER;
 
-	odph_thread_create(&worker_thread, &thr_common, &thr_param, 1);
+	odph_thread_create(&gbl_args->worker_thread, &thr_common, &thr_param, 1);
 
-	odph_thread_join(&worker_thread, 1);
+	odph_thread_join(&gbl_args->worker_thread, 1);
 
 	ret = gbl_args->bench_failed;
 

--- a/test/performance/odp_cpu_bench.c
+++ b/test/performance/odp_cpu_bench.c
@@ -82,6 +82,8 @@ typedef struct thread_args_t {
 typedef struct {
 	/* Thread specific arguments */
 	thread_args_t thread[MAX_WORKERS];
+	/* Thread states for odph_thread_create() and odph_thread_join() */
+	odph_thread_t thread_tbl[MAX_WORKERS];
 	/* Barriers to synchronize main and workers */
 	odp_barrier_t init_barrier;
 	odp_barrier_t term_barrier;
@@ -521,7 +523,6 @@ int main(int argc, char *argv[])
 {
 	stats_t *stats[MAX_WORKERS];
 	odph_helper_options_t helper_options;
-	odph_thread_t thread_tbl[MAX_WORKERS];
 	odph_thread_common_param_t thr_common;
 	odph_thread_param_t thr_param[MAX_WORKERS];
 	odp_cpumask_t cpumask;
@@ -776,14 +777,13 @@ int main(int argc, char *argv[])
 		thr_param[i].thr_type = ODP_THREAD_WORKER;
 	}
 
-	memset(thread_tbl, 0, sizeof(thread_tbl));
-	odph_thread_create(thread_tbl, &thr_common, thr_param, num_workers);
+	odph_thread_create(gbl_args->thread_tbl, &thr_common, thr_param, num_workers);
 
 	ret = print_stats(num_workers, stats, gbl_args->appl.time,
 			  gbl_args->appl.accuracy);
 
 	/* Master thread waits for other threads to exit */
-	odph_thread_join(thread_tbl, num_workers);
+	odph_thread_join(gbl_args->thread_tbl, num_workers);
 
 	for (i = 0; i < num_groups; i++) {
 		for (j = 0; j < QUEUES_PER_GROUP; j++) {

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -1091,13 +1091,14 @@ int main(int argc, char *argv[])
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 	int num_workers = 1;
 	odph_helper_options_t helper_options;
-	odph_thread_t thread_tbl[num_workers];
+	odph_thread_t *thread_tbl;
 	odph_thread_common_param_t thr_common;
 	odph_thread_param_t thr_param;
 	odp_instance_t instance;
 	odp_init_t init_param;
 	odp_pool_capability_t pool_capa;
 	odp_crypto_capability_t crypto_capa;
+	odp_shm_t shm;
 	uint32_t max_seg_len;
 	unsigned i;
 
@@ -1124,6 +1125,18 @@ int main(int argc, char *argv[])
 
 	/* Init this thread */
 	odp_init_local(instance, ODP_THREAD_WORKER);
+
+	shm = odp_shm_reserve("thread_tbl_shm", sizeof(odph_thread_t) * num_workers, 0, 0);
+	if (shm == ODP_SHM_INVALID) {
+		ODPH_ERR("Shared mem reserve failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	thread_tbl = odp_shm_addr(shm);
+	if (thread_tbl == NULL) {
+		ODPH_ERR("Shared mem addr failed.\n");
+		exit(EXIT_FAILURE);
+	}
 
 	odp_sys_info_print();
 
@@ -1223,7 +1236,6 @@ int main(int argc, char *argv[])
 			thr_param.arg = &test_run_arg;
 			thr_param.thr_type = ODP_THREAD_WORKER;
 
-			memset(thread_tbl, 0, sizeof(thread_tbl));
 			odph_thread_create(thread_tbl, &thr_common, &thr_param, num_workers);
 
 			odph_thread_join(thread_tbl, num_workers);
@@ -1245,6 +1257,11 @@ int main(int argc, char *argv[])
 		odp_queue_destroy(out_queue);
 	if (odp_pool_destroy(pool)) {
 		ODPH_ERR("Error: pool destroy\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (odp_shm_free(shm)) {
+		ODPH_ERR("Error: shm free failed\n");
 		exit(EXIT_FAILURE);
 	}
 

--- a/test/performance/odp_random.c
+++ b/test/performance/odp_random.c
@@ -34,6 +34,7 @@ struct test_global_t {
 	uint32_t rounds;
 
 	thread_arg_t thread_arg[ODP_THREAD_COUNT_MAX];
+	odph_thread_t thread_worker[ODP_THREAD_COUNT_MAX];
 
 	struct {
 		uint64_t nsec[ODP_THREAD_COUNT_MAX];
@@ -342,7 +343,6 @@ static void test_type(odp_instance_t instance, test_global_t *global, odp_random
 	odp_cpumask_t cpumask;
 	odph_thread_common_param_t thr_common;
 	odph_thread_param_t thr_param[num_threads];
-	odph_thread_t thr_worker[num_threads];
 
 	if (odp_cpumask_default_worker(&cpumask, num_threads) != num_threads) {
 		ODPH_ERR("Failed to get default CPU mask.\n");
@@ -364,14 +364,13 @@ static void test_type(odp_instance_t instance, test_global_t *global, odp_random
 			thr_param[i].start = test_random_latency;
 	}
 
-	memset(&thr_worker, 0, sizeof(thr_worker));
-
-	if (odph_thread_create(thr_worker, &thr_common, thr_param, num_threads) != num_threads) {
+	if (odph_thread_create(global->thread_worker, &thr_common, thr_param,
+			       num_threads) != num_threads) {
 		ODPH_ERR("Failed to create worker threads.\n");
 		exit(EXIT_FAILURE);
 	}
 
-	if (odph_thread_join(thr_worker, num_threads) != num_threads) {
+	if (odph_thread_join(global->thread_worker, num_threads) != num_threads) {
 		ODPH_ERR("Failed to join worker threads.\n");
 		exit(EXIT_FAILURE);
 	}

--- a/test/performance/odp_sched_latency.c
+++ b/test/performance/odp_sched_latency.c
@@ -120,6 +120,7 @@ typedef struct {
 	odp_queue_t      queue[NUM_PRIOS][MAX_QUEUES]; /**< Scheduled queues */
 
 	odp_schedule_group_t group[NUM_PRIOS][MAX_GROUPS];
+	odph_thread_t thread_tbl[ODP_THREAD_COUNT_MAX];
 
 } test_globals_t;
 
@@ -840,7 +841,6 @@ int main(int argc, char *argv[])
 	int i, j, ret;
 	int num_group, tot_group;
 	odp_schedule_group_t group[2 * MAX_GROUPS];
-	odph_thread_t thread_tbl[ODP_THREAD_COUNT_MAX];
 	int err = 0;
 	int num_workers = 0;
 	odp_shm_t shm = ODP_SHM_INVALID;
@@ -1011,7 +1011,6 @@ int main(int argc, char *argv[])
 	odp_barrier_init(&globals->barrier, num_workers);
 
 	/* Create and launch worker threads */
-	memset(thread_tbl, 0, sizeof(thread_tbl));
 
 	odph_thread_common_param_init(&thr_common);
 	thr_common.instance = instance;
@@ -1023,10 +1022,10 @@ int main(int argc, char *argv[])
 	thr_param.arg = NULL;
 	thr_param.thr_type = ODP_THREAD_WORKER;
 
-	odph_thread_create(thread_tbl, &thr_common, &thr_param, num_workers);
+	odph_thread_create(globals->thread_tbl, &thr_common, &thr_param, num_workers);
 
 	/* Wait for worker threads to terminate */
-	odph_thread_join(thread_tbl, num_workers);
+	odph_thread_join(globals->thread_tbl, num_workers);
 
 	printf("ODP scheduling latency test complete\n\n");
 

--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -128,6 +128,7 @@ typedef struct {
 	uint64_t tx_pkt_sum;
 
 	odp_schedule_config_t schedule_config;
+	odph_thread_t thread[MAX_WORKERS];
 
 } test_global_t;
 
@@ -1447,7 +1448,6 @@ int main(int argc, char *argv[])
 	odp_shm_t shm;
 	odp_time_t t1 = ODP_TIME_NULL, t2 = ODP_TIME_NULL;
 	odph_helper_options_t helper_options;
-	odph_thread_t thread[MAX_WORKERS];
 	test_options_t test_options;
 	int ret = 0;
 
@@ -1530,7 +1530,7 @@ int main(int argc, char *argv[])
 	odp_barrier_init(&test_global->worker_start,
 			 test_global->opt.num_worker + 1);
 
-	start_workers(thread, test_global);
+	start_workers(test_global->thread, test_global);
 
 	/* Synchronize pktio configuration with workers. Worker are now ready
 	 * to process packets. */
@@ -1543,7 +1543,7 @@ int main(int argc, char *argv[])
 
 	t1 = odp_time_local();
 
-	wait_workers(thread, test_global);
+	wait_workers(test_global->thread, test_global);
 
 	t2 = odp_time_local();
 

--- a/test/performance/odp_scheduling.c
+++ b/test/performance/odp_scheduling.c
@@ -65,6 +65,8 @@ typedef struct {
 	test_args_t      args;
 	odp_queue_t      queue[NUM_PRIOS][QUEUES_PER_PRIO];
 	queue_context_t  queue_ctx[NUM_PRIOS][QUEUES_PER_PRIO];
+	odph_thread_t    thread_tbl[ODP_THREAD_COUNT_MAX];
+
 } test_globals_t;
 
 /* Prints and initializes queue statistics */
@@ -792,7 +794,6 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 int main(int argc, char *argv[])
 {
 	odph_helper_options_t helper_options;
-	odph_thread_t *thread_tbl;
 	test_args_t args;
 	int num_workers;
 	odp_cpumask_t cpumask;
@@ -853,12 +854,6 @@ int main(int argc, char *argv[])
 	printf("num worker threads: %i\n", num_workers);
 	printf("first CPU:          %i\n", odp_cpumask_first(&cpumask));
 	printf("cpu mask:           %s\n", cpumaskstr);
-
-	thread_tbl = calloc(sizeof(odph_thread_t), num_workers);
-	if (!thread_tbl) {
-		ODPH_ERR("no memory for thread_tbl\n");
-		return -1;
-	}
 
 	/* Test cycle count frequency */
 	test_cpu_freq();
@@ -1005,11 +1000,10 @@ int main(int argc, char *argv[])
 	thr_param.start    = run_thread;
 	thr_param.arg      = NULL;
 
-	odph_thread_create(thread_tbl, &thr_common, &thr_param, num_workers);
+	odph_thread_create(globals->thread_tbl, &thr_common, &thr_param, num_workers);
 
 	/* Wait for worker threads to terminate */
-	odph_thread_join(thread_tbl, num_workers);
-	free(thread_tbl);
+	odph_thread_join(globals->thread_tbl, num_workers);
 
 	printf("ODP example complete\n\n");
 


### PR DESCRIPTION
Update `odph_thread_create()` specification to state that memory for output
thread table must be allocated from SHM memory in process mode. This is
required for child process startup synchronization.