### PR TITLE
[PATCH v3] linux-gen: ipsec: fix ipsec status event free

### DIFF
--- a/platform/linux-generic/odp_ipsec_events.c
+++ b/platform/linux-generic/odp_ipsec_events.c
@@ -124,6 +124,7 @@ void _odp_ipsec_status_free(ipsec_status_t status)
 {
 	odp_event_t ev = ipsec_status_to_event(status);
 
+	_odp_event_type_set(ev, ODP_EVENT_BUFFER);
 	odp_buffer_free(buffer_from_event(ev));
 }
 


### PR DESCRIPTION
When freeing IPsec status events, reset type of the event to `ODP_EVENT_BUFFER` before freeing. This way next allocation of the freed buffer will have the correct type set passing internal sanity checks.

v3:
- Added reviewed-by tags
- Rebased