### PR TITLE
[PATCH v3] api: crypto: clarify that parse flags are not affected

### DIFF
--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -200,6 +200,11 @@ int odp_crypto_result(odp_crypto_packet_result_t *result,
  * Performs the SYNC cryptographic operations specified during session creation
  * on the packets. All arrays should be of num_pkt size.
  *
+ * Result of the crypto operation can be checked using odp_crypto_result().
+ * Parse flags in packet metadata are not affected by the crypto operation.
+ * In particular, odp_packet_has_error() can not be used for checking if the
+ * crypto operation succeeded.
+ *
  * Use of the pkt_out parameter depends on the configured crypto operation
  * type as described below.
  *

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -746,14 +746,7 @@ static void alg_test_execute(const alg_test_param_t *param)
 		      param->ref->aad, digest_offset))
 		return;
 
-	/*
-	 * API is not explicit about whether a failed crypto op
-	 * sets the has_error packet flag or leaves it unchanged.
-	 * Let's allow both behaviours.
-	 */
 	test_packet_get_md(pkt_out, &md_out);
-	if (param->wrong_digest)
-		md_out.has_error = 0;
 
 	if (param->op_type == ODP_CRYPTO_OP_TYPE_OOP) {
 		test_packet_md_t md;


### PR DESCRIPTION
api: crypto: clarify that parse flags are not affected
validation: crypto: do not allow has_error packet flag to change
