### PR TITLE
[PATCH v1] test: sched_perf: print SHM in verbose mode

### DIFF
--- a/test/performance/odp_sched_perf.c
+++ b/test/performance/odp_sched_perf.c
@@ -1375,6 +1375,9 @@ int main(int argc, char **argv)
 	if (create_queues(global))
 		return -1;
 
+	if (global->test_options.verbose)
+		odp_shm_print_all();
+
 	/* Start workers */
 	start_workers(global, instance);
 


### PR DESCRIPTION
Print SHM memory reservations which may be useful information when debugging.
