### PR TITLE
[PATCH v3] validation: crypto & ipsec

### DIFF
--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -968,6 +968,7 @@ static void alg_test_op(alg_test_param_t *param)
 	}
 }
 
+static int combo_warning_shown;
 static int oop_warning_shown;
 
 typedef enum {
@@ -1029,9 +1030,12 @@ static odp_crypto_session_t session_create(odp_crypto_op_t op,
 	rc = odp_crypto_session_create(&ses_params, &session, &status);
 
 	if (rc < 0 && status == ODP_CRYPTO_SES_ERR_ALG_COMBO) {
-		printf("\n    Unsupported algorithm combination: %s, %s\n",
-		       cipher_alg_name(cipher_alg),
-		       auth_alg_name(auth_alg));
+		if (!combo_warning_shown) {
+			combo_warning_shown = 1;
+			printf("\n    Unsupported algorithm combination: %s, %s\n",
+			       cipher_alg_name(cipher_alg),
+			       auth_alg_name(auth_alg));
+		}
 		return ODP_CRYPTO_SESSION_INVALID;
 	}
 
@@ -2301,6 +2305,8 @@ static void test_combo_variants(odp_cipher_alg_t cipher, odp_auth_alg_t auth)
 	CU_ASSERT(num == num_ciphers);
 	num = odp_crypto_auth_capability(auth, auth_capa, num_auths);
 	CU_ASSERT(num == num_auths);
+
+	combo_warning_shown = 0;
 
 	for (int n = 0; n < num_ciphers; n++)
 		for (int i = 0; i < num_auths; i++) {

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -2263,6 +2263,11 @@ static void test_combo_variants(odp_cipher_alg_t cipher, odp_auth_alg_t auth)
 {
 	int num, num_ciphers, num_auths;
 
+	/* ODP API says AES-GMAC can be combined with the null cipher only */
+	if (auth == ODP_AUTH_ALG_AES_GMAC &&
+	    cipher != ODP_CIPHER_ALG_NULL)
+		return;
+
 	if (check_alg_support(cipher, auth) == ODP_TEST_INACTIVE)
 		return;
 

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -22,7 +22,7 @@ static int full_test;
 #define MAX_FAILURE_PRINTS 20
 
 #define PKT_POOL_NUM  64
-#define PKT_POOL_LEN  (1 * 1024)
+#define PKT_POOL_LEN  1200 /* enough for a test packet and some headroom */
 #define UAREA_SIZE 8
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -1672,6 +1672,9 @@ static void test_auth_hash_in_auth_range(odp_auth_alg_t auth,
 	const odp_packet_data_range_t cipher_range = {.offset = 0, .length = 0};
 	odp_packet_data_range_t auth_range;
 
+	if (!full_test && capa->digest_len % 4 != 0)
+		return;
+
 	/*
 	 * Create test packets with auth hash in the authenticated range and
 	 * zeroes in the hash location in the plaintext packet.
@@ -2260,6 +2263,9 @@ static void test_combo(const crypto_suite_t *suite,
 /* Iterate and test different cipher/auth range and hash locations */
 static void test_combo_ranges(const crypto_suite_t *suite)
 {
+	if (!full_test && suite->auth_capa->digest_len % 4 != 0)
+		return;
+
 	for (int overlap = 0; overlap < NUM_RANGE_OVERLAPS; overlap++)
 		for (int location = 0; location < NUM_HASH_LOCATIONS; location++) {
 			if (suite->order == AUTH_CIPHERTEXT &&

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -864,12 +864,26 @@ static void alg_test_execute(const alg_test_param_t *param)
 		CU_ASSERT(test_packet_is_md_equal(&md_out, &md_in));
 	}
 
+	if (param->cipher_alg != ODP_CIPHER_ALG_NULL &&
+	    param->auth_alg != ODP_AUTH_ALG_NULL &&
+	    param->digest_offset >= cipher_range.offset &&
+	    param->digest_offset < cipher_range.offset + cipher_range.length) {
+		/*
+		 * Not all implementations support digest offset in cipher
+		 * range, so allow crypto op failure without further checks
+		 * in this case.
+		 */
+		if (!ok)
+			goto out;
+	}
+
 	if (param->wrong_digest) {
 		CU_ASSERT(!ok);
 	} else {
 		CU_ASSERT(ok);
 	}
 	check_output_packet_data(pkt_out, &expected);
+out:
 	odp_packet_free(pkt_out);
 }
 


### PR DESCRIPTION
Miscellaneous minor validation test tweaks to allow current and future odp-dpdk pass validation tests even when some algorithm combinations etc are not supported:

validation: crypto: do not combine aes-gmac with any cipher
validation: crypto: do not require support for digest in cipher range
validation: crypto: increase max packet size of packet pool
validation: crypto: reduce the number of unsupported combo warnings
validation: crypto: test all digest lengths in full test only
validation: ipsec: allow sa creation failure for unsupported algos