### PR TITLE
[PATCH v1] Make example run scripts more aligned to test/performance/odp_l2fwd_run.sh and CI friendly

### DIFF
--- a/example/Makefile.inc
+++ b/example/Makefile.inc
@@ -1,6 +1,6 @@
 include $(top_srcdir)/Makefile.inc
 
-TESTS_ENVIRONMENT = EXEEXT=${EXEEXT}
+TESTS_ENVIRONMENT = ODP_PLATFORM=${with_platform} EXEEXT=${EXEEXT}
 
 LDADD = $(LIB)/libodphelper.la $(LIB)/lib$(ODP_LIB_NAME).la
 

--- a/example/classifier/Makefile.am
+++ b/example/classifier/Makefile.am
@@ -24,8 +24,6 @@ all-local:
 			fi \
 		done \
 	fi
-	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/classifier/pktio_env \
-		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/classifier/Makefile.am
+++ b/example/classifier/Makefile.am
@@ -5,9 +5,7 @@ bin_PROGRAMS = odp_classifier
 odp_classifier_SOURCES = odp_classifier.c
 
 if test_example
-if ODP_PKTIO_PCAP
 TESTS = odp_classifier_run.sh
-endif
 endif
 EXTRA_DIST = odp_classifier_run.sh udp64.pcap
 

--- a/example/classifier/odp_classifier_run.sh
+++ b/example/classifier/odp_classifier_run.sh
@@ -6,11 +6,17 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+SRC_DIR=$(dirname $0)
+TEST_EXAMPLE_DIR=platform/$ODP_PLATFORM/test/example
+PLATFORM_TEST_EXAMPLE=${SRC_DIR}/../../${TEST_EXAMPLE_DIR}
+
 if  [ -f ./pktio_env ]; then
 	. ./pktio_env
+elif [ -f ${PLATFORM_TEST_EXAMPLE}/classifier/pktio_env ]; then
+        . ${PLATFORM_TEST_EXAMPLE}/classifier/pktio_env
 else
 	echo "BUG: unable to find pktio_env!"
-	echo "pktio_env has to be in current directory"
+	echo "pktio_env has to be in current or platform example directory"
 	exit 1
 fi
 

--- a/example/generator/Makefile.am
+++ b/example/generator/Makefile.am
@@ -24,8 +24,6 @@ all-local:
 			fi \
 		done \
 	fi
-	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/generator/pktio_env \
-		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/generator/generator_run.sh
+++ b/example/generator/generator_run.sh
@@ -6,11 +6,17 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+SRC_DIR=$(dirname $0)
+TEST_EXAMPLE_DIR=platform/$ODP_PLATFORM/test/example
+PLATFORM_TEST_EXAMPLE=${SRC_DIR}/../../${TEST_EXAMPLE_DIR}
+
 if  [ -f ./pktio_env ]; then
 	. ./pktio_env
+elif [ -f ${PLATFORM_TEST_EXAMPLE}/generator/pktio_env ]; then
+        . ${PLATFORM_TEST_EXAMPLE}/generator/pktio_env
 else
 	echo "BUG: unable to find pktio_env!"
-	echo "pktio_env has to be in current directory"
+	echo "pktio_env has to be in current or platform example directory"
 	exit 1
 fi
 

--- a/example/generator/generator_run.sh
+++ b/example/generator/generator_run.sh
@@ -16,7 +16,13 @@ fi
 
 setup_interfaces
 
-./odp_generator${EXEEXT} -w 1 -n 1 -I $IF0 -m u
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
+$STDBUF ./odp_generator${EXEEXT} -w 1 -n 1 -I $IF0 -m u
 STATUS=$?
 
 if [ "$STATUS" -ne 0 ]; then

--- a/example/l2fwd_simple/Makefile.am
+++ b/example/l2fwd_simple/Makefile.am
@@ -24,8 +24,6 @@ all-local:
 			fi \
 		done \
 	fi
-	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/l2fwd_simple/pktio_env \
-		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/l2fwd_simple/Makefile.am
+++ b/example/l2fwd_simple/Makefile.am
@@ -5,9 +5,7 @@ bin_PROGRAMS = odp_l2fwd_simple
 odp_l2fwd_simple_SOURCES = odp_l2fwd_simple.c
 
 if test_example
-if ODP_PKTIO_PCAP
 TESTS = l2fwd_simple_run.sh
-endif
 endif
 EXTRA_DIST = l2fwd_simple_run.sh udp64.pcap
 

--- a/example/l2fwd_simple/l2fwd_simple_run.sh
+++ b/example/l2fwd_simple/l2fwd_simple_run.sh
@@ -16,7 +16,13 @@ fi
 
 setup_interfaces
 
-./odp_l2fwd_simple${EXEEXT} $IF0 $IF1 02:00:00:00:00:01 02:00:00:00:00:02 -t 2
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
+$STDBUF ./odp_l2fwd_simple${EXEEXT} $IF0 $IF1 02:00:00:00:00:01 02:00:00:00:00:02 -t 2
 STATUS=$?
 
 if [ "$STATUS" -ne 0 ]; then

--- a/example/l2fwd_simple/l2fwd_simple_run.sh
+++ b/example/l2fwd_simple/l2fwd_simple_run.sh
@@ -6,11 +6,17 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+SRC_DIR=$(dirname $0)
+TEST_EXAMPLE_DIR=platform/$ODP_PLATFORM/test/example
+PLATFORM_TEST_EXAMPLE=${SRC_DIR}/../../${TEST_EXAMPLE_DIR}
+
 if  [ -f ./pktio_env ]; then
   . ./pktio_env
+elif [ -f ${PLATFORM_TEST_EXAMPLE}/l2fwd_simple/pktio_env ]; then
+        . ${PLATFORM_TEST_EXAMPLE}/l2fwd_simple/pktio_env
 else
   echo "BUG: unable to find pktio_env!"
-  echo "pktio_env has to be in current directory"
+  echo "pktio_env has to be in current or platform example directory"
   exit 1
 fi
 

--- a/example/l3fwd/Makefile.am
+++ b/example/l3fwd/Makefile.am
@@ -29,8 +29,6 @@ all-local:
 			fi \
 		done \
 	fi
-	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/l3fwd/pktio_env \
-		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/l3fwd/Makefile.am
+++ b/example/l3fwd/Makefile.am
@@ -10,9 +10,7 @@ odp_l3fwd_SOURCES = \
 		    odp_l3fwd_lpm.h
 
 if test_example
-if ODP_PKTIO_PCAP
 TESTS = odp_l3fwd_run.sh
-endif
 endif
 EXTRA_DIST = odp_l3fwd_run.sh udp64.pcap
 

--- a/example/l3fwd/odp_l3fwd_run.sh
+++ b/example/l3fwd/odp_l3fwd_run.sh
@@ -16,7 +16,13 @@ fi
 
 setup_interfaces
 
-./odp_l3fwd${EXEEXT} -i $IF0,$IF1 -r "10.0.0.0/24,$IF1" -d 1
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
+$STDBUF ./odp_l3fwd${EXEEXT} -i $IF0,$IF1 -r "10.0.0.0/24,$IF1" -d 1
 
 STATUS=$?
 

--- a/example/l3fwd/odp_l3fwd_run.sh
+++ b/example/l3fwd/odp_l3fwd_run.sh
@@ -6,11 +6,17 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+SRC_DIR=$(dirname $0)
+TEST_EXAMPLE_DIR=platform/$ODP_PLATFORM/test/example
+PLATFORM_TEST_EXAMPLE=${SRC_DIR}/../../${TEST_EXAMPLE_DIR}
+
 if  [ -f ./pktio_env ]; then
 	. ./pktio_env
+elif [ -f ${PLATFORM_TEST_EXAMPLE}/l3fwd/pktio_env ]; then
+        . ${PLATFORM_TEST_EXAMPLE}/l3fwd/pktio_env
 else
 	echo "BUG: unable to find pktio_env!"
-	echo "pktio_env has to be in current directory"
+	echo "pktio_env has to be in current or platform example directory"
 	exit 1
 fi
 

--- a/example/packet/Makefile.am
+++ b/example/packet/Makefile.am
@@ -27,8 +27,6 @@ all-local:
 			fi \
 		done \
 	fi
-	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/packet/pktio_env \
-		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/packet/Makefile.am
+++ b/example/packet/Makefile.am
@@ -8,9 +8,7 @@ odp_packet_dump_SOURCES = odp_packet_dump.c
 odp_pktio_SOURCES = odp_pktio.c
 
 if test_example
-if ODP_PKTIO_PCAP
 TESTS = packet_dump_run.sh pktio_run.sh
-endif
 endif
 EXTRA_DIST = packet_dump_run.sh pktio_run.sh udp64.pcap
 

--- a/example/packet/packet_dump_run.sh
+++ b/example/packet/packet_dump_run.sh
@@ -6,11 +6,17 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+SRC_DIR=$(dirname $0)
+TEST_EXAMPLE_DIR=platform/$ODP_PLATFORM/test/example
+PLATFORM_TEST_EXAMPLE=${SRC_DIR}/../../${TEST_EXAMPLE_DIR}
+
 if  [ -f ./pktio_env ]; then
   . ./pktio_env
+elif [ -f ${PLATFORM_TEST_EXAMPLE}/packet/pktio_env ]; then
+        . ${PLATFORM_TEST_EXAMPLE}/packet/pktio_env
 else
   echo "BUG: unable to find pktio_env!"
-  echo "pktio_env has to be in current directory"
+  echo "pktio_env has to be in current or platform example directory"
   exit 1
 fi
 

--- a/example/packet/packet_dump_run.sh
+++ b/example/packet/packet_dump_run.sh
@@ -16,7 +16,13 @@ fi
 
 setup_interfaces
 
-./odp_packet_dump${EXEEXT} -i $IF0 -n 10 -o 0 -l 64
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
+$STDBUF ./odp_packet_dump${EXEEXT} -i $IF0 -n 10 -o 0 -l 64
 STATUS=$?
 if [ "$STATUS" -ne 0 ]; then
   echo "Error: status was: $STATUS, expected 0"

--- a/example/packet/pktio_run.sh
+++ b/example/packet/pktio_run.sh
@@ -16,8 +16,14 @@ fi
 
 setup_interfaces
 
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
 # burst mode
-./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 0
+$STDBUF ./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 0
 STATUS=$?
 if [ ${STATUS} -ne 0 ]; then
 	echo "Error: status ${STATUS}"
@@ -28,7 +34,7 @@ validate_result
 echo "Pass -m 0: status ${STATUS}"
 
 # queue mode
-./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 1
+$STDBUF ./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 1
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then
@@ -40,7 +46,7 @@ validate_result
 echo "Pass -m 1: status ${STATUS}"
 
 # sched/queue mode
-./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 2
+$STDBUF ./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 2
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then
@@ -52,7 +58,7 @@ validate_result
 echo "Pass -m 2: status ${STATUS}"
 
 # cpu number option test 1
-./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 0 -c 1
+$STDBUF ./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 0 -c 1
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then

--- a/example/packet/pktio_run.sh
+++ b/example/packet/pktio_run.sh
@@ -6,11 +6,17 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+SRC_DIR=$(dirname $0)
+TEST_EXAMPLE_DIR=platform/$ODP_PLATFORM/test/example
+PLATFORM_TEST_EXAMPLE=${SRC_DIR}/../../${TEST_EXAMPLE_DIR}
+
 if  [ -f ./pktio_env ]; then
 	. ./pktio_env
+elif [ -f ${PLATFORM_TEST_EXAMPLE}/packet/pktio_env ]; then
+        . ${PLATFORM_TEST_EXAMPLE}/packet/pktio_env
 else
         echo "BUG: unable to find pktio_env!"
-        echo "pktio_env has to be in current directory"
+        echo "pktio_env has to be in current or platform example directory"
         exit 1
 fi
 

--- a/example/ping/Makefile.am
+++ b/example/ping/Makefile.am
@@ -5,9 +5,7 @@ bin_PROGRAMS = odp_ping
 odp_ping_SOURCES = odp_ping.c
 
 if test_example
-if ODP_PKTIO_PCAP
 TESTS = ping_run.sh
-endif
 endif
 EXTRA_DIST = ping_run.sh icmp_echo_req.pcap
 

--- a/example/ping/Makefile.am
+++ b/example/ping/Makefile.am
@@ -24,8 +24,6 @@ all-local:
 			fi \
 		done \
 	fi
-	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/ping/pktio_env \
-		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/ping/ping_run.sh
+++ b/example/ping/ping_run.sh
@@ -6,11 +6,17 @@
 # SPDX-License-Identifier:     BSD-3-Clause
 #
 
+SRC_DIR=$(dirname $0)
+TEST_EXAMPLE_DIR=platform/$ODP_PLATFORM/test/example
+PLATFORM_TEST_EXAMPLE=${SRC_DIR}/../../${TEST_EXAMPLE_DIR}
+
 if  [ -f ./pktio_env ]; then
 	. ./pktio_env
+elif [ -f ${PLATFORM_TEST_EXAMPLE}/ping/pktio_env ]; then
+        . ${PLATFORM_TEST_EXAMPLE}/ping/pktio_env
 else
         echo "BUG: unable to find pktio_env!"
-        echo "pktio_env has to be in current directory"
+        echo "pktio_env has to be in current or platform example directory"
         exit 1
 fi
 

--- a/example/ping/ping_run.sh
+++ b/example/ping/ping_run.sh
@@ -16,9 +16,15 @@ fi
 
 setup_interfaces
 
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
 # Ping test with 100 ICMP echo request packets. Timeout 5 sec.
 # Promiscuous and verbose mode enabled.
-./odp_ping${EXEEXT} -v -p -t 5 -n 100 -i $IF0
+$STDBUF ./odp_ping${EXEEXT} -v -p -t 5 -n 100 -i $IF0
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then

--- a/example/simple_pipeline/Makefile.am
+++ b/example/simple_pipeline/Makefile.am
@@ -5,9 +5,7 @@ bin_PROGRAMS = odp_simple_pipeline
 odp_simple_pipeline_SOURCES = odp_simple_pipeline.c
 
 if test_example
-if ODP_PKTIO_PCAP
 TESTS = simple_pipeline_run.sh
-endif
 endif
 EXTRA_DIST = simple_pipeline_run.sh udp64.pcap
 

--- a/example/simple_pipeline/Makefile.am
+++ b/example/simple_pipeline/Makefile.am
@@ -24,8 +24,6 @@ all-local:
 			fi \
 		done \
 	fi
-	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/simple_pipeline/pktio_env \
-		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/simple_pipeline/simple_pipeline_run.sh
+++ b/example/simple_pipeline/simple_pipeline_run.sh
@@ -9,11 +9,17 @@
 # Exit code expected by automake for skipped tests
 TEST_SKIPPED=77
 
+SRC_DIR=$(dirname $0)
+TEST_EXAMPLE_DIR=platform/$ODP_PLATFORM/test/example
+PLATFORM_TEST_EXAMPLE=${SRC_DIR}/../../${TEST_EXAMPLE_DIR}
+
 if  [ -f ./pktio_env ]; then
   . ./pktio_env
+elif [ -f ${PLATFORM_TEST_EXAMPLE}/simple_pipeline/pktio_env ]; then
+        . ${PLATFORM_TEST_EXAMPLE}/simple_pipeline/pktio_env
 else
   echo "BUG: unable to find pktio_env!"
-  echo "pktio_env has to be in current directory"
+  echo "pktio_env has to be in current or platform example directory"
   exit 1
 fi
 

--- a/example/simple_pipeline/simple_pipeline_run.sh
+++ b/example/simple_pipeline/simple_pipeline_run.sh
@@ -24,7 +24,13 @@ fi
 
 setup_interfaces
 
-./odp_simple_pipeline${EXEEXT} -i $IF0,$IF1 -e -t 1 -a 1
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
+$STDBUF ./odp_simple_pipeline${EXEEXT} -i $IF0,$IF1 -e -t 1 -a 1
 STATUS=$?
 
 if [ "$STATUS" -ne 0 ]; then

--- a/example/switch/Makefile.am
+++ b/example/switch/Makefile.am
@@ -5,9 +5,7 @@ bin_PROGRAMS = odp_switch
 odp_switch_SOURCES = odp_switch.c
 
 if test_example
-if ODP_PKTIO_PCAP
 TESTS = switch_run.sh
-endif
 endif
 EXTRA_DIST = switch_run.sh udp64.pcap
 

--- a/example/switch/Makefile.am
+++ b/example/switch/Makefile.am
@@ -22,8 +22,6 @@ all-local:
 			fi \
 		done \
 	fi
-	ln -f -s $(top_srcdir)/platform/$(with_platform)/test/example/switch/pktio_env \
-		pktio_env
 clean-local:
 	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
 		for f in $(EXTRA_DIST); do \

--- a/example/switch/switch_run.sh
+++ b/example/switch/switch_run.sh
@@ -8,11 +8,17 @@
 
 RETVAL=0
 
+SRC_DIR=$(dirname $0)
+TEST_EXAMPLE_DIR=platform/$ODP_PLATFORM/test/example
+PLATFORM_TEST_EXAMPLE=${SRC_DIR}/../../${TEST_EXAMPLE_DIR}
+
 if  [ -f ./pktio_env ]; then
   . ./pktio_env
+elif [ -f ${PLATFORM_TEST_EXAMPLE}/switch/pktio_env ]; then
+        . ${PLATFORM_TEST_EXAMPLE}/switch/pktio_env
 else
   echo "BUG: unable to find pktio_env!"
-  echo "pktio_env has to be in current directory"
+  echo "pktio_env has to be in current or platform example directory"
   exit 1
 fi
 

--- a/example/switch/switch_run.sh
+++ b/example/switch/switch_run.sh
@@ -18,7 +18,13 @@ fi
 
 setup_interfaces
 
-./odp_switch${EXEEXT} -i $IF0,$IF1,$IF2,$IF3 -t 1 -a 1
+if [ "$(which stdbuf)" != "" ]; then
+	STDBUF="stdbuf -o 0"
+else
+	STDBUF=
+fi
+
+$STDBUF ./odp_switch${EXEEXT} -i $IF0,$IF1,$IF2,$IF3 -t 1 -a 1
 STATUS=$?
 if [ "$STATUS" -ne 0 ]; then
   echo "Error: status was: $STATUS, expected 0"

--- a/platform/linux-generic/test/Makefile.am
+++ b/platform/linux-generic/test/Makefile.am
@@ -17,8 +17,7 @@ TESTS += validation/api/pktio/pktio_run.sh \
 
 SUBDIRS += validation/api/pktio\
 	  validation/api/shmem\
-	  pktio_ipc \
-	  example
+	  pktio_ipc
 
 if ODP_PKTIO_PCAP
 TESTS += validation/api/pktio/pktio_run_pcap.sh
@@ -36,6 +35,10 @@ else
 if test_perf
 SUBDIRS += validation/api/pktio
 endif
+endif
+
+if test_example
+SUBDIRS += example
 endif
 
 TEST_EXTENSIONS = .sh

--- a/platform/linux-generic/test/example/classifier/Makefile.am
+++ b/platform/linux-generic/test/example/classifier/Makefile.am
@@ -1,1 +1,23 @@
 EXTRA_DIST = pktio_env
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi
+
+.NOTPARALLEL:

--- a/platform/linux-generic/test/example/generator/Makefile.am
+++ b/platform/linux-generic/test/example/generator/Makefile.am
@@ -1,1 +1,23 @@
 EXTRA_DIST = pktio_env
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi
+
+.NOTPARALLEL:

--- a/platform/linux-generic/test/example/l2fwd_simple/Makefile.am
+++ b/platform/linux-generic/test/example/l2fwd_simple/Makefile.am
@@ -1,1 +1,23 @@
 EXTRA_DIST = pktio_env
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi
+
+.NOTPARALLEL:

--- a/platform/linux-generic/test/example/l3fwd/Makefile.am
+++ b/platform/linux-generic/test/example/l3fwd/Makefile.am
@@ -1,1 +1,23 @@
 EXTRA_DIST = pktio_env
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi
+
+.NOTPARALLEL:

--- a/platform/linux-generic/test/example/packet/Makefile.am
+++ b/platform/linux-generic/test/example/packet/Makefile.am
@@ -1,1 +1,23 @@
 EXTRA_DIST = pktio_env
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi
+
+.NOTPARALLEL:

--- a/platform/linux-generic/test/example/ping/Makefile.am
+++ b/platform/linux-generic/test/example/ping/Makefile.am
@@ -1,1 +1,23 @@
 EXTRA_DIST = pktio_env
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi
+
+.NOTPARALLEL:

--- a/platform/linux-generic/test/example/simple_pipeline/Makefile.am
+++ b/platform/linux-generic/test/example/simple_pipeline/Makefile.am
@@ -1,1 +1,23 @@
 EXTRA_DIST = pktio_env
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi
+
+.NOTPARALLEL:

--- a/platform/linux-generic/test/example/switch/Makefile.am
+++ b/platform/linux-generic/test/example/switch/Makefile.am
@@ -1,1 +1,23 @@
 EXTRA_DIST = pktio_env
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(EXTRA_DIST); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi
+
+.NOTPARALLEL:

--- a/test/performance/odp_packet_gen_run.sh
+++ b/test/performance/odp_packet_gen_run.sh
@@ -49,8 +49,14 @@ run_packet_gen()
 	# Runs 500 * 10ms = 5 sec
 	# Sends 500 packets through both interfaces => total 1000 packets
 
+	if [ "$(which stdbuf)" != "" ]; then
+		STDBUF="stdbuf -o 0"
+	else
+		STDBUF=
+	fi
+
 	# Static packet length
-	odp_packet_gen${EXEEXT} -i $IF0,$IF1 -b 1 -g 10000000 -q 500 -w 10
+	$STDBUF odp_packet_gen${EXEEXT} -i $IF0,$IF1 -b 1 -g 10000000 -q 500 -w 10
 	ret=$?
 
 	if [ $ret -eq 2 ]; then
@@ -63,7 +69,7 @@ run_packet_gen()
 	fi
 
 	# Random packet length
-	odp_packet_gen${EXEEXT} -i $IF0,$IF1 -b 1 -g 10000000 -q 500 -L 60,1514,10 -w 10
+	$STDBUF odp_packet_gen${EXEEXT} -i $IF0,$IF1 -b 1 -g 10000000 -q 500 -L 60,1514,10 -w 10
 	ret=$?
 
 	if [ $ret -eq 2 ]; then

--- a/test/performance/odp_sched_latency_run.sh
+++ b/test/performance/odp_sched_latency_run.sh
@@ -16,10 +16,16 @@ run()
 	echo odp_sched_latency_run starts requesting $1 worker threads
 	echo =========================================================
 
+	if [ "$(which stdbuf)" != "" ]; then
+		STDBUF="stdbuf -o 0"
+	else
+		STDBUF=
+	fi
+
 	if [ $(nproc) -lt $1 ]; then
 		echo "Not enough CPU cores. Skipping test."
 	else
-		$TEST_DIR/odp_sched_latency${EXEEXT} -c $1 || exit $?
+		$STDBUF $TEST_DIR/odp_sched_latency${EXEEXT} -c $1 || exit $?
 	fi
 }
 

--- a/test/performance/odp_sched_pktio_run.sh
+++ b/test/performance/odp_sched_pktio_run.sh
@@ -54,8 +54,14 @@ run_sched_pktio()
 		exit 1
 	fi
 
+	if [ "$(which stdbuf)" != "" ]; then
+		STDBUF="stdbuf -o 0"
+	else
+		STDBUF=
+	fi
+
 	# 1 worker
-	odp_sched_pktio${EXEEXT} -i $IF1,$IF2 -c 1 -s &
+	$STDBUF odp_sched_pktio${EXEEXT} -i $IF1,$IF2 -c 1 -s &
 
 	TEST_PID=$!
 

--- a/test/performance/odp_scheduling_run.sh
+++ b/test/performance/odp_scheduling_run.sh
@@ -16,10 +16,16 @@ run()
 	echo odp_scheduling_run starts requesting $1 worker threads
 	echo ======================================================
 
+	if [ "$(which stdbuf)" != "" ]; then
+		STDBUF="stdbuf -o 0"
+	else
+		STDBUF=
+	fi
+
 	if [ $(nproc) -lt $1 ]; then
 		echo "Not enough CPU cores. Skipping test."
 	else
-		$TEST_DIR/odp_scheduling${EXEEXT} -c $1
+		$STDBUF $TEST_DIR/odp_scheduling${EXEEXT} -c $1
 		RET_VAL=$?
 		if [ $RET_VAL -ne 0 ]; then
 			echo odp_scheduling FAILED


### PR DESCRIPTION
commit cb533ac0a62bd9ba35dbfc5d0bb5754bcbe4bed6 (HEAD -> dev-run-script-changes, origin/dev-run-script-changes)
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Thu Nov 10 15:09:43 2022 +0530

    example: remove ODP_PKTIO_PCAP condition to run tests

    ODP_PKTIO_PCAP is a linux-generic platform specific define
    and hence remove it from examples so that all the examples can
    run on other platforms too.

    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit a96f38ceddc86efed825329d72342e78686af5f7
Author: Sunil Kumar Kori <skori@marvell.com>
Date:   Tue Aug 23 23:21:37 2022 +0530

    example: move pktio_env reference logic to run script

    Unlike script like test/performance/odp_l2fwd_run.sh,
    currently the pktio_env referenced by examples is done by doing a
    symlink of that file. Symbolic link doesn't work when we make
    distribution package or copy build folder to CI machine to run.
    So make it similar to odp_l2fwd_run.sh.

    Also add ODP_PLATFORM in example test environment like done for
    test/.

    Signed-off-by: Sunil Kumar Kori <skori@marvell.com>

commit 5449461714809d2a9b1b5324f8532c3cd5e61ec6
Author: Sunil Kumar Kori <skori@marvell.com>
Date:   Thu Aug 18 17:17:52 2022 +0530

    example: use stdbuf prepended to example and perf test scripts

    Use stdbuf to turn off output buffering and get periodic output.
    This is useful for CI monitoring.

    Signed-off-by: Sunil Kumar Kori <skori@marvell.com>

commit 0c8a4d88d2de92c9c00cffebc6a59f393aa414e5
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Thu Nov 10 15:26:00 2022 +0530

    linux-gen: copy pktio_env when build out of tree

    For make check to pass when build out of tree, copy
    the pktio_env to build directory.

    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>