### PR TITLE
[PATCH v3] api: crypto: fix out-of-date text in hash_result_offset specification

### DIFF
--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -812,7 +812,7 @@ typedef struct odp_crypto_packet_op_param_t {
 	 *  In case of encode sessions the calculated hash will be stored in
 	 *  this offset.
 	 *
-	 *  If the hash_result_not_in_auth_range session parameter is false,
+	 *  If the hash_result_in_auth_range session parameter is true,
 	 *  the hash result location may overlap auth_range. In that case the
 	 *  result location will be zeroed in decode sessions before hash
 	 *  calculation. Zeroing is not done in encode sessions.


### PR DESCRIPTION
Fix a stale reference to the renamed hash_result_not_in_auth_range session parameter to use the correct name (hash_result_in_auth_range) in the comment text of hash_result_offset. The parameter was renamed before the patch was merged to master but one occurrence of the old name was missed.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>