### PR TITLE
[PATCH v4] test: ipsecfwd: add option for direct reception 

### DIFF
--- a/test/performance/odp_ipsecfwd.c
+++ b/test/performance/odp_ipsecfwd.c
@@ -819,8 +819,6 @@ static odp_bool_t setup_pktios(prog_config_t *config)
 		pktio->num_tx_qs = config->num_output_qs;
 		odp_pktout_queue_param_init(&pktout_param);
 		pktout_param.num_queues = pktio->num_tx_qs;
-		pktout_param.op_mode = config->num_thrs > (int)pktio->num_tx_qs ?
-			ODP_PKTIO_OP_MT : ODP_PKTIO_OP_MT_UNSAFE;
 
 		if (odp_pktout_queue_config(pktio->handle, &pktout_param) < 0) {
 			ODPH_ERR("Error configuring packet I/O output queues (%s)\n", pktio->name);


### PR DESCRIPTION
This patchset adds an option to not use scheduler with `odp_ipsecfwd`. Tester throughput increases slightly as scheduling overhead disappears. 

Additionally, packets are now forwarded with bursts instead of single packet at a time after lookup, this further increases tester thoughput if a lot of packets are destined to the same output per processing loop.

v2:
- Added a separate patch where existing processing functions are moved earlier
- Changed "no scheduler" option to "direct RX" option and changed title accordingly
- Rebased

v3: 
- Addressed Janne's comments

v4:
- Added reviewed-by tag