### PR TITLE
[PATCH v2] helper: cli: add commands, reorganize existing commands

### DIFF
--- a/helper/cli.c
+++ b/helper/cli.c
@@ -308,9 +308,8 @@ static int cli_log(odp_log_level_t level, const char *fmt, ...)
 	return r;
 }
 
-static int cmd_call_odp_cls_print_all(struct cli_def *cli,
-				      const char *command ODP_UNUSED,
-				      char *argv[] ODP_UNUSED, int argc)
+static int cmd_odp_cls_print_all(struct cli_def *cli, const char *command ODP_UNUSED,
+				 char *argv[] ODP_UNUSED, int argc)
 {
 	if (check_num_args(cli, argc, 0))
 		return CLI_ERROR;
@@ -320,9 +319,8 @@ static int cmd_call_odp_cls_print_all(struct cli_def *cli,
 	return CLI_OK;
 }
 
-static int cmd_call_odp_ipsec_print(struct cli_def *cli,
-				    const char *command ODP_UNUSED,
-				    char *argv[] ODP_UNUSED, int argc)
+static int cmd_odp_ipsec_print(struct cli_def *cli, const char *command ODP_UNUSED,
+			       char *argv[] ODP_UNUSED, int argc)
 {
 	if (check_num_args(cli, argc, 0))
 		return CLI_ERROR;
@@ -332,9 +330,8 @@ static int cmd_call_odp_ipsec_print(struct cli_def *cli,
 	return CLI_OK;
 }
 
-static int cmd_call_odp_shm_print_all(struct cli_def *cli,
-				      const char *command ODP_UNUSED,
-				      char *argv[] ODP_UNUSED, int argc)
+static int cmd_odp_shm_print_all(struct cli_def *cli, const char *command ODP_UNUSED,
+				 char *argv[] ODP_UNUSED, int argc)
 {
 	if (check_num_args(cli, argc, 0))
 		return CLI_ERROR;
@@ -344,9 +341,8 @@ static int cmd_call_odp_shm_print_all(struct cli_def *cli,
 	return CLI_OK;
 }
 
-static int cmd_call_odp_sys_config_print(struct cli_def *cli,
-					 const char *command ODP_UNUSED,
-					 char *argv[] ODP_UNUSED, int argc)
+static int cmd_odp_sys_config_print(struct cli_def *cli, const char *command ODP_UNUSED,
+				    char *argv[] ODP_UNUSED, int argc)
 {
 	if (check_num_args(cli, argc, 0))
 		return CLI_ERROR;
@@ -356,9 +352,8 @@ static int cmd_call_odp_sys_config_print(struct cli_def *cli,
 	return CLI_OK;
 }
 
-static int cmd_call_odp_sys_info_print(struct cli_def *cli,
-				       const char *command ODP_UNUSED,
-				       char *argv[] ODP_UNUSED, int argc)
+static int cmd_odp_sys_info_print(struct cli_def *cli, const char *command ODP_UNUSED,
+				  char *argv[] ODP_UNUSED, int argc)
 {
 	if (check_num_args(cli, argc, 0))
 		return CLI_ERROR;
@@ -368,9 +363,8 @@ static int cmd_call_odp_sys_info_print(struct cli_def *cli,
 	return CLI_OK;
 }
 
-static int cmd_call_odp_pktio_print(struct cli_def *cli,
-				    const char *command ODP_UNUSED,
-				    char *argv[], int argc)
+static int cmd_odp_pktio_print(struct cli_def *cli, const char *command ODP_UNUSED, char *argv[],
+			       int argc)
 {
 	if (check_num_args(cli, argc, 1))
 		return CLI_ERROR;
@@ -387,9 +381,8 @@ static int cmd_call_odp_pktio_print(struct cli_def *cli,
 	return CLI_OK;
 }
 
-static int cmd_call_odp_pktio_extra_stats_print(struct cli_def *cli,
-						const char *command ODP_UNUSED,
-						char *argv[], int argc)
+static int cmd_odp_pktio_extra_stats_print(struct cli_def *cli, const char *command ODP_UNUSED,
+					   char *argv[], int argc)
 {
 	if (check_num_args(cli, argc, 1))
 		return CLI_ERROR;
@@ -406,9 +399,8 @@ static int cmd_call_odp_pktio_extra_stats_print(struct cli_def *cli,
 	return CLI_OK;
 }
 
-static int cmd_call_odp_pool_print(struct cli_def *cli,
-				   const char *command ODP_UNUSED, char *argv[],
-				   int argc)
+static int cmd_odp_pool_print(struct cli_def *cli, const char *command ODP_UNUSED, char *argv[],
+			      int argc)
 {
 	if (check_num_args(cli, argc, 1))
 		return CLI_ERROR;
@@ -425,9 +417,8 @@ static int cmd_call_odp_pool_print(struct cli_def *cli,
 	return CLI_OK;
 }
 
-static int cmd_call_odp_queue_print(struct cli_def *cli,
-				    const char *command ODP_UNUSED,
-				    char *argv[], int argc)
+static int cmd_odp_queue_print(struct cli_def *cli, const char *command ODP_UNUSED, char *argv[],
+			       int argc)
 {
 	if (check_num_args(cli, argc, 1))
 		return CLI_ERROR;
@@ -444,9 +435,8 @@ static int cmd_call_odp_queue_print(struct cli_def *cli,
 	return CLI_OK;
 }
 
-static int cmd_call_odp_queue_print_all(struct cli_def *cli,
-					const char *command ODP_UNUSED,
-					char *argv[] ODP_UNUSED, int argc)
+static int cmd_odp_queue_print_all(struct cli_def *cli, const char *command ODP_UNUSED,
+				   char *argv[] ODP_UNUSED, int argc)
 {
 	if (check_num_args(cli, argc, 0))
 		return CLI_ERROR;
@@ -456,9 +446,8 @@ static int cmd_call_odp_queue_print_all(struct cli_def *cli,
 	return CLI_OK;
 }
 
-static int cmd_call_odp_shm_print(struct cli_def *cli,
-				  const char *command ODP_UNUSED, char *argv[],
-				  int argc)
+static int cmd_odp_shm_print(struct cli_def *cli, const char *command ODP_UNUSED, char *argv[],
+			     int argc)
 {
 	if (check_num_args(cli, argc, 1))
 		return CLI_ERROR;
@@ -682,48 +671,44 @@ static int cmd_user_cmd(struct cli_def *cli ODP_UNUSED, const char *command,
 
 static struct cli_def *create_cli(cli_shm_t *shm)
 {
-	struct cli_command *c;
 	struct cli_def *cli;
 
 	cli = cli_init();
 	cli_set_banner(cli, NULL);
 	cli_set_hostname(cli, shm->cli_param.hostname);
 
-	c = cli_register_command(cli, NULL, "call", NULL,
-				 PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
-				 "Call ODP API function.");
-	cli_register_command(cli, c, "odp_cls_print_all",
-			     cmd_call_odp_cls_print_all,
+	cli_register_command(cli, NULL, "odp_cls_print_all",
+			     cmd_odp_cls_print_all,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
-	cli_register_command(cli, c, "odp_ipsec_print",
-			     cmd_call_odp_ipsec_print,
+	cli_register_command(cli, NULL, "odp_ipsec_print",
+			     cmd_odp_ipsec_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
-	cli_register_command(cli, c, "odp_pktio_print",
-			     cmd_call_odp_pktio_print,
+	cli_register_command(cli, NULL, "odp_pktio_print",
+			     cmd_odp_pktio_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, c, "odp_pktio_extra_stats_print",
-			     cmd_call_odp_pktio_extra_stats_print,
+	cli_register_command(cli, NULL, "odp_pktio_extra_stats_print",
+			     cmd_odp_pktio_extra_stats_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, c, "odp_pool_print",
-			     cmd_call_odp_pool_print,
+	cli_register_command(cli, NULL, "odp_pool_print",
+			     cmd_odp_pool_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, c, "odp_queue_print",
-			     cmd_call_odp_queue_print,
+	cli_register_command(cli, NULL, "odp_queue_print",
+			     cmd_odp_queue_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, c, "odp_queue_print_all",
-			     cmd_call_odp_queue_print_all,
+	cli_register_command(cli, NULL, "odp_queue_print_all",
+			     cmd_odp_queue_print_all,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
-	cli_register_command(cli, c, "odp_shm_print_all",
-			     cmd_call_odp_shm_print_all,
+	cli_register_command(cli, NULL, "odp_shm_print_all",
+			     cmd_odp_shm_print_all,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
-	cli_register_command(cli, c, "odp_shm_print",
-			     cmd_call_odp_shm_print,
+	cli_register_command(cli, NULL, "odp_shm_print",
+			     cmd_odp_shm_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, c, "odp_sys_config_print",
-			     cmd_call_odp_sys_config_print,
+	cli_register_command(cli, NULL, "odp_sys_config_print",
+			     cmd_odp_sys_config_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
-	cli_register_command(cli, c, "odp_sys_info_print",
-			     cmd_call_odp_sys_info_print,
+	cli_register_command(cli, NULL, "odp_sys_info_print",
+			     cmd_odp_sys_info_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
 	cli_register_command(cli, NULL, "pktio_stats_print",
 			     cmd_pktio_stats_print,

--- a/helper/cli.c
+++ b/helper/cli.c
@@ -458,6 +458,17 @@ static int cmd_odp_queue_print_all(struct cli_def *cli, const char *command ODP_
 	return CLI_OK;
 }
 
+static int cmd_odp_schedule_print(struct cli_def *cli, const char *command ODP_UNUSED,
+				  char *argv[] ODP_UNUSED, int argc)
+{
+	if (check_num_args(cli, argc, 0))
+		return CLI_ERROR;
+
+	odp_schedule_print();
+
+	return CLI_OK;
+}
+
 static int cmd_odp_shm_print(struct cli_def *cli, const char *command ODP_UNUSED, char *argv[],
 			     int argc)
 {
@@ -705,6 +716,7 @@ static struct cli_def *create_cli(cli_shm_t *shm)
 	CMD(odp_pool_print, "<name>");
 	CMD(odp_queue_print_all, NULL);
 	CMD(odp_queue_print, "<name>");
+	CMD(odp_schedule_print, NULL);
 	CMD(odp_shm_print_all, NULL);
 	CMD(odp_shm_print, "<name>");
 	CMD(odp_sys_config_print, NULL);

--- a/helper/cli.c
+++ b/helper/cli.c
@@ -678,48 +678,24 @@ static struct cli_def *create_cli(cli_shm_t *shm)
 	cli_set_banner(cli, NULL);
 	cli_set_hostname(cli, shm->cli_param.hostname);
 
-	cli_register_command(cli, NULL, "odp_cls_print_all",
-			     cmd_odp_cls_print_all,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
-	cli_register_command(cli, NULL, "odp_ipsec_print",
-			     cmd_odp_ipsec_print,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
-	cli_register_command(cli, NULL, "odp_pktio_print",
-			     cmd_odp_pktio_print,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, NULL, "odp_pktio_extra_stats_print",
-			     cmd_odp_pktio_extra_stats_print,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, NULL, "odp_pool_print",
-			     cmd_odp_pool_print,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, NULL, "odp_queue_print",
-			     cmd_odp_queue_print,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, NULL, "odp_queue_print_all",
-			     cmd_odp_queue_print_all,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
-	cli_register_command(cli, NULL, "odp_shm_print_all",
-			     cmd_odp_shm_print_all,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
-	cli_register_command(cli, NULL, "odp_shm_print",
-			     cmd_odp_shm_print,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, NULL, "odp_sys_config_print",
-			     cmd_odp_sys_config_print,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
-	cli_register_command(cli, NULL, "odp_sys_info_print",
-			     cmd_odp_sys_info_print,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
-	cli_register_command(cli, NULL, "odp_pktio_stats_print",
-			     cmd_odp_pktio_stats_print,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, NULL, "odp_pktio_queue_stats_print",
-			     cmd_odp_pktio_queue_stats_print,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, NULL, "odp_pktio_event_queue_stats_print",
-			     cmd_odp_pktio_event_queue_stats_print,
-			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
+#define CMD(name, help) \
+	cli_register_command(cli, NULL, #name, cmd_ ## name, \
+			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, help)
+
+	CMD(odp_cls_print_all, NULL);
+	CMD(odp_ipsec_print, NULL);
+	CMD(odp_pktio_event_queue_stats_print, "<name>");
+	CMD(odp_pktio_extra_stats_print, "<name>");
+	CMD(odp_pktio_print, "<name>");
+	CMD(odp_pktio_queue_stats_print, "<name>");
+	CMD(odp_pktio_stats_print, "<name>");
+	CMD(odp_pool_print, "<name>");
+	CMD(odp_queue_print_all, NULL);
+	CMD(odp_queue_print, "<name>");
+	CMD(odp_shm_print_all, NULL);
+	CMD(odp_shm_print, "<name>");
+	CMD(odp_sys_config_print, NULL);
+	CMD(odp_sys_info_print, NULL);
 
 	for (uint32_t i = 0; i < shm->num_user_commands; i++) {
 		cli_register_command(cli, NULL, shm->user_cmd[i].name,

--- a/helper/cli.c
+++ b/helper/cli.c
@@ -399,6 +399,18 @@ static int cmd_odp_pktio_extra_stats_print(struct cli_def *cli, const char *comm
 	return CLI_OK;
 }
 
+static int cmd_odp_pool_print_all(struct cli_def *cli,
+				  const char *command ODP_UNUSED,
+				  char *argv[] ODP_UNUSED, int argc)
+{
+	if (check_num_args(cli, argc, 0))
+		return CLI_ERROR;
+
+	odp_pool_print_all();
+
+	return CLI_OK;
+}
+
 static int cmd_odp_pool_print(struct cli_def *cli, const char *command ODP_UNUSED, char *argv[],
 			      int argc)
 {
@@ -689,6 +701,7 @@ static struct cli_def *create_cli(cli_shm_t *shm)
 	CMD(odp_pktio_print, "<name>");
 	CMD(odp_pktio_queue_stats_print, "<name>");
 	CMD(odp_pktio_stats_print, "<name>");
+	CMD(odp_pool_print_all, NULL);
 	CMD(odp_pool_print, "<name>");
 	CMD(odp_queue_print_all, NULL);
 	CMD(odp_queue_print, "<name>");

--- a/helper/cli.c
+++ b/helper/cli.c
@@ -464,8 +464,8 @@ static int cmd_odp_shm_print(struct cli_def *cli, const char *command ODP_UNUSED
 	return CLI_OK;
 }
 
-static int cmd_pktio_stats_print(struct cli_def *cli, const char *command ODP_UNUSED, char *argv[],
-				 int argc)
+static int cmd_odp_pktio_stats_print(struct cli_def *cli, const char *command ODP_UNUSED,
+				     char *argv[], int argc)
 {
 	if (check_num_args(cli, argc, 1))
 		return CLI_ERROR;
@@ -519,8 +519,8 @@ static void cli_log_pktout_queue_stats(odp_pktout_queue_stats_t *stats)
 	cli_log(ODP_LOG_PRINT, "  errors: %" PRIu64 "\n", stats->errors);
 }
 
-static int cmd_pktio_queue_stats_print(struct cli_def *cli, const char *command ODP_UNUSED,
-				       char *argv[], int argc)
+static int cmd_odp_pktio_queue_stats_print(struct cli_def *cli, const char *command ODP_UNUSED,
+					   char *argv[], int argc)
 {
 	if (check_num_args(cli, argc, 1))
 		return CLI_ERROR;
@@ -583,8 +583,9 @@ static int cmd_pktio_queue_stats_print(struct cli_def *cli, const char *command 
 	return CLI_OK;
 }
 
-static int cmd_pktio_event_queue_stats_print(struct cli_def *cli, const char *command ODP_UNUSED,
-					     char *argv[], int argc)
+static int cmd_odp_pktio_event_queue_stats_print(struct cli_def *cli,
+						 const char *command ODP_UNUSED, char *argv[],
+						 int argc)
 {
 	if (check_num_args(cli, argc, 1))
 		return CLI_ERROR;
@@ -710,14 +711,14 @@ static struct cli_def *create_cli(cli_shm_t *shm)
 	cli_register_command(cli, NULL, "odp_sys_info_print",
 			     cmd_odp_sys_info_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
-	cli_register_command(cli, NULL, "pktio_stats_print",
-			     cmd_pktio_stats_print,
+	cli_register_command(cli, NULL, "odp_pktio_stats_print",
+			     cmd_odp_pktio_stats_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, NULL, "pktio_queue_stats_print",
-			     cmd_pktio_queue_stats_print,
+	cli_register_command(cli, NULL, "odp_pktio_queue_stats_print",
+			     cmd_odp_pktio_queue_stats_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
-	cli_register_command(cli, NULL, "pktio_event_queue_stats_print",
-			     cmd_pktio_event_queue_stats_print,
+	cli_register_command(cli, NULL, "odp_pktio_event_queue_stats_print",
+			     cmd_odp_pktio_event_queue_stats_print,
 			     PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "<name>");
 
 	for (uint32_t i = 0; i < shm->num_user_commands; i++) {


### PR DESCRIPTION
- Remove the "call" command and move commands to top level.
- Prefix commands with "odp_".
- Add command odp_pool_print_all.
- Add command odp_schedule_print.
- Alphabetize the commands.

v2:
- Add review tags.
