### PR TITLE
[PATCH v6] api: pktio: PFC support

### DIFF
--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -405,6 +405,15 @@ typedef struct odp_bp_param_t {
 	 */
 	odp_threshold_t threshold;
 
+	/**
+	 * PFC priority level
+	 *
+	 * When enabled (#ODP_PKTIO_LINK_PFC_ON), PFC frames are generated when the above
+	 * threshold is exceeded. The generated frames request the receiver to temporary halt
+	 * transmission of traffic on this priority level (0 .. 7).
+	 */
+	uint8_t pfc_level;
+
 } odp_bp_param_t;
 
 /**

--- a/include/odp/api/spec/packet_io_types.h
+++ b/include/odp/api/spec/packet_io_types.h
@@ -562,6 +562,19 @@ typedef struct odp_pktio_parser_config_t {
 
 } odp_pktio_parser_config_t;
 
+/** Ethernet flow control modes */
+typedef enum odp_pktio_link_pause_t {
+	/** Flow control mode is unknown */
+	ODP_PKTIO_LINK_PAUSE_UNKNOWN = -1,
+	/** No flow control */
+	ODP_PKTIO_LINK_PAUSE_OFF = 0,
+	/** Pause frame flow control enabled */
+	ODP_PKTIO_LINK_PAUSE_ON = 1,
+	/** Priority-based Flow Control (PFC) enabled */
+	ODP_PKTIO_LINK_PFC_ON = 2
+
+} odp_pktio_link_pause_t;
+
 /**
  * Packet IO configuration options
  *
@@ -1079,13 +1092,6 @@ typedef enum odp_pktio_link_duplex_t {
 	ODP_PKTIO_LINK_DUPLEX_FULL = 1
 
 } odp_pktio_link_duplex_t;
-
-/** Ethernet pause frame (flow control) mode */
-typedef enum odp_pktio_link_pause_t {
-	ODP_PKTIO_LINK_PAUSE_UNKNOWN = -1,
-	ODP_PKTIO_LINK_PAUSE_OFF = 0,
-	ODP_PKTIO_LINK_PAUSE_ON  = 1
-} odp_pktio_link_pause_t;
 
 /**
  * Packet IO link information

--- a/include/odp/api/spec/packet_io_types.h
+++ b/include/odp/api/spec/packet_io_types.h
@@ -659,6 +659,47 @@ typedef struct odp_pktio_config_t {
 	/** Packet input reassembly configuration */
 	odp_reass_config_t reassembly;
 
+	/** Link flow control configuration */
+	struct {
+		/** Reception of flow control frames
+		 *
+		 *  Configures interface operation when an Ethernet flow control frame is received:
+		 *    * ODP_PKTIO_LINK_PAUSE_OFF:  Flow control is disabled
+		 *    * ODP_PKTIO_LINK_PAUSE_ON:   Enable traditional Ethernet pause frame handling.
+		 *                                 When a pause frame is received, all packet output
+		 *                                 is halted temporarily.
+		 *    * ODP_PKTIO_LINK_PFC_ON:     Enable Priority-based Flow Control (PFC)
+		 *                                 handling. When a PFC frame is received, packet
+		 *                                 output of certain (VLAN) class of service levels
+		 *                                 are halted temporarily.
+		 *
+		 *  The default value is ODP_PKTIO_LINK_PAUSE_OFF.
+		 */
+		odp_pktio_link_pause_t pause_rx;
+
+		/** Transmission of flow control frames
+		 *
+		 *  Configures Ethernet flow control frame generation on the interface:
+		 *    * ODP_PKTIO_LINK_PAUSE_OFF:  Flow control is disabled
+		 *    * ODP_PKTIO_LINK_PAUSE_ON:   Enable traditional Ethernet pause frame
+		 *                                 generation. Pause frames are generated to request
+		 *                                 the remote end of the link to halt all
+		 *                                 transmissions temporarily.
+		 *    * ODP_PKTIO_LINK_PFC_ON:     Enable Priority-based Flow Control (PFC) frame
+		 *                                 generation. PFC frames are generated to request
+		 *                                 the remote end of the link to halt transmission
+		 *                                 of certain (VLAN) class of service levels
+		 *                                 temporarily.
+		 *
+		 *  When PFC is enabled, classifier API is used to configure CoS nodes with back
+		 *  pressure threshold and PFC priority level parameters (odp_bp_param_t).
+		 *
+		 *  The default value is ODP_PKTIO_LINK_PAUSE_OFF.
+		 */
+		odp_pktio_link_pause_t pause_tx;
+
+	} flow_control;
+
 } odp_pktio_config_t;
 
 /**
@@ -957,6 +998,22 @@ typedef struct odp_pktio_capability_t {
 
 	/** Statistics counters capabilities */
 	odp_pktio_stats_capability_t stats;
+
+	/** Supported flow control modes */
+	struct {
+		/** Reception of traditional Ethernet pause frames */
+		uint32_t pause_rx: 1;
+
+		/** Reception of PFC frames */
+		uint32_t pfc_rx: 1;
+
+		/** Generation of traditional Ethernet pause frames */
+		uint32_t pause_tx: 1;
+
+		/** Generation of PFC frames */
+		uint32_t pfc_tx: 1;
+
+	} flow_control;
 
 } odp_pktio_capability_t;
 

--- a/include/odp/api/spec/packet_io_types.h
+++ b/include/odp/api/spec/packet_io_types.h
@@ -992,9 +992,13 @@ typedef struct odp_lso_profile_param_t {
 
 /** Link status */
 typedef enum odp_pktio_link_status_t {
+	/** Link status is unknown */
 	ODP_PKTIO_LINK_STATUS_UNKNOWN = -1,
+	/** Link status is down */
 	ODP_PKTIO_LINK_STATUS_DOWN = 0,
+	/** Link status is up */
 	ODP_PKTIO_LINK_STATUS_UP = 1
+
 } odp_pktio_link_status_t;
 
 /**
@@ -1062,13 +1066,18 @@ typedef enum odp_pktio_link_autoneg_t {
 	ODP_PKTIO_LINK_AUTONEG_OFF = 0,
 	/** Autonegotiation enabled */
 	ODP_PKTIO_LINK_AUTONEG_ON  = 1
+
 } odp_pktio_link_autoneg_t;
 
 /** Duplex mode */
 typedef enum odp_pktio_link_duplex_t {
+	/** Link duplex mode is unknown */
 	ODP_PKTIO_LINK_DUPLEX_UNKNOWN = -1,
+	/** Half duplex mode */
 	ODP_PKTIO_LINK_DUPLEX_HALF = 0,
+	/** Full duplex mode */
 	ODP_PKTIO_LINK_DUPLEX_FULL = 1
+
 } odp_pktio_link_duplex_t;
 
 /** Ethernet pause frame (flow control) mode */

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -602,6 +602,12 @@ int odp_pktio_config(odp_pktio_t hdl, const odp_pktio_config_t *config)
 		return -1;
 	}
 
+	if (config->flow_control.pause_rx != ODP_PKTIO_LINK_PAUSE_OFF ||
+	    config->flow_control.pause_tx != ODP_PKTIO_LINK_PAUSE_OFF) {
+		_ODP_ERR("Link flow control is not supported\n");
+		return -1;
+	}
+
 	lock_entry(entry);
 	if (entry->state == PKTIO_STATE_STARTED) {
 		unlock_entry(entry);
@@ -1509,6 +1515,8 @@ void odp_pktio_config_init(odp_pktio_config_t *config)
 
 	config->parser.layer = ODP_PROTO_LAYER_ALL;
 	config->reassembly.max_num_frags = 2;
+	config->flow_control.pause_rx = ODP_PKTIO_LINK_PAUSE_OFF;
+	config->flow_control.pause_tx = ODP_PKTIO_LINK_PAUSE_OFF;
 }
 
 int odp_pktio_info(odp_pktio_t hdl, odp_pktio_info_t *info)
@@ -1813,6 +1821,10 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 	capa->reassembly.ip = false;
 	capa->reassembly.ipv4 = false;
 	capa->reassembly.ipv6 = false;
+	capa->flow_control.pause_rx = 0;
+	capa->flow_control.pfc_rx = 0;
+	capa->flow_control.pause_tx = 0;
+	capa->flow_control.pfc_tx = 0;
 
 	return ret;
 }

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1750,6 +1750,8 @@ static void pktio_test_pktio_config(void)
 	CU_ASSERT(!config.reassembly.en_ipv6);
 	CU_ASSERT(config.reassembly.max_wait_time == 0);
 	CU_ASSERT(config.reassembly.max_num_frags == 2);
+	CU_ASSERT(config.flow_control.pause_rx == ODP_PKTIO_LINK_PAUSE_OFF);
+	CU_ASSERT(config.flow_control.pause_tx == ODP_PKTIO_LINK_PAUSE_OFF);
 
 	/* Indicate packet refs might be used */
 	config.pktout.bit.no_packet_refs = 0;
@@ -1823,11 +1825,13 @@ static void pktio_test_link_info(void)
 			  link_info.duplex == ODP_PKTIO_LINK_DUPLEX_HALF ||
 			  link_info.duplex == ODP_PKTIO_LINK_DUPLEX_FULL);
 		CU_ASSERT(link_info.pause_rx == ODP_PKTIO_LINK_PAUSE_UNKNOWN ||
+			  link_info.pause_rx == ODP_PKTIO_LINK_PAUSE_OFF ||
 			  link_info.pause_rx == ODP_PKTIO_LINK_PAUSE_ON ||
-			  link_info.pause_rx == ODP_PKTIO_LINK_PAUSE_OFF);
+			  link_info.pause_rx == ODP_PKTIO_LINK_PFC_ON);
 		CU_ASSERT(link_info.pause_tx == ODP_PKTIO_LINK_PAUSE_UNKNOWN ||
+			  link_info.pause_tx == ODP_PKTIO_LINK_PAUSE_OFF ||
 			  link_info.pause_tx == ODP_PKTIO_LINK_PAUSE_ON ||
-			  link_info.pause_tx == ODP_PKTIO_LINK_PAUSE_OFF);
+			  link_info.pause_tx == ODP_PKTIO_LINK_PFC_ON);
 		CU_ASSERT(link_info.status == ODP_PKTIO_LINK_STATUS_UNKNOWN ||
 			  link_info.status == ODP_PKTIO_LINK_STATUS_UP ||
 			  link_info.status == ODP_PKTIO_LINK_STATUS_DOWN);

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1843,6 +1843,242 @@ static void pktio_test_link_info(void)
 	}
 }
 
+static int pktio_check_flow_control(int pfc, int rx)
+{
+	odp_pktio_t pktio;
+	odp_pktio_capability_t capa;
+	odp_pktio_param_t pktio_param;
+	int ret;
+
+	odp_pktio_param_init(&pktio_param);
+	pktio_param.in_mode = ODP_PKTIN_MODE_SCHED;
+
+	pktio = odp_pktio_open(iface_name[0], pool[0], &pktio_param);
+	if (pktio == ODP_PKTIO_INVALID)
+		return ODP_TEST_INACTIVE;
+
+	ret = odp_pktio_capability(pktio, &capa);
+	(void)odp_pktio_close(pktio);
+
+	if (ret < 0)
+		return ODP_TEST_INACTIVE;
+
+	if (pfc == 0 && rx == 1 && capa.flow_control.pause_rx == 1)
+		return ODP_TEST_ACTIVE;
+
+	if (pfc == 1 && rx == 1 && capa.flow_control.pfc_rx == 1)
+		return ODP_TEST_ACTIVE;
+
+	if (pfc == 0 && rx == 0 && capa.flow_control.pause_tx == 1)
+		return ODP_TEST_ACTIVE;
+
+	if (pfc == 1 && rx == 0 && capa.flow_control.pfc_tx == 1)
+		return ODP_TEST_ACTIVE;
+
+	return ODP_TEST_INACTIVE;
+}
+
+static int pktio_check_pause_rx(void)
+{
+	return pktio_check_flow_control(0, 1);
+}
+
+static int pktio_check_pause_tx(void)
+{
+	return pktio_check_flow_control(0, 0);
+}
+
+static int pktio_check_pause_both(void)
+{
+	int rx = pktio_check_pause_rx();
+	int tx = pktio_check_pause_tx();
+
+	if (rx == ODP_TEST_ACTIVE && tx == ODP_TEST_ACTIVE)
+		return ODP_TEST_ACTIVE;
+
+	return ODP_TEST_INACTIVE;
+}
+
+static int pktio_check_pfc_rx(void)
+{
+	return pktio_check_flow_control(1, 1);
+}
+
+static int pktio_check_pfc_tx(void)
+{
+	return pktio_check_flow_control(1, 0);
+}
+
+static int pktio_check_pfc_both(void)
+{
+	int rx = pktio_check_pfc_rx();
+	int tx = pktio_check_pfc_tx();
+
+	if (rx == ODP_TEST_ACTIVE && tx == ODP_TEST_ACTIVE)
+		return ODP_TEST_ACTIVE;
+
+	return ODP_TEST_INACTIVE;
+}
+
+static odp_cos_t set_default_cos(odp_pktio_t pktio, odp_queue_t queue)
+{
+	odp_cls_cos_param_t cos_param;
+	odp_cos_t cos;
+	int ret;
+
+	odp_cls_cos_param_init(&cos_param);
+	cos_param.queue = queue;
+	cos_param.pool  = pool[0];
+
+	cos = odp_cls_cos_create("Default CoS", &cos_param);
+	CU_ASSERT_FATAL(cos != ODP_COS_INVALID);
+
+	ret = odp_pktio_default_cos_set(pktio, cos);
+	CU_ASSERT_FATAL(ret == 0);
+
+	return cos;
+}
+
+static odp_cos_t create_pfc_cos(odp_cos_t default_cos, odp_queue_t queue, odp_pmr_t *pmr_out)
+{
+	odp_cls_cos_param_t cos_param;
+	odp_cos_t cos;
+	odp_pmr_param_t pmr_param;
+	odp_pmr_t pmr;
+	uint8_t pcp = 1;
+	uint8_t mask = 0x7;
+
+	/* Setup a CoS to control generation of PFC frame generation. PFC for the VLAN
+	 * priority level is generated when queue/pool resource usage gets above 80%. */
+	odp_cls_cos_param_init(&cos_param);
+	cos_param.queue = queue;
+	cos_param.pool = pool[0];
+	cos_param.bp.enable = 1;
+	cos_param.bp.threshold.type = ODP_THRESHOLD_PERCENT;
+	cos_param.bp.threshold.percent.max = 80;
+	cos_param.bp.pfc_level = pcp;
+
+	cos = odp_cls_cos_create("PFC CoS", &cos_param);
+	CU_ASSERT_FATAL(cos != ODP_COS_INVALID);
+
+	odp_cls_pmr_param_init(&pmr_param);
+	pmr_param.term        = ODP_PMR_VLAN_PCP_0;
+	pmr_param.match.value = &pcp;
+	pmr_param.match.mask  = &mask;
+	pmr_param.val_sz      = 1;
+
+	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
+	CU_ASSERT_FATAL(pmr != ODP_PMR_INVALID);
+
+	*pmr_out = pmr;
+
+	return cos;
+}
+
+static void pktio_config_flow_control(int pfc, int rx, int tx)
+{
+	odp_pktio_t pktio;
+	odp_pktio_config_t config;
+	int ret;
+	odp_cos_t default_cos = ODP_COS_INVALID;
+	odp_cos_t cos = ODP_COS_INVALID;
+	odp_pmr_t pmr = ODP_PMR_INVALID;
+	odp_queue_t queue = ODP_QUEUE_INVALID;
+	odp_pktio_link_pause_t mode = ODP_PKTIO_LINK_PAUSE_ON;
+
+	pktio = create_pktio(0, ODP_PKTIN_MODE_SCHED, ODP_PKTOUT_MODE_DIRECT);
+	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
+
+	odp_pktio_config_init(&config);
+
+	if (pfc)
+		mode = ODP_PKTIO_LINK_PFC_ON;
+
+	if (rx)
+		config.flow_control.pause_rx = mode;
+
+	if (tx)
+		config.flow_control.pause_tx = mode;
+
+	ret = odp_pktio_config(pktio, &config);
+	CU_ASSERT_FATAL(ret == 0);
+
+	if (pfc && tx) {
+		/* Enable classifier for PFC backpressure configuration. Overrides previous
+		 * pktin queue config. */
+		odp_pktin_queue_param_t pktin_param;
+
+		odp_pktin_queue_param_init(&pktin_param);
+
+		pktin_param.classifier_enable = 1;
+
+		ret = odp_pktin_queue_config(pktio, &pktin_param);
+		CU_ASSERT_FATAL(ret == 0);
+	}
+
+	ret = odp_pktio_start(pktio);
+	CU_ASSERT(ret == 0);
+
+	if (pfc && tx) {
+		odp_queue_param_t qparam;
+
+		odp_queue_param_init(&qparam);
+		qparam.type = ODP_QUEUE_TYPE_SCHED;
+
+		queue = odp_queue_create("CoS queue", &qparam);
+		CU_ASSERT_FATAL(queue != ODP_QUEUE_INVALID);
+
+		default_cos = set_default_cos(pktio, queue);
+
+		cos = create_pfc_cos(default_cos, queue, &pmr);
+	}
+
+	if (pmr != ODP_PMR_INVALID)
+		odp_cls_pmr_destroy(pmr);
+
+	if (cos != ODP_COS_INVALID)
+		odp_cos_destroy(cos);
+
+	if (default_cos != ODP_COS_INVALID)
+		odp_cos_destroy(default_cos);
+
+	if (queue != ODP_QUEUE_INVALID)
+		odp_queue_destroy(queue);
+
+	CU_ASSERT(odp_pktio_stop(pktio) == 0);
+	CU_ASSERT(odp_pktio_close(pktio) == 0);
+}
+
+static void pktio_test_enable_pause_rx(void)
+{
+	pktio_config_flow_control(0, 1, 0);
+}
+
+static void pktio_test_enable_pause_tx(void)
+{
+	pktio_config_flow_control(0, 0, 1);
+}
+
+static void pktio_test_enable_pause_both(void)
+{
+	pktio_config_flow_control(0, 1, 1);
+}
+
+static void pktio_test_enable_pfc_rx(void)
+{
+	pktio_config_flow_control(1, 1, 0);
+}
+
+static void pktio_test_enable_pfc_tx(void)
+{
+	pktio_config_flow_control(1, 0, 1);
+}
+
+static void pktio_test_enable_pfc_both(void)
+{
+	pktio_config_flow_control(1, 1, 1);
+}
+
 static void pktio_test_pktin_queue_config_direct(void)
 {
 	odp_pktio_t pktio;
@@ -4937,6 +5173,12 @@ odp_testinfo_t pktio_suite_unsegmented[] = {
 				  pktio_check_pktout_compl_plain_queue),
 	ODP_TEST_INFO_CONDITIONAL(pktio_test_pktout_compl_sched_queue,
 				  pktio_check_pktout_compl_sched_queue),
+	ODP_TEST_INFO_CONDITIONAL(pktio_test_enable_pause_rx, pktio_check_pause_rx),
+	ODP_TEST_INFO_CONDITIONAL(pktio_test_enable_pause_tx, pktio_check_pause_tx),
+	ODP_TEST_INFO_CONDITIONAL(pktio_test_enable_pause_both, pktio_check_pause_both),
+	ODP_TEST_INFO_CONDITIONAL(pktio_test_enable_pfc_rx, pktio_check_pfc_rx),
+	ODP_TEST_INFO_CONDITIONAL(pktio_test_enable_pfc_tx, pktio_check_pfc_tx),
+	ODP_TEST_INFO_CONDITIONAL(pktio_test_enable_pfc_both, pktio_check_pfc_both),
 	ODP_TEST_INFO_NULL
 };
 


### PR DESCRIPTION
Initial support to enable PFC flow control. It is left implementation specific (for future development) how packet output halts a traffic priority level.

v2:
 - Renamed config parameter names to pause_rx/pause_tx. These match the current names in link info.
 - Added flow control capability fields
 
 v3:
 - Rebased
 - Grouped API config parameters inside "flow_control" structure
 - Added minimal implementation and first test case
 
v4:
 - Rebased
 - Added pause/PFC configuration test case