### PR TITLE
[PATCH v4] api: timer: clarify periodic first_tick documentation

### DIFF
--- a/include/odp/api/spec/timer_types.h
+++ b/include/odp/api/spec/timer_types.h
@@ -476,9 +476,10 @@ typedef struct odp_timer_start_t {
 typedef struct odp_timer_periodic_start_t {
 	/** First expiration time
 	 *
-	 *  The first expiration time in absolute timer ticks. When zero, timer expiration starts
-	 *  from the current time. After the first expiration, timer expiration continues with the
-	 *  defined frequency. The tick value must be within one timer period from the current time.
+	 *  The first expiration time in absolute timer ticks. When zero, the first expiration time
+	 *  is one period after the current time. After the first expiration, timer expiration
+	 *  continues with the defined frequency. The tick value must be within one timer period
+	 *  from the current time.
 	 */
 	uint64_t first_tick;
 


### PR DESCRIPTION
Clarify that zero first_tick means that the first expiration time is one period after the current time, not at the current time.