### PR TITLE
[PATCH v2] linux-gen: atomic: optimize min/max operations on ARM

### DIFF
--- a/platform/linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h
@@ -205,6 +205,34 @@ static inline void _odp_atomic_dec_u64(odp_atomic_u64_t *atom)
 	_odp_atomic_sub_u64(atom, 1);
 }
 
+static inline void _odp_atomic_max_u32(odp_atomic_u32_t *atom, uint32_t val)
+{
+	__asm__ volatile("stumax   %w[val], %[atom]"
+			 : [atom] "+Q" (atom->v)
+			 : [val] "r" (val));
+}
+
+static inline void _odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t val)
+{
+	__asm__ volatile("stumin   %w[val], %[atom]"
+			 : [atom] "+Q" (atom->v)
+			 : [val] "r" (val));
+}
+
+static inline void _odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t val)
+{
+	__asm__ volatile("stumax   %[val], %[atom]"
+			 : [atom] "+Q" (atom->v)
+			 : [val] "r" (val));
+}
+
+static inline void _odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t val)
+{
+	__asm__ volatile("stumin   %[val], %[atom]"
+			 : [atom] "+Q" (atom->v)
+			 : [val] "r" (val));
+}
+
 static inline void _odp_atomic_add_rel_u32(odp_atomic_u32_t *atom, uint32_t val)
 {
 	__asm__ volatile("staddl   %w[val], %[atom]"

--- a/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
@@ -30,6 +30,32 @@ static inline void _odp_atomic_dec_u32(odp_atomic_u32_t *atom)
 	(void)__atomic_fetch_sub(&atom->v, 1, __ATOMIC_RELAXED);
 }
 
+static inline void _odp_atomic_max_u32(odp_atomic_u32_t *atom, uint32_t new_val)
+{
+	uint32_t old_val;
+
+	old_val = __atomic_load_n(&atom->v, __ATOMIC_RELAXED);
+
+	while (new_val > old_val) {
+		if (__atomic_compare_exchange_n(&atom->v, &old_val, new_val, 0 /* strong */,
+						__ATOMIC_RELAXED, __ATOMIC_RELAXED))
+			break;
+	}
+}
+
+static inline void _odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t new_val)
+{
+	uint32_t old_val;
+
+	old_val = __atomic_load_n(&atom->v, __ATOMIC_RELAXED);
+
+	while (new_val < old_val) {
+		if (__atomic_compare_exchange_n(&atom->v, &old_val, new_val, 0 /* strong */,
+						__ATOMIC_RELAXED, __ATOMIC_RELAXED))
+			break;
+	}
+}
+
 static inline void _odp_atomic_add_rel_u32(odp_atomic_u32_t *atom, uint32_t val)
 {
 	(void)__atomic_fetch_add(&atom->v, val, __ATOMIC_RELEASE);
@@ -58,6 +84,32 @@ static inline void _odp_atomic_inc_u64(odp_atomic_u64_t *atom)
 static inline void _odp_atomic_dec_u64(odp_atomic_u64_t *atom)
 {
 	(void)__atomic_fetch_sub(&atom->v, 1, __ATOMIC_RELAXED);
+}
+
+static inline void _odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t new_val)
+{
+	uint64_t old_val;
+
+	old_val = __atomic_load_n(&atom->v, __ATOMIC_RELAXED);
+
+	while (new_val > old_val) {
+		if (__atomic_compare_exchange_n(&atom->v, &old_val, new_val, 0 /* strong */,
+						__ATOMIC_RELAXED, __ATOMIC_RELAXED))
+			break;
+	}
+}
+
+static inline void _odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t new_val)
+{
+	uint64_t old_val;
+
+	old_val = __atomic_load_n(&atom->v, __ATOMIC_RELAXED);
+
+	while (new_val < old_val) {
+		if (__atomic_compare_exchange_n(&atom->v, &old_val, new_val, 0 /* strong */,
+						__ATOMIC_RELAXED, __ATOMIC_RELAXED))
+			break;
+	}
 }
 
 #ifndef ODP_ATOMIC_U64_LOCK

--- a/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
@@ -149,28 +149,14 @@ _ODP_INLINE uint32_t odp_atomic_xchg_u32(odp_atomic_u32_t *atom,
 	return __atomic_exchange_n(&atom->v, new_val, __ATOMIC_RELAXED);
 }
 
-_ODP_INLINE void odp_atomic_max_u32(odp_atomic_u32_t *atom, uint32_t new_max)
+_ODP_INLINE void odp_atomic_max_u32(odp_atomic_u32_t *atom, uint32_t val)
 {
-	uint32_t old_val;
-
-	old_val = odp_atomic_load_u32(atom);
-
-	while (new_max > old_val) {
-		if (odp_atomic_cas_u32(atom, &old_val, new_max))
-			break;
-	}
+	_odp_atomic_max_u32(atom, val);
 }
 
-_ODP_INLINE void odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t new_min)
+_ODP_INLINE void odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t val)
 {
-	uint32_t old_val;
-
-	old_val = odp_atomic_load_u32(atom);
-
-	while (new_min < old_val) {
-		if (odp_atomic_cas_u32(atom, &old_val, new_min))
-			break;
-	}
+	_odp_atomic_min_u32(atom, val);
 }
 
 #ifdef ODP_ATOMIC_U64_LOCK
@@ -325,6 +311,30 @@ _ODP_INLINE int odp_atomic_cas_acq_rel_u64(odp_atomic_u64_t *atom,
 	return ret;
 }
 
+_ODP_INLINE void odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t new_val)
+{
+	uint64_t old_val;
+
+	old_val = odp_atomic_load_u64(atom);
+
+	while (new_val > old_val) {
+		if (odp_atomic_cas_u64(atom, &old_val, new_val))
+			break;
+	}
+}
+
+_ODP_INLINE void odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t new_val)
+{
+	uint64_t old_val;
+
+	old_val = odp_atomic_load_u64(atom);
+
+	while (new_val < old_val) {
+		if (odp_atomic_cas_u64(atom, &old_val, new_val))
+			break;
+	}
+}
+
 #else /* !ODP_ATOMIC_U64_LOCK */
 
 _ODP_INLINE void odp_atomic_init_u64(odp_atomic_u64_t *atom, uint64_t val)
@@ -447,31 +457,17 @@ _ODP_INLINE int odp_atomic_cas_acq_rel_u64(odp_atomic_u64_t *atom,
 					   __ATOMIC_RELAXED);
 }
 
+_ODP_INLINE void odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t val)
+{
+	_odp_atomic_max_u64(atom, val);
+}
+
+_ODP_INLINE void odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t val)
+{
+	_odp_atomic_min_u64(atom, val);
+}
+
 #endif /* !ODP_ATOMIC_U64_LOCK */
-
-_ODP_INLINE void odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t new_max)
-{
-	uint64_t old_val;
-
-	old_val = odp_atomic_load_u64(atom);
-
-	while (new_max > old_val) {
-		if (odp_atomic_cas_u64(atom, &old_val, new_max))
-			break;
-	}
-}
-
-_ODP_INLINE void odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t new_min)
-{
-	uint64_t old_val;
-
-	old_val = odp_atomic_load_u64(atom);
-
-	while (new_min < old_val) {
-		if (odp_atomic_cas_u64(atom, &old_val, new_min))
-			break;
-	}
-}
 
 _ODP_INLINE uint32_t odp_atomic_load_acq_u32(odp_atomic_u32_t *atom)
 {

--- a/test/performance/odp_atomic_perf.c
+++ b/test/performance/odp_atomic_perf.c
@@ -18,8 +18,9 @@
 /* Default number of test rounds */
 #define NUM_ROUNDS 1000000u
 
-/* Initial value for atomic variables */
-#define INIT_VAL 1234567
+/* Initial value for atomic variables. Supports up to 2 billion
+ * rounds of 32-bit min and max tests. */
+#define INIT_VAL 0x80000000
 
 /* Max number of workers if num_cpu=0 */
 #define DEFAULT_MAX_WORKERS 10


### PR DESCRIPTION
ARM ISA v8.1 introduced specific instructions for atomic minimum and maximum value updates (e.g. STUMIN and STUMAX). Utilize these instructions when available. Optimization is similar to previous optimization of atomic add operations to utilize STADD instruction.