### PR TITLE
[PATCH v4] example/test/validation: remove usage of deprecated timer functions

### DIFF
--- a/doc/images/timeout_fsm.gv
+++ b/doc/images/timeout_fsm.gv
@@ -8,17 +8,13 @@ digraph timer_state_machine {
 	TO_Unalloc -> TO_Alloc [label="odp_timeout_alloc()"];
 	TO_Alloc -> TO_Unalloc [label="odp_timeout_free()"];
 	TO_Alloc -> TO_Pending [fontcolor=green,
-			       label="odp_timer_set_abs()"];
-	TO_Alloc -> TO_Pending [fontcolor=green,
-			       label="odp_timer_set_rel()"];
+			       label="odp_timer_start()"];
 	TO_Pending -> TO_Alloc [fontcolor=green,
 			       label="odp_timer_cancel()"];
 	TO_Pending -> TO_Enqueued [fontcolor=green, label="timer expires"];
 	TO_Enqueued -> TO_Delivered [label="odp_schedule()"];
 	TO_Delivered -> TO_Pending [fontcolor=green,
-				   label="odp_timer_set_abs()"];
-	TO_Delivered -> TO_Pending [fontcolor=green,
-				   label="odp_timer_set_rel()"];
+				   label="odp_timer_start()"];
 	TO_Delivered -> TO_Delivered [label="odp_timeout_from_event()"];
 	TO_Delivered -> TO_Delivered [label="odp_timeout_timer()"];
 	TO_Delivered -> TO_Unalloc

--- a/doc/images/timer_fsm.gv
+++ b/doc/images/timer_fsm.gv
@@ -3,17 +3,12 @@ digraph timer_state_machine {
 	node [fontsize=28];
 	edge [fontsize=28];
 	node [shape=doublecircle]; Timer_Unalloc;
-	node [shape=circle]; Timer_Alloc Timer_Set Timer_Expired
+	node [shape=circle]; Timer_Alloc Timer_Active Timer_Expired
 	Timer_Unalloc -> Timer_Alloc [label="odp_timer_alloc()"];
 	Timer_Alloc -> Timer_Unalloc [label="odp_timer_free()"];
-	Timer_Alloc -> Timer_Set [fontcolor=green,label="odp_timer_set_abs()"];
-	Timer_Alloc -> Timer_Set [fontcolor=green,label="odp_timer_set_rel()"];
-	Timer_Set -> Timer_Alloc [fontcolor=green,label="odp_timer_cancel()"];
-	Timer_Set -> Timer_Expired [fontcolor=green,label="timer expires"];
+	Timer_Alloc -> Timer_Active [fontcolor=green,label="odp_timer_start()"];
+	Timer_Active -> Timer_Alloc [fontcolor=green,label="odp_timer_cancel()"];
+	Timer_Active -> Timer_Expired [fontcolor=green,label="timer expires"];
 	Timer_Expired -> Timer_Unalloc [label="odp_timer_free()"];
-	Timer_Expired -> Timer_Set [fontcolor=green,
-				   label="odp_timer_set_abs()"];
-	Timer_Expired -> Timer_Set [fontcolor=green,
-				   label="odp_timer_set_rel()"];
-
+	Timer_Expired -> Timer_Active [fontcolor=green, label="odp_timer_start()"];
 }

--- a/doc/users-guide/users-guide-timer.adoc
+++ b/doc/users-guide/users-guide-timer.adoc
@@ -46,11 +46,11 @@ as an input parameter to enable the pool-specific conversion ratios to be
 used.
 
 Associated with each timer pool is a free running tick counter that can be
-sampled at any time via the `odp_timer_current_tick()` API. Timers can be set
-to an absolute future tick value via `odp_timer_set_abs()` or to a future tick
-value relative to the current tick via `odp_timer_set_rel()`.  Implementations
-may impose minimum and maximum future values supported by a given timer pool
-and timer set operations will fail if the requested value is outside of the
+sampled at any time via the `odp_timer_current_tick()` API. Timers are started
+with `odp_timer_start()` and the expiration time can be an absolute future tick
+value or a future tick value relative to the current tick. Implementations may
+impose minimum and maximum future values supported by a given timer pool and
+timer start operations will fail if the requested value is outside of the
 supported range.
 
 Before a set timer expires, it can be canceled via the `odp_timer_cancel()`

--- a/example/debug/odp_debug.c
+++ b/example/debug/odp_debug.c
@@ -372,6 +372,7 @@ static int timer_debug(void)
 	odp_timer_capability_t timer_capa;
 	odp_timer_pool_t timer_pool;
 	odp_timer_pool_param_t timer_param;
+	odp_timer_start_t start_param;
 	odp_timer_t timer;
 	odp_queue_t queue;
 	odp_queue_param_t queue_param;
@@ -452,8 +453,13 @@ static int timer_debug(void)
 	odp_timeout_print(timeout);
 
 	event = odp_timeout_to_event(timeout);
-	if (odp_timer_set_rel(timer, tick, &event) != ODP_TIMER_SUCCESS)
-		ODPH_ERR("Timer set failed.\n");
+
+	start_param.tick_type = ODP_TIMER_TICK_REL;
+	start_param.tick = tick;
+	start_param.tmo_ev = event;
+
+	if (odp_timer_start(timer, &start_param) != ODP_TIMER_SUCCESS)
+		ODPH_ERR("Timer start failed.\n");
 
 	printf("\n");
 	odp_timer_print(timer);

--- a/example/timer/odp_timer_simple.c
+++ b/example/timer/odp_timer_simple.c
@@ -129,13 +129,19 @@ int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 
 	for (i = 0; i < 5; i++) {
 		odp_time_t time;
+		odp_timer_start_t start_param;
 
 		/* Program timeout action on current tick + period */
 		tick = odp_timer_current_tick(timer_pool);
-		rc = odp_timer_set_abs(tim, tick + period, &ev);
+
+		start_param.tick_type = ODP_TIMER_TICK_ABS;
+		start_param.tick = tick + period;
+		start_param.tmo_ev = ev;
+
+		rc = odp_timer_start(tim, &start_param);
 		/* Too early or too late timeout requested */
 		if (odp_unlikely(rc != ODP_TIMER_SUCCESS))
-			ODPH_ABORT("odp_timer_set_abs() failed: %d\n", rc);
+			ODPH_ABORT("odp_timer_start() failed: %d\n", rc);
 
 		/* Wait for 2 seconds for timeout action to be generated */
 		ev = odp_schedule(&queue, sched_tmo);

--- a/example/timer/odp_timer_test.c
+++ b/example/timer/odp_timer_test.c
@@ -121,14 +121,19 @@ static void test_abs_timeouts(int thr, test_globals_t *gbls)
 		int wait = 0;
 		odp_event_t ev;
 		odp_timer_set_t rc;
+		odp_timer_start_t start_param;
 
 		if (ttp) {
 			tick += period;
-			rc = odp_timer_set_abs(ttp->tim, tick, &ttp->ev);
+
+			start_param.tick_type = ODP_TIMER_TICK_ABS;
+			start_param.tick = tick;
+			start_param.tmo_ev = ttp->ev;
+
+			rc = odp_timer_start(ttp->tim, &start_param);
 			if (odp_unlikely(rc != ODP_TIMER_SUCCESS)) {
 				/* Too early or too late timeout requested */
-				ODPH_ABORT("odp_timer_set_abs() failed: %s\n",
-					   timerset2str(rc));
+				ODPH_ABORT("odp_timer_start() failed: %s\n", timerset2str(rc));
 			}
 		}
 

--- a/test/performance/odp_timer_perf.c
+++ b/test/performance/odp_timer_perf.c
@@ -698,7 +698,11 @@ static int set_cancel_mode_worker(void *arg)
 			period_tick = global->timer_pool[i].period_tick;
 			tick = start_tick + j * period_tick;
 
-			status = odp_timer_set_rel(timer, tick, &ev);
+			start_param.tick_type = ODP_TIMER_TICK_REL;
+			start_param.tick = tick;
+			start_param.tmo_ev = ev;
+
+			status = odp_timer_start(timer, &start_param);
 			num_tmo++;
 			num_set++;
 

--- a/test/performance/odp_timer_perf.c
+++ b/test/performance/odp_timer_perf.c
@@ -438,6 +438,7 @@ static int set_timers(test_global_t *global)
 			odp_event_t ev;
 			int status;
 			timer_ctx_t *ctx = &global->timer_ctx[i][j];
+			odp_timer_start_t start_param;
 
 			/* Set timers backwards, the last timer is set first */
 			if (j == 0)
@@ -456,9 +457,11 @@ static int set_timers(test_global_t *global)
 			tick_ns = odp_timer_ns_to_tick(tp, nsec);
 			nsec    = nsec - period_ns;
 
-			status = odp_timer_set_abs(timer, tick_cur + tick_ns,
-						   &ev);
+			start_param.tick_type = ODP_TIMER_TICK_ABS;
+			start_param.tick = tick_cur + tick_ns;
+			start_param.tmo_ev = ev;
 
+			status = odp_timer_start(timer, &start_param);
 			if (status != ODP_TIMER_SUCCESS) {
 				ODPH_ERR("Timer set %i/%i (ret %i)\n", i, j, status);
 				return -1;
@@ -656,6 +659,7 @@ static int set_cancel_mode_worker(void *arg)
 	odp_timer_t timer;
 	odp_timer_pool_t tp;
 	odp_timeout_t tmo;
+	odp_timer_start_t start_param;
 	thread_arg_t *thread_arg = arg;
 	test_global_t *global = thread_arg->global;
 	test_options_t *test_options = &global->test_options;
@@ -746,7 +750,11 @@ static int set_cancel_mode_worker(void *arg)
 				if (status < 0)
 					continue;
 
-				status = odp_timer_set_abs(timer, tick + j * period_tick, &ev);
+				start_param.tick_type = ODP_TIMER_TICK_ABS;
+				start_param.tick = tick + j * period_tick;
+				start_param.tmo_ev = ev;
+
+				status = odp_timer_start(timer, &start_param);
 				num_set++;
 
 				if (status != ODP_TIMER_SUCCESS) {


### PR DESCRIPTION
Remove usage of deprecated API functions `odp_timer_set_abs()` and `odp_timer_set_rel()`.