### PR TITLE
[PATCH v2] helper: threads: fix synchronized thread start in process mode

### DIFF
--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -83,8 +83,11 @@ typedef struct {
 /** Helper internal thread start arguments. Used both in process and thread
  *  mode */
 typedef struct {
-	/** Atomic variable to sync status */
-	odp_atomic_u32_t status;
+	/** Thread status */
+	uint32_t status;
+
+	/** Thread initialization status */
+	odp_atomic_u32_t *init_status;
 
 	/** Process or thread */
 	odp_mem_model_t mem_model;


### PR DESCRIPTION
Memory for odph_thread_create() output thread table is given by application, so there is no guarantee that the memory can be used to synchronize child process startup. Fix this by using mmap() to create the necessary memory for thread startup synchronization.

Signed-off-by: Matias Elo <matias.elo@nokia.com>