### PR TITLE
[PATCH v2] ipsec: small fixes and switch to basic crypto op type

### DIFF
--- a/example/ipsec_crypto/odp_ipsec_cache.c
+++ b/example/ipsec_crypto/odp_ipsec_cache.c
@@ -71,6 +71,7 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 
 	/* Setup parameters and call crypto library to create session */
 	params.op = (in) ? ODP_CRYPTO_OP_DECODE : ODP_CRYPTO_OP_ENCODE;
+	params.op_type = ODP_CRYPTO_OP_TYPE_BASIC;
 	params.auth_cipher_text = TRUE;
 	if (CRYPTO_API_SYNC == api_mode) {
 		params.op_mode = ODP_CRYPTO_SYNC;
@@ -83,11 +84,6 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 		params.output_pool = out_pool;
 		entry->async = TRUE;
 	}
-
-	if (CRYPTO_API_ASYNC_NEW_BUFFER == api_mode)
-		entry->in_place = FALSE;
-	else
-		entry->in_place = TRUE;
 
 	entry->sa_flags = 0;
 

--- a/example/ipsec_crypto/odp_ipsec_cache.h
+++ b/example/ipsec_crypto/odp_ipsec_cache.h
@@ -22,8 +22,7 @@ extern "C" {
  */
 typedef enum {
 	CRYPTO_API_SYNC,              /**< Synchronous mode */
-	CRYPTO_API_ASYNC_IN_PLACE,    /**< Asynchronous in place */
-	CRYPTO_API_ASYNC_NEW_BUFFER   /**< Asynchronous new buffer */
+	CRYPTO_API_ASYNC,             /**< Asynchronous mode */
 } crypto_api_mode_e;
 
 /**
@@ -31,7 +30,6 @@ typedef enum {
  */
 typedef struct ipsec_cache_entry_s {
 	struct ipsec_cache_entry_s  *next;        /**< Next entry on list */
-	odp_bool_t                   in_place;    /**< Crypto API mode */
 	odp_bool_t                   async;       /**< ASYNC or SYNC mode */
 	int                          sa_flags;
 	uint32_t                     src_ip;      /**< Source v4 address */

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -631,6 +631,7 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 	crypto_param.op = (ODP_IPSEC_DIR_INBOUND == param->dir) ?
 			ODP_CRYPTO_OP_DECODE :
 			ODP_CRYPTO_OP_ENCODE;
+	crypto_param.op_type = ODP_CRYPTO_OP_TYPE_BASIC;
 	crypto_param.auth_cipher_text = 1;
 	if (param->proto == ODP_IPSEC_AH)
 		crypto_param.hash_result_in_auth_range = 1;

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -336,8 +336,10 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index, odp_packet_t pkt
 		/* Try IPsec inline processing */
 		if (pktio_entry->config.inbound_ipsec &&
 		    !pkt_hdr->p.flags.ip_err &&
-		    odp_packet_has_ipsec(pkt))
+		    odp_packet_has_ipsec(pkt)) {
 			_odp_ipsec_try_inline(&pkt);
+			pkt_hdr = packet_hdr(pkt);
+		}
 
 		if (!pkt_hdr->p.flags.all.error) {
 			octets += pkt_len;

--- a/platform/linux-generic/test/example/ipsec_api/pktio_env
+++ b/platform/linux-generic/test/example/ipsec_api/pktio_env
@@ -35,7 +35,7 @@ if [ -n "$WITH_OPENSSL_CRYPTO" ] && [ ${WITH_OPENSSL_CRYPTO} -eq 0 ]; then
 	exit 77
 fi
 
-if [ ${ODPH_PROC_MODE} -eq 1 ]; then
+if [ -n "$ODPH_PROC_MODE" ] && [ ${ODPH_PROC_MODE} -ne 0 ]; then
 	echo "Process mode not supported. Skipping."
 	exit 77
 fi

--- a/platform/linux-generic/test/example/ipsec_crypto/pktio_env
+++ b/platform/linux-generic/test/example/ipsec_crypto/pktio_env
@@ -35,7 +35,7 @@ if [ -n "$WITH_OPENSSL_CRYPTO" ] && [ ${WITH_OPENSSL_CRYPTO} -eq 0 ]; then
 	exit 77
 fi
 
-if [ ${ODPH_PROC_MODE} -eq 1 ]; then
+if [ -n "$ODPH_PROC_MODE" ] && [ ${ODPH_PROC_MODE} -ne 0 ]; then
 	echo "Process mode not supported. Skipping."
 	exit 77
 fi


### PR DESCRIPTION
example: ipsec_crypto: switch to basic crypto operation type
linux-gen: test: fix skipping ipsec examples in process mode
linux-gen: loop: fix use of stale pkt_hdr after inline ipsec
linux-gen: ipsec: switch to basic crypto operation type
