### PR TITLE
[PATCH v3] linux-gen: crypto: fix uninitialized variable access

### DIFF
--- a/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
+++ b/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
@@ -877,9 +877,6 @@ static odp_packet_t get_output_packet(const odp_crypto_generic_session_t *sessio
 {
 	int rc;
 
-	if (odp_likely(session->p.op_type == ODP_CRYPTO_OP_TYPE_BASIC))
-		return pkt_in;
-
 	if (odp_likely(pkt_in == pkt_out))
 		return pkt_out;
 
@@ -914,9 +911,13 @@ int crypto_int(odp_packet_t pkt_in,
 
 	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
 
-	out_pkt = get_output_packet(session, pkt_in, *pkt_out);
-	if (odp_unlikely(out_pkt == ODP_PACKET_INVALID))
-		return -1;
+	if (odp_likely(session->p.op_type == ODP_CRYPTO_OP_TYPE_BASIC)) {
+		out_pkt = pkt_in;
+	} else {
+		out_pkt = get_output_packet(session, pkt_in, *pkt_out);
+		if (odp_unlikely(out_pkt == ODP_PACKET_INVALID))
+			return -1;
+	}
 
 	/* Invoke the crypto function */
 	session->func(out_pkt, param, session);

--- a/platform/linux-generic/odp_crypto_ipsecmb.c
+++ b/platform/linux-generic/odp_crypto_ipsecmb.c
@@ -856,9 +856,6 @@ static odp_packet_t get_output_packet(const odp_crypto_generic_session_t *sessio
 {
 	int rc;
 
-	if (odp_likely(session->p.op_type == ODP_CRYPTO_OP_TYPE_BASIC))
-		return pkt_in;
-
 	if (odp_likely(pkt_in == pkt_out))
 		return pkt_out;
 
@@ -896,9 +893,13 @@ int crypto_int(odp_packet_t pkt_in,
 
 	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
 
-	out_pkt = get_output_packet(session, pkt_in, *pkt_out);
-	if (odp_unlikely(out_pkt == ODP_PACKET_INVALID))
-		return -1;
+	if (odp_likely(session->p.op_type == ODP_CRYPTO_OP_TYPE_BASIC)) {
+		out_pkt = pkt_in;
+	} else {
+		out_pkt = get_output_packet(session, pkt_in, *pkt_out);
+		if (odp_unlikely(out_pkt == ODP_PACKET_INVALID))
+			return -1;
+	}
 
 	/* Invoke the crypto function */
 	if (session->do_cipher_first) {

--- a/platform/linux-generic/odp_crypto_null.c
+++ b/platform/linux-generic/odp_crypto_null.c
@@ -487,9 +487,6 @@ static odp_packet_t get_output_packet(const odp_crypto_generic_session_t *sessio
 {
 	int rc;
 
-	if (odp_likely(session->p.op_type == ODP_CRYPTO_OP_TYPE_BASIC))
-		return pkt_in;
-
 	if (odp_likely(pkt_in == pkt_out))
 		return pkt_out;
 
@@ -525,9 +522,13 @@ int crypto_int(odp_packet_t pkt_in,
 
 	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
 
-	out_pkt = get_output_packet(session, pkt_in, *pkt_out);
-	if (odp_unlikely(out_pkt == ODP_PACKET_INVALID))
-		return -1;
+	if (odp_likely(session->p.op_type == ODP_CRYPTO_OP_TYPE_BASIC)) {
+		out_pkt = pkt_in;
+	} else {
+		out_pkt = get_output_packet(session, pkt_in, *pkt_out);
+		if (odp_unlikely(out_pkt == ODP_PACKET_INVALID))
+			return -1;
+	}
 
 	/* Fill in result */
 	packet_subtype_set(out_pkt, ODP_EVENT_PACKET_CRYPTO);

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -2638,9 +2638,6 @@ static odp_packet_t get_output_packet(const odp_crypto_generic_session_t *sessio
 {
 	int rc;
 
-	if (odp_likely(session->p.op_type == ODP_CRYPTO_OP_TYPE_BASIC))
-		return pkt_in;
-
 	if (odp_likely(pkt_in == pkt_out))
 		return pkt_out;
 
@@ -2678,9 +2675,13 @@ int crypto_int(odp_packet_t pkt_in,
 
 	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
 
-	out_pkt = get_output_packet(session, pkt_in, *pkt_out);
-	if (odp_unlikely(out_pkt == ODP_PACKET_INVALID))
-		return -1;
+	if (odp_likely(session->p.op_type == ODP_CRYPTO_OP_TYPE_BASIC)) {
+		out_pkt = pkt_in;
+	} else {
+		out_pkt = get_output_packet(session, pkt_in, *pkt_out);
+		if (odp_unlikely(out_pkt == ODP_PACKET_INVALID))
+			return -1;
+	}
 
 	if (ODP_DEBUG) {
 		if (session->p.auth_alg != ODP_AUTH_ALG_NULL &&


### PR DESCRIPTION
The output packet pointer of crypto_int() may point to an uninitialized packet handle with the basic crypto operation type. Do not access the uninitialized handle even for the purpose of passing it to a function that would ignore it. Such uninitialized access could result in undefined behaviour.