### PR TITLE
[PATCH v4] test: ipsecfwd: add support for burst processing

### DIFF
--- a/test/performance/odp_ipsecfwd.c
+++ b/test/performance/odp_ipsecfwd.c
@@ -35,7 +35,7 @@
 #define MAX_SA_QUEUES 1024U
 #define PKT_SIZE 1024U
 #define PKT_CNT 32768U
-#define NUM_EVS 32U
+#define MAX_BURST 32U
 #define ORDERED 0U
 
 #define ALG_ENTRY(_alg_name, _type) \
@@ -59,7 +59,7 @@ typedef enum {
 } parse_result_t;
 
 enum {
-	DIR_IN = 0U,
+	DIR_IN = 0,
 	DIR_OUT
 };
 
@@ -162,6 +162,7 @@ static exposed_alg_t exposed_algs[] = {
 /* SPIs for in and out directions */
 static odp_ipsec_sa_t *spi_to_sa_map[2U][MAX_SPIS];
 static odp_atomic_u32_t is_running;
+static const int ipsec_out_mark;
 
 static void init_config(prog_config_t *config)
 {
@@ -904,17 +905,29 @@ static inline odp_ipsec_sa_t *get_in_sa(odp_packet_t pkt)
 	return spi <= UINT16_MAX ? spi_to_sa_map[DIR_IN][spi] : NULL;
 }
 
-static inline odp_bool_t process_ipsec_in(odp_packet_t pkt, const odp_ipsec_sa_t *sa)
+static inline int process_ipsec_in(odp_packet_t pkts[], const odp_ipsec_sa_t sas[], int num)
 {
 	odp_ipsec_in_param_t param;
+	int left, sent = 0, ret;
 
 	memset(&param, 0, sizeof(param));
-	param.num_sa = 1;
-	param.sa = sa;
 	/* IPsec in/out need to be identified somehow, so use user_ptr for this. */
-	odp_packet_user_ptr_set(pkt, NULL);
+	for (int i = 0; i < num; ++i)
+		odp_packet_user_ptr_set(pkts[i], NULL);
 
-	return odp_ipsec_in_enq(&pkt, 1, &param) == 1;
+	while (sent < num) {
+		left = num - sent;
+		param.num_sa = left;
+		param.sa = &sas[sent];
+		ret = odp_ipsec_in_enq(&pkts[sent], left, &param);
+
+		if (odp_unlikely(ret <= 0))
+			break;
+
+		sent += ret;
+	}
+
+	return sent;
 }
 
 static inline odp_ipsec_sa_t *get_out_sa(odp_packet_t pkt)
@@ -933,17 +946,29 @@ static inline odp_ipsec_sa_t *get_out_sa(odp_packet_t pkt)
 	return dst_port ? spi_to_sa_map[DIR_OUT][dst_port] : NULL;
 }
 
-static inline odp_bool_t process_ipsec_out(odp_packet_t pkt, const odp_ipsec_sa_t *sa)
+static inline int process_ipsec_out(odp_packet_t pkts[], const odp_ipsec_sa_t sas[], int num)
 {
 	odp_ipsec_out_param_t param;
+	int left, sent = 0, ret;
 
 	memset(&param, 0, sizeof(param));
-	param.num_sa = 1;
-	param.sa = sa;
 	/* IPsec in/out need to be identified somehow, so use user_ptr for this. */
-	odp_packet_user_ptr_set(pkt, sa);
+	for (int i = 0; i < num; ++i)
+		odp_packet_user_ptr_set(pkts[i], &ipsec_out_mark);
 
-	return odp_ipsec_out_enq(&pkt, 1, &param) == 1;
+	while (sent < num) {
+		left = num - sent;
+		param.num_sa = left;
+		param.sa = &sas[sent];
+		ret = odp_ipsec_out_enq(&pkts[sent], left, &param);
+
+		if (odp_unlikely(ret <= 0))
+			break;
+
+		sent += ret;
+	}
+
+	return sent;
 }
 
 static inline const pktio_t *lookup_and_apply(odp_packet_t pkt, odph_table_t fwd_tbl,
@@ -986,72 +1011,109 @@ static inline const pktio_t *lookup_and_apply(odp_packet_t pkt, odph_table_t fwd
 	return fwd->pktio;
 }
 
-static inline odp_bool_t forward_packet(odp_packet_t pkt, odph_table_t fwd_tbl, stats_t *stats)
+static inline uint32_t forward_packets(odp_packet_t pkts[], int num, odph_table_t fwd_tbl)
 {
+	odp_packet_t pkt;
 	uint8_t hash = 0U;
-	const pktio_t *pktio = lookup_and_apply(pkt, fwd_tbl, &hash);
+	const pktio_t *pktio;
+	uint32_t num_procd = 0U;
 
-	if (pktio == NULL) {
-		++stats->discards;
-		return false;
+	for (int i = 0; i < num; ++i) {
+		pkt = pkts[i];
+		pktio = lookup_and_apply(pkt, fwd_tbl, &hash);
+
+		if (pktio == NULL) {
+			odp_packet_free(pkt);
+			continue;
+		}
+
+		if (odp_unlikely(!pktio->send_fn(pktio, hash % pktio->num_tx_qs, pkt))) {
+			odp_packet_free(pkt);
+			continue;
+		}
+
+		++num_procd;
 	}
 
-	if (odp_unlikely(!pktio->send_fn(pktio, hash % pktio->num_tx_qs, pkt))) {
-		++stats->discards;
-		return false;
-	}
-
-	return true;
+	return num_procd;
 }
 
-static inline void process_packet_out(odp_packet_t pkt, odph_table_t fwd_tbl, stats_t *stats)
+static inline void process_packets_out(odp_packet_t pkts[], int num, odph_table_t fwd_tbl,
+				       stats_t *stats)
 {
-	odp_ipsec_sa_t *sa;
+	odp_packet_t pkt, pkts_ips[MAX_BURST], pkts_fwd[MAX_BURST];
+	odp_ipsec_sa_t *sa, sas[MAX_BURST];
+	int num_pkts_ips = 0, num_pkts_fwd = 0, num_procd;
 
-	sa = get_out_sa(pkt);
+	for (int i = 0; i < num; ++i) {
+		pkt = pkts[i];
+		sa = get_out_sa(pkt);
 
-	if (sa != NULL) {
-		if (odp_unlikely(!process_ipsec_out(pkt, sa))) {
-			++stats->ipsec_out_errs;
-			goto err;
+		if (sa != NULL) {
+			sas[num_pkts_ips] = *sa;
+			pkts_ips[num_pkts_ips] = pkt;
+			++num_pkts_ips;
+		} else {
+			pkts_fwd[num_pkts_fwd++] = pkt;
 		}
-	} else {
-		if (!forward_packet(pkt, fwd_tbl, stats))
-			goto err;
-
-		++stats->fwd_pkts;
 	}
 
-	return;
+	if (num_pkts_ips > 0) {
+		num_procd = process_ipsec_out(pkts_ips, sas, num_pkts_ips);
 
-err:
-	odp_packet_free(pkt);
+		if (odp_unlikely(num_procd < num_pkts_ips)) {
+			num_procd = num_procd < 0 ? 0 : num_procd;
+			stats->ipsec_out_errs += num_pkts_ips - num_procd;
+			odp_packet_free_multi(&pkts_ips[num_procd], num_pkts_ips - num_procd);
+		}
+	}
+
+	if (num_pkts_fwd > 0) {
+		num_procd = forward_packets(pkts_fwd, num_pkts_fwd, fwd_tbl);
+		stats->discards += num_pkts_fwd - num_procd;
+		stats->fwd_pkts += num_procd;
+	}
 }
 
-static inline void process_packet_in(odp_packet_t pkt, odph_table_t fwd_tbl, stats_t *stats)
+static inline void process_packets_in(odp_packet_t pkts[], int num, odph_table_t fwd_tbl,
+				      stats_t *stats)
 {
-	odp_ipsec_sa_t *sa;
+	odp_packet_t pkt, pkts_ips[MAX_BURST], pkts_out[MAX_BURST];
+	odp_ipsec_sa_t *sa, sas[MAX_BURST];
+	int num_pkts_ips = 0, num_pkts_out = 0, num_procd;
 
-	if (odp_unlikely(odp_packet_has_error(pkt))) {
-		++stats->discards;
-		goto err;
-	}
+	for (int i = 0; i < num; ++i) {
+		pkt = pkts[i];
 
-	sa = get_in_sa(pkt);
-
-	if (sa != NULL) {
-		if (odp_unlikely(!process_ipsec_in(pkt, sa))) {
-			++stats->ipsec_in_errs;
-			goto err;
+		if (odp_unlikely(odp_packet_has_error(pkt))) {
+			++stats->discards;
+			odp_packet_free(pkt);
+			continue;
 		}
-	} else {
-		process_packet_out(pkt, fwd_tbl, stats);
+
+		sa = get_in_sa(pkt);
+
+		if (sa != NULL) {
+			sas[num_pkts_ips] = *sa;
+			pkts_ips[num_pkts_ips] = pkt;
+			++num_pkts_ips;
+		} else {
+			pkts_out[num_pkts_out++] = pkt;
+		}
 	}
 
-	return;
+	if (num_pkts_ips > 0) {
+		num_procd = process_ipsec_in(pkts_ips, sas, num_pkts_ips);
 
-err:
-	odp_packet_free(pkt);
+		if (odp_unlikely(num_procd < num_pkts_ips)) {
+			num_procd = num_procd < 0 ? 0 : num_procd;
+			stats->ipsec_in_errs += num_pkts_ips - num_procd;
+			odp_packet_free_multi(&pkts_ips[num_procd], num_pkts_ips - num_procd);
+		}
+	}
+
+	if (num_pkts_out > 0)
+		process_packets_out(pkts_out, num_pkts_out, fwd_tbl, stats);
 }
 
 static inline odp_bool_t is_ipsec_in(odp_packet_t pkt)
@@ -1059,37 +1121,47 @@ static inline odp_bool_t is_ipsec_in(odp_packet_t pkt)
 	return odp_packet_user_ptr(pkt) == NULL;
 }
 
-static inline void complete_ipsec_op(odp_packet_t pkt, odph_table_t fwd_tbl, stats_t *stats)
+static inline void complete_ipsec_ops(odp_packet_t pkts[], int num, odph_table_t fwd_tbl,
+				      stats_t *stats)
 {
+	odp_packet_t pkt, pkts_out[MAX_BURST], pkts_fwd[MAX_BURST];
+	odp_bool_t is_in;
 	odp_ipsec_packet_result_t result;
-	const odp_bool_t is_in = is_ipsec_in(pkt);
+	int num_pkts_out = 0, num_pkts_fwd = 0, num_procd;
 
-	if (odp_unlikely(odp_ipsec_result(&result, pkt) < 0)) {
-		is_in ? ++stats->ipsec_in_errs : ++stats->ipsec_out_errs;
-		goto err;
+	for (int i = 0; i < num; ++i) {
+		pkt = pkts[i];
+		is_in = is_ipsec_in(pkt);
+
+		if (odp_unlikely(odp_ipsec_result(&result, pkt) < 0)) {
+			is_in ? ++stats->ipsec_in_errs : ++stats->ipsec_out_errs;
+			odp_packet_free(pkt);
+			continue;
+		}
+
+		if (odp_unlikely(result.status.all != ODP_IPSEC_OK)) {
+			is_in ? ++stats->ipsec_in_errs : ++stats->ipsec_out_errs;
+			odp_packet_free(pkt);
+			continue;
+		}
+
+		if (is_in) {
+			++stats->ipsec_in_pkts;
+			pkts_out[num_pkts_out++] = pkt;
+		} else {
+			++stats->ipsec_out_pkts;
+			pkts_fwd[num_pkts_fwd++] = pkt;
+		}
 	}
 
-	if (odp_unlikely(result.status.all != ODP_IPSEC_OK)) {
-		is_in ? ++stats->ipsec_in_errs : ++stats->ipsec_out_errs;
-		goto err;
+	if (num_pkts_out > 0)
+		process_packets_out(pkts_out, num_pkts_out, fwd_tbl, stats);
+
+	if (num_pkts_fwd > 0) {
+		num_procd = forward_packets(pkts_fwd, num_pkts_fwd, fwd_tbl);
+		stats->discards += num_pkts_fwd - num_procd;
+		stats->fwd_pkts += num_procd;
 	}
-
-	if (is_in) {
-		++stats->ipsec_in_pkts;
-		process_packet_out(pkt, fwd_tbl, stats);
-	} else {
-		++stats->ipsec_out_pkts;
-
-		if (!forward_packet(pkt, fwd_tbl, stats))
-			goto err;
-
-		++stats->fwd_pkts;
-	}
-
-	return;
-
-err:
-	odp_packet_free(pkt);
 }
 
 static inline void check_ipsec_status_ev(odp_event_t ev, stats_t *stats)
@@ -1119,19 +1191,20 @@ static void drain_events(void)
 static int process_packets(void *args)
 {
 	thread_config_t *config = args;
-	odp_event_t evs[NUM_EVS];
+	odp_event_t evs[MAX_BURST], ev;
 	int cnt;
-	odp_event_t ev;
 	odp_event_type_t type;
 	odp_event_subtype_t subtype;
-	odp_packet_t pkt;
+	odp_packet_t pkt, pkts_in[MAX_BURST], pkts_ips[MAX_BURST];
 	odph_table_t fwd_tbl = config->prog_config->fwd_tbl;
 	stats_t *stats = &config->stats;
 
 	odp_barrier_wait(&config->prog_config->init_barrier);
 
 	while (odp_atomic_load_u32(&is_running)) {
-		cnt = odp_schedule_multi_no_wait(NULL, evs, NUM_EVS);
+		int num_pkts_in = 0, num_pkts_ips = 0;
+		/* TODO: Add possibility to configure scheduler and ipsec enq/deq burst sizes. */
+		cnt = odp_schedule_multi_no_wait(NULL, evs, MAX_BURST);
 
 		if (cnt == 0)
 			continue;
@@ -1143,9 +1216,9 @@ static int process_packets(void *args)
 
 			if (type == ODP_EVENT_PACKET) {
 				if (subtype == ODP_EVENT_PACKET_BASIC) {
-					process_packet_in(pkt, fwd_tbl, stats);
+					pkts_in[num_pkts_in++] = pkt;
 				} else if (subtype == ODP_EVENT_PACKET_IPSEC) {
-					complete_ipsec_op(pkt, fwd_tbl, stats);
+					pkts_ips[num_pkts_ips++] = pkt;
 				} else {
 					++stats->discards;
 					odp_event_free(ev);
@@ -1157,6 +1230,12 @@ static int process_packets(void *args)
 				odp_event_free(ev);
 			}
 		}
+
+		if (num_pkts_in > 0)
+			process_packets_in(pkts_in, num_pkts_in, fwd_tbl, stats);
+
+		if (num_pkts_ips > 0)
+			complete_ipsec_ops(pkts_ips, num_pkts_ips, fwd_tbl, stats);
 	}
 
 	odp_barrier_wait(&config->prog_config->term_barrier);


### PR DESCRIPTION
Add burst support to packet handling. This enables passing more than a single packet at a time to IPsec processing pipelines, potentially increasing tester throughput.

v2:
- Added a retry logic to IPsec in/out enqueuing

v3:
- Inlined IPsec in/out enqueuing retry logic

v4:
- Rebased
- Added reviewed-by tag