### PR TITLE
[PATCH v2] test: perf: l2fwd: fix more dependency to odp_generator

### DIFF
--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -74,6 +74,8 @@ odp_timer_perf_SOURCES = odp_timer_perf.c
 
 # l2fwd test depends on generator example
 EXTRA_odp_l2fwd_DEPENDENCIES = $(top_builddir)/example/generator/odp_generator$(EXEEXT)
+$(top_builddir)/example/generator/odp_generator$(EXEEXT):
+	$(MAKE) -C $(top_builddir)/example/generator odp_generator$(EXEEXT)
 
 dist_check_SCRIPTS = $(TESTSCRIPTS)
 


### PR DESCRIPTION
The previous fix to this does not work when ODP is configured with --without-examples and built out-of-tree (i.e. configure is run in some other directory than ODP base directory).

Fix by adding a recipe to explicitly go to the generator directory to build it.

Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>

v2:
- Re-word subject line.
- Add review tags.
