### PR TITLE
[PATCH v5] api: cls: clarify destroy order

### DIFF
--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -780,7 +780,7 @@ int odp_cos_queue_set(odp_cos_t cos, odp_queue_t queue);
 * @param cos           CoS handle
 *
 * @retval Queue handle associated with the given class-of-service
-* @retval ODP_QUEUE_INVALID on failure
+* @retval ODP_QUEUE_INVALID on failure, or if the queue has not been set
 */
 odp_queue_t odp_cos_queue(odp_cos_t cos);
 

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -750,6 +750,11 @@ odp_queue_t odp_cls_hash_result(odp_cos_t cos, odp_packet_t packet);
 /**
  * Discard a class-of-service along with all its associated resources
  *
+ * Before destroying a CoS, all the PMRs referring to the CoS (as a source or
+ * destination CoS) must be destroyed first. Also, the CoS must not be in use
+ * as the default CoS in any pktio (@see odp_pktio_default_cos_set()) or as the
+ * destination CoS of any IPsec SA.
+ *
  * @param cos          CoS handle
  *
  * @retval  0 on success

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -622,7 +622,8 @@ typedef enum {
  */
 typedef struct odp_cls_cos_param {
 	/** Action to take. When action is ODP_COS_ACTION_DROP, all the other
-	 * parameters are ignored.
+	 * parameters are ignored. If action is ODP_COS_ACTION_ENQUEUE, then
+	 * queue must be set, or num_queue must be greater than one.
 	 *
 	 * The final match in the CoS chain defines the action for a packet.
 	 * I.e. packet is dropped only when the CoS of the last matching rule
@@ -773,9 +774,12 @@ int odp_cos_destroy(odp_cos_t cos);
 /**
  * Assign a queue for a class-of-service
  *
+ * Action of the given CoS may not be ODP_COS_ACTION_DROP.
+ *
  * @param cos          CoS handle
  * @param queue        Handle of the queue where all packets of this specific
- *                     class of service will be enqueued.
+ *                     class of service will be enqueued. Must not be
+ *                     ODP_QUEUE_INVALID.
  *
  * @retval  0 on success
  * @retval <0 on failure
@@ -788,7 +792,8 @@ int odp_cos_queue_set(odp_cos_t cos, odp_queue_t queue);
 * @param cos           CoS handle
 *
 * @retval Queue handle associated with the given class-of-service
-* @retval ODP_QUEUE_INVALID on failure, or if the queue has not been set
+* @retval ODP_QUEUE_INVALID on failure, or if there are multiple queues, or if
+*         the CoS action is ODP_COS_ACTION_DROP.
 */
 odp_queue_t odp_cos_queue(odp_cos_t cos);
 

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -671,7 +671,15 @@ typedef struct odp_cls_cos_param {
 			odp_pktin_hash_proto_t hash_proto;
 		};
 	};
-	/** Pool associated with CoS */
+	/** Pool associated with CoS
+	 *
+	 * May be set to ODP_POOL_INVALID, in which case the default pool of
+	 * the originating packet input is used (@see odp_pktio_open()). If
+	 * there is no originating packet input (e.g. with lookaside IPsec),
+	 * then this parameter must be set to a valid pool.
+	 *
+	 * Default is ODP_POOL_INVALID.
+	 */
 	odp_pool_t pool;
 
 #if ODP_DEPRECATED_API
@@ -1017,7 +1025,7 @@ int odp_cls_cos_pool_set(odp_cos_t cos, odp_pool_t pool_id);
 * @param cos        CoS handle
 *
 * @retval pool handle of the associated pool
-* @retval ODP_POOL_INVALID if no associated pool found or in case of an error
+* @retval ODP_POOL_INVALID on failure, or if the pool has not been set
 */
 odp_pool_t odp_cls_cos_pool(odp_cos_t cos);
 

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -103,7 +103,7 @@ extern "C" {
  *	 the odp_pktio_default_cos_set() routine, or because a matching PMR
  *	 assigned the packet to a specific CoS. The default pool specified
  *	 here is applicable only for those packets that are not assigned to a
- *	 more specific CoS.
+ *	 more specific CoS that specifies another pool.
  *
  * @see odp_pktio_start(), odp_pktio_stop(), odp_pktio_close()
  */

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -663,8 +663,8 @@ int odp_pktio_mac_addr_set(odp_pktio_t pktio, const void *mac_addr,
  *
  * @param pktio        Ingress port pktio handle.
  * @param default_cos  Class-of-service set to all packets arriving at this
- *                     ingress port, unless overridden by subsequent
- *                     header-based filters.
+ *                     ingress port. Use ODP_COS_INVALID to remove the default
+ *                     CoS.
  *
  * @retval  0 on success
  * @retval <0 on failure

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -59,15 +59,16 @@ odp_pool_t odp_pool_create(const char *name, const odp_pool_param_t *param);
 /**
  * Destroy a pool previously created by odp_pool_create()
  *
+ * This routine destroys a previously created pool, and will destroy any
+ * internal shared memory objects associated with the pool. The pool must not
+ * be in use (in pktio, classifier, timer, etc.) when calling this function.
+ * Results are undefined if an attempt is made to destroy a pool that contains
+ * allocated or otherwise active buffers.
+ *
  * @param pool    Handle of the pool to be destroyed
  *
  * @retval 0 Success
  * @retval -1 Failure
- *
- * @note This routine destroys a previously created pool, and will destroy any
- * internal shared memory objects associated with the pool. Results are
- * undefined if an attempt is made to destroy a pool that contains allocated
- * or otherwise active buffers.
  */
 int odp_pool_destroy(odp_pool_t pool);
 

--- a/include/odp/api/spec/queue.h
+++ b/include/odp/api/spec/queue.h
@@ -50,9 +50,9 @@ odp_queue_t odp_queue_create(const char *name, const odp_queue_param_t *param);
  * Destroy ODP queue
  *
  * Destroys ODP queue. The queue must be empty and detached from other
- * ODP API (crypto, pktio, etc). Application must ensure that no other
- * operations on this queue are invoked in parallel. Otherwise behavior
- * is undefined.
+ * ODP API (crypto, pktio, classifier, timer, etc). Application must ensure
+ * that no other operations on this queue are invoked in parallel. Otherwise
+ * behavior is undefined.
  *
  * @param queue    Queue handle
  *

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -534,17 +534,20 @@ odp_cls_drop_t odp_cos_drop(odp_cos_t cos_id)
 int odp_pktio_default_cos_set(odp_pktio_t pktio_in, odp_cos_t default_cos)
 {
 	pktio_entry_t *entry;
-	cos_t *cos;
+	cos_t *cos = NULL;
 
 	entry = get_pktio_entry(pktio_in);
 	if (entry == NULL) {
 		_ODP_ERR("Invalid odp_pktio_t handle\n");
 		return -1;
 	}
-	cos = get_cos_entry(default_cos);
-	if (cos == NULL) {
-		_ODP_ERR("Invalid odp_cos_t handle\n");
-		return -1;
+
+	if (default_cos != ODP_COS_INVALID) {
+		cos = get_cos_entry(default_cos);
+		if (cos == NULL) {
+			_ODP_ERR("Invalid odp_cos_t handle\n");
+			return -1;
+		}
 	}
 
 	entry->cls.default_cos = cos;

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -250,6 +250,9 @@ odp_cos_t odp_cls_cos_create(const char *name, const odp_cls_cos_param_t *param_
 		param.queue = ODP_QUEUE_INVALID;
 		param.pool = ODP_POOL_INVALID;
 		param.vector.enable = false;
+	} else {
+		if (param.num_queue == 1 && param.queue == ODP_QUEUE_INVALID)
+			return ODP_COS_INVALID;
 	}
 
 	/* num_queue should not be zero */
@@ -429,6 +432,11 @@ int odp_cos_queue_set(odp_cos_t cos_id, odp_queue_t queue_id)
 
 	if (cos == NULL) {
 		_ODP_ERR("Invalid odp_cos_t handle\n");
+		return -1;
+	}
+
+	if (queue_id == ODP_QUEUE_INVALID) {
+		_ODP_ERR("Invalid queue\n");
 		return -1;
 	}
 
@@ -1720,11 +1728,6 @@ int _odp_cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 
 	if (cos->action == ODP_COS_ACTION_DROP)
 		return 1;
-
-	if (cos->queue == ODP_QUEUE_INVALID && cos->num_queue == 1) {
-		odp_atomic_inc_u64(&cos->stats.discards);
-		return 1;
-	}
 
 	*pool = cos->pool;
 	if (*pool == ODP_POOL_INVALID)

--- a/test/validation/api/classification/odp_classification_basic.c
+++ b/test/validation/api/classification/odp_classification_basic.c
@@ -203,13 +203,14 @@ static void classification_test_create_pmr_match(void)
 	retval = odp_cls_pmr_destroy(ODP_PMR_INVALID);
 	CU_ASSERT(retval < 0);
 
+	odp_cos_destroy(cos);
 	odp_queue_destroy(queue);
 	odp_pool_destroy(pool);
 	odp_pool_destroy(pkt_pool);
-	odp_cos_destroy(cos);
+	odp_pktio_default_cos_set(pktio, ODP_COS_INVALID);
+	odp_cos_destroy(default_cos);
 	odp_queue_destroy(default_queue);
 	odp_pool_destroy(default_pool);
-	odp_cos_destroy(default_cos);
 	odp_pktio_close(pktio);
 }
 
@@ -401,13 +402,14 @@ static void classification_test_pmr_composite_create(void)
 	retval = odp_cls_pmr_destroy(pmr_composite);
 	CU_ASSERT(retval == 0);
 
+	odp_cos_destroy(cos);
 	odp_queue_destroy(queue);
 	odp_pool_destroy(pool);
 	odp_pool_destroy(pkt_pool);
-	odp_cos_destroy(cos);
+	odp_pktio_default_cos_set(pktio, ODP_COS_INVALID);
+	odp_cos_destroy(default_cos);
 	odp_queue_destroy(default_queue);
 	odp_pool_destroy(default_pool);
-	odp_cos_destroy(default_cos);
 	odp_pktio_close(pktio);
 }
 

--- a/test/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/validation/api/classification/odp_classification_test_pmr.c
@@ -194,9 +194,10 @@ static void classification_test_pktin_classifier_flag(void)
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 
 	odp_packet_free(pkt);
-	odp_cos_destroy(cos);
-	odp_cos_destroy(default_cos);
 	odp_cls_pmr_destroy(pmr);
+	odp_cos_destroy(cos);
+	odp_pktio_default_cos_set(pktio, ODP_COS_INVALID);
+	odp_cos_destroy(default_cos);
 	stop_pktio(pktio);
 	odp_queue_destroy(queue);
 	odp_queue_destroy(default_queue);
@@ -366,9 +367,10 @@ static void _classification_test_pmr_term_tcp_dport(int num_pkt)
 	CU_ASSERT(sent_queue == recv_queue);
 	CU_ASSERT(sent_default == recv_default);
 
-	odp_cos_destroy(cos);
-	odp_cos_destroy(default_cos);
 	odp_cls_pmr_destroy(pmr);
+	odp_cos_destroy(cos);
+	odp_pktio_default_cos_set(pktio, ODP_COS_INVALID);
+	odp_cos_destroy(default_cos);
 	stop_pktio(pktio);
 	odp_queue_destroy(queue);
 	odp_queue_destroy(default_queue);
@@ -457,9 +459,10 @@ static void test_pmr(const odp_pmr_param_t *pmr_param, odp_packet_t pkt,
 	}
 
 	odp_packet_free(pkt);
+	odp_cls_pmr_destroy(pmr);
 	odp_cos_destroy(cos);
+	odp_pktio_default_cos_set(pktio, ODP_COS_INVALID);
 	odp_cos_destroy(default_cos);
-	odp_cls_pmr_destroy(pmr);      /* XXX ordering */
 	stop_pktio(pktio);
 	odp_pool_destroy(default_pool);
 	odp_pool_destroy(pool);
@@ -747,9 +750,10 @@ static void classification_test_pmr_term_dmac(void)
 	CU_ASSERT(recvpool == default_pool);
 	CU_ASSERT(retqueue == default_queue);
 
-	odp_cos_destroy(cos);
-	odp_cos_destroy(default_cos);
 	odp_cls_pmr_destroy(pmr);
+	odp_cos_destroy(cos);
+	odp_pktio_default_cos_set(pktio, ODP_COS_INVALID);
+	odp_cos_destroy(default_cos);
 	odp_packet_free(pkt);
 	stop_pktio(pktio);
 	odp_pool_destroy(default_pool);
@@ -1080,9 +1084,10 @@ static void classification_test_pmr_pool_set(void)
 	CU_ASSERT(retqueue == queue);
 	odp_packet_free(pkt);
 
-	odp_cos_destroy(cos);
-	odp_cos_destroy(default_cos);
 	odp_cls_pmr_destroy(pmr);
+	odp_cos_destroy(cos);
+	odp_pktio_default_cos_set(pktio, ODP_COS_INVALID);
+	odp_cos_destroy(default_cos);
 	stop_pktio(pktio);
 	odp_pool_destroy(default_pool);
 	odp_pool_destroy(pool);
@@ -1180,9 +1185,10 @@ static void classification_test_pmr_queue_set(void)
 	CU_ASSERT(retqueue == queue_new);
 	odp_packet_free(pkt);
 
-	odp_cos_destroy(cos);
-	odp_cos_destroy(default_cos);
 	odp_cls_pmr_destroy(pmr);
+	odp_cos_destroy(cos);
+	odp_pktio_default_cos_set(pktio, ODP_COS_INVALID);
+	odp_cos_destroy(default_cos);
 	stop_pktio(pktio);
 	odp_pool_destroy(default_pool);
 	odp_pool_destroy(pool);
@@ -1603,15 +1609,15 @@ static void test_pmr_series(const int num_udp, int marking)
 	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
 	CU_ASSERT(retqueue == default_queue);
 	odp_packet_free(pkt);
+	odp_cls_pmr_destroy(pmr_ip);
 
 	for (i = 0; i < num_udp; i++) {
-		odp_cos_destroy(cos_udp[i]);
 		odp_cls_pmr_destroy(pmr_udp[i]);
+		odp_cos_destroy(cos_udp[i]);
 	}
 
 	odp_cos_destroy(cos_ip);
-	odp_cls_pmr_destroy(pmr_ip);
-
+	odp_pktio_default_cos_set(pktio, ODP_COS_INVALID);
 	odp_cos_destroy(default_cos);
 	stop_pktio(pktio);
 	odp_pool_destroy(default_pool);

--- a/test/validation/api/classification/odp_classification_tests.c
+++ b/test/validation/api/classification/odp_classification_tests.c
@@ -162,6 +162,16 @@ static int classification_suite_common_term(odp_bool_t enable_pktv)
 		retcode = -1;
 	}
 
+	for (i = 0; i < CLS_ENTRIES; i++) {
+		if (pmr_list[i] != ODP_PMR_INVALID)
+			odp_cls_pmr_destroy(pmr_list[i]);
+	}
+
+	for (i = 0; i < CLS_ENTRIES; i++) {
+		if (cos_list[i] != ODP_COS_INVALID)
+			odp_cos_destroy(cos_list[i]);
+	}
+
 	if (0 != odp_pool_destroy(pool_default)) {
 		ODPH_ERR("Pool_default destroy failed\n");
 		retcode = -1;
@@ -172,16 +182,6 @@ static int classification_suite_common_term(odp_bool_t enable_pktv)
 			ODPH_ERR("Packet vector pool destroy failed\n");
 			retcode = -1;
 		}
-	}
-
-	for (i = 0; i < CLS_ENTRIES; i++) {
-		if (cos_list[i] != ODP_COS_INVALID)
-			odp_cos_destroy(cos_list[i]);
-	}
-
-	for (i = 0; i < CLS_ENTRIES; i++) {
-		if (pmr_list[i] != ODP_PMR_INVALID)
-			odp_cls_pmr_destroy(pmr_list[i]);
 	}
 
 	for (i = 0; i < CLS_ENTRIES; i++) {

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -2041,8 +2041,10 @@ static void pktio_config_flow_control(int pfc, int rx, int tx)
 	if (cos != ODP_COS_INVALID)
 		odp_cos_destroy(cos);
 
-	if (default_cos != ODP_COS_INVALID)
+	if (default_cos != ODP_COS_INVALID) {
+		odp_pktio_default_cos_set(pktio, ODP_COS_INVALID);
 		odp_cos_destroy(default_cos);
+	}
 
 	if (queue != ODP_QUEUE_INVALID)
 		odp_queue_destroy(queue);


### PR DESCRIPTION
Clarify the order in which CoSes, PMRs, pools and queues should be destroyed. Allow default CoS to be removed. Allow CoS pool to be set to ODP_POOL_INVALID.
