### PR TITLE
[PATCH v4] validation: dma: verify maximum concurrent transfers

### DIFF
--- a/test/validation/api/dma/dma.c
+++ b/test/validation/api/dma/dma.c
@@ -269,9 +269,10 @@ static void test_dma_compl_pool(void)
 {
 	odp_pool_t pool;
 	odp_pool_info_t pool_info;
-	odp_dma_compl_t compl;
+	odp_dma_compl_t compl[global.dma_capa.max_transfers];
 	uint64_t u64;
 	int ret;
+	uint32_t i, j;
 	const char *name = COMPL_POOL_NAME;
 
 	CU_ASSERT_FATAL(global.compl_pool != ODP_POOL_INVALID);
@@ -288,14 +289,21 @@ static void test_dma_compl_pool(void)
 	CU_ASSERT(pool_info.dma_pool_param.num == global.dma_capa.max_transfers);
 	CU_ASSERT(pool_info.dma_pool_param.cache_size == global.cache_size);
 
-	compl = odp_dma_compl_alloc(global.compl_pool);
+	for (i = 0; i < global.dma_capa.max_transfers; i++) {
+		compl[i] = odp_dma_compl_alloc(global.compl_pool);
 
-	u64 = odp_dma_compl_to_u64(compl);
-	CU_ASSERT(u64 != odp_dma_compl_to_u64(ODP_DMA_COMPL_INVALID));
-	printf("\n    DMA compl handle: 0x%" PRIx64 "\n", u64);
-	odp_dma_compl_print(compl);
+		u64 = odp_dma_compl_to_u64(compl[i]);
+		CU_ASSERT(u64 != odp_dma_compl_to_u64(ODP_DMA_COMPL_INVALID));
 
-	odp_dma_compl_free(compl);
+		if (compl[i] == ODP_DMA_COMPL_INVALID)
+			break;
+
+		printf("\n    DMA compl handle: 0x%" PRIx64 "\n", u64);
+		odp_dma_compl_print(compl[i]);
+	}
+
+	for (j = 0; j < i; j++)
+		odp_dma_compl_free(compl[j]);
 }
 
 static void test_dma_compl_pool_same_name(void)

--- a/test/validation/api/dma/dma.c
+++ b/test/validation/api/dma/dma.c
@@ -330,6 +330,36 @@ static void test_dma_compl_pool_same_name(void)
 	CU_ASSERT_FATAL(odp_pool_destroy(pool_b) == 0);
 }
 
+static void test_dma_compl_pool_max_pools(void)
+{
+	odp_dma_pool_param_t dma_pool_param;
+	/* Max pools minus the ones already created in global init */
+	uint32_t num = global.dma_capa.pool.max_pools - 2, i, j;
+	odp_pool_t pools[num];
+	int ret;
+
+	odp_dma_pool_param_init(&dma_pool_param);
+	dma_pool_param.num = global.dma_capa.max_transfers;
+
+	for (i = 0; i < num; i++) {
+		pools[i] = odp_dma_pool_create(NULL, &dma_pool_param);
+		CU_ASSERT(pools[i] != ODP_POOL_INVALID);
+
+		if (pools[i] == ODP_POOL_INVALID) {
+			ODPH_ERR("DMA completion pool create failed: %u / %u\n", i, num);
+			break;
+		}
+	}
+
+	for (j = 0; j < i; j++) {
+		ret = odp_pool_destroy(pools[j]);
+		CU_ASSERT(ret == 0);
+
+		if (ret == -1)
+			ODPH_ERR("DMA completion pool destroy failed: %u / %u\n", j, i);
+	}
+}
+
 static void init_source(uint8_t *src, uint32_t len)
 {
 	uint32_t i;
@@ -1266,6 +1296,7 @@ odp_testinfo_t dma_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(test_dma_debug, check_sync),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_compl_pool, check_event),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_compl_pool_same_name, check_event),
+	ODP_TEST_INFO_CONDITIONAL(test_dma_compl_pool_max_pools, check_event),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_addr_to_addr_sync, check_sync),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_addr_to_addr_sync_mtrs, check_sync),
 	ODP_TEST_INFO_CONDITIONAL(test_dma_addr_to_addr_sync_mseg, check_sync),


### PR DESCRIPTION
Add and modify tests to verify that maximum signaled in-flight transfer count is handled correctly.

With synchronous transfers, run more than maximum in-flight transfer count back to back to verify proper implementation resource handling.

With asynchronous transfers, start maximum in-flight count of transfers and wait for completion (poll/event).

v2:
- Added testing of maximum completion event allocation
- Added a new test for max DMA pools
- Took maximum segment length into account when configuring transfers

v3:
- Matias' comments

v4:
- Added reviewed-by tag