### PR TITLE
[PATCH v2] linux-gen: socket_xdp: fix potential undefined behavior

### DIFF
--- a/platform/linux-generic/pktio/socket_xdp.c
+++ b/platform/linux-generic/pktio/socket_xdp.c
@@ -652,9 +652,9 @@ static void handle_pending_tx(xdp_sock_t *sock, uint8_t *base_addr, int num)
 	compl_q = &sock->compl_q;
 	sent = xsk_ring_cons__peek(compl_q, num, &start_idx);
 
-	odp_packet_t packets[sent];
-
 	if (sent) {
+		odp_packet_t packets[sent];
+
 		for (uint32_t i = 0U; i < sent; ++i) {
 			frame_off = *xsk_ring_cons__comp_addr(compl_q, start_idx++);
 			frame_off = xsk_umem__extract_addr(frame_off);


### PR DESCRIPTION
When handling pending TX descriptors, define array for sent packets only if there actually were packets sent, i.e. corresponding descriptors available in a completion queue.

v2:
- Added reviewed-by tags