### PR TITLE
[PATCH v3] test: cunit: provide option to run tests on control thread

### DIFF
--- a/test/performance/odp_cpu_bench.c
+++ b/test/performance/odp_cpu_bench.c
@@ -26,7 +26,11 @@
 /* Default number of entries in the test lookup table */
 #define DEF_LOOKUP_TBL_SIZE (1024 * 1024)
 
-#define MAX_WORKERS      (ODP_THREAD_COUNT_MAX - 1)
+#define MAX_WORKERS                                                                                \
+	(((ODP_THREAD_COUNT_MAX - 1) > (MAX_GROUPS * QUEUES_PER_GROUP)) ?                          \
+		 (MAX_GROUPS * QUEUES_PER_GROUP) :                                                 \
+		 (ODP_THREAD_COUNT_MAX - 1))
+
 ODP_STATIC_ASSERT(MAX_WORKERS <= MAX_GROUPS * QUEUES_PER_GROUP,
 		  "Not enough queues for all workers");
 


### PR DESCRIPTION
By default run all the tests on worker thread and
provide option to run tests on control thread.

This is needed because control threads will be slower and have less performance w.r.t fast path API.
For example, in our case, control thread will only support packet burst of 1 which would fail pktio_main test
case(pktio_test_recv_queue()) which tries to do burst enqueue of packets.


Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>