### PR TITLE
[PATCH v2] test: validation: remove unnecessary cunit includes

### DIFF
--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -8,7 +8,6 @@
 #include <malloc.h>
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
-#include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include <unistd.h>
 

--- a/test/validation/api/barrier/barrier.c
+++ b/test/validation/api/barrier/barrier.c
@@ -8,7 +8,6 @@
 #include <malloc.h>
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
-#include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include <unistd.h>
 

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -7,7 +7,6 @@
 
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
-#include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include "test_vectors.h"
 

--- a/test/validation/api/lock/lock.c
+++ b/test/validation/api/lock/lock.c
@@ -7,7 +7,6 @@
 #include <malloc.h>
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
-#include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include <unistd.h>
 


### PR DESCRIPTION
CUnit API is included through odp_cunit_common.h. Remove direct CUnit includes from test applications.
