### PR TITLE
[PATCH v2] test: crypto: fix GCC 9.2 warning

### DIFF
--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -1197,6 +1197,7 @@ int main(int argc, char *argv[])
 	odp_init_local(instance, ODP_THREAD_WORKER);
 
 	odp_sys_info_print();
+	memset(&crypto_capa, 0, sizeof(crypto_capa));
 
 	if (odp_crypto_capability(&crypto_capa)) {
 		ODPH_ERR("Crypto capability request failed.\n");


### PR DESCRIPTION
GCC 9.2 complains that crypto capability structure might be uninitialized when used even though it should always be properly initialized by a successful `odp_crypto_capability()` call.

Fix this by simply always initializing the structure to zero.

v2:
- Added reviewed-by tag
- Rebased