### PR TITLE
[PATCH v2] api: buffer: split header files

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -13,6 +13,7 @@ odpapiinclude_HEADERS = \
 	odp/api/atomic.h \
 	odp/api/barrier.h \
 	odp/api/buffer.h \
+	odp/api/buffer_types.h \
 	odp/api/byteorder.h \
 	odp/api/chksum.h \
 	odp/api/classification.h \
@@ -78,6 +79,7 @@ odpapispecinclude_HEADERS = \
 		  odp/api/spec/atomic.h \
 		  odp/api/spec/barrier.h \
 		  odp/api/spec/buffer.h \
+		  odp/api/spec/buffer_types.h \
 		  odp/api/spec/byteorder.h \
 		  odp/api/spec/chksum.h \
 		  odp/api/spec/classification.h \
@@ -146,6 +148,7 @@ odpapiabidefaultinclude_HEADERS = \
 	odp/api/abi-default/atomic.h \
 	odp/api/abi-default/barrier.h \
 	odp/api/abi-default/buffer.h \
+	odp/api/abi-default/buffer_types.h \
 	odp/api/abi-default/byteorder.h \
 	odp/api/abi-default/classification.h \
 	odp/api/abi-default/comp.h \
@@ -205,6 +208,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm32-linux/odp/api/abi/atomic.h \
 	odp/arch/arm32-linux/odp/api/abi/barrier.h \
 	odp/arch/arm32-linux/odp/api/abi/buffer.h \
+	odp/arch/arm32-linux/odp/api/abi/buffer_types.h \
 	odp/arch/arm32-linux/odp/api/abi/byteorder.h \
 	odp/arch/arm32-linux/odp/api/abi/classification.h \
 	odp/arch/arm32-linux/odp/api/abi/comp.h \
@@ -260,6 +264,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm64-linux/odp/api/abi/atomic.h \
 	odp/arch/arm64-linux/odp/api/abi/barrier.h \
 	odp/arch/arm64-linux/odp/api/abi/buffer.h \
+	odp/arch/arm64-linux/odp/api/abi/buffer_types.h \
 	odp/arch/arm64-linux/odp/api/abi/byteorder.h \
 	odp/arch/arm64-linux/odp/api/abi/classification.h \
 	odp/arch/arm64-linux/odp/api/abi/comp.h \
@@ -315,6 +320,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/default-linux/odp/api/abi/atomic.h \
 	odp/arch/default-linux/odp/api/abi/barrier.h \
 	odp/arch/default-linux/odp/api/abi/buffer.h \
+	odp/arch/default-linux/odp/api/abi/buffer_types.h \
 	odp/arch/default-linux/odp/api/abi/byteorder.h \
 	odp/arch/default-linux/odp/api/abi/classification.h \
 	odp/arch/default-linux/odp/api/abi/comp.h \
@@ -370,6 +376,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/power64-linux/odp/api/abi/atomic.h \
 	odp/arch/power64-linux/odp/api/abi/barrier.h \
 	odp/arch/power64-linux/odp/api/abi/buffer.h \
+	odp/arch/power64-linux/odp/api/abi/buffer_types.h \
 	odp/arch/power64-linux/odp/api/abi/byteorder.h \
 	odp/arch/power64-linux/odp/api/abi/classification.h \
 	odp/arch/power64-linux/odp/api/abi/comp.h \
@@ -425,6 +432,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_32-linux/odp/api/abi/atomic.h \
 	odp/arch/x86_32-linux/odp/api/abi/barrier.h \
 	odp/arch/x86_32-linux/odp/api/abi/buffer.h \
+	odp/arch/x86_32-linux/odp/api/abi/buffer_types.h \
 	odp/arch/x86_32-linux/odp/api/abi/byteorder.h \
 	odp/arch/x86_32-linux/odp/api/abi/classification.h \
 	odp/arch/x86_32-linux/odp/api/abi/comp.h \
@@ -480,6 +488,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_64-linux/odp/api/abi/atomic.h \
 	odp/arch/x86_64-linux/odp/api/abi/barrier.h \
 	odp/arch/x86_64-linux/odp/api/abi/buffer.h \
+	odp/arch/x86_64-linux/odp/api/abi/buffer_types.h \
 	odp/arch/x86_64-linux/odp/api/abi/byteorder.h \
 	odp/arch/x86_64-linux/odp/api/abi/classification.h \
 	odp/arch/x86_64-linux/odp/api/abi/comp.h \

--- a/include/odp/api/abi-default/buffer.h
+++ b/include/odp/api/abi-default/buffer.h
@@ -11,20 +11,7 @@
 extern "C" {
 #endif
 
-/** @internal Dummy type for strong typing */
-typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_buffer_t;
-
-/** @ingroup odp_buffer
- *  @{
- */
-
-typedef _odp_abi_buffer_t *odp_buffer_t;
-
-#define ODP_BUFFER_INVALID   ((odp_buffer_t)0)
-
-/**
- * @}
- */
+/* Empty header required due to the inline functions */
 
 #ifdef __cplusplus
 }

--- a/include/odp/api/abi-default/buffer_types.h
+++ b/include/odp/api/abi-default/buffer_types.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2017-2018, Linaro Limited
+ * Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_ABI_BUFFER_TYPES_H_
+#define ODP_ABI_BUFFER_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @internal Dummy type for strong typing */
+typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_buffer_t;
+
+/** @ingroup odp_buffer
+ *  @{
+ */
+
+typedef _odp_abi_buffer_t *odp_buffer_t;
+
+#define ODP_BUFFER_INVALID   ((odp_buffer_t)0)
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/api/buffer_types.h
+++ b/include/odp/api/buffer_types.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP buffer types
+ */
+
+#ifndef ODP_API_BUFFER_TYPES_H_
+#define ODP_API_BUFFER_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/abi/buffer_types.h>
+
+#include <odp/api/spec/buffer_types.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/api/spec/buffer.h
+++ b/include/odp/api/spec/buffer.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
+ * Copyright (c) 2022-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -8,7 +8,7 @@
 /**
  * @file
  *
- * ODP buffer descriptor
+ * ODP buffer
  */
 
 #ifndef ODP_API_SPEC_BUFFER_H_
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 
+#include <odp/api/buffer_types.h>
 #include <odp/api/event_types.h>
 #include <odp/api/pool_types.h>
 #include <odp/api/std_types.h>
@@ -26,16 +27,6 @@ extern "C" {
 /** @defgroup odp_buffer ODP BUFFER
  *  Buffer event metadata and operations.
  *  @{
- */
-
-/**
- * @typedef odp_buffer_t
- * ODP buffer
- */
-
-/**
- * @def ODP_BUFFER_INVALID
- * Invalid buffer
  */
 
 /**

--- a/include/odp/api/spec/buffer_types.h
+++ b/include/odp/api/spec/buffer_types.h
@@ -1,0 +1,45 @@
+/* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP buffer types
+ */
+
+#ifndef ODP_API_SPEC_BUFFER_TYPES_H_
+#define ODP_API_SPEC_BUFFER_TYPES_H_
+#include <odp/visibility_begin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup odp_buffer
+ *  @{
+ */
+
+/**
+ * @typedef odp_buffer_t
+ * ODP buffer
+ */
+
+/**
+ * @def ODP_BUFFER_INVALID
+ * Invalid buffer
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <odp/visibility_end.h>
+#endif

--- a/include/odp/arch/arm32-linux/odp/api/abi/buffer_types.h
+++ b/include/odp/arch/arm32-linux/odp/api/abi/buffer_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/buffer_types.h>

--- a/include/odp/arch/arm64-linux/odp/api/abi/buffer_types.h
+++ b/include/odp/arch/arm64-linux/odp/api/abi/buffer_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/buffer_types.h>

--- a/include/odp/arch/default-linux/odp/api/abi/buffer_types.h
+++ b/include/odp/arch/default-linux/odp/api/abi/buffer_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/buffer_types.h>

--- a/include/odp/arch/power64-linux/odp/api/abi/buffer_types.h
+++ b/include/odp/arch/power64-linux/odp/api/abi/buffer_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/buffer_types.h>

--- a/include/odp/arch/x86_32-linux/odp/api/abi/buffer_types.h
+++ b/include/odp/arch/x86_32-linux/odp/api/abi/buffer_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/buffer_types.h>

--- a/include/odp/arch/x86_64-linux/odp/api/abi/buffer_types.h
+++ b/include/odp/arch/x86_64-linux/odp/api/abi/buffer_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/buffer_types.h>

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -72,6 +72,7 @@ odpapiabiarchinclude_HEADERS += \
 		  include-abi/odp/api/abi/atomic.h \
 		  include-abi/odp/api/abi/barrier.h \
 		  include-abi/odp/api/abi/buffer.h \
+		  include-abi/odp/api/abi/buffer_types.h \
 		  include-abi/odp/api/abi/byteorder.h \
 		  include-abi/odp/api/abi/classification.h \
 		  include-abi/odp/api/abi/comp.h \

--- a/platform/linux-generic/include-abi/odp/api/abi/buffer.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/buffer.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -7,7 +8,7 @@
 /**
  * @file
  *
- * ODP buffer descriptor
+ * ODP buffer
  */
 
 #ifndef ODP_API_ABI_BUFFER_H_
@@ -17,23 +18,8 @@
 extern "C" {
 #endif
 
-#include <odp/api/std_types.h>
-#include <odp/api/plat/strong_types.h>
-
-/** @ingroup odp_buffer
- *  @{
- */
-
-typedef ODP_HANDLE_T(odp_buffer_t);
-
-#define ODP_BUFFER_INVALID _odp_cast_scalar(odp_buffer_t, 0)
-
-/* Inlined functions for non-ABI compat mode */
+/* Inlined API functions */
 #include <odp/api/plat/buffer_inlines.h>
-
-/**
- * @}
- */
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include-abi/odp/api/abi/buffer_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/buffer_types.h
@@ -1,0 +1,40 @@
+/* Copyright (c) 2015-2018, Linaro Limited
+ * Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP buffer types
+ */
+
+#ifndef ODP_API_ABI_BUFFER_TYPES_H_
+#define ODP_API_ABI_BUFFER_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/std_types.h>
+#include <odp/api/plat/strong_types.h>
+
+/** @ingroup odp_buffer
+ *  @{
+ */
+
+typedef ODP_HANDLE_T(odp_buffer_t);
+
+#define ODP_BUFFER_INVALID _odp_cast_scalar(odp_buffer_t, 0)
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp/api/plat/buffer_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/buffer_inlines.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2022, Nokia
+/* Copyright (c) 2019-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -7,10 +7,9 @@
 #ifndef ODP_PLAT_BUFFER_INLINES_H_
 #define ODP_PLAT_BUFFER_INLINES_H_
 
+#include <odp/api/buffer_types.h>
 #include <odp/api/event.h>
 #include <odp/api/pool_types.h>
-
-#include <odp/api/abi/buffer.h>
 
 #include <odp/api/plat/buffer_inline_types.h>
 #include <odp/api/plat/debug_inlines.h>

--- a/platform/linux-generic/include/odp/api/plat/event_validation_external.h
+++ b/platform/linux-generic/include/odp/api/plat/event_validation_external.h
@@ -18,7 +18,7 @@
 
 #include <odp/autoheader_external.h>
 
-#include <odp/api/buffer.h>
+#include <odp/api/buffer_types.h>
 #include <odp/api/event_types.h>
 #include <odp/api/hints.h>
 #include <odp/api/packet_types.h>


### PR DESCRIPTION
Split buffer API into separate header files for functions and types. This fixes circular dependency issues with inline headers.

Signed-off-by: Matias Elo <matias.elo@nokia.com>