### PR TITLE
[PATCH v2]  crypto perf test bug fix and improvements

### DIFF
--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -2884,6 +2884,17 @@ int crypto_int(odp_packet_t pkt_in,
 	if (odp_unlikely(out_pkt == ODP_PACKET_INVALID))
 		return -1;
 
+	if (ODP_DEBUG) {
+		if (session->p.auth_alg != ODP_AUTH_ALG_NULL &&
+		    param->hash_result_offset + session->p.auth_digest_len
+		    > odp_packet_len(out_pkt)) {
+			_ODP_ERR("Invalid hash result offset\n");
+			rc_cipher = ODP_CRYPTO_ALG_ERR_DATA_SIZE;
+			rc_auth = ODP_CRYPTO_ALG_ERR_DATA_SIZE;
+			goto out;
+		}
+	}
+
 	crypto_init(session);
 
 	/* Invoke the functions */
@@ -2895,6 +2906,7 @@ int crypto_int(odp_packet_t pkt_in,
 		rc_cipher = session->cipher.func(out_pkt, param, session);
 	}
 
+out:
 	/* Fill in result */
 	packet_subtype_set(out_pkt, ODP_EVENT_PACKET_CRYPTO);
 	op_result = get_op_result_from_packet(out_pkt);

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -408,6 +408,49 @@ static crypto_alg_config_t algs_config[] = {
 			.auth_aad_len = AAD_LEN,
 		},
 	},
+	{
+		.name = "zuc-eea3",
+		.session = {
+			.cipher_alg = ODP_CIPHER_ALG_ZUC_EEA3,
+			.cipher_key = {
+				.data = test_key16,
+				.length = sizeof(test_key16)
+			},
+			.cipher_iv_len = 16,
+			.auth_alg = ODP_AUTH_ALG_NULL,
+		},
+	},
+	{
+		.name = "zuc-eia3",
+		.session = {
+			.cipher_alg = ODP_CIPHER_ALG_NULL,
+			.auth_alg = ODP_AUTH_ALG_ZUC_EIA3,
+			.auth_key = {
+				.data = test_key16,
+				.length = sizeof(test_key16)
+			},
+			.auth_iv_len = 16,
+			.auth_digest_len = 4,
+		},
+	},
+	{
+		.name = "zuc-eea3-zuc-eia3",
+		.session = {
+			.cipher_alg = ODP_CIPHER_ALG_ZUC_EEA3,
+			.cipher_key = {
+				.data = test_key16,
+				.length = sizeof(test_key16)
+			},
+			.cipher_iv_len = 16,
+			.auth_alg = ODP_AUTH_ALG_ZUC_EIA3,
+			.auth_key = {
+				.data = test_key16,
+				.length = sizeof(test_key16)
+			},
+			.auth_iv_len = 16,
+			.auth_digest_len = 4,
+		},
+	},
 };
 
 /**
@@ -890,6 +933,9 @@ static int check_cipher_alg(const odp_crypto_capability_t *capa,
 		if (capa->ciphers.bit.chacha20_poly1305)
 			return 0;
 		break;
+	case ODP_CIPHER_ALG_ZUC_EEA3:
+		if (capa->ciphers.bit.zuc_eea3)
+			return 0;
 	default:
 		break;
 	}
@@ -941,6 +987,9 @@ static int check_auth_alg(const odp_crypto_capability_t *capa,
 		if (capa->auths.bit.chacha20_poly1305)
 			return 0;
 		break;
+	case ODP_AUTH_ALG_ZUC_EIA3:
+		if (capa->auths.bit.zuc_eia3)
+			return 0;
 	default:
 		break;
 	}

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -611,6 +611,7 @@ create_session_from_config(odp_crypto_session_t *session,
 	odp_crypto_session_param_init(&params);
 	memcpy(&params, &config->session, sizeof(odp_crypto_session_param_t));
 	params.op = ODP_CRYPTO_OP_ENCODE;
+	params.auth_cipher_text = true;
 
 	/* Lookup the packet pool */
 	pkt_pool = odp_pool_lookup("packet_pool");


### PR DESCRIPTION
test: performance: crypto: improve printouts when session creation fails
test: performance: crypto: fix out-of-bounds hash result offset
linux-gen: crypto: check hash result offset against pkt len in debug builds
test: performance: ipsec: authenticate cipher text instead of vice versa
test: performance: crypto: add zuc-eea3 and zuc-eia3 tests
