### PR TITLE
[PATCH v6] api: stash: add new strict size create parameter

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.26"
+config_file_version = "0.1.27"
 
 # System options
 system: {
@@ -271,12 +271,6 @@ stash: {
 	# The value may be rounded up by the implementation. For optimal memory
 	# usage set value to a power of two - 1.
 	max_num_obj = 4095
-
-	# Strict size
-	#
-	# When set to 0, application can attempt to store more handles into a
-	# stash than it specified in the creation parameters.
-	strict_size = 1
 }
 
 timer: {

--- a/include/odp/api/spec/stash.h
+++ b/include/odp/api/spec/stash.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2022, Nokia
+/* Copyright (c) 2020-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -109,8 +109,7 @@ uint64_t odp_stash_to_u64(odp_stash_t stash);
  * Store object handles into the stash. Handle values are opaque data to
  * ODP implementation and may be e.g. pointers or indexes to arbitrary objects.
  * Application specifies object handle size and maximum number of handles to be
- * stored in stash creation parameters. Application must not attempt to store
- * more handles into the stash than it specifies in the creation parameters.
+ * stored in stash creation parameters.
  *
  * A successful operation returns the actual number of object handles stored.
  * If the return value is less than 'num', the remaining handles at the end of

--- a/include/odp/api/spec/stash_types.h
+++ b/include/odp/api/spec/stash_types.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2022, Nokia
+/* Copyright (c) 2020-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -219,10 +219,11 @@ typedef struct odp_stash_param_t {
 	 */
 	odp_stash_op_mode_t get_mode;
 
-	/** Maximum number of object handles
+	/** Number of object handles
 	 *
-	 *  This is the maximum number of object handles application will store
-	 *  in the stash. The value must not exceed 'max_num_obj' capability.
+	 *  Application must be able to store at least this many object handles
+	 *  into the stash. An implementation may round up the value. The given
+	 *  value must not exceed 'max_num_obj' capability.
 	 */
 	uint64_t num_obj;
 
@@ -264,6 +265,15 @@ typedef struct odp_stash_param_t {
 	 * actually used. All counters are disabled by default.
 	 */
 	odp_stash_stats_opt_t stats;
+
+	/**
+	 * Strict size
+	 *
+	 * If true, application never attempts to store more handles into the stash than specified
+	 * in the 'num_obj' parameter. Implementation may use this value as a hint for performance
+	 * optimizations. The default value is false.
+	 */
+	odp_bool_t strict_size;
 
 } odp_stash_param_t;
 

--- a/include/odp/api/spec/stash_types.h
+++ b/include/odp/api/spec/stash_types.h
@@ -156,11 +156,7 @@ typedef struct odp_stash_capability_t {
 	 */
 	uint32_t max_stashes;
 
-	/** Maximum number of object handles per stash
-	 *
-	 *  The value of zero means that limited only by the available
-	 *  memory size.
-	 */
+	/** Maximum number of object handles per stash */
 	uint64_t max_num_obj;
 
 	/** Maximum object handle size in bytes

--- a/include/odp/api/spec/stash_types.h
+++ b/include/odp/api/spec/stash_types.h
@@ -156,8 +156,37 @@ typedef struct odp_stash_capability_t {
 	 */
 	uint32_t max_stashes;
 
-	/** Maximum number of object handles per stash */
+	/** Maximum common number of object handles per stash for any object size
+	 *
+	 *  An application is able to store at least this many objects when using any of the
+	 *  supported object sizes. Some of the per object size values listed in 'max_num' may be
+	 *  larger than this common value.
+	 */
 	uint64_t max_num_obj;
+
+	/** Maximum number of object handles per stash for each object size
+	 *
+	 *  Values for unsupported object handle sizes are set to zero.
+	 */
+	struct {
+		/** Maximum number of 1 byte object handles */
+		uint64_t u8;
+
+		/** Maximum number of 2 byte object handles */
+		uint64_t u16;
+
+		/** Maximum number of 4 byte object handles */
+		uint64_t u32;
+
+		/** Maximum number of 8 byte object handles */
+		uint64_t u64;
+
+		/** Maximum number of 16 byte object handles */
+		uint64_t u128;
+
+		/** Maximum number of 'max_obj_size' object handles */
+		uint64_t max_obj_size;
+	} max_num;
 
 	/** Maximum object handle size in bytes
 	 *
@@ -219,7 +248,7 @@ typedef struct odp_stash_param_t {
 	 *
 	 *  Application must be able to store at least this many object handles
 	 *  into the stash. An implementation may round up the value. The given
-	 *  value must not exceed 'max_num_obj' capability.
+	 *  value must not exceed 'max_num' capability.
 	 */
 	uint64_t num_obj;
 

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -3,7 +3,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [26])
+m4_define([_odp_config_version_minor], [27])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-generic/odp_stash.c
+++ b/platform/linux-generic/odp_stash.c
@@ -251,7 +251,14 @@ int odp_stash_capability(odp_stash_capability_t *capa, odp_stash_type_t type)
 
 	capa->max_stashes_any_type = max_stashes;
 	capa->max_stashes          = max_stashes;
+
 	capa->max_num_obj          = stash_global->max_num_obj;
+	capa->max_num.u8           = stash_global->max_num_obj;
+	capa->max_num.u16          = stash_global->max_num_obj;
+	capa->max_num.u32          = stash_global->max_num_obj;
+	capa->max_num.u64          = stash_global->max_num_obj;
+	capa->max_num.max_obj_size = stash_global->max_num_obj;
+
 	capa->max_obj_size         = sizeof(uint64_t);
 	capa->max_get_batch        = MIN_RING_SIZE;
 	capa->max_put_batch        = MIN_RING_SIZE;

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.26"
+config_file_version = "0.1.27"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/packet_align.conf
+++ b/platform/linux-generic/test/packet_align.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.26"
+config_file_version = "0.1.27"
 
 pool: {
 	pkt: {

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.26"
+config_file_version = "0.1.27"
 
 # Shared memory options
 shm: {

--- a/platform/linux-generic/test/sched-basic.conf
+++ b/platform/linux-generic/test/sched-basic.conf
@@ -1,12 +1,11 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.26"
+config_file_version = "0.1.27"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {
 	prio_spread = 3
 	load_balance = 0
-	order_stash_size = 0
 	powersave: {
 		poll_time_nsec = 5000
 		sleep_time_nsec = 50000

--- a/platform/linux-generic/test/stash-custom.conf
+++ b/platform/linux-generic/test/stash-custom.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.26"
+config_file_version = "0.1.27"
 
 # Test overflow safe stash variant
 stash: {

--- a/test/validation/api/stash/stash.c
+++ b/test/validation/api/stash/stash.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2022, Nokia
+/* Copyright (c) 2020-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -147,6 +147,7 @@ static void param_defaults(uint8_t fill)
 	CU_ASSERT(param.stats.all == 0);
 	CU_ASSERT(param.stats.bit.count == 0);
 	CU_ASSERT(param.stats.bit.cache_count == 0);
+	CU_ASSERT(param.strict_size == 0);
 }
 
 static void stash_param_defaults(void)
@@ -449,7 +450,8 @@ static void stash_stats_u32(void)
 	CU_ASSERT_FATAL(odp_stash_destroy(stash) == 0);
 }
 
-static void stash_default_put(uint32_t size, int32_t burst, stash_op_t op, int batch)
+static void stash_default_put(uint32_t size, int32_t burst, stash_op_t op, int batch,
+			      odp_bool_t strict_size)
 {
 	odp_stash_t stash;
 	odp_stash_param_t param;
@@ -505,6 +507,7 @@ static void stash_default_put(uint32_t size, int32_t burst, stash_op_t op, int b
 	param.num_obj    = num;
 	param.obj_size   = size;
 	param.cache_size = global.cache_size_default;
+	param.strict_size = strict_size;
 
 	stash = odp_stash_create("test_stash_default", &param);
 
@@ -652,7 +655,8 @@ static void stash_default_put(uint32_t size, int32_t burst, stash_op_t op, int b
 	CU_ASSERT_FATAL(odp_stash_destroy(stash) == 0);
 }
 
-static void stash_fifo_put(uint32_t size, int32_t burst, stash_op_t op, int batch)
+static void stash_fifo_put(uint32_t size, int32_t burst, stash_op_t op, int batch,
+			   odp_bool_t strict_size)
 {
 	odp_stash_t stash;
 	odp_stash_param_t param;
@@ -701,6 +705,7 @@ static void stash_fifo_put(uint32_t size, int32_t burst, stash_op_t op, int batc
 	param.type     = ODP_STASH_TYPE_FIFO;
 	param.num_obj  = num;
 	param.obj_size = size;
+	param.strict_size = strict_size;
 
 	stash = odp_stash_create("test_stash_fifo", &param);
 
@@ -912,282 +917,338 @@ static int check_support_fifo(void)
 
 static void stash_default_put_u64_1(void)
 {
-	stash_default_put(sizeof(uint64_t), 1, STASH_GEN, 0);
+	stash_default_put(sizeof(uint64_t), 1, STASH_GEN, 0, false);
+	stash_default_put(sizeof(uint64_t), 1, STASH_GEN, 0, true);
 }
 
 static void stash_default_put_u64_n(void)
 {
-	stash_default_put(sizeof(uint64_t), BURST, STASH_GEN, 0);
+	stash_default_put(sizeof(uint64_t), BURST, STASH_GEN, 0, false);
+	stash_default_put(sizeof(uint64_t), BURST, STASH_GEN, 0, true);
 }
 
 static void stash_default_u64_put_u64_1(void)
 {
-	stash_default_put(sizeof(uint64_t), 1, STASH_U64, 0);
+	stash_default_put(sizeof(uint64_t), 1, STASH_U64, 0, false);
+	stash_default_put(sizeof(uint64_t), 1, STASH_U64, 0, true);
 }
 
 static void stash_default_u64_put_u64_n(void)
 {
-	stash_default_put(sizeof(uint64_t), BURST, STASH_U64, 0);
+	stash_default_put(sizeof(uint64_t), BURST, STASH_U64, 0, false);
+	stash_default_put(sizeof(uint64_t), BURST, STASH_U64, 0, true);
 }
 
 static void stash_default_put_ptr_1(void)
 {
-	stash_default_put(sizeof(uintptr_t), 1, STASH_PTR, 0);
+	stash_default_put(sizeof(uintptr_t), 1, STASH_PTR, 0, false);
+	stash_default_put(sizeof(uintptr_t), 1, STASH_PTR, 0, true);
 }
 
 static void stash_default_put_ptr_n(void)
 {
-	stash_default_put(sizeof(uintptr_t), BURST, STASH_PTR, 0);
+	stash_default_put(sizeof(uintptr_t), BURST, STASH_PTR, 0, false);
+	stash_default_put(sizeof(uintptr_t), BURST, STASH_PTR, 0, true);
 }
 
 static void stash_default_put_u64_1_batch(void)
 {
-	stash_default_put(sizeof(uint64_t), 1, STASH_GEN, 1);
+	stash_default_put(sizeof(uint64_t), 1, STASH_GEN, 1, false);
+	stash_default_put(sizeof(uint64_t), 1, STASH_GEN, 1, true);
 }
 
 static void stash_default_put_u64_n_batch(void)
 {
-	stash_default_put(sizeof(uint64_t), BATCH, STASH_GEN, 1);
+	stash_default_put(sizeof(uint64_t), BATCH, STASH_GEN, 1, false);
+	stash_default_put(sizeof(uint64_t), BATCH, STASH_GEN, 1, true);
 }
 
 static void stash_default_u64_put_u64_1_batch(void)
 {
-	stash_default_put(sizeof(uint64_t), 1, STASH_U64, 1);
+	stash_default_put(sizeof(uint64_t), 1, STASH_U64, 1, false);
+	stash_default_put(sizeof(uint64_t), 1, STASH_U64, 1, true);
 }
 
 static void stash_default_u64_put_u64_n_batch(void)
 {
-	stash_default_put(sizeof(uint64_t), BATCH, STASH_U64, 1);
+	stash_default_put(sizeof(uint64_t), BATCH, STASH_U64, 1, false);
+	stash_default_put(sizeof(uint64_t), BATCH, STASH_U64, 1, true);
 }
 
 static void stash_default_put_ptr_1_batch(void)
 {
-	stash_default_put(sizeof(uintptr_t), 1, STASH_PTR, 1);
+	stash_default_put(sizeof(uintptr_t), 1, STASH_PTR, 1, false);
+	stash_default_put(sizeof(uintptr_t), 1, STASH_PTR, 1, true);
 }
 
 static void stash_default_put_ptr_n_batch(void)
 {
-	stash_default_put(sizeof(uintptr_t), BATCH, STASH_PTR, 1);
+	stash_default_put(sizeof(uintptr_t), BATCH, STASH_PTR, 1, false);
+	stash_default_put(sizeof(uintptr_t), BATCH, STASH_PTR, 1, true);
 }
 
 static void stash_default_put_u32_1(void)
 {
-	stash_default_put(sizeof(uint32_t), 1, STASH_GEN, 0);
+	stash_default_put(sizeof(uint32_t), 1, STASH_GEN, 0, false);
+	stash_default_put(sizeof(uint32_t), 1, STASH_GEN, 0, true);
 }
 
 static void stash_default_put_u32_n(void)
 {
-	stash_default_put(sizeof(uint32_t), BURST, STASH_GEN, 0);
+	stash_default_put(sizeof(uint32_t), BURST, STASH_GEN, 0, false);
+	stash_default_put(sizeof(uint32_t), BURST, STASH_GEN, 0, true);
 }
 
 static void stash_default_u32_put_u32_1(void)
 {
-	stash_default_put(sizeof(uint32_t), 1, STASH_U32, 0);
+	stash_default_put(sizeof(uint32_t), 1, STASH_U32, 0, false);
+	stash_default_put(sizeof(uint32_t), 1, STASH_U32, 0, true);
 }
 
 static void stash_default_u32_put_u32_n(void)
 {
-	stash_default_put(sizeof(uint32_t), BURST, STASH_U32, 0);
+	stash_default_put(sizeof(uint32_t), BURST, STASH_U32, 0, false);
+	stash_default_put(sizeof(uint32_t), BURST, STASH_U32, 0, true);
 }
 
 static void stash_default_put_u16_1(void)
 {
-	stash_default_put(sizeof(uint16_t), 1, STASH_GEN, 0);
+	stash_default_put(sizeof(uint16_t), 1, STASH_GEN, 0, false);
+	stash_default_put(sizeof(uint16_t), 1, STASH_GEN, 0, true);
 }
 
 static void stash_default_put_u16_n(void)
 {
-	stash_default_put(sizeof(uint16_t), BURST, STASH_GEN, 0);
+	stash_default_put(sizeof(uint16_t), BURST, STASH_GEN, 0, false);
+	stash_default_put(sizeof(uint16_t), BURST, STASH_GEN, 0, true);
 }
 
 static void stash_default_put_u8_1(void)
 {
-	stash_default_put(sizeof(uint8_t), 1, STASH_GEN, 0);
+	stash_default_put(sizeof(uint8_t), 1, STASH_GEN, 0, false);
+	stash_default_put(sizeof(uint8_t), 1, STASH_GEN, 0, true);
 }
 
 static void stash_default_put_u8_n(void)
 {
-	stash_default_put(sizeof(uint8_t), BURST, STASH_GEN, 0);
+	stash_default_put(sizeof(uint8_t), BURST, STASH_GEN, 0, false);
+	stash_default_put(sizeof(uint8_t), BURST, STASH_GEN, 0, true);
 }
 
 static void stash_default_put_u32_1_batch(void)
 {
-	stash_default_put(sizeof(uint32_t), 1, STASH_GEN, 1);
+	stash_default_put(sizeof(uint32_t), 1, STASH_GEN, 1, false);
+	stash_default_put(sizeof(uint32_t), 1, STASH_GEN, 1, true);
 }
 
 static void stash_default_put_u32_n_batch(void)
 {
-	stash_default_put(sizeof(uint32_t), BATCH, STASH_GEN, 1);
+	stash_default_put(sizeof(uint32_t), BATCH, STASH_GEN, 1, false);
+	stash_default_put(sizeof(uint32_t), BATCH, STASH_GEN, 1, true);
 }
 
 static void stash_default_u32_put_u32_1_batch(void)
 {
-	stash_default_put(sizeof(uint32_t), 1, STASH_U32, 1);
+	stash_default_put(sizeof(uint32_t), 1, STASH_U32, 1, false);
+	stash_default_put(sizeof(uint32_t), 1, STASH_U32, 1, true);
 }
 
 static void stash_default_u32_put_u32_n_batch(void)
 {
-	stash_default_put(sizeof(uint32_t), BATCH, STASH_U32, 1);
+	stash_default_put(sizeof(uint32_t), BATCH, STASH_U32, 1, false);
+	stash_default_put(sizeof(uint32_t), BATCH, STASH_U32, 1, true);
 }
 
 static void stash_default_put_u16_1_batch(void)
 {
-	stash_default_put(sizeof(uint16_t), 1, STASH_GEN, 1);
+	stash_default_put(sizeof(uint16_t), 1, STASH_GEN, 1, false);
+	stash_default_put(sizeof(uint16_t), 1, STASH_GEN, 1, true);
 }
 
 static void stash_default_put_u16_n_batch(void)
 {
-	stash_default_put(sizeof(uint16_t), BATCH, STASH_GEN, 1);
+	stash_default_put(sizeof(uint16_t), BATCH, STASH_GEN, 1, false);
+	stash_default_put(sizeof(uint16_t), BATCH, STASH_GEN, 1, true);
 }
 
 static void stash_default_put_u8_1_batch(void)
 {
-	stash_default_put(sizeof(uint8_t), 1, STASH_GEN, 1);
+	stash_default_put(sizeof(uint8_t), 1, STASH_GEN, 1, false);
+	stash_default_put(sizeof(uint8_t), 1, STASH_GEN, 1, true);
 }
 
 static void stash_default_put_u8_n_batch(void)
 {
-	stash_default_put(sizeof(uint8_t), BATCH, STASH_GEN, 1);
+	stash_default_put(sizeof(uint8_t), BATCH, STASH_GEN, 1, false);
+	stash_default_put(sizeof(uint8_t), BATCH, STASH_GEN, 1, true);
 }
 
 static void stash_fifo_put_u64_1(void)
 {
-	stash_fifo_put(sizeof(uint64_t), 1, STASH_GEN, 0);
+	stash_fifo_put(sizeof(uint64_t), 1, STASH_GEN, 0, false);
+	stash_fifo_put(sizeof(uint64_t), 1, STASH_GEN, 0, true);
 }
 
 static void stash_fifo_put_u64_n(void)
 {
-	stash_fifo_put(sizeof(uint64_t), BURST, STASH_GEN, 0);
+	stash_fifo_put(sizeof(uint64_t), BURST, STASH_GEN, 0, false);
+	stash_fifo_put(sizeof(uint64_t), BURST, STASH_GEN, 0, true);
 }
 
 static void stash_fifo_u64_put_u64_1(void)
 {
-	stash_fifo_put(sizeof(uint64_t), 1, STASH_U64, 0);
+	stash_fifo_put(sizeof(uint64_t), 1, STASH_U64, 0, false);
+	stash_fifo_put(sizeof(uint64_t), 1, STASH_U64, 0, true);
 }
 
 static void stash_fifo_u64_put_u64_n(void)
 {
-	stash_fifo_put(sizeof(uint64_t), BURST, STASH_U64, 0);
+	stash_fifo_put(sizeof(uint64_t), BURST, STASH_U64, 0, false);
+	stash_fifo_put(sizeof(uint64_t), BURST, STASH_U64, 0, true);
 }
 
 static void stash_fifo_put_ptr_1(void)
 {
-	stash_fifo_put(sizeof(uintptr_t), 1, STASH_PTR, 0);
+	stash_fifo_put(sizeof(uintptr_t), 1, STASH_PTR, 0, false);
+	stash_fifo_put(sizeof(uintptr_t), 1, STASH_PTR, 0, true);
 }
 
 static void stash_fifo_put_ptr_n(void)
 {
-	stash_fifo_put(sizeof(uintptr_t), BURST, STASH_PTR, 0);
+	stash_fifo_put(sizeof(uintptr_t), BURST, STASH_PTR, 0, false);
+	stash_fifo_put(sizeof(uintptr_t), BURST, STASH_PTR, 0, true);
 }
 
 static void stash_fifo_put_u32_1(void)
 {
-	stash_fifo_put(sizeof(uint32_t), 1, STASH_GEN, 0);
+	stash_fifo_put(sizeof(uint32_t), 1, STASH_GEN, 0, false);
+	stash_fifo_put(sizeof(uint32_t), 1, STASH_GEN, 0, true);
 }
 
 static void stash_fifo_put_u32_n(void)
 {
-	stash_fifo_put(sizeof(uint32_t), BURST, STASH_GEN, 0);
+	stash_fifo_put(sizeof(uint32_t), BURST, STASH_GEN, 0, false);
+	stash_fifo_put(sizeof(uint32_t), BURST, STASH_GEN, 0, true);
 }
 
 static void stash_fifo_u32_put_u32_1(void)
 {
-	stash_fifo_put(sizeof(uint32_t), 1, STASH_U32, 0);
+	stash_fifo_put(sizeof(uint32_t), 1, STASH_U32, 0, false);
+	stash_fifo_put(sizeof(uint32_t), 1, STASH_U32, 0, true);
 }
 
 static void stash_fifo_u32_put_u32_n(void)
 {
-	stash_fifo_put(sizeof(uint32_t), BURST, STASH_U32, 0);
+	stash_fifo_put(sizeof(uint32_t), BURST, STASH_U32, 0, false);
+	stash_fifo_put(sizeof(uint32_t), BURST, STASH_U32, 0, true);
 }
 
 static void stash_fifo_put_u16_1(void)
 {
-	stash_fifo_put(sizeof(uint16_t), 1, STASH_GEN, 0);
+	stash_fifo_put(sizeof(uint16_t), 1, STASH_GEN, 0, false);
+	stash_fifo_put(sizeof(uint16_t), 1, STASH_GEN, 0, true);
 }
 
 static void stash_fifo_put_u16_n(void)
 {
-	stash_fifo_put(sizeof(uint16_t), BURST, STASH_GEN, 0);
+	stash_fifo_put(sizeof(uint16_t), BURST, STASH_GEN, 0, false);
+	stash_fifo_put(sizeof(uint16_t), BURST, STASH_GEN, 0, true);
 }
 
 static void stash_fifo_put_u8_1(void)
 {
-	stash_fifo_put(sizeof(uint8_t), 1, STASH_GEN, 0);
+	stash_fifo_put(sizeof(uint8_t), 1, STASH_GEN, 0, false);
+	stash_fifo_put(sizeof(uint8_t), 1, STASH_GEN, 0, true);
 }
 
 static void stash_fifo_put_u8_n(void)
 {
-	stash_fifo_put(sizeof(uint8_t), BURST, STASH_GEN, 0);
+	stash_fifo_put(sizeof(uint8_t), BURST, STASH_GEN, 0, false);
+	stash_fifo_put(sizeof(uint8_t), BURST, STASH_GEN, 0, true);
 }
 
 static void stash_fifo_put_u64_1_batch(void)
 {
-	stash_fifo_put(sizeof(uint64_t), 1, STASH_GEN, 1);
+	stash_fifo_put(sizeof(uint64_t), 1, STASH_GEN, 1, false);
+	stash_fifo_put(sizeof(uint64_t), 1, STASH_GEN, 1, true);
 }
 
 static void stash_fifo_put_u64_n_batch(void)
 {
-	stash_fifo_put(sizeof(uint64_t), BATCH, STASH_GEN, 1);
+	stash_fifo_put(sizeof(uint64_t), BATCH, STASH_GEN, 1, false);
+	stash_fifo_put(sizeof(uint64_t), BATCH, STASH_GEN, 1, true);
 }
 
 static void stash_fifo_u64_put_u64_1_batch(void)
 {
-	stash_fifo_put(sizeof(uint64_t), 1, STASH_U64, 1);
+	stash_fifo_put(sizeof(uint64_t), 1, STASH_U64, 1, false);
+	stash_fifo_put(sizeof(uint64_t), 1, STASH_U64, 1, true);
 }
 
 static void stash_fifo_u64_put_u64_n_batch(void)
 {
-	stash_fifo_put(sizeof(uint64_t), BATCH, STASH_U64, 1);
+	stash_fifo_put(sizeof(uint64_t), BATCH, STASH_U64, 1, false);
+	stash_fifo_put(sizeof(uint64_t), BATCH, STASH_U64, 1, true);
 }
 
 static void stash_fifo_put_ptr_1_batch(void)
 {
-	stash_fifo_put(sizeof(uintptr_t), 1, STASH_PTR, 1);
+	stash_fifo_put(sizeof(uintptr_t), 1, STASH_PTR, 1, false);
+	stash_fifo_put(sizeof(uintptr_t), 1, STASH_PTR, 1, true);
 }
 
 static void stash_fifo_put_ptr_n_batch(void)
 {
-	stash_fifo_put(sizeof(uintptr_t), BATCH, STASH_PTR, 1);
+	stash_fifo_put(sizeof(uintptr_t), BATCH, STASH_PTR, 1, false);
+	stash_fifo_put(sizeof(uintptr_t), BATCH, STASH_PTR, 1, true);
 }
 
 static void stash_fifo_put_u32_1_batch(void)
 {
-	stash_fifo_put(sizeof(uint32_t), 1, STASH_GEN, 1);
+	stash_fifo_put(sizeof(uint32_t), 1, STASH_GEN, 1, false);
+	stash_fifo_put(sizeof(uint32_t), 1, STASH_GEN, 1, true);
 }
 
 static void stash_fifo_put_u32_n_batch(void)
 {
-	stash_fifo_put(sizeof(uint32_t), BATCH, STASH_GEN, 1);
+	stash_fifo_put(sizeof(uint32_t), BATCH, STASH_GEN, 1, false);
+	stash_fifo_put(sizeof(uint32_t), BATCH, STASH_GEN, 1, true);
 }
 
 static void stash_fifo_u32_put_u32_1_batch(void)
 {
-	stash_fifo_put(sizeof(uint32_t), 1, STASH_U32, 1);
+	stash_fifo_put(sizeof(uint32_t), 1, STASH_U32, 1, false);
+	stash_fifo_put(sizeof(uint32_t), 1, STASH_U32, 1, true);
 }
 
 static void stash_fifo_u32_put_u32_n_batch(void)
 {
-	stash_fifo_put(sizeof(uint32_t), BATCH, STASH_U32, 1);
+	stash_fifo_put(sizeof(uint32_t), BATCH, STASH_U32, 1, false);
+	stash_fifo_put(sizeof(uint32_t), BATCH, STASH_U32, 1, true);
 }
 
 static void stash_fifo_put_u16_1_batch(void)
 {
-	stash_fifo_put(sizeof(uint16_t), 1, STASH_GEN, 1);
+	stash_fifo_put(sizeof(uint16_t), 1, STASH_GEN, 1, false);
+	stash_fifo_put(sizeof(uint16_t), 1, STASH_GEN, 1, true);
 }
 
 static void stash_fifo_put_u16_n_batch(void)
 {
-	stash_fifo_put(sizeof(uint16_t), BATCH, STASH_GEN, 1);
+	stash_fifo_put(sizeof(uint16_t), BATCH, STASH_GEN, 1, false);
+	stash_fifo_put(sizeof(uint16_t), BATCH, STASH_GEN, 1, true);
 }
 
 static void stash_fifo_put_u8_1_batch(void)
 {
-	stash_fifo_put(sizeof(uint8_t), 1, STASH_GEN, 1);
+	stash_fifo_put(sizeof(uint8_t), 1, STASH_GEN, 1, false);
+	stash_fifo_put(sizeof(uint8_t), 1, STASH_GEN, 1, true);
 }
 
 static void stash_fifo_put_u8_n_batch(void)
 {
-	stash_fifo_put(sizeof(uint8_t), BATCH, STASH_GEN, 1);
+	stash_fifo_put(sizeof(uint8_t), BATCH, STASH_GEN, 1, false);
+	stash_fifo_put(sizeof(uint8_t), BATCH, STASH_GEN, 1, true);
 }
 
 odp_testinfo_t stash_suite[] = {

--- a/test/validation/api/stash/stash.c
+++ b/test/validation/api/stash/stash.c
@@ -7,6 +7,8 @@
 #include <odp_api.h>
 #include "odp_cunit_common.h"
 
+#include <string.h>
+
 #define MAGIC_U64  0x8b7438fa56c82e96
 #define MAGIC_U32  0x74a13b94
 #define MAGIC_U16  0x25bf
@@ -111,10 +113,9 @@ static int stash_suite_init(void)
 static void stash_capability(void)
 {
 	odp_stash_capability_t capa;
-	int ret;
 
 	memset(&capa, 0, sizeof(odp_stash_capability_t));
-	CU_ASSERT(odp_stash_capability(&capa, ODP_STASH_TYPE_DEFAULT) == 0);
+	CU_ASSERT_FATAL(odp_stash_capability(&capa, ODP_STASH_TYPE_DEFAULT) == 0);
 	CU_ASSERT(capa.max_stashes_any_type > 0);
 	CU_ASSERT(capa.max_stashes > 0);
 	CU_ASSERT(capa.max_num_obj > 0);
@@ -122,16 +123,43 @@ static void stash_capability(void)
 	CU_ASSERT(capa.max_get_batch >= 1);
 	CU_ASSERT(capa.max_put_batch >= 1);
 
+	CU_ASSERT(capa.max_num.u8 >= capa.max_num_obj);
+	CU_ASSERT(capa.max_num.u16 >= capa.max_num_obj);
+	CU_ASSERT(capa.max_num.u32 >= capa.max_num_obj);
+	CU_ASSERT(capa.max_num.max_obj_size >= capa.max_num_obj);
+	if (capa.max_obj_size >= 8)
+		CU_ASSERT(capa.max_num.u64 >= capa.max_num_obj);
+	if (capa.max_obj_size < 8)
+		CU_ASSERT(capa.max_num.u64 == 0);
+	if (capa.max_obj_size >= 16)
+		CU_ASSERT(capa.max_num.u128 >= capa.max_num_obj);
+	if (capa.max_obj_size < 16)
+		CU_ASSERT(capa.max_num.u128 == 0);
+
 	memset(&capa, 0, sizeof(odp_stash_capability_t));
-	ret = odp_stash_capability(&capa, ODP_STASH_TYPE_FIFO);
-	CU_ASSERT(ret == 0);
+	CU_ASSERT_FATAL(odp_stash_capability(&capa, ODP_STASH_TYPE_FIFO) == 0);
 	CU_ASSERT(capa.max_stashes_any_type > 0);
-	if (ret == 0 && capa.max_stashes) {
-		CU_ASSERT(capa.max_num_obj > 0);
-		CU_ASSERT(capa.max_obj_size >= sizeof(uint32_t));
-		CU_ASSERT(capa.max_get_batch >= 1);
-		CU_ASSERT(capa.max_put_batch >= 1);
-	}
+
+	if (capa.max_stashes == 0)
+		return;
+
+	CU_ASSERT(capa.max_num_obj > 0);
+	CU_ASSERT(capa.max_obj_size >= sizeof(uint32_t));
+	CU_ASSERT(capa.max_get_batch >= 1);
+	CU_ASSERT(capa.max_put_batch >= 1);
+
+	CU_ASSERT(capa.max_num.u8 >= capa.max_num_obj);
+	CU_ASSERT(capa.max_num.u16 >= capa.max_num_obj);
+	CU_ASSERT(capa.max_num.u32 >= capa.max_num_obj);
+	CU_ASSERT(capa.max_num.max_obj_size >= capa.max_num_obj);
+	if (capa.max_obj_size >= 8)
+		CU_ASSERT(capa.max_num.u64 >= capa.max_num_obj);
+	if (capa.max_obj_size < 8)
+		CU_ASSERT(capa.max_num.u64 == 0);
+	if (capa.max_obj_size >= 16)
+		CU_ASSERT(capa.max_num.u128 >= capa.max_num_obj);
+	if (capa.max_obj_size < 16)
+		CU_ASSERT(capa.max_num.u128 == 0);
 }
 
 static void param_defaults(uint8_t fill)


### PR DESCRIPTION
Add new stash create parameter odp_stash_param_t.strict_size. When this option is enabled, application must never attempt to store more handles into the stash than specified in the odp_stash_param_t.num_obj parameter. Depending on the implementation, this may enable performance optimization. The new option is disabled by default and the total object count limitation is removed from odp_stash_put() function.

Signed-off-by: Matias Elo <matias.elo@nokia.com>