### PR TITLE
[PATCH v4] api: packet: support additional l3 and l4 protocol types

### DIFF
--- a/include/odp/api/abi-default/packet_types.h
+++ b/include/odp/api/abi-default/packet_types.h
@@ -46,39 +46,6 @@ typedef _odp_abi_packet_tx_compl_t *odp_packet_tx_compl_t;
 #define ODP_PACKET_VECTOR_INVALID   ((odp_packet_vector_t)0)
 #define ODP_PACKET_TX_COMPL_INVALID ((odp_packet_tx_compl_t)0)
 
-typedef uint8_t odp_proto_l2_type_t;
-
-#define ODP_PROTO_L2_TYPE_NONE   0
-#define ODP_PROTO_L2_TYPE_ETH    1
-
-typedef uint8_t odp_proto_l3_type_t;
-
-#define ODP_PROTO_L3_TYPE_NONE   0
-#define ODP_PROTO_L3_TYPE_ARP    1
-#define ODP_PROTO_L3_TYPE_RARP   2
-#define ODP_PROTO_L3_TYPE_MPLS   3
-#define ODP_PROTO_L3_TYPE_IPV4   4
-#define ODP_PROTO_L3_TYPE_IPV6   6
-
-typedef uint8_t odp_proto_l4_type_t;
-
-/* Numbers from IANA Assigned Internet Protocol Numbers list */
-#define ODP_PROTO_L4_TYPE_NONE      0
-#define ODP_PROTO_L4_TYPE_ICMPV4    1
-#define ODP_PROTO_L4_TYPE_IGMP      2
-#define ODP_PROTO_L4_TYPE_IPV4      4
-#define ODP_PROTO_L4_TYPE_TCP       6
-#define ODP_PROTO_L4_TYPE_UDP       17
-#define ODP_PROTO_L4_TYPE_IPV6      41
-#define ODP_PROTO_L4_TYPE_GRE       47
-#define ODP_PROTO_L4_TYPE_ESP       50
-#define ODP_PROTO_L4_TYPE_AH        51
-#define ODP_PROTO_L4_TYPE_ICMPV6    58
-#define ODP_PROTO_L4_TYPE_NO_NEXT   59
-#define ODP_PROTO_L4_TYPE_IPCOMP    108
-#define ODP_PROTO_L4_TYPE_SCTP      132
-#define ODP_PROTO_L4_TYPE_ROHC      142
-
 /** Packet Color */
 typedef enum {
 	ODP_PACKET_GREEN = 0,

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1685,6 +1685,11 @@ odp_proto_l2_type_t odp_packet_l2_type(odp_packet_t pkt);
  *
  * Returns layer 3 protocol type. Initial type value is ODP_PROTO_L3_TYPE_NONE.
  *
+ * In addition to protocol types specified in ODP_PROTO_L3_TYPE_* defines,
+ * the function may also return other L3 protocol types (e.g. from IEEE
+ * EtherTypes list) recognized by the parser. If protocol type is not
+ * recognized, ODP_PROTO_L3_TYPE_NONE is returned.
+ *
  * @param      pkt      Packet handle
  *
  * @return Layer 3 protocol type
@@ -1695,6 +1700,11 @@ odp_proto_l3_type_t odp_packet_l3_type(odp_packet_t pkt);
  * Layer 4 protocol type
  *
  * Returns layer 4 protocol type. Initial type value is ODP_PROTO_L4_TYPE_NONE.
+ *
+ * In addition to protocol types specified in ODP_PROTO_L4_TYPE_* defines,
+ * the function may also return other L4 protocol types (e.g. from IANA protocol
+ * number list) recognized by the parser. If protocol type is not recognized,
+ * ODP_PROTO_L4_TYPE_NONE is returned.
  *
  * @param      pkt      Packet handle
  *

--- a/include/odp/api/spec/packet_types.h
+++ b/include/odp/api/spec/packet_types.h
@@ -89,95 +89,92 @@ extern "C" {
 #define ODP_NUM_PACKET_COLORS 3
 
 /**
- * @typedef odp_proto_l2_type_t
  * Layer 2 protocol type
  */
+typedef uint8_t odp_proto_l2_type_t;
+
+/** Layer 2 protocol type not defined */
+#define ODP_PROTO_L2_TYPE_NONE      0
+
+ /** Layer 2 protocol is Ethernet */
+#define ODP_PROTO_L2_TYPE_ETH       1
 
 /**
- * @def ODP_PROTO_L2_TYPE_NONE
- * Layer 2 protocol type not defined
- *
- * @def ODP_PROTO_L2_TYPE_ETH
- * Layer 2 protocol is Ethernet
- */
-
-/**
- * @typedef odp_proto_l3_type_t
  * Layer 3 protocol type
  */
+typedef uint16_t odp_proto_l3_type_t;
+
+/** Layer 3 protocol type not defined */
+#define ODP_PROTO_L3_TYPE_NONE      0xFFFF
+
+/* Types from IEEE EtherType assignments list */
+
+/** Layer 3 protocol is ARP */
+#define ODP_PROTO_L3_TYPE_ARP       0x0806
+
+/** Layer 3 protocol is RARP */
+#define ODP_PROTO_L3_TYPE_RARP      0x8035
+
+/** Layer 3 protocol is MPLS */
+#define ODP_PROTO_L3_TYPE_MPLS      0x8847
+
+/** Layer 3 protocol type is IPv4 */
+#define ODP_PROTO_L3_TYPE_IPV4      0x0800
+
+/** Layer 3 protocol type is IPv6 */
+#define ODP_PROTO_L3_TYPE_IPV6      0x86DD
 
 /**
- * @def ODP_PROTO_L3_TYPE_NONE
- * Layer 3 protocol type not defined
- *
- * @def ODP_PROTO_L3_TYPE_ARP
- * Layer 3 protocol is ARP
- *
- * @def ODP_PROTO_L3_TYPE_RARP
- * Layer 3 protocol is RARP
- *
- * @def ODP_PROTO_L3_TYPE_MPLS
- * Layer 3 protocol is MPLS
- *
- * @def ODP_PROTO_L3_TYPE_IPV4
- * Layer 3 protocol type is IPv4
- *
- * @def ODP_PROTO_L3_TYPE_IPV6
- * Layer 3 protocol type is IPv6
- */
-
-/**
- * @typedef odp_proto_l4_type_t
  * Layer 4 protocol type
  */
+typedef uint8_t odp_proto_l4_type_t;
 
-/**
- * @def ODP_PROTO_L4_TYPE_NONE
- * Layer 4 protocol type not defined
- *
- * @def ODP_PROTO_L4_TYPE_ICMPV4
- * Layer 4 protocol type is ICMPv4
- *
- * @def ODP_PROTO_L4_TYPE_IGMP
- * Layer 4 protocol type is IGMP
- *
- * @def ODP_PROTO_L4_TYPE_IPV4
- * Layer 4 protocol type is IPv4
- *
- * @def ODP_PROTO_L4_TYPE_TCP
- * Layer 4 protocol type is TCP
- *
- * @def ODP_PROTO_L4_TYPE_UDP
- * Layer 4 protocol type is UDP
- *
- * @def ODP_PROTO_L4_TYPE_IPV6
- * Layer 4 protocol type is IPv6
- *
- * @def ODP_PROTO_L4_TYPE_GRE
- * Layer 4 protocol type is GRE
- *
- * @def ODP_PROTO_L4_TYPE_ESP
- * Layer 4 protocol type is IPSEC ESP
- *
- * @def ODP_PROTO_L4_TYPE_AH
- * Layer 4 protocol type is IPSEC AH
- *
- * @def ODP_PROTO_L4_TYPE_ICMPV6
- * Layer 4 protocol type is ICMPv6
- *
- * @def ODP_PROTO_L4_TYPE_NO_NEXT
- * Layer 4 protocol type is "No Next Header".
- * Protocol / next header number is 59.
- *
- * @def ODP_PROTO_L4_TYPE_IPCOMP
- * Layer 4 protocol type is IP Payload Compression Protocol
- *
- * @def ODP_PROTO_L4_TYPE_SCTP
- * Layer 4 protocol type is SCTP
- *
- * @def ODP_PROTO_L4_TYPE_ROHC
- * Layer 4 protocol type is ROHC
- */
+/** Layer 4 protocol type not defined */
+ #define ODP_PROTO_L4_TYPE_NONE     255
+
+/* Types from IANA assigned Internet protocol numbers list */
+
+/** Layer 4 protocol type is ICMPv4 */
+ #define ODP_PROTO_L4_TYPE_ICMPV4   1
+
+/** Layer 4 protocol type is IGMP */
+#define ODP_PROTO_L4_TYPE_IGMP      2
+
+/** Layer 4 protocol type is IPv4 */
+#define ODP_PROTO_L4_TYPE_IPV4      4
+
+/** Layer 4 protocol type is TCP */
+ #define ODP_PROTO_L4_TYPE_TCP      6
+
+/** Layer 4 protocol type is UDP */
+#define ODP_PROTO_L4_TYPE_UDP       17
+
+/** Layer 4 protocol type is IPv6 */
+#define ODP_PROTO_L4_TYPE_IPV6      41
+
+/** Layer 4 protocol type is GRE */
+#define ODP_PROTO_L4_TYPE_GRE       47
+
+/** Layer 4 protocol type is IPSEC ESP */
+#define ODP_PROTO_L4_TYPE_ESP       50
+
+/** Layer 4 protocol type is IPSEC AH */
+#define ODP_PROTO_L4_TYPE_AH        51
+
+/** Layer 4 protocol type is ICMPv6 */
+#define ODP_PROTO_L4_TYPE_ICMPV6    58
+
+/** Layer 4 protocol type is No Next Header for IPv6 */
+#define ODP_PROTO_L4_TYPE_NO_NEXT   59
+
+/** Layer 4 protocol type is IP Payload Compression Protocol */
+#define ODP_PROTO_L4_TYPE_IPCOMP    108
+
+/** Layer 4 protocol type is SCTP */
+#define ODP_PROTO_L4_TYPE_SCTP      132
+
+/** Layer 4 protocol type is ROHC */
+#define ODP_PROTO_L4_TYPE_ROHC      142
 
 /**
  * @typedef odp_packet_chksum_status_t

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_types.h
@@ -49,39 +49,6 @@ typedef ODP_HANDLE_T(odp_packet_tx_compl_t);
 
 #define ODP_PACKET_OFFSET_INVALID 0xffff
 
-typedef uint8_t odp_proto_l2_type_t;
-
-#define ODP_PROTO_L2_TYPE_NONE   0
-#define ODP_PROTO_L2_TYPE_ETH    1
-
-typedef uint8_t odp_proto_l3_type_t;
-
-#define ODP_PROTO_L3_TYPE_NONE   0
-#define ODP_PROTO_L3_TYPE_ARP    1
-#define ODP_PROTO_L3_TYPE_RARP   2
-#define ODP_PROTO_L3_TYPE_MPLS   3
-#define ODP_PROTO_L3_TYPE_IPV4   4
-#define ODP_PROTO_L3_TYPE_IPV6   6
-
-typedef uint8_t odp_proto_l4_type_t;
-
-/* Numbers from IANA Assigned Internet Protocol Numbers list */
-#define ODP_PROTO_L4_TYPE_NONE      0
-#define ODP_PROTO_L4_TYPE_ICMPV4    1
-#define ODP_PROTO_L4_TYPE_IGMP      2
-#define ODP_PROTO_L4_TYPE_IPV4      4
-#define ODP_PROTO_L4_TYPE_TCP       6
-#define ODP_PROTO_L4_TYPE_UDP       17
-#define ODP_PROTO_L4_TYPE_IPV6      41
-#define ODP_PROTO_L4_TYPE_GRE       47
-#define ODP_PROTO_L4_TYPE_ESP       50
-#define ODP_PROTO_L4_TYPE_AH        51
-#define ODP_PROTO_L4_TYPE_ICMPV6    58
-#define ODP_PROTO_L4_TYPE_NO_NEXT   59
-#define ODP_PROTO_L4_TYPE_IPCOMP    108
-#define ODP_PROTO_L4_TYPE_SCTP      132
-#define ODP_PROTO_L4_TYPE_ROHC      142
-
 typedef enum {
 	ODP_PACKET_GREEN = 0,
 	ODP_PACKET_YELLOW = 1,


### PR DESCRIPTION
Move odp_proto_l2_type_t, odp_proto_l3_type_t, and odp_proto_l4_type_t types and defines from ABI to API header. L3 protocol type define values have been changed to match actual EtherType values. The size of odp_proto_l3_type_t is increased to accommodate this.

Allow odp_packet_l3_type() and odp_packet_l4_type() functions to return also other protocol types than the ones defined in ODP_PROTO_L3_TYPE_* and ODP_PROTO_L4_TYPE_* defines. This enables implementations to support additional protocols without having to add each one to the ODP API.

Signed-off-by: Matias Elo <matias.elo@nokia.com>