### PR TITLE
[PATCH v6] github_ci: update arm64 ci dpdk versions

### DIFF
--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -302,15 +302,3 @@ jobs:
       - name: Failure log
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
-
-  Run_dpdk-22_11:
-    if: ${{ github.repository == 'OpenDataPlane/odp' }}
-    runs-on: [self-hosted, ARM64]
-    steps:
-      - uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v3
-      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
-               -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native-dpdk_22.11 /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done

--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -166,7 +166,7 @@ jobs:
       fail-fast: false
       matrix:
         cc: [gcc, clang]
-        cflags: ['-march=armv8.2-a -O2', '-march=armv8-a+lse -O2']
+        cflags: ['-march=armv8.2-a -O2', '-march=armv8.2-a+crypto -O2']
     steps:
       - uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -27,7 +27,7 @@ jobs:
           - cc: clang
             conf: '--enable-lto --enable-abi-compat'
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/build_${ARCH}.sh
@@ -47,7 +47,7 @@ jobs:
         cc_ver: [10, 11, 12]
         conf: ['', '--enable-lto']
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="gcc-${{matrix.cc_ver}}" -e CXX="g++-${{matrix.cc_ver}}"
                -e CONF="${CONF} ${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/build_static.sh
@@ -64,7 +64,7 @@ jobs:
         cc: [gcc, clang]
         os: ['ubuntu_18.04', 'rocky_linux_8']
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${{matrix.os}}-${ARCH}-native /odp/scripts/ci/build_${ARCH}.sh
@@ -83,7 +83,7 @@ jobs:
         cc_ver: [10, 11, 12]
         conf: ['', '--enable-abi-compat']
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="gcc-${{matrix.cc_ver}}" -e CXX="g++-${{matrix.cc_ver}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/build_${ARCH}.sh
@@ -95,7 +95,7 @@ jobs:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
     runs-on: [self-hosted, ARM64]
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/out_of_tree.sh
@@ -114,7 +114,7 @@ jobs:
       matrix:
         cc: [gcc, clang]
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/build_${ARCH}.sh
@@ -130,7 +130,7 @@ jobs:
       matrix:
         conf: ['--enable-user-guides', '--enable-user-guides --enable-abi-compat']
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/distcheck.sh
@@ -151,7 +151,7 @@ jobs:
                '--disable-host-optimization --enable-abi-compat',
                '--without-openssl --without-pcap', '--with-crypto=armv8crypto', '--with-crypto=ipsecmb']
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}" -e ARCH="${ARCH}"
                -e CXX=g++-10 -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
@@ -168,7 +168,7 @@ jobs:
         cc: [gcc, clang]
         cflags: ['-march=armv8.2-a -O2', '-march=armv8.2-a+crypto -O2']
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}" -e ARCH="${ARCH}"
                -e CXX=g++-10 -e CFLAGS="${{matrix.cflags}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
@@ -184,7 +184,7 @@ jobs:
       matrix:
         os: ['ubuntu_18.04', 'ubuntu_22.04']
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${{matrix.os}}-${ARCH}-native /odp/scripts/ci/check.sh
@@ -196,7 +196,7 @@ jobs:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
     runs-on: [self-hosted, ARM64]
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/sched-basic.conf $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
@@ -208,7 +208,7 @@ jobs:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
     runs-on: [self-hosted, ARM64]
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/stash-custom.conf $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
@@ -220,7 +220,7 @@ jobs:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
     runs-on: [self-hosted, ARM64]
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_SCHEDULER=sp $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
@@ -232,7 +232,7 @@ jobs:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
     runs-on: [self-hosted, ARM64]
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_SCHEDULER=scalable -e CI_SKIP=pktio_test_pktin_event_sched $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
@@ -244,7 +244,7 @@ jobs:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
     runs-on: [self-hosted, ARM64]
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/process-mode.conf
@@ -257,7 +257,7 @@ jobs:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
     runs-on: [self-hosted, ARM64]
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/inline-timer.conf
@@ -270,7 +270,7 @@ jobs:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
     runs-on: [self-hosted, ARM64]
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/packet_align.conf
@@ -283,7 +283,7 @@ jobs:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
     runs-on: [self-hosted, ARM64]
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native-dpdk_20.11 /odp/scripts/ci/check.sh
@@ -295,7 +295,7 @@ jobs:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
     runs-on: [self-hosted, ARM64]
     steps:
-      - uses: AutoModality/action-clean@v1.1.0
+      - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native-dpdk_21.11 /odp/scripts/ci/check.sh

--- a/scripts/ci/build_arm64.sh
+++ b/scripts/ci/build_arm64.sh
@@ -11,6 +11,10 @@ if [ "$TARGET_ARCH" == "$BUILD_ARCH" ]; then
 	if [ "${CC#clang}" != "${CC}" ] ; then
 		export CXX="clang++"
 	fi
+
+	# Required by CentOS and Rocky Linux to find DPDK install
+	export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib64/pkgconfig
+
 else
 	# Cross compilation
 	if [ "${CC#clang}" != "${CC}" ] ; then


### PR DESCRIPTION
The default DPDK release has been changed to v22.11. The arm64 test containers have been updated to use this release.