### PR TITLE
[PATCH v5] api: event: add function for reading event user area address

### DIFF
--- a/include/odp/api/spec/event.h
+++ b/include/odp/api/spec/event.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
+ * Copyright (c) 2022-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -78,6 +78,20 @@ odp_event_type_t odp_event_types(odp_event_t event,
  */
 int odp_event_type_multi(const odp_event_t event[], int num,
 			 odp_event_type_t *type);
+
+/**
+ * Event user area
+ *
+ * Returns pointer to the user area associated with the event. This maps to the
+ * user area of underlying event type (e.g. odp_packet_user_area() for packets).
+ * If the event does not have user area, NULL is returned.
+ *
+ * @param      event    Event handle
+ *
+ * @return Pointer to the user area of the event
+ * @retval NULL  The event does not have user area
+ */
+void *odp_event_user_area(odp_event_t event);
 
 /**
  * Filter and convert packet events

--- a/platform/linux-generic/include/odp/api/plat/event_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/event_inlines.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2022, Nokia
+ * Copyright (c) 2022-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -8,11 +8,17 @@
 #ifndef ODP_PLAT_EVENT_INLINES_H_
 #define ODP_PLAT_EVENT_INLINES_H_
 
+#include <odp/api/buffer_types.h>
+#include <odp/api/dma.h>
 #include <odp/api/event_types.h>
 #include <odp/api/packet_types.h>
+#include <odp/api/timer_types.h>
 
+#include <odp/api/plat/buffer_inline_types.h>
 #include <odp/api/plat/event_inline_types.h>
+#include <odp/api/plat/event_vector_inline_types.h>
 #include <odp/api/plat/packet_inline_types.h>
+#include <odp/api/plat/timer_inline_types.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
@@ -21,6 +27,7 @@
 	#define _ODP_INLINE static inline
 	#define odp_event_type __odp_event_type
 	#define odp_event_type_multi __odp_event_type_multi
+	#define odp_event_user_area __odp_event_user_area
 	#define odp_event_subtype __odp_event_subtype
 	#define odp_event_types __odp_event_types
 	#define odp_event_flow_id __odp_event_flow_id
@@ -57,6 +64,26 @@ _ODP_INLINE int odp_event_type_multi(const odp_event_t event[], int num,
 	*type_out = type;
 
 	return i;
+}
+
+_ODP_INLINE void *odp_event_user_area(odp_event_t event)
+{
+	const odp_event_type_t type = __odp_event_type_get(event);
+
+	switch (type) {
+	case ODP_EVENT_BUFFER:
+		return _odp_buffer_get((odp_buffer_t)event, void *, uarea_addr);
+	case ODP_EVENT_PACKET:
+		return _odp_pkt_get((odp_packet_t)event, void *, user_area);
+	case ODP_EVENT_PACKET_VECTOR:
+		return _odp_event_vect_get((odp_packet_vector_t)event, void *, uarea_addr);
+	case ODP_EVENT_TIMEOUT:
+		return _odp_timeout_hdr_field((odp_timeout_t)event, void *, uarea_addr);
+	case ODP_EVENT_DMA_COMPL:
+		return odp_dma_compl_user_area((odp_dma_compl_t)event);
+	default:
+		return NULL;
+	}
 }
 
 _ODP_INLINE odp_event_subtype_t odp_event_subtype(odp_event_t event)

--- a/test/validation/api/buffer/buffer.c
+++ b/test/validation/api/buffer/buffer.c
@@ -536,6 +536,8 @@ static void buffer_test_user_area(void)
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 
 	for (i = 0; i < num; i++) {
+		odp_event_t ev;
+
 		buffer[i] = odp_buffer_alloc(pool);
 
 		if (buffer[i] == ODP_BUFFER_INVALID)
@@ -545,6 +547,9 @@ static void buffer_test_user_area(void)
 		addr = odp_buffer_user_area(buffer[i]);
 		CU_ASSERT_FATAL(addr != NULL);
 		CU_ASSERT(prev != addr);
+
+		ev = odp_buffer_to_event(buffer[i]);
+		CU_ASSERT(odp_event_user_area(ev) == addr);
 
 		prev = addr;
 		memset(addr, 0, size);

--- a/test/validation/api/dma/dma.c
+++ b/test/validation/api/dma/dma.c
@@ -431,6 +431,8 @@ static void test_dma_compl_user_area(void)
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 
 	for (i = 0; i < num; i++) {
+		odp_event_t ev;
+
 		compl_evs[i] = odp_dma_compl_alloc(pool);
 
 		if (compl_evs[i] == ODP_DMA_COMPL_INVALID)
@@ -440,6 +442,9 @@ static void test_dma_compl_user_area(void)
 
 		CU_ASSERT_FATAL(addr != NULL);
 		CU_ASSERT(prev != addr);
+
+		ev = odp_dma_compl_to_event(compl_evs[i]);
+		CU_ASSERT(odp_event_user_area(ev) == addr);
 
 		prev = addr;
 		memset(addr, 0, size);

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -458,6 +458,9 @@ static void ipsec_status_event_handle(odp_event_t ev_status,
 	CU_ASSERT_EQUAL(1, odp_event_is_valid(ev_status));
 	CU_ASSERT_EQUAL_FATAL(ODP_EVENT_IPSEC_STATUS, odp_event_type(ev_status));
 
+	/* No user area for IPsec status events */
+	CU_ASSERT(odp_event_user_area(ev_status) == NULL);
+
 	CU_ASSERT_EQUAL(0, odp_ipsec_status(&status, ev_status));
 	CU_ASSERT_EQUAL(ODP_IPSEC_STATUS_WARN, status.id);
 	CU_ASSERT_EQUAL(sa, status.sa);

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -3267,6 +3267,8 @@ static void packet_vector_test_user_area(void)
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 
 	for (i = 0; i < num; i++) {
+		odp_event_t ev;
+
 		pktv[i] = odp_packet_vector_alloc(pool);
 
 		if (pktv[i] == ODP_PACKET_VECTOR_INVALID)
@@ -3276,6 +3278,9 @@ static void packet_vector_test_user_area(void)
 		addr = odp_packet_vector_user_area(pktv[i]);
 		CU_ASSERT_FATAL(addr != NULL);
 		CU_ASSERT(prev != addr);
+
+		ev = odp_packet_vector_to_event(pktv[i]);
+		CU_ASSERT(odp_event_user_area(ev) == addr);
 
 		prev = addr;
 		memset(addr, 0, size);
@@ -3448,6 +3453,7 @@ static void packet_test_user_area(void)
 	odp_pool_param_t param;
 	odp_packet_t pkt;
 	odp_pool_t pool;
+	odp_event_t ev;
 
 	memcpy(&param, &default_param, sizeof(odp_pool_param_t));
 
@@ -3463,6 +3469,8 @@ static void packet_test_user_area(void)
 	} else {
 		CU_ASSERT(odp_packet_user_area(pkt) == NULL);
 	}
+	ev = odp_packet_to_event(pkt);
+	CU_ASSERT(odp_event_user_area(ev) == odp_packet_user_area(pkt));
 
 	odp_packet_free(pkt);
 	CU_ASSERT(odp_pool_destroy(pool) == 0);
@@ -3476,6 +3484,8 @@ static void packet_test_user_area(void)
 	pkt = odp_packet_alloc(pool, param.pkt.len);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT_FATAL(odp_packet_user_area(pkt) != NULL);
+	ev = odp_packet_to_event(pkt);
+	CU_ASSERT(odp_event_user_area(ev) == odp_packet_user_area(pkt));
 	CU_ASSERT(odp_packet_user_area_size(pkt) >= 1);
 	*(char *)odp_packet_user_area(pkt) = 0;
 	CU_ASSERT_FATAL(odp_packet_is_valid(pkt) == 1);
@@ -3488,6 +3498,8 @@ static void packet_test_user_area(void)
 	pkt = odp_packet_alloc(pool, param.pkt.len);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
 	CU_ASSERT_FATAL(odp_packet_user_area(pkt) != NULL);
+	ev = odp_packet_to_event(pkt);
+	CU_ASSERT(odp_event_user_area(ev) == odp_packet_user_area(pkt));
 	CU_ASSERT(odp_packet_user_area_size(pkt) == param.pkt.uarea_size);
 	memset(odp_packet_user_area(pkt), 0, param.pkt.uarea_size);
 	CU_ASSERT_FATAL(odp_packet_is_valid(pkt) == 1);

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -3645,6 +3645,9 @@ static void pktio_test_pktout_compl_event(bool use_plain_queue)
 			CU_ASSERT(odp_packet_tx_compl_user_ptr(tx_compl) ==
 				  (const void *)&pkt_seq[i]);
 
+			/* No user area for TX completion events */
+			CU_ASSERT(odp_event_user_area(ev) == NULL);
+
 			/* Alternatively call event free / compl free */
 			if (i % 2)
 				odp_packet_tx_compl_free(tx_compl);
@@ -3679,6 +3682,10 @@ static void pktio_test_pktout_compl_event(bool use_plain_queue)
 					break;
 				}
 			}
+
+			/* No user area for TX completion events */
+			CU_ASSERT(odp_event_user_area(ev) == NULL);
+
 			/* Check that sequence number is found */
 			CU_ASSERT(j < TX_BATCH_LEN);
 

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -517,6 +517,8 @@ static void timer_test_timeout_user_area(void)
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 
 	for (i = 0; i < num; i++) {
+		odp_event_t ev;
+
 		tmo[i] = odp_timeout_alloc(pool);
 
 		if (tmo[i] == ODP_TIMEOUT_INVALID)
@@ -527,6 +529,9 @@ static void timer_test_timeout_user_area(void)
 		addr = odp_timeout_user_area(tmo[i]);
 		CU_ASSERT_FATAL(addr != NULL);
 		CU_ASSERT(prev != addr);
+
+		ev = odp_timeout_to_event(tmo[i]);
+		CU_ASSERT(odp_event_user_area(ev) == addr);
 
 		prev = addr;
 		memset(addr, 0, size);


### PR DESCRIPTION
Add odp_event_user_area() function which returns a pointer to the user area associated with the event. If the event does not have user area, NULL is returned.

This PR needs to rebased on top of #1811 before merge.