### PR TITLE
[PATCH v2] linux-gen: sched: add config option for adjusting ordered queue stash size

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.22"
+config_file_version = "0.1.23"
 
 # System options
 system: {
@@ -234,6 +234,15 @@ sched_basic: {
 		worker  = 1
 		control = 1
 	}
+
+	# Ordered queue reorder stash size
+	#
+	# Number of events each thread can stash internally before having to
+	# wait for the right order context. Reorder stash can improve
+	# performance if threads process events in bursts. If 'order_stash_size'
+	# > 0, events may be dropped by the implementation if the target queue
+	# is full. To prevent this set 'order_stash_size' to 0.
+	order_stash_size = 512
 }
 
 timer: {

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -3,7 +3,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [22])
+m4_define([_odp_config_version_minor], [23])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.22"
+config_file_version = "0.1.23"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/packet_align.conf
+++ b/platform/linux-generic/test/packet_align.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.22"
+config_file_version = "0.1.23"
 
 pool: {
 	pkt: {

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.22"
+config_file_version = "0.1.23"
 
 # Shared memory options
 shm: {

--- a/platform/linux-generic/test/sched-basic.conf
+++ b/platform/linux-generic/test/sched-basic.conf
@@ -1,9 +1,10 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.22"
+config_file_version = "0.1.23"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {
 	prio_spread = 3
 	load_balance = 0
+	order_stash_size = 0
 }


### PR DESCRIPTION

Add new configuration option `sched_basic.order_stash_size`, which can be used to adjust the size of implementation internal per thread ordered queue reorder stash. If 'order_stash_size' > 0, events may be dropped by the implementation if the target queue is full. To prevent this set 'order_stash_size' to 0.

Signed-off-by: Matias Elo <matias.elo@nokia.com>