### PR TITLE
[PATCH v1] validation: time: reset count before reading ts

### DIFF
--- a/test/validation/api/time/time.c
+++ b/test/validation/api/time/time.c
@@ -139,6 +139,7 @@ static void time_test_monotony(void)
 	lns_t2 = odp_time_local_ns();
 	gns_t2 = odp_time_global_ns();
 
+	count = 0;
 	while (count < BUSY_LOOP_CNT) {
 		count++;
 	};


### PR DESCRIPTION
Reset busy loop count to zero before reading the next set of
timestamps.

Signed-off-by: Pavan Nikhilesh <pbhagavatula@marvell.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>