### PR TITLE
[PATCH v3] fix a couple of cases of uninitialized data

### DIFF
--- a/helper/test/chksum.c
+++ b/helper/test/chksum.c
@@ -107,6 +107,9 @@ int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 				       ODPH_IPV4HDR_LEN);
 	ip->proto = ODPH_IPPROTO_UDP;
 	ip->id = odp_cpu_to_be_16(1);
+	ip->tos = 0;
+	ip->frag_offset = 0;
+	ip->ttl = 0;
 	odp_packet_has_ipv4_set(test_packet, 1);
 	if (odph_ipv4_csum_update(test_packet) < 0)
 		status = -1;

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -322,7 +322,7 @@ static int _ipc_init_master(pktio_entry_t *pktio_entry,
 		goto free_s_prod;
 	}
 
-	memcpy(pinfo->master.pool_name, pool_name, strlen(pool_name));
+	strcpy(pinfo->master.pool_name, pool_name);
 
 	/* Export ring info for the slave process to use */
 	pinfo->master.ring_size = ring_size;

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -300,6 +300,8 @@ static void pktio_init_packet_eth_ipv4(odp_packet_t pkt, uint8_t proto)
 	seq = odp_atomic_fetch_inc_u32(&ip_seq);
 	ip->id = odp_cpu_to_be_16(seq);
 	ip->chksum = 0;
+	ip->frag_offset = 0;
+	ip->tos = 0;
 	odph_ipv4_csum_update(pkt);
 }
 


### PR DESCRIPTION
Fix a couple of cases where potentially uninitialized data in shm blocks are being used. These problems were revealed by filling all shm blocks with 0xaa.

v2:
- Initialize IP header fields before checksum.

v3:
- Rebase.
- Add review tags.
