### PR TITLE
[PATCH v6] linux-gen: loop: add multi-queue support

### DIFF
--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
+ * Copyright (c) 2019-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -68,12 +68,8 @@ struct pktio_if_ops;
 #define PKTIO_PRIVATE_SIZE 33792
 #elif defined(_ODP_PKTIO_XDP)
 #define PKTIO_PRIVATE_SIZE 29696
-#elif defined(_ODP_PKTIO_DPDK) && ODP_CACHE_LINE_SIZE == 128
-#define PKTIO_PRIVATE_SIZE 4160
-#elif defined(_ODP_PKTIO_DPDK)
-#define PKTIO_PRIVATE_SIZE 3968
 #else
-#define PKTIO_PRIVATE_SIZE 384
+#define PKTIO_PRIVATE_SIZE 9216
 #endif
 
 typedef struct ODP_ALIGNED_CACHE {


### PR DESCRIPTION
This patchset adds multi-queue support to loop packet I/O. This enables more realistic packet I/O application testing.

Additionally, relevant statistics are refactored and simple hashing is implemented to distribute packets to RX queues.

v2:
- Utilized `odp_hash_crc32()` for queue hashing

v3:
- Matias' comments

v4:
- Added reviewed-by tag

v5:
- Swapped to `odp_hash_crc32c()`