### PR TITLE
[PATCH v4] validation: timer: fix periodic timer duration calculation

### DIFF
--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -2392,7 +2392,7 @@ static void timer_test_periodic(odp_queue_type_t queue_type, int use_first)
 	odp_event_t ev;
 	odp_timer_t timer;
 	odp_time_t t1, t2;
-	uint64_t tick, cur_tick, period_ns, duration_ns, diff_ns;
+	uint64_t tick, cur_tick, period_ns, duration_ns, diff_ns, offset_ns;
 	double freq, freq_out, min_freq, max_freq;
 	int ret;
 	const char *user_ctx = "User context";
@@ -2509,10 +2509,14 @@ static void timer_test_periodic(odp_queue_type_t queue_type, int use_first)
 
 	memset(&start_param, 0, sizeof(odp_timer_periodic_start_t));
 	cur_tick = odp_timer_current_tick(timer_pool);
-	tick = cur_tick + odp_timer_ns_to_tick(timer_pool, period_ns / 2);
+	offset_ns = period_ns / 2;
+	tick = cur_tick + odp_timer_ns_to_tick(timer_pool, offset_ns);
 
-	if (use_first)
+	if (use_first) {
+		/* First tick moves timer to start before the first period */
+		duration_ns -= (period_ns - offset_ns);
 		start_param.first_tick = tick;
+	}
 
 	start_param.freq_multiplier = multiplier;
 	start_param.tmo_ev = ev;

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
+ * Copyright (c) 2019-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -2521,7 +2521,8 @@ static void timer_test_periodic(odp_queue_type_t queue_type, int use_first)
 	ODPH_DBG("  Current tick:    %" PRIu64 "\n", cur_tick);
 	ODPH_DBG("  First tick:      %" PRIu64 "\n", start_param.first_tick);
 	ODPH_DBG("  Multiplier:      %" PRIu64 "\n", start_param.freq_multiplier);
-	ODPH_DBG("Test duration ns:  %" PRIu64 "\n", duration_ns);
+	ODPH_DBG("  Period:          %" PRIu64 " nsec\n", period_ns);
+	ODPH_DBG("Expected duration: %" PRIu64 " nsec\n", duration_ns);
 
 	ret = odp_timer_periodic_start(timer, &start_param);
 
@@ -2575,6 +2576,8 @@ static void timer_test_periodic(odp_queue_type_t queue_type, int use_first)
 	/* Stop periodic timer */
 	ret = odp_timer_periodic_cancel(timer);
 	CU_ASSERT_FATAL(ret == 0);
+
+	ODPH_DBG("Measured duration: %" PRIu64 " nsec\n", diff_ns);
 
 	t1 = odp_time_local();
 	while (1) {


### PR DESCRIPTION
Usage of first tick reduces period of the first timeout.