### PR TITLE
[PATCH v6] linux-gen: sched: implement power saving sleep in schedule loop

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.25"
+config_file_version = "0.1.26"
 
 # System options
 system: {
@@ -243,6 +243,32 @@ sched_basic: {
 	# > 0, events may be dropped by the implementation if the target queue
 	# is full. To prevent this set 'order_stash_size' to 0.
 	order_stash_size = 512
+
+	# Power saving options for schedule with wait
+	#
+	# When waiting for events during a schedule call, save power by
+	# sleeping in the poll loop. First, run schedule loop normally for
+	# poll_time_nsec nanoseconds. If there are no events to schedule in that
+	# time, continue polling, but sleep for sleep_time_nsec nanoseconds on
+	# each round.
+	#
+	# During sleep, the thread is not polling for packet input or timers.
+	# Each thread measures time and sleeps independently of other threads.
+	#
+	# When using this feature, it may be necessary to decrease
+	# /proc/<pid>/timerslack_ns, or use a real-time priority. Sleeping may
+	# have an adverse effect on performance for a short time after sleep.
+	powersave: {
+		# Time in nsec to poll before sleeping
+		#
+		# <1: Disabled. Never sleep. sleep_time_nsec is ignored.
+		poll_time_nsec = 0
+
+		# Time in nsec to sleep
+		#
+		# Actual sleep time may vary.
+		sleep_time_nsec = 0
+	}
 }
 
 stash: {

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -14,6 +14,7 @@ extern "C" {
 
 #include <odp/api/queue.h>
 #include <odp/api/schedule.h>
+#include <odp/api/plat/schedule_inline_types.h>
 
 #include <odp_event_internal.h>
 #include <odp_queue_if.h>
@@ -59,6 +60,7 @@ typedef void (*schedule_order_lock_start_fn_t)(void);
 typedef void (*schedule_order_lock_wait_fn_t)(void);
 typedef uint32_t (*schedule_max_ordered_locks_fn_t)(void);
 typedef void (*schedule_get_config_fn_t)(schedule_config_t *config);
+typedef const _odp_schedule_api_fn_t *(*schedule_sched_api_fn_t)(void);
 
 typedef struct schedule_fn_t {
 	schedule_pktio_start_fn_t   pktio_start;
@@ -80,6 +82,7 @@ typedef struct schedule_fn_t {
 	schedule_order_unlock_lock_fn_t  order_unlock_lock;
 	schedule_max_ordered_locks_fn_t max_ordered_locks;
 	schedule_get_config_fn_t        get_config;
+	schedule_sched_api_fn_t		sched_api;
 
 } schedule_fn_t;
 

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -3,7 +3,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [25])
+m4_define([_odp_config_version_minor], [26])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -292,6 +292,11 @@ typedef struct {
 
 	order_context_t order[CONFIG_MAX_SCHED_QUEUES];
 
+	struct {
+		uint32_t poll_time;
+		struct timespec sleep_time;
+	} powersave;
+
 	/* Scheduler interface config options (not used in fast path) */
 	schedule_config_t config_if;
 	uint32_t max_queues;
@@ -519,6 +524,26 @@ static int read_config_file(sched_global_t *sched)
 	}
 
 	sched->config_if.group_enable.control = val;
+	_ODP_PRINT("  %s: %i\n", str, val);
+
+	str = "sched_basic.powersave.poll_time_nsec";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		_ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+
+	sched->powersave.poll_time = _ODP_MAX(0, val);
+	_ODP_PRINT("  %s: %i\n", str, val);
+
+	str = "sched_basic.powersave.sleep_time_nsec";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		_ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+
+	val = _ODP_MAX(0, val);
+	sched->powersave.sleep_time.tv_sec = val / 1000000000;
+	sched->powersave.sleep_time.tv_nsec = val % 1000000000;
 	_ODP_PRINT("  %s: %i\n", str, val);
 
 	_ODP_PRINT("  dynamic load balance: %s\n", sched->load_balance ? "ON" : "OFF");

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -2199,6 +2199,13 @@ int _odp_sched_basic_get_spread(uint32_t queue_index)
 	return sched->queue[queue_index].spread;
 }
 
+const _odp_schedule_api_fn_t _odp_schedule_basic_api;
+
+static const _odp_schedule_api_fn_t *sched_api(void)
+{
+	return &_odp_schedule_basic_api;
+}
+
 /* Fill in scheduler interface */
 const schedule_fn_t _odp_schedule_basic_fn = {
 	.pktio_start = schedule_pktio_start,
@@ -2216,7 +2223,8 @@ const schedule_fn_t _odp_schedule_basic_fn = {
 	.order_lock = order_lock,
 	.order_unlock = order_unlock,
 	.max_ordered_locks = schedule_max_ordered_locks,
-	.get_config = schedule_get_config
+	.get_config = schedule_get_config,
+	.sched_api = sched_api,
 };
 
 /* Fill in scheduler API calls */

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -30,14 +30,8 @@ int _odp_schedule_configured(void)
 #include <odp/visibility_end.h>
 
 extern const schedule_fn_t _odp_schedule_sp_fn;
-extern const _odp_schedule_api_fn_t _odp_schedule_sp_api;
-
 extern const schedule_fn_t _odp_schedule_basic_fn;
-extern const _odp_schedule_api_fn_t _odp_schedule_basic_api;
-
-extern const schedule_fn_t  _odp_schedule_scalable_fn;
-extern const _odp_schedule_api_fn_t _odp_schedule_scalable_api;
-
+extern const schedule_fn_t _odp_schedule_scalable_fn;
 const schedule_fn_t *_odp_sched_fn;
 int _odp_sched_id;
 
@@ -153,21 +147,23 @@ int _odp_schedule_init_global(void)
 	if (!strcmp(sched, "basic")) {
 		_odp_sched_id = _ODP_SCHED_ID_BASIC;
 		_odp_sched_fn = &_odp_schedule_basic_fn;
-		_odp_sched_api = &_odp_schedule_basic_api;
 	} else if (!strcmp(sched, "sp")) {
 		_odp_sched_id = _ODP_SCHED_ID_SP;
 		_odp_sched_fn = &_odp_schedule_sp_fn;
-		_odp_sched_api = &_odp_schedule_sp_api;
 	} else if (!strcmp(sched, "scalable")) {
 		_odp_sched_id = _ODP_SCHED_ID_SCALABLE;
 		_odp_sched_fn = &_odp_schedule_scalable_fn;
-		_odp_sched_api = &_odp_schedule_scalable_api;
 	} else {
 		_ODP_ABORT("Unknown scheduler specified via ODP_SCHEDULER\n");
 		return -1;
 	}
 
-	return _odp_sched_fn->init_global();
+	if (_odp_sched_fn->init_global())
+		return -1;
+
+	_odp_sched_api = _odp_sched_fn->sched_api();
+
+	return 0;
 }
 
 int _odp_schedule_term_global(void)

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -1846,19 +1846,19 @@ static int schedule_init_global(void)
 	 * GROUP_CONTROL groups.
 	 */
 	odp_thrmask_zero(&mask);
-	tmp_all = odp_schedule_group_create("__group_all", &mask);
+	tmp_all = schedule_group_create("__group_all", &mask);
 	if (tmp_all != ODP_SCHED_GROUP_ALL) {
 		_ODP_ERR("Could not create ODP_SCHED_GROUP_ALL()\n");
 		goto failed_create_group_all;
 	}
 
-	tmp_wrkr = odp_schedule_group_create("__group_worker", &mask);
+	tmp_wrkr = schedule_group_create("__group_worker", &mask);
 	if (tmp_wrkr != ODP_SCHED_GROUP_WORKER) {
 		_ODP_ERR("Could not create ODP_SCHED_GROUP_WORKER()\n");
 		goto failed_create_group_worker;
 	}
 
-	tmp_ctrl = odp_schedule_group_create("__group_control", &mask);
+	tmp_ctrl = schedule_group_create("__group_control", &mask);
 	if (tmp_ctrl != ODP_SCHED_GROUP_CONTROL) {
 		_ODP_ERR("Could not create ODP_SCHED_GROUP_CONTROL()\n");
 		goto failed_create_group_control;
@@ -1872,15 +1872,15 @@ static int schedule_init_global(void)
 
 failed_create_group_control:
 	if (tmp_ctrl != ODP_SCHED_GROUP_INVALID)
-		odp_schedule_group_destroy(ODP_SCHED_GROUP_CONTROL);
+		schedule_group_destroy(ODP_SCHED_GROUP_CONTROL);
 
 failed_create_group_worker:
 	if (tmp_wrkr != ODP_SCHED_GROUP_INVALID)
-		odp_schedule_group_destroy(ODP_SCHED_GROUP_WORKER);
+		schedule_group_destroy(ODP_SCHED_GROUP_WORKER);
 
 failed_create_group_all:
 	if (tmp_all != ODP_SCHED_GROUP_INVALID)
-		odp_schedule_group_destroy(ODP_SCHED_GROUP_ALL);
+		schedule_group_destroy(ODP_SCHED_GROUP_ALL);
 
 failed_sched_shm_pool_create:
 
@@ -1892,15 +1892,15 @@ static int schedule_term_global(void)
 	/* Destroy enabled sched groups for default GROUP_ALL, GROUP_WORKER and
 	 * GROUP_CONTROL groups. */
 	if (global->config_if.group_enable.all) {
-		if (odp_schedule_group_destroy(ODP_SCHED_GROUP_ALL) != 0)
+		if (schedule_group_destroy(ODP_SCHED_GROUP_ALL) != 0)
 			_ODP_ERR("Failed to destroy ODP_SCHED_GROUP_ALL\n");
 	}
 	if (global->config_if.group_enable.worker) {
-		if (odp_schedule_group_destroy(ODP_SCHED_GROUP_WORKER) != 0)
+		if (schedule_group_destroy(ODP_SCHED_GROUP_WORKER) != 0)
 			_ODP_ERR("Failed to destroy ODP_SCHED_GROUP_WORKER\n");
 	}
 	if (global->config_if.group_enable.control) {
-		if (odp_schedule_group_destroy(ODP_SCHED_GROUP_CONTROL) != 0)
+		if (schedule_group_destroy(ODP_SCHED_GROUP_CONTROL) != 0)
 			_ODP_ERR("Failed to destroy ODP_SCHED_GROUP_CONTROL\n");
 	}
 
@@ -1932,21 +1932,19 @@ static int schedule_init_local(void)
 	odp_spinlock_lock(&global->init_lock);
 
 	if (global->config_if.group_enable.all) {
-		if (odp_schedule_group_join(ODP_SCHED_GROUP_ALL, &mask) != 0) {
+		if (schedule_group_join(ODP_SCHED_GROUP_ALL, &mask) != 0) {
 			_ODP_ERR("Failed to join ODP_SCHED_GROUP_ALL\n");
 			goto failed_to_join_grp_all;
 		}
 	}
 	if (global->config_if.group_enable.control && thr_type == ODP_THREAD_CONTROL) {
-		if (odp_schedule_group_join(ODP_SCHED_GROUP_CONTROL,
-					    &mask) != 0) {
+		if (schedule_group_join(ODP_SCHED_GROUP_CONTROL, &mask) != 0) {
 			_ODP_ERR("Failed to join ODP_SCHED_GROUP_CONTROL\n");
 			goto failed_to_join_grp_ctrl;
 		}
 	}
 	if (global->config_if.group_enable.worker && thr_type == ODP_THREAD_WORKER) {
-		if (odp_schedule_group_join(ODP_SCHED_GROUP_WORKER,
-					    &mask) != 0) {
+		if (schedule_group_join(ODP_SCHED_GROUP_WORKER, &mask) != 0) {
 			_ODP_ERR("Failed to join ODP_SCHED_GROUP_WORKER\n");
 			goto failed_to_join_grp_wrkr;
 		}
@@ -1959,7 +1957,7 @@ static int schedule_init_local(void)
 failed_to_join_grp_wrkr:
 failed_to_join_grp_ctrl:
 	if (global->config_if.group_enable.all)
-		odp_schedule_group_leave(ODP_SCHED_GROUP_ALL, &mask);
+		schedule_group_leave(ODP_SCHED_GROUP_ALL, &mask);
 
 failed_to_join_grp_all:
 	odp_spinlock_unlock(&global->init_lock);
@@ -1982,17 +1980,15 @@ static int schedule_term_local(void)
 	odp_thrmask_set(&mask, thr_id);
 
 	if (global->config_if.group_enable.all) {
-		if (odp_schedule_group_leave(ODP_SCHED_GROUP_ALL, &mask) != 0)
+		if (schedule_group_leave(ODP_SCHED_GROUP_ALL, &mask) != 0)
 			_ODP_ERR("Failed to leave ODP_SCHED_GROUP_ALL\n");
 	}
 	if (global->config_if.group_enable.control && thr_type == ODP_THREAD_CONTROL) {
-		if (odp_schedule_group_leave(ODP_SCHED_GROUP_CONTROL,
-					     &mask) != 0)
+		if (schedule_group_leave(ODP_SCHED_GROUP_CONTROL, &mask) != 0)
 			_ODP_ERR("Failed to leave ODP_SCHED_GROUP_CONTROL\n");
 	}
 	if (global->config_if.group_enable.worker && thr_type == ODP_THREAD_WORKER) {
-		if (odp_schedule_group_leave(ODP_SCHED_GROUP_WORKER,
-					     &mask) != 0)
+		if (schedule_group_leave(ODP_SCHED_GROUP_WORKER, &mask) != 0)
 			_ODP_ERR("Failed to leave ODP_SCHED_GROUP_WORKER\n");
 	}
 
@@ -2026,16 +2022,16 @@ static int schedule_config(const odp_schedule_config_t *config)
 
 	/* Destroy disabled predefined scheduling groups. */
 	if (!config->sched_group.all) {
-		if (odp_schedule_group_destroy(ODP_SCHED_GROUP_ALL) != 0)
+		if (schedule_group_destroy(ODP_SCHED_GROUP_ALL) != 0)
 			_ODP_ERR("Failed to destroy ODP_SCHED_GROUP_ALL\n");
 	}
 	if (!config->sched_group.worker) {
-		if (odp_schedule_group_destroy(ODP_SCHED_GROUP_WORKER) != 0)
+		if (schedule_group_destroy(ODP_SCHED_GROUP_WORKER) != 0)
 			_ODP_ERR("Failed to destroy ODP_SCHED_GROUP_WORKER\n");
 	}
 
 	if (!config->sched_group.control) {
-		if (odp_schedule_group_destroy(ODP_SCHED_GROUP_CONTROL) != 0)
+		if (schedule_group_destroy(ODP_SCHED_GROUP_CONTROL) != 0)
 			_ODP_ERR("Failed to destroy ODP_SCHED_GROUP_CONTROL\n");
 	}
 
@@ -2187,6 +2183,13 @@ static void schedule_print(void)
 	_ODP_PRINT("\n");
 }
 
+const _odp_schedule_api_fn_t _odp_schedule_scalable_api;
+
+static const _odp_schedule_api_fn_t *sched_api(void)
+{
+	return &_odp_schedule_scalable_api;
+}
+
 const schedule_fn_t _odp_schedule_scalable_fn = {
 	.pktio_start	= pktio_start,
 	.thr_add	= thr_add,
@@ -2203,6 +2206,7 @@ const schedule_fn_t _odp_schedule_scalable_fn = {
 	.order_lock	= order_lock,
 	.order_unlock	= order_unlock,
 	.max_ordered_locks = schedule_max_ordered_locks,
+	.sched_api	= sched_api,
 };
 
 const _odp_schedule_api_fn_t _odp_schedule_scalable_api = {

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -1059,6 +1059,13 @@ static void get_config(schedule_config_t *config)
 	*config = sched_global->config_if;
 }
 
+const _odp_schedule_api_fn_t _odp_schedule_sp_api;
+
+static const _odp_schedule_api_fn_t *sched_api(void)
+{
+	return &_odp_schedule_sp_api;
+}
+
 /* Fill in scheduler interface */
 const schedule_fn_t _odp_schedule_sp_fn = {
 	.pktio_start   = pktio_start,
@@ -1076,7 +1083,8 @@ const schedule_fn_t _odp_schedule_sp_fn = {
 	.order_lock    = order_lock,
 	.order_unlock  = order_unlock,
 	.max_ordered_locks = max_ordered_locks,
-	.get_config    = get_config
+	.get_config    = get_config,
+	.sched_api     = sched_api,
 };
 
 /* Fill in scheduler API calls */

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.25"
+config_file_version = "0.1.26"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/packet_align.conf
+++ b/platform/linux-generic/test/packet_align.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.25"
+config_file_version = "0.1.26"
 
 pool: {
 	pkt: {

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.25"
+config_file_version = "0.1.26"
 
 # Shared memory options
 shm: {

--- a/platform/linux-generic/test/sched-basic.conf
+++ b/platform/linux-generic/test/sched-basic.conf
@@ -7,4 +7,8 @@ sched_basic: {
 	prio_spread = 3
 	load_balance = 0
 	order_stash_size = 0
+	powersave: {
+		poll_time_nsec = 5000
+		sleep_time_nsec = 50000
+	}
 }

--- a/platform/linux-generic/test/sched-basic.conf
+++ b/platform/linux-generic/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.25"
+config_file_version = "0.1.26"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {

--- a/platform/linux-generic/test/stash-custom.conf
+++ b/platform/linux-generic/test/stash-custom.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.25"
+config_file_version = "0.1.26"
 
 # Test overflow safe stash variant
 stash: {


### PR DESCRIPTION
Optionally, when there are no events to schedule, sleep for a while to save power. Add power saving config file options poll_time and sleep_time.

v2:
- Change sleep_time to struct timespec.
- Clean up schedule_loop_sleep().
- Move comment about *_sleep functions.

v3:
- Change conf file option names.
- Remove change to schedule_multi_wait().

v4:
- _odp_schedule_basic_sleep_api comments.

v5:
- Update config file version.