### PR TITLE
[PATCH v4] linux-gen: stash: reserve all memory from a single shm block

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.23"
+config_file_version = "0.1.24"
 
 # System options
 system: {
@@ -243,6 +243,17 @@ sched_basic: {
 	# > 0, events may be dropped by the implementation if the target queue
 	# is full. To prevent this set 'order_stash_size' to 0.
 	order_stash_size = 512
+}
+
+stash: {
+	# Maximum number of stashes
+	max_num = 512
+
+	# Maximum number of objects in a stash
+	#
+	# The value may be rounded up by the implementation. For optimal memory
+	# usage set value to a power of two - 1.
+	max_num_obj = 4095
 }
 
 timer: {

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2019-2021, Nokia
+ * Copyright (c) 2019-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -66,7 +66,7 @@ extern "C" {
 /*
  * Maximum number of stashes
  */
-#define CONFIG_MAX_STASHES 128
+#define CONFIG_MAX_STASHES 2048
 
 /*
  * Maximum number of packet IO resources
@@ -134,10 +134,10 @@ extern "C" {
 /*
  * Number of shared memory blocks reserved for implementation internal use.
  *
- * Each stash requires one SHM block, each pool requires three blocks (buffers,
- * ring, user area), and 20 blocks are reserved for per ODP module global data.
+ * Each pool requires three blocks (buffers, ring, user area), and 20 blocks
+ * are reserved for per ODP module global data.
  */
-#define CONFIG_INTERNAL_SHM_BLOCKS (CONFIG_MAX_STASHES + (ODP_CONFIG_POOLS * 3)  + 20)
+#define CONFIG_INTERNAL_SHM_BLOCKS ((ODP_CONFIG_POOLS * 3) + 20)
 
 /*
  * Maximum number of shared memory blocks.

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -3,7 +3,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [23])
+m4_define([_odp_config_version_minor], [24])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-generic/odp_stash.c
+++ b/platform/linux-generic/odp_stash.c
@@ -73,6 +73,16 @@ typedef struct stash_global_t {
 
 static stash_global_t *stash_global;
 
+static inline stash_t *stash_entry(odp_stash_t st)
+{
+	return (stash_t *)(uintptr_t)st;
+}
+
+static inline odp_stash_t stash_handle(stash_t *stash)
+{
+	return (odp_stash_t)(uintptr_t)stash;
+}
+
 int _odp_stash_init_global(void)
 {
 	odp_shm_t shm;
@@ -305,19 +315,15 @@ odp_stash_t odp_stash_create(const char *name, const odp_stash_param_t *param)
 	stash_global->stash_state[index] = STASH_ACTIVE;
 	odp_ticketlock_unlock(&stash_global->lock);
 
-	return (odp_stash_t)stash;
+	return stash_handle(stash);
 }
 
 int odp_stash_destroy(odp_stash_t st)
 {
-	stash_t *stash;
-
 	if (st == ODP_STASH_INVALID)
 		return -1;
 
-	stash = (stash_t *)(uintptr_t)st;
-
-	free_index(stash->index);
+	free_index(stash_entry(st)->index);
 
 	return 0;
 }
@@ -342,7 +348,7 @@ odp_stash_t odp_stash_lookup(const char *name)
 		if (stash_global->stash_state[i] == STASH_ACTIVE &&
 		    strcmp(stash->name, name) == 0) {
 			odp_ticketlock_unlock(&stash_global->lock);
-			return (odp_stash_t)stash;
+			return stash_handle(stash);
 		}
 	}
 
@@ -353,11 +359,9 @@ odp_stash_t odp_stash_lookup(const char *name)
 
 static inline int32_t stash_put(odp_stash_t st, const void *obj, int32_t num)
 {
-	stash_t *stash;
+	stash_t *stash = stash_entry(st);
 	uint32_t obj_size;
 	int32_t i;
-
-	stash = (stash_t *)(uintptr_t)st;
 
 	if (odp_unlikely(st == ODP_STASH_INVALID))
 		return -1;
@@ -421,7 +425,7 @@ int32_t odp_stash_put_batch(odp_stash_t st, const void *obj, int32_t num)
 static inline int32_t stash_put_u32(odp_stash_t st, const uint32_t val[],
 				    int32_t num)
 {
-	stash_t *stash = (stash_t *)(uintptr_t)st;
+	stash_t *stash = stash_entry(st);
 
 	if (odp_unlikely(st == ODP_STASH_INVALID))
 		return -1;
@@ -448,7 +452,7 @@ int32_t odp_stash_put_u32_batch(odp_stash_t st, const uint32_t val[],
 static inline int32_t stash_put_u64(odp_stash_t st, const uint64_t val[],
 				    int32_t num)
 {
-	stash_t *stash = (stash_t *)(uintptr_t)st;
+	stash_t *stash = stash_entry(st);
 
 	if (odp_unlikely(st == ODP_STASH_INVALID))
 		return -1;
@@ -475,7 +479,7 @@ int32_t odp_stash_put_u64_batch(odp_stash_t st, const uint64_t val[],
 static inline int32_t stash_put_ptr(odp_stash_t st, const uintptr_t ptr[],
 				    int32_t num)
 {
-	stash_t *stash = (stash_t *)(uintptr_t)st;
+	stash_t *stash = stash_entry(st);
 
 	if (odp_unlikely(st == ODP_STASH_INVALID))
 		return -1;
@@ -508,11 +512,9 @@ int32_t odp_stash_put_ptr_batch(odp_stash_t st,	const uintptr_t ptr[],
 
 static inline int32_t stash_get(odp_stash_t st, void *obj, int32_t num, odp_bool_t batch)
 {
-	stash_t *stash;
+	stash_t *stash = stash_entry(st);
 	uint32_t obj_size;
 	uint32_t i, num_deq;
-
-	stash = (stash_t *)(uintptr_t)st;
 
 	if (odp_unlikely(st == ODP_STASH_INVALID))
 		return -1;
@@ -584,7 +586,7 @@ int32_t odp_stash_get_batch(odp_stash_t st, void *obj, int32_t num)
 
 int32_t odp_stash_get_u32(odp_stash_t st, uint32_t val[], int32_t num)
 {
-	stash_t *stash = (stash_t *)(uintptr_t)st;
+	stash_t *stash = stash_entry(st);
 
 	if (odp_unlikely(st == ODP_STASH_INVALID))
 		return -1;
@@ -597,7 +599,7 @@ int32_t odp_stash_get_u32(odp_stash_t st, uint32_t val[], int32_t num)
 
 int32_t odp_stash_get_u32_batch(odp_stash_t st, uint32_t val[], int32_t num)
 {
-	stash_t *stash = (stash_t *)(uintptr_t)st;
+	stash_t *stash = stash_entry(st);
 
 	if (odp_unlikely(st == ODP_STASH_INVALID))
 		return -1;
@@ -609,7 +611,7 @@ int32_t odp_stash_get_u32_batch(odp_stash_t st, uint32_t val[], int32_t num)
 
 int32_t odp_stash_get_u64(odp_stash_t st, uint64_t val[], int32_t num)
 {
-	stash_t *stash = (stash_t *)(uintptr_t)st;
+	stash_t *stash = stash_entry(st);
 
 	if (odp_unlikely(st == ODP_STASH_INVALID))
 		return -1;
@@ -622,7 +624,7 @@ int32_t odp_stash_get_u64(odp_stash_t st, uint64_t val[], int32_t num)
 
 int32_t odp_stash_get_u64_batch(odp_stash_t st, uint64_t val[], int32_t num)
 {
-	stash_t *stash = (stash_t *)(uintptr_t)st;
+	stash_t *stash = stash_entry(st);
 
 	if (odp_unlikely(st == ODP_STASH_INVALID))
 		return -1;
@@ -634,7 +636,7 @@ int32_t odp_stash_get_u64_batch(odp_stash_t st, uint64_t val[], int32_t num)
 
 int32_t odp_stash_get_ptr(odp_stash_t st, uintptr_t ptr[], int32_t num)
 {
-	stash_t *stash = (stash_t *)(uintptr_t)st;
+	stash_t *stash = stash_entry(st);
 
 	if (odp_unlikely(st == ODP_STASH_INVALID))
 		return -1;
@@ -654,7 +656,7 @@ int32_t odp_stash_get_ptr(odp_stash_t st, uintptr_t ptr[], int32_t num)
 
 int32_t odp_stash_get_ptr_batch(odp_stash_t st, uintptr_t ptr[], int32_t num)
 {
-	stash_t *stash = (stash_t *)(uintptr_t)st;
+	stash_t *stash = stash_entry(st);
 
 	if (odp_unlikely(st == ODP_STASH_INVALID))
 		return -1;
@@ -696,7 +698,7 @@ static uint32_t stash_obj_count(stash_t *stash)
 
 void odp_stash_print(odp_stash_t st)
 {
-	stash_t *stash = (stash_t *)(uintptr_t)st;
+	stash_t *stash = stash_entry(st);
 
 	if (st == ODP_STASH_INVALID) {
 		_ODP_ERR("Bad stash handle\n");
@@ -716,7 +718,7 @@ void odp_stash_print(odp_stash_t st)
 
 int odp_stash_stats(odp_stash_t st, odp_stash_stats_t *stats)
 {
-	stash_t *stash = (stash_t *)(uintptr_t)st;
+	stash_t *stash = stash_entry(st);
 
 	if (st == ODP_STASH_INVALID) {
 		_ODP_ERR("Bad stash handle\n");

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.23"
+config_file_version = "0.1.24"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/packet_align.conf
+++ b/platform/linux-generic/test/packet_align.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.23"
+config_file_version = "0.1.24"
 
 pool: {
 	pkt: {

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.23"
+config_file_version = "0.1.24"
 
 # Shared memory options
 shm: {

--- a/platform/linux-generic/test/sched-basic.conf
+++ b/platform/linux-generic/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.23"
+config_file_version = "0.1.24"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {


### PR DESCRIPTION
Use one common SHM block for all stash memory. This enables creating a large number of stashes without hitting the SHM block count limit, for the cost of having to pre-reserve the memory during global init.

The amount of required memory can be adjusted with new configuration file options:
- stash:max_num:     maximum number of stashes
- stash:max_num_obj: maximum number of objects in a stash

Signed-off-by: Matias Elo <matias.elo@nokia.com>