### PR TITLE
[PATCH v2] linux-gen: packet: avoid bad-function-cast warning from inline header

### DIFF
--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -650,8 +650,9 @@ _ODP_INLINE void *odp_packet_buf_head(odp_packet_buf_t pkt_buf)
 
 _ODP_INLINE uint32_t odp_packet_buf_data_offset(odp_packet_buf_t pkt_buf)
 {
-	return (uint32_t)((uintptr_t)_odp_pkt_get(pkt_buf, void *, seg_data) -
-				(uintptr_t)odp_packet_buf_head(pkt_buf));
+	void *buf_head = odp_packet_buf_head(pkt_buf);
+
+	return (uint32_t)((uintptr_t)_odp_pkt_get(pkt_buf, void *, seg_data) - (uintptr_t)buf_head);
 }
 
 _ODP_INLINE void odp_packet_buf_data_set(odp_packet_buf_t pkt_buf, uint32_t data_offset,


### PR DESCRIPTION
Previously, a warning was thrown if bad-function-cast warning was enabled in application build with non-abi-compat ODP library.

Signed-off-by: Matias Elo <matias.elo@nokia.com>