### PR TITLE
[PATCH v4] api: pool: clarify odp_pool_capability_t.max_pools specification

### DIFF
--- a/include/odp/api/spec/dma_types.h
+++ b/include/odp/api/spec/dma_types.h
@@ -69,7 +69,9 @@ extern "C" {
  * Pool statistics are not supported with DMA completion event pools.
  */
 typedef struct odp_dma_pool_capability_t {
-	/** Maximum number of DMA completion event pools */
+	/** Maximum number of DMA completion event pools
+	 *
+	 *  See odp_pool_capability_t::max_pools for total capability. */
 	uint32_t max_pools;
 
 	/** Maximum number of DMA completion events in a pool */

--- a/include/odp/api/spec/pool_types.h
+++ b/include/odp/api/spec/pool_types.h
@@ -151,7 +151,7 @@ typedef struct odp_pool_stats_t {
  * Pool capabilities
  */
 typedef struct odp_pool_capability_t {
-	/** Maximum number of pools of any type */
+	/** Maximum number of pools of any type (odp_pool_type_t) */
 	uint32_t max_pools;
 
 	/** Buffer pool capabilities  */

--- a/test/validation/api/dma/dma.c
+++ b/test/validation/api/dma/dma.c
@@ -181,7 +181,7 @@ static void test_dma_capability(void)
 	odp_dma_capability_t capa;
 
 	memset(&capa, 0, sizeof(odp_dma_capability_t));
-	CU_ASSERT(odp_dma_capability(&capa) == 0);
+	CU_ASSERT_FATAL(odp_dma_capability(&capa) == 0);
 
 	if (capa.max_sessions == 0)
 		return;
@@ -196,8 +196,12 @@ static void test_dma_capability(void)
 	CU_ASSERT(capa.compl_mode_mask & ODP_DMA_COMPL_SYNC);
 
 	if (capa.compl_mode_mask & ODP_DMA_COMPL_EVENT) {
+		odp_pool_capability_t pool_capa;
+
+		CU_ASSERT_FATAL(odp_pool_capability(&pool_capa) == 0);
+
 		CU_ASSERT(capa.queue_type_sched || capa.queue_type_plain);
-		CU_ASSERT(capa.pool.max_pools > 0);
+		CU_ASSERT(capa.pool.max_pools > 0 && capa.pool.max_pools <= pool_capa.max_pools);
 		CU_ASSERT(capa.pool.max_num > 0);
 		CU_ASSERT(capa.pool.min_cache_size <= capa.pool.max_cache_size);
 	}


### PR DESCRIPTION
Clarify that odp_pool_capability_t.max_pools is used for all pool types defined in odp_pool_type_t. Also, added reference to DMA pool capability (odp_dma_pool_capability_t.max_pools) to make this clearer.