### PR TITLE
[PATCH v7] linux-gen: sched: improve timer behavior when power saving sleep is enabled

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -240,8 +240,9 @@ sched_basic: {
 	# When waiting for events during a schedule call, save power by
 	# sleeping in the poll loop. First, run schedule loop normally for
 	# poll_time_nsec nanoseconds. If there are no events to schedule in that
-	# time, continue polling, but sleep for sleep_time_nsec nanoseconds on
-	# each round.
+	# time, continue polling, but sleep on each round. Sleep time is
+	# sleep_time_nsec nanoseconds, or the time to the next timer expiration,
+	# whichever is smaller. Timer pools are scanned just before sleep.
 	#
 	# During sleep, the thread is not polling for packet input or timers.
 	# Each thread measures time and sleeps independently of other threads.
@@ -257,7 +258,7 @@ sched_basic: {
 
 		# Time in nsec to sleep
 		#
-		# Actual sleep time may vary.
+		# Must be less than one second. Actual sleep time may vary.
 		sleep_time_nsec = 0
 	}
 }

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -21,7 +21,6 @@ extern "C" {
 #include <odp_config_internal.h>
 
 #include <libconfig.h>
-#include <pthread.h>
 #include <stdint.h>
 #include <sys/types.h>
 

--- a/platform/linux-generic/include/odp_timer_internal.h
+++ b/platform/linux-generic/include/odp_timer_internal.h
@@ -22,6 +22,12 @@
 #include <odp_global_data.h>
 #include <odp_pool_internal.h>
 
+/*
+ * Use as the argument to timer_run() to force a scan and to ignore rate
+ * limit.
+ */
+#define TIMER_SCAN_FORCE INT32_MAX
+
 /**
  * Internal Timeout header
  */

--- a/platform/linux-generic/include/odp_timer_internal.h
+++ b/platform/linux-generic/include/odp_timer_internal.h
@@ -48,13 +48,15 @@ ODP_STATIC_ASSERT(sizeof(odp_timeout_hdr_t) <= ODP_CACHE_LINE_SIZE,
 
 /* A larger decrement value should be used after receiving events compared to
  * an 'empty' call. */
-void _odp_timer_run_inline(int dec);
+uint64_t _odp_timer_run_inline(int dec);
 
 /* Static inline wrapper to minimize modification of schedulers. */
-static inline void timer_run(int dec)
+static inline uint64_t timer_run(int dec)
 {
 	if (odp_global_rw->inline_timers)
-		_odp_timer_run_inline(dec);
+		return _odp_timer_run_inline(dec);
+
+	return UINT64_MAX;
 }
 
 #endif

--- a/platform/linux-generic/odp_cpumask.c
+++ b/platform/linux-generic/odp_cpumask.c
@@ -7,7 +7,6 @@
 #include <odp_posix_extensions.h>
 
 #include <sched.h>
-#include <pthread.h>
 
 #include <odp/api/cpumask.h>
 #include <odp/api/init.h>

--- a/platform/linux-generic/odp_cpumask_task.c
+++ b/platform/linux-generic/odp_cpumask_task.c
@@ -12,7 +12,6 @@
 #include <odp_debug_internal.h>
 #include <odp_global_data.h>
 
-#include <pthread.h>
 #include <sched.h>
 
 int odp_cpumask_default_worker(odp_cpumask_t *mask, int max_num)

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -1698,16 +1698,13 @@ static inline int schedule_loop_sleep(odp_queue_t *out_queue, uint64_t wait,
 			nanosleep(&ts, NULL);
 		}
 
-		if (wait != ODP_SCHED_WAIT || !sleep) {
+		if (!sleep || wait != ODP_SCHED_WAIT)
 			current = odp_time_local();
-			if (odp_time_cmp(start_sleep, current) < 0)
-				sleep = 1;
-		}
 
-		if (wait == ODP_SCHED_WAIT)
-			continue;
+		if (!sleep && odp_time_cmp(start_sleep, current) < 0)
+			sleep = 1;
 
-		if (odp_time_cmp(end, current) < 0)
+		if (wait != ODP_SCHED_WAIT && odp_time_cmp(end, current) < 0)
 			break;
 	}
 

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -26,7 +26,6 @@
 #include <odp/api/cpu.h>
 
 #include <errno.h>
-#include <pthread.h>
 #include <string.h>
 #include <stdio.h>
 #include <inttypes.h>


### PR DESCRIPTION
When using inline timers and power saving sleep, limit sleep duration according to the next timeout.