### PR TITLE
[PATCH v7] api: memory usage debug info

### DIFF
--- a/include/odp/api/abi-default/shared_memory.h
+++ b/include/odp/api/abi-default/shared_memory.h
@@ -23,6 +23,9 @@ typedef _odp_abi_shm_t *odp_shm_t;
 #define ODP_SHM_INVALID   ((odp_shm_t)0)
 #define ODP_SHM_NAME_LEN  32
 
+#define ODP_SHM_IOVA_INVALID ((uint64_t)-1)
+#define ODP_SHM_PA_INVALID   ODP_SHM_IOVA_INVALID
+
 /**
  * @}
  */

--- a/include/odp/api/spec/shared_memory.h
+++ b/include/odp/api/spec/shared_memory.h
@@ -40,8 +40,6 @@ extern "C" {
  * Maximum shared memory block name length in chars including null char
  */
 
- /* Shared memory flags */
-
 /**
  * @def ODP_SHM_IOVA_INVALID
  * Invalid IOVA address
@@ -217,22 +215,25 @@ int odp_shm_capability(odp_shm_capability_t *capa);
  * Reserve a contiguous block of shared memory
  *
  * Reserve a contiguous block of shared memory that fulfills size, alignment
- * and shareability (ODP_SHM_* flags) requirements. In general, a name is
- * optional and does not need to be unique. However, if the block will be
+ * and shareability (ODP_SHM_* flags) requirements. By default (without flags), the memory
+ * block can be shared between all threads of the ODP instance. Memory address (odp_shm_addr())
+ * shareability depends on application memory model and #ODP_SHM_SINGLE_VA flag usage.
+ *
+ * Name is optional and does not need to be unique. However, if the block will be
  * searched with odp_shm_lookup() or odp_shm_import(), a unique name is needed
  * for correct match.
  *
- * @param name   Name of the block or NULL. Maximum string length is
- *               ODP_SHM_NAME_LEN.
+ * @param name   Name of the block or NULL. Maximum string length is ODP_SHM_NAME_LEN.
  * @param size   Block size in bytes
  * @param align  Block alignment in bytes
  * @param flags  Shared memory parameter flags (ODP_SHM_*). Default value is 0.
  *
  * @return Handle of the reserved block
  * @retval ODP_SHM_INVALID on failure
+ *
+ * @see odp_mem_model_t
  */
-odp_shm_t odp_shm_reserve(const char *name, uint64_t size, uint64_t align,
-			  uint32_t flags);
+odp_shm_t odp_shm_reserve(const char *name, uint64_t size, uint64_t align, uint32_t flags);
 
 /**
  * Free a contiguous block of shared memory
@@ -293,9 +294,7 @@ void *odp_shm_addr(odp_shm_t shm);
 /**
  * Shared memory block info
  *
- * Get information about the specified shared memory block. This is the only
- * shared memory API function which accepts invalid shm handles (any bit value)
- * without causing undefined behavior.
+ * Get information about the specified shared memory block.
  *
  * @param      shm   Block handle
  * @param[out] info  Block info pointer for output

--- a/include/odp/api/spec/shared_memory.h
+++ b/include/odp/api/spec/shared_memory.h
@@ -43,6 +43,16 @@ extern "C" {
  /* Shared memory flags */
 
 /**
+ * @def ODP_SHM_IOVA_INVALID
+ * Invalid IOVA address
+ */
+
+/**
+ * @def ODP_SHM_PA_INVALID
+ * Invalid physical address
+ */
+
+/**
  * Application SW only, no HW access
  *
  * @deprecated  When set, application will not share the reserved memory with HW
@@ -123,7 +133,41 @@ typedef struct odp_shm_info_t {
 
 	/** ODP_SHM_* flags */
 	uint32_t    flags;
+
+	/**
+	 * Number of memory segments
+	 *
+	 * Number of segments in physical (or IOVA) address space that map memory to
+	 * the SHM block. More information about each segment can be retrieved with
+	 * odp_shm_segment_info(). Number of segments is always at least one, also when
+	 * physical (or IOVA) segmentation information is not available. */
+	uint32_t num_seg;
+
 } odp_shm_info_t;
+
+/**
+ * SHM memory segment info
+ */
+typedef struct odp_shm_segment_info_t {
+	/** Segment start address (virtual) */
+	uintptr_t addr;
+
+	/** Segment start address in IO virtual address (IOVA) space
+	 *
+	 *  Value is ODP_SHM_IOVA_INVALID when IOVA address is not available.
+	 */
+	uint64_t iova;
+
+	/** Segment start address in physical address space
+	 *
+	 *  Value is ODP_SHM_PA_INVALID when physical address is not available.
+	 */
+	uint64_t pa;
+
+	/** Segment length in bytes */
+	uint64_t len;
+
+} odp_shm_segment_info_t;
 
 /**
  * Shared memory capabilities
@@ -260,6 +304,27 @@ void *odp_shm_addr(odp_shm_t shm);
  * @retval <0 on failure
  */
 int odp_shm_info(odp_shm_t shm, odp_shm_info_t *info);
+
+/**
+ * SHM block segmentation information
+ *
+ * Retrieve information about each memory segment of an SHM block. SHM info call outputs the number
+ * of memory segments (@see odp_shm_info_t.num_seg). A single segment info call may be used
+ * to request information for all the segments, or for a subset of those. Use 'index' and 'num'
+ * parameters to specify the segments. Segment indexing starts from zero and continues to
+ * odp_shm_info_t.num_seg - 1. Segment infos are written in virtual memory address order and
+ * without address overlaps. Segment info array must have at least 'num' elements.
+ *
+ * @param      shm    SHM block handle
+ * @param      index  Index of the first segment to retrieve information
+ * @param      num    Number of segments to retrieve information
+ * @param[out] info   Segment info array for output
+ *
+ * @retval 0 on success
+ * @retval <0 on failure
+ */
+int odp_shm_segment_info(odp_shm_t shm, uint32_t index, uint32_t num,
+			 odp_shm_segment_info_t info[]);
 
 /**
  * Print all shared memory blocks

--- a/include/odp/api/spec/system_info.h
+++ b/include/odp/api/spec/system_info.h
@@ -24,6 +24,9 @@ extern "C" {
  *  @{
  */
 
+/** Maximum memory block name length in chars (including null char) */
+#define ODP_SYSTEM_MEMBLOCK_NAME_LEN 64
+
 /**
  * CPU instruction set architecture (ISA) families
  */
@@ -192,6 +195,70 @@ typedef struct odp_system_info_t {
 } odp_system_info_t;
 
 /**
+ * Memory information
+ */
+typedef struct odp_system_meminfo_t {
+	/**
+	 * Total mapped memory
+	 *
+	 * Total amount of memory (in bytes) in all memory pages that are reserved by
+	 * this ODP instance from the system.
+	 */
+	uint64_t total_mapped;
+
+	/**
+	 * Total memory usage
+	 *
+	 * Total amount of memory (in bytes) that is currently in use by this ODP instance.
+	 * This is a subset of 'total_mapped' bytes.
+	 */
+	uint64_t total_used;
+
+	/**
+	 * Total memory usage overheads
+	 *
+	 * Total amount of memory (in bytes) that is currently consumed by roundings to
+	 * alignment/block/page size limits, etc. overheads. This is a subset of 'total_used'
+	 * bytes.
+	 */
+	uint64_t total_overhead;
+
+} odp_system_meminfo_t;
+
+/**
+ * Memory block information
+ */
+typedef struct odp_system_memblock_t {
+	/** Memory block name */
+	char name[ODP_SYSTEM_MEMBLOCK_NAME_LEN];
+
+	/** Start address of the block */
+	uintptr_t addr;
+
+	/**
+	 * Memory usage
+	 *
+	 * Total amount of memory (in bytes) that is used by this block.
+	 */
+	uint64_t used;
+
+	/**
+	 * Memory usage overheads
+	 *
+	 * Total amount of memory (in bytes) that is currently consumed by rounding to
+	 * alignment/block/page size limits, etc. overheads. This is a subset of 'used' bytes.
+	 */
+	uint64_t overhead;
+
+	/** Memory page size in bytes
+	 *
+	 *  Page size used for this block.
+	 */
+	uint64_t page_size;
+
+} odp_system_memblock_t;
+
+/**
  * Retrieve system information
  *
  * Fills in system information structure on success. The call is not intended
@@ -203,6 +270,27 @@ typedef struct odp_system_info_t {
  * @retval <0 on failure
  */
 int odp_system_info(odp_system_info_t *info);
+
+/**
+ * Retrieve ODP memory usage information
+ *
+ * Retrieves information about ODP memory usage for debugging and monitoring purposes. A successful
+ * call fills in system memory info and outputs up to 'num' elements into memory block info array.
+ * Each array element represents a memory block used due to an API call (SHM reservation, pool
+ * creation, etc) or an implementation internal memory allocation.
+ *
+ * When return value is 'num' or less, it indicates the number of elements written. If return value
+ * is larger than 'num', all 'num' elements were written and the return value indicates the number
+ * of elements that would have been written into a large enough array.
+ *
+ * @param[out] info     Pointer to memory info struct for output
+ * @param[out] block    Pointer memory block info array for output
+ * @param      num      Maximum number of array elements to output (0 ... array size)
+ *
+ * @return  Number of array elements written / would have been written
+ * @retval <0 on failure
+ */
+int32_t odp_system_meminfo(odp_system_meminfo_t *info, odp_system_memblock_t block[], int32_t num);
 
 /**
  * Default system huge page size in bytes

--- a/platform/linux-generic/include-abi/odp/api/abi/shared_memory.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/shared_memory.h
@@ -31,6 +31,9 @@ typedef ODP_HANDLE_T(odp_shm_t);
 
 #define ODP_SHM_NAME_LEN 32
 
+#define ODP_SHM_IOVA_INVALID ((uint64_t)-1)
+#define ODP_SHM_PA_INVALID   ODP_SHM_IOVA_INVALID
+
 /**
  * @}
  */

--- a/platform/linux-generic/odp_shared_memory.c
+++ b/platform/linux-generic/odp_shared_memory.c
@@ -124,6 +124,31 @@ int odp_shm_info(odp_shm_t shm, odp_shm_info_t *info)
 	info->size = ishm_info.size;
 	info->page_size = ishm_info.page_size;
 	info->flags = ishm_info.user_flags;
+	info->num_seg = 1;
+
+	return 0;
+}
+
+int odp_shm_segment_info(odp_shm_t shm, uint32_t index, uint32_t num,
+			 odp_shm_segment_info_t seg_info[])
+{
+	odp_shm_info_t info;
+
+	/* No physical memory segment information available */
+	if (index != 0 || num != 1) {
+		_ODP_ERR("Only single segment supported (%u, %u)\n", index, num);
+		return -1;
+	}
+
+	if (odp_shm_info(shm, &info)) {
+		_ODP_ERR("SHM info call failed\n");
+		return -1;
+	}
+
+	seg_info[0].addr = (uintptr_t)info.addr;
+	seg_info[0].iova = ODP_SHM_IOVA_INVALID;
+	seg_info[0].pa   = ODP_SHM_PA_INVALID;
+	seg_info[0].len  = info.size;
 
 	return 0;
 }

--- a/test/validation/api/system/system.c
+++ b/test/validation/api/system/system.c
@@ -579,6 +579,51 @@ static void system_test_info(void)
 	}
 }
 
+static void system_test_meminfo(void)
+{
+	const int32_t max_num = 128;
+	odp_system_meminfo_t info, info_0;
+	int32_t ret, ret_0, num, i;
+	odp_system_memblock_t block[max_num];
+
+	/* Meminfo without blocks */
+	ret_0 = odp_system_meminfo(&info_0, NULL, 0);
+	CU_ASSERT_FATAL(ret_0 >= 0);
+
+	ret = odp_system_meminfo(&info, block, max_num);
+	CU_ASSERT_FATAL(ret >= 0);
+
+	/* Totals should match independent of per block output */
+	CU_ASSERT(ret == ret_0);
+	CU_ASSERT(info_0.total_mapped == info.total_mapped);
+	CU_ASSERT(info_0.total_used == info.total_used);
+	CU_ASSERT(info_0.total_overhead == info.total_overhead);
+
+	CU_ASSERT(info.total_mapped >= info.total_used);
+	CU_ASSERT(info.total_used >= info.total_overhead);
+
+	num = ret;
+	if (ret > max_num)
+		num = max_num;
+
+	printf("\n\n");
+	printf("System meminfo contain %i blocks, printing %i blocks:\n", ret, num);
+
+	printf("  %s %-32s %16s %14s %14s %12s\n", "index", "name", "addr",
+	       "used", "overhead", "page_size");
+
+	for (i = 0; i < num; i++) {
+		printf("  [%3i] %-32s %16" PRIxPTR " %14" PRIu64 " %14" PRIu64 " %12" PRIu64 "\n",
+		       i, block[i].name, block[i].addr, block[i].used, block[i].overhead,
+		       block[i].page_size);
+	}
+
+	printf("\n");
+	printf("Total mapped:   %" PRIu64 "\n", info.total_mapped);
+	printf("Total used:     %" PRIu64 "\n", info.total_used);
+	printf("Total overhead: %" PRIu64 "\n\n", info.total_overhead);
+}
+
 odp_testinfo_t system_suite[] = {
 	ODP_TEST_INFO(test_version_api_str),
 	ODP_TEST_INFO(test_version_str),
@@ -609,6 +654,7 @@ odp_testinfo_t system_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(system_test_cpu_cycles_long_period,
 				  system_check_cycle_counter),
 	ODP_TEST_INFO(system_test_info),
+	ODP_TEST_INFO(system_test_meminfo),
 	ODP_TEST_INFO(system_test_info_print),
 	ODP_TEST_INFO(system_test_config_print),
 	ODP_TEST_INFO_NULL,


### PR DESCRIPTION
Adds new system and SHM API functions which can be used to monitor/debug ODP instance memory usage.

v2: updated documentation of odp_shm_reserve() operation without flags (3rd commit)
v3: added system meminfo implementation and test
v4: added odp_shm_segment_info() implementation and test
v6: Moved IOVA/PA_INVALID defines to ABI file. Use defines in implementation and test.