### PR TITLE
[PATCH v2] validation: shm: fix shmem_test_info() block size

### DIFF
--- a/test/validation/api/shmem/shmem.c
+++ b/test/validation/api/shmem/shmem.c
@@ -277,7 +277,7 @@ static void shmem_test_info(void)
 	int support_pa = 0;
 	int support_iova = 0;
 
-	if (_global_shm_capa.max_size < size)
+	if (_global_shm_capa.max_size && _global_shm_capa.max_size < size)
 		size = _global_shm_capa.max_size;
 
 	if (_global_shm_capa.max_align < align)


### PR DESCRIPTION
Use test default block size if odp_shm_capability_t.max_size is zero.

Signed-off-by: Matias Elo <matias.elo@nokia.com>