### PR TITLE
[PATCH v1] api: pktio: add matching input and output queue count capability

### DIFF
--- a/include/odp/api/spec/packet_io_types.h
+++ b/include/odp/api/spec/packet_io_types.h
@@ -889,6 +889,19 @@ typedef struct odp_pktin_vector_capability_t {
  * ODP_PKTOUT_MODE_DIRECT mode.
  */
 typedef struct odp_pktio_capability_t {
+	/** Equal number of input and output queues
+	 *
+	 * When set, the same number of input and output queues has to be used.
+	 * This applies only if both directions are enabled. If one direction
+	 * is disabled, queue count is limited only by the capabilities of the
+	 * enabled direction.
+	 *
+	 * @see odp_pktin_queue_param_t and odp_pktout_queue_param_t for input
+	 * and output queue count configuration.
+	 * @see odp_pktin_mode_t and odp_pktout_mode_t for direction mode
+	 * configuration. */
+	odp_bool_t equal_num_queues;
+
 	/** Maximum number of input queues
 	 *
 	 * Value does not exceed ODP_PKTIN_MAX_QUEUES. */

--- a/platform/linux-generic/pktio/socket_xdp.c
+++ b/platform/linux-generic/pktio/socket_xdp.c
@@ -852,8 +852,10 @@ static int set_queue_capability(int fd, const char *devname, odp_pktio_capabilit
 		channels.max_combined = 1U;
 	}
 
-	max_channels = _ODP_MIN((uint32_t)ODP_PKTOUT_MAX_QUEUES, channels.max_combined);
-	capa->max_input_queues = _ODP_MIN((uint32_t)ODP_PKTIN_MAX_QUEUES, max_channels);
+	max_channels = _ODP_MIN((uint32_t)ODP_PKTIN_MAX_QUEUES,
+				_ODP_MIN((uint32_t)ODP_PKTOUT_MAX_QUEUES, channels.max_combined));
+	capa->equal_num_queues = true;
+	capa->max_input_queues = max_channels;
 	capa->max_output_queues = max_channels;
 
 	return 0;


### PR DESCRIPTION
This patchset adds a new packet I/O capability to signal that an equal amount of input and output queues is required to be configured. This is due to sometimes supporting a differing amount is not possible or somewhat cumbersome for an implementation.

Additionally, AF_XDP socket-based packet I/O driver now signals this requirement.