### PR TITLE
[PATCH v3] linux-gen: ipsec: improve IV generation and use non-random IVs

### DIFF
--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -87,6 +87,9 @@ int _odp_ipsec_status_send(odp_queue_t queue,
 
 #define IPSEC_MAX_SALT_LEN	4    /**< Maximum salt length in bytes */
 
+#define CBC_SALT_LEN		8
+#define CBC_IV_LEN		(CBC_SALT_LEN + sizeof(uint64_t))
+
 #define IPSEC_SEQ_HI_LEN	4    /**< ESN Higher bits length in bytes */
 
 /* The minimum supported AR window size */
@@ -167,7 +170,10 @@ struct ipsec_sa_s {
 	uint32_t	esp_iv_len;
 	uint32_t	esp_pad_mask;
 
-	uint8_t		salt[IPSEC_MAX_SALT_LEN];
+	union {
+		uint8_t		salt[IPSEC_MAX_SALT_LEN];
+		uint8_t         cbc_salt[CBC_SALT_LEN];
+	};
 	uint32_t	salt_length;
 	odp_ipsec_lookup_mode_t lookup_mode;
 
@@ -186,6 +192,7 @@ struct ipsec_sa_s {
 
 			/* Only for outbound */
 			unsigned	use_counter_iv : 1;
+			unsigned	use_cbc_iv : 1;
 			unsigned	tun_ipv4 : 1;
 
 			/* Only for inbound */

--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -83,7 +83,7 @@ int _odp_ipsec_status_send(odp_queue_t queue,
 			   int result,
 			   odp_ipsec_warn_t warn);
 
-#define IPSEC_MAX_IV_LEN	32   /**< Maximum IV length in bytes */
+#define IPSEC_MAX_IV_LEN	16   /**< Maximum cipher IV length in bytes */
 
 #define IPSEC_MAX_SALT_LEN	4    /**< Maximum salt length in bytes */
 

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -1404,10 +1404,6 @@ static int ipsec_out_iv(ipsec_state_t *state,
 		/* Both GCM and CTR use 8-bit counters */
 		_ODP_ASSERT(sizeof(seq_no) == ipsec_sa->esp_iv_len);
 
-		/* Check for overrun */
-		if (seq_no == 0)
-			return -1;
-
 		memcpy(state->iv, ipsec_sa->salt, ipsec_sa->salt_length);
 		memcpy(state->iv + ipsec_sa->salt_length, &seq_no,
 		       ipsec_sa->esp_iv_len);


### PR DESCRIPTION
Use non-random but still unpredictable IVs for AES-CBC to get rid of random number generation overhead. DES-CBC and 3DES-CBC continue using random IVs due to their shorter IV length. Make also a couple of small optimizations in IV handling.