### PR TITLE
[PATCH v4] crypto: bug fix and cleanup

### DIFF
--- a/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
+++ b/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
@@ -932,7 +932,7 @@ int crypto_int(odp_packet_t pkt_in,
 		int ret;
 		int md_copy;
 
-		md_copy = _odp_packet_copy_md_possible(session->p.output_pool,
+		md_copy = _odp_packet_copy_md_possible(odp_packet_pool(out_pkt),
 						       odp_packet_pool(pkt_in));
 		if (odp_unlikely(md_copy < 0)) {
 			ODP_ERR("Unable to copy packet metadata\n");

--- a/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
+++ b/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
@@ -904,53 +904,71 @@ int odp_crypto_result(odp_crypto_packet_result_t *result,
 	return 0;
 }
 
+static int copy_data_and_metadata(odp_packet_t dst, odp_packet_t src)
+{
+	int md_copy;
+	int rc;
+
+	md_copy = _odp_packet_copy_md_possible(odp_packet_pool(dst),
+					       odp_packet_pool(src));
+	if (odp_unlikely(md_copy < 0)) {
+		ODP_ERR("Unable to copy packet metadata\n");
+		return -1;
+	}
+
+	rc = odp_packet_copy_from_pkt(dst, 0, src, 0, odp_packet_len(src));
+	if (odp_unlikely(rc < 0)) {
+		ODP_ERR("Unable to copy packet data\n");
+		return -1;
+	}
+
+	_odp_packet_copy_md(packet_hdr(dst), packet_hdr(src), md_copy);
+	return 0;
+}
+
+static odp_packet_t get_output_packet(const odp_crypto_generic_session_t *session,
+				      odp_packet_t pkt_in,
+				      odp_packet_t pkt_out)
+{
+	int rc;
+
+	if (odp_likely(pkt_in == pkt_out))
+		return pkt_out;
+
+	if (pkt_out == ODP_PACKET_INVALID) {
+		odp_pool_t pool = session->p.output_pool;
+
+		ODP_ASSERT(pool != ODP_POOL_INVALID);
+		if (pool == odp_packet_pool(pkt_in)) {
+			pkt_out = pkt_in;
+		} else {
+			pkt_out = odp_packet_copy(pkt_in, pool);
+			if (odp_likely(pkt_out != ODP_PACKET_INVALID))
+				odp_packet_free(pkt_in);
+		}
+		return pkt_out;
+	}
+	rc = copy_data_and_metadata(pkt_out, pkt_in);
+	if (odp_unlikely(rc < 0))
+		return ODP_PACKET_INVALID;
+
+	odp_packet_free(pkt_in);
+	return pkt_out;
+}
+
 static
 int crypto_int(odp_packet_t pkt_in,
 	       odp_packet_t *pkt_out,
 	       const odp_crypto_packet_op_param_t *param)
 {
 	odp_crypto_generic_session_t *session;
-	odp_bool_t allocated = false;
-	odp_packet_t out_pkt = *pkt_out;
+	odp_packet_t out_pkt;
 
 	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
 
-	/* Resolve output buffer */
-	if (odp_unlikely(ODP_PACKET_INVALID == out_pkt) &&
-	    ODP_POOL_INVALID != session->p.output_pool) {
-		out_pkt = odp_packet_alloc(session->p.output_pool,
-					   odp_packet_len(pkt_in));
-		allocated = true;
-	}
-
-	if (odp_unlikely(ODP_PACKET_INVALID == out_pkt)) {
-		ODP_DBG("Alloc failed.\n");
+	out_pkt = get_output_packet(session, pkt_in, *pkt_out);
+	if (odp_unlikely(out_pkt == ODP_PACKET_INVALID))
 		return -1;
-	}
-
-	if (odp_unlikely(pkt_in != out_pkt)) {
-		int ret;
-		int md_copy;
-
-		md_copy = _odp_packet_copy_md_possible(odp_packet_pool(out_pkt),
-						       odp_packet_pool(pkt_in));
-		if (odp_unlikely(md_copy < 0)) {
-			ODP_ERR("Unable to copy packet metadata\n");
-			goto err;
-		}
-
-		ret = odp_packet_copy_from_pkt(out_pkt,
-					       0,
-					       pkt_in,
-					       0,
-					       odp_packet_len(pkt_in));
-		if (odp_unlikely(ret < 0))
-			goto err;
-
-		_odp_packet_copy_md(packet_hdr(out_pkt), packet_hdr(pkt_in), md_copy);
-		odp_packet_free(pkt_in);
-		pkt_in = ODP_PACKET_INVALID;
-	}
 
 	/* Invoke the crypto function */
 	session->func(out_pkt, param, session);
@@ -961,14 +979,6 @@ int crypto_int(odp_packet_t pkt_in,
 	*pkt_out = out_pkt;
 
 	return 0;
-
-err:
-	if (allocated) {
-		odp_packet_free(out_pkt);
-		*pkt_out = ODP_PACKET_INVALID;
-	}
-
-	return -1;
 }
 
 int odp_crypto_op(const odp_packet_t pkt_in[],

--- a/platform/linux-generic/odp_crypto_null.c
+++ b/platform/linux-generic/odp_crypto_null.c
@@ -515,7 +515,7 @@ int crypto_int(odp_packet_t pkt_in,
 		int ret;
 		int md_copy;
 
-		md_copy = _odp_packet_copy_md_possible(session->p.output_pool,
+		md_copy = _odp_packet_copy_md_possible(odp_packet_pool(out_pkt),
 						       odp_packet_pool(pkt_in));
 		if (odp_unlikely(md_copy < 0)) {
 			ODP_ERR("Unable to copy packet metadata\n");

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -2846,7 +2846,7 @@ int crypto_int(odp_packet_t pkt_in,
 		int ret;
 		int md_copy;
 
-		md_copy = _odp_packet_copy_md_possible(session->p.output_pool,
+		md_copy = _odp_packet_copy_md_possible(odp_packet_pool(out_pkt),
 						       odp_packet_pool(pkt_in));
 		if (odp_unlikely(md_copy < 0)) {
 			ODP_ERR("Unable to copy packet metadata\n");

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -2815,6 +2815,58 @@ int odp_crypto_result(odp_crypto_packet_result_t *result,
 	return 0;
 }
 
+static int copy_data_and_metadata(odp_packet_t dst, odp_packet_t src)
+{
+	int md_copy;
+	int rc;
+
+	md_copy = _odp_packet_copy_md_possible(odp_packet_pool(dst),
+					       odp_packet_pool(src));
+	if (odp_unlikely(md_copy < 0)) {
+		ODP_ERR("Unable to copy packet metadata\n");
+		return -1;
+	}
+
+	rc = odp_packet_copy_from_pkt(dst, 0, src, 0, odp_packet_len(src));
+	if (odp_unlikely(rc < 0)) {
+		ODP_ERR("Unable to copy packet data\n");
+		return -1;
+	}
+
+	_odp_packet_copy_md(packet_hdr(dst), packet_hdr(src), md_copy);
+	return 0;
+}
+
+static odp_packet_t get_output_packet(const odp_crypto_generic_session_t *session,
+				      odp_packet_t pkt_in,
+				      odp_packet_t pkt_out)
+{
+	int rc;
+
+	if (odp_likely(pkt_in == pkt_out))
+		return pkt_out;
+
+	if (pkt_out == ODP_PACKET_INVALID) {
+		odp_pool_t pool = session->p.output_pool;
+
+		ODP_ASSERT(pool != ODP_POOL_INVALID);
+		if (pool == odp_packet_pool(pkt_in)) {
+			pkt_out = pkt_in;
+		} else {
+			pkt_out = odp_packet_copy(pkt_in, pool);
+			if (odp_likely(pkt_out != ODP_PACKET_INVALID))
+				odp_packet_free(pkt_in);
+		}
+		return pkt_out;
+	}
+	rc = copy_data_and_metadata(pkt_out, pkt_in);
+	if (odp_unlikely(rc < 0))
+		return ODP_PACKET_INVALID;
+
+	odp_packet_free(pkt_in);
+	return pkt_out;
+}
+
 static
 int crypto_int(odp_packet_t pkt_in,
 	       odp_packet_t *pkt_out,
@@ -2823,48 +2875,14 @@ int crypto_int(odp_packet_t pkt_in,
 	odp_crypto_alg_err_t rc_cipher = ODP_CRYPTO_ALG_ERR_NONE;
 	odp_crypto_alg_err_t rc_auth = ODP_CRYPTO_ALG_ERR_NONE;
 	odp_crypto_generic_session_t *session;
-	odp_bool_t allocated = false;
-	odp_packet_t out_pkt = *pkt_out;
+	odp_packet_t out_pkt;
 	odp_crypto_packet_result_t *op_result;
 
 	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
 
-	/* Resolve output buffer */
-	if (ODP_PACKET_INVALID == out_pkt &&
-	    ODP_POOL_INVALID != session->p.output_pool) {
-		out_pkt = odp_packet_alloc(session->p.output_pool,
-					   odp_packet_len(pkt_in));
-		allocated = true;
-	}
-
-	if (odp_unlikely(ODP_PACKET_INVALID == out_pkt)) {
-		ODP_DBG("Alloc failed.\n");
+	out_pkt = get_output_packet(session, pkt_in, *pkt_out);
+	if (odp_unlikely(out_pkt == ODP_PACKET_INVALID))
 		return -1;
-	}
-
-	if (pkt_in != out_pkt) {
-		int ret;
-		int md_copy;
-
-		md_copy = _odp_packet_copy_md_possible(odp_packet_pool(out_pkt),
-						       odp_packet_pool(pkt_in));
-		if (odp_unlikely(md_copy < 0)) {
-			ODP_ERR("Unable to copy packet metadata\n");
-			goto err;
-		}
-
-		ret = odp_packet_copy_from_pkt(out_pkt,
-					       0,
-					       pkt_in,
-					       0,
-					       odp_packet_len(pkt_in));
-		if (odp_unlikely(ret < 0))
-			goto err;
-
-		_odp_packet_copy_md(packet_hdr(out_pkt), packet_hdr(pkt_in), md_copy);
-		odp_packet_free(pkt_in);
-		pkt_in = ODP_PACKET_INVALID;
-	}
 
 	crypto_init(session);
 
@@ -2892,14 +2910,6 @@ int crypto_int(odp_packet_t pkt_in,
 	*pkt_out = out_pkt;
 
 	return 0;
-
-err:
-	if (allocated) {
-		odp_packet_free(out_pkt);
-		*pkt_out = ODP_PACKET_INVALID;
-	}
-
-	return -1;
 }
 
 int odp_crypto_op(const odp_packet_t pkt_in[],


### PR DESCRIPTION
commits in v2:

linux-gen: crypto: fix pool checking before metadata copying

    The packet metadata copying check in a crypto operation assumes that the
    pool of the output packet is the pool configured in the session, but that
    is not necessarily the case when an ODP application passes an explicit
    output packet to a crypto operation. In that case the pool of the session
    could even be ODP_POOL_INVALID.

linux-gen: crypto: reuse input packet as output packet if possible

    Do not allocate a new packet but reuse the input packet when a crypto
    operation is requested to allocate the output packet and the input
    packet and the session use the same packet pool.

    Make the code cleaner by moving output packet allocation and preparation
    to its own function from crypto_int().
