### PR TITLE
[PATCH v4] linux-gen, helper: re-enable print format warnings

### DIFF
--- a/helper/include/odp/helper/odph_debug.h
+++ b/helper/include/odp/helper/odph_debug.h
@@ -64,7 +64,7 @@ typedef enum odph_log_level {
 #define ODPH_LOG(level, fmt, ...) \
 do { \
 	if (level != ODPH_LOG_DBG || ODPH_DEBUG_PRINT == 1) \
-		fprintf(stderr, "%s:%d:%s():" fmt, __FILE__, \
+		fprintf(stderr, "%s:%d:%s(): " fmt, __FILE__, \
 		__LINE__, __func__, ##__VA_ARGS__); \
 	if (level == ODPH_LOG_ABORT) \
 		abort(); \

--- a/helper/include/odp/helper/odph_debug.h
+++ b/helper/include/odp/helper/odph_debug.h
@@ -63,25 +63,11 @@ typedef enum odph_log_level {
  */
 #define ODPH_LOG(level, fmt, ...) \
 do { \
-	switch (level) { \
-	case ODPH_LOG_ERR: \
+	if (level != ODPH_LOG_DBG || ODPH_DEBUG_PRINT == 1) \
 		fprintf(stderr, "%s:%d:%s():" fmt, __FILE__, \
 		__LINE__, __func__, ##__VA_ARGS__); \
-		break; \
-	case ODPH_LOG_DBG: \
-		if (ODPH_DEBUG_PRINT == 1) \
-			fprintf(stderr, "%s:%d:%s():" fmt, __FILE__, \
-			__LINE__, __func__, ##__VA_ARGS__); \
-		break; \
-	case ODPH_LOG_ABORT: \
-		fprintf(stderr, "%s:%d:%s(): " fmt, __FILE__, \
-		__LINE__, __func__, ##__VA_ARGS__); \
+	if (level == ODPH_LOG_ABORT) \
 		abort(); \
-		break; \
-	default: \
-		fprintf(stderr, "Unknown LOG level"); \
-		break;\
-	} \
 } while (0)
 
 /**

--- a/helper/include/odp/helper/odph_debug.h
+++ b/helper/include/odp/helper/odph_debug.h
@@ -24,13 +24,15 @@
 extern "C" {
 #endif
 
+#pragma GCC diagnostic push
+
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#endif
+
 /** @addtogroup odph_debug ODPH DEBUG
  *  @{
  */
-
-/* Avoid "ISO C99 requires at least one argument for the "..."  in a variadic
- * macro" errors when building with 'pedantic' option. */
-#pragma GCC system_header
 
 /**
  * Assert macro for applications and helper code
@@ -85,25 +87,39 @@ do { \
 /**
  * Debug printing macro, which prints output when DEBUG flag is set.
  */
-#define ODPH_DBG(fmt, ...) \
-		ODPH_LOG(ODPH_LOG_DBG, fmt, ##__VA_ARGS__)
+#define ODPH_DBG(...) \
+	do { \
+		__extension__ ({ \
+			ODPH_LOG(ODPH_LOG_DBG, ##__VA_ARGS__); \
+		}); \
+	} while (0)
 
 /**
  * Print output to stderr (file, line and function).
  */
-#define ODPH_ERR(fmt, ...) \
-		ODPH_LOG(ODPH_LOG_ERR, fmt, ##__VA_ARGS__)
+#define ODPH_ERR(...) \
+	do { \
+		__extension__ ({ \
+			ODPH_LOG(ODPH_LOG_ERR, ##__VA_ARGS__); \
+		}); \
+	} while (0)
 
 /**
  * Print output to stderr (file, line and function),
  * then abort.
  */
-#define ODPH_ABORT(fmt, ...) \
-		ODPH_LOG(ODPH_LOG_ABORT, fmt, ##__VA_ARGS__)
+#define ODPH_ABORT(...) \
+	do { \
+		__extension__ ({ \
+			ODPH_LOG(ODPH_LOG_ABORT, ##__VA_ARGS__); \
+		}); \
+	} while (0)
 
 /**
  * @}
  */
+
+#pragma GCC diagnostic pop
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp/api/plat/debug_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/debug_inlines.h
@@ -30,19 +30,21 @@
 extern "C" {
 #endif
 
-/* Avoid "ISO C99 requires at least one argument for the "..."  in a variadic
- * macro" errors when building with 'pedantic' option. */
-#pragma GCC system_header
+#pragma GCC diagnostic push
+
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#endif
 
 extern odp_log_func_t ODP_PRINTF_FORMAT(2, 3) _odp_log_fn;
 extern odp_abort_func_t _odp_abort_fn;
 
-#define _ODP_LOG_FN(level, fmt, ...) \
+#define _ODP_LOG_FN(level, ...) \
 	do { \
 		if (_odp_this_thread && _odp_this_thread->log_fn) \
-			_odp_this_thread->log_fn(level, fmt, ##__VA_ARGS__); \
+			_odp_this_thread->log_fn(level, ##__VA_ARGS__); \
 		else \
-			_odp_log_fn(level, fmt, ##__VA_ARGS__); \
+			_odp_log_fn(level, ##__VA_ARGS__); \
 	} while (0)
 
 /**
@@ -64,25 +66,33 @@ extern odp_abort_func_t _odp_abort_fn;
 /*
  * Print debug message to log, if ODP_DEBUG_PRINT flag is set (ignores CONFIG_DEBUG_LEVEL).
  */
-#define _ODP_DBG(fmt, ...) \
+#define _ODP_DBG(...) \
 	do { \
 		if (ODP_DEBUG_PRINT == 1) \
-			_ODP_LOG(ODP_LOG_DBG, fmt, ##__VA_ARGS__);\
+			__extension__ ({ \
+				_ODP_LOG(ODP_LOG_DBG, ##__VA_ARGS__); \
+			}); \
 	} while (0)
 
 /**
  * Log error message.
  */
-#define _ODP_ERR(fmt, ...) \
-	_ODP_LOG(ODP_LOG_ERR, fmt, ##__VA_ARGS__)
+#define _ODP_ERR(...) \
+	do { \
+		__extension__ ({ \
+			_ODP_LOG(ODP_LOG_ERR, ##__VA_ARGS__); \
+		}); \
+	} while (0)
 
 /**
  * Log abort message and then stop execution (by default call abort()).
  * This function should not return.
  */
-#define _ODP_ABORT(fmt, ...) \
+#define _ODP_ABORT(...) \
 	do { \
-		_ODP_LOG(ODP_LOG_ABORT, fmt, ##__VA_ARGS__); \
+		__extension__ ({ \
+			_ODP_LOG(ODP_LOG_ABORT, ##__VA_ARGS__); \
+		}); \
 		_odp_abort_fn(); \
 	} while (0)
 
@@ -90,8 +100,10 @@ extern odp_abort_func_t _odp_abort_fn;
  * Log print message when the application calls one of the ODP APIs
  * specifically for dumping internal data.
  */
-#define _ODP_PRINT(fmt, ...) \
-	_ODP_LOG_FN(ODP_LOG_PRINT, fmt, ##__VA_ARGS__)
+#define _ODP_PRINT(...) \
+	_ODP_LOG_FN(ODP_LOG_PRINT, ##__VA_ARGS__)
+
+#pragma GCC diagnostic pop
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp/api/plat/debug_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/debug_inlines.h
@@ -51,7 +51,7 @@ extern odp_abort_func_t _odp_abort_fn;
  * ODP LOG macro.
  */
 #define _ODP_LOG(level, fmt, ...) \
-		 _ODP_LOG_FN(level, "%s:%d:%s():" fmt, __FILE__, \
+		 _ODP_LOG_FN(level, "%s:%d:%s(): " fmt, __FILE__, \
 		 __LINE__, __func__, ##__VA_ARGS__)
 
 /**

--- a/platform/linux-generic/include/odp_debug_internal.h
+++ b/platform/linux-generic/include/odp_debug_internal.h
@@ -30,9 +30,11 @@
 extern "C" {
 #endif
 
-/* Avoid "ISO C99 requires at least one argument for the "..."  in a variadic
- * macro" errors when building with 'pedantic' option. */
-#pragma GCC system_header
+#pragma GCC diagnostic push
+
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#endif
 
 /* Debug level configure option. Zero is the highest level. Value of N prints debug messages from
  * level 0 to N. */
@@ -49,20 +51,24 @@ extern "C" {
 /*
  * Print debug message to log, if ODP_DEBUG_PRINT flag is set and CONFIG_DEBUG_LEVEL is high enough.
  */
-#define ODP_DBG_LVL(level, fmt, ...) \
+#define ODP_DBG_LVL(level, ...) \
 	do { \
 		if (ODP_DEBUG_PRINT == 1 && CONFIG_DEBUG_LEVEL >= (level)) \
-			_ODP_LOG(ODP_LOG_DBG, fmt, ##__VA_ARGS__);\
+			__extension__ ({ \
+				_ODP_LOG(ODP_LOG_DBG, ##__VA_ARGS__); \
+			}); \
 	} while (0)
 
 /*
  * Same as ODP_DBG_LVL() but does not add file/line/function name prefix
  */
-#define ODP_DBG_RAW(level, fmt, ...) \
+#define ODP_DBG_RAW(level, ...) \
 	do { \
 		if (ODP_DEBUG_PRINT == 1 && CONFIG_DEBUG_LEVEL >= (level)) \
-			_ODP_LOG_FN(ODP_LOG_DBG, fmt, ##__VA_ARGS__);\
+			_ODP_LOG_FN(ODP_LOG_DBG, ##__VA_ARGS__); \
 	} while (0)
+
+#pragma GCC diagnostic pop
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Print format warnings were disabled as a side effect of enabling compilation with `-pedantic`. Re-enable them.