### PR TITLE
[PATCH v2] Revert "helper: allow cli.h to be included individually"

### DIFF
--- a/helper/include/odp/helper/cli.h
+++ b/helper/include/odp/helper/cli.h
@@ -21,10 +21,6 @@
 extern "C" {
 #endif
 
-#include <odp/helper/autoheader_external.h>
-
-#if defined ODPH_CLI && ODPH_CLI
-
 #include <stdint.h>
 #include <stdarg.h>
 
@@ -177,8 +173,6 @@ int odph_cli_term(void);
 /**
  * @}
  */
-
-#endif
 
 #ifdef __cplusplus
 }

--- a/helper/include/odp/helper/odph_api.h
+++ b/helper/include/odp/helper/odph_api.h
@@ -22,7 +22,6 @@ extern "C" {
 
 #include <odp/helper/odph_debug.h>
 #include <odp/helper/chksum.h>
-#include <odp/helper/cli.h>
 #include <odp/helper/odph_cuckootable.h>
 #include <odp/helper/eth.h>
 #include <odp/helper/gtp.h>
@@ -40,6 +39,10 @@ extern "C" {
 #include <odp/helper/threads.h>
 #include <odp/helper/udp.h>
 #include <odp/helper/version.h>
+
+#ifdef ODPH_CLI
+#include <odp/helper/cli.h>
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This reverts commit 65a7f559c173ddbe9738c9c03bf9dbfc52279bc0.

cli.h is optional, so it cannot be included unconditionally.

Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

v2:
- Add review tags.
