### PR TITLE
[PATCH v5] api: timer: new timer cancel return values

### DIFF
--- a/example/timer/odp_timer_accuracy.c
+++ b/example/timer/odp_timer_accuracy.c
@@ -656,7 +656,7 @@ static int start_timers(test_global_t *test_global)
 		num_tmo = 1;
 
 	for (i = 0; i < num_tmo; i++) {
-		odp_timer_set_t retval;
+		odp_timer_retval_t retval;
 
 		for (j = 0; j < burst; j++) {
 			timer_ctx_t *ctx = &test_global->timer_ctx[idx];
@@ -980,7 +980,7 @@ static void run_test(test_global_t *test_global)
 			/* Reset timer for next period */
 			odp_timer_t tim;
 			uint64_t nsec, tick;
-			odp_timer_set_t ret;
+			odp_timer_retval_t ret;
 			unsigned int j;
 			unsigned int retries = test_global->opt.early_retry;
 			uint64_t start_ns = test_global->start_ns;

--- a/example/timer/odp_timer_test.c
+++ b/example/timer/odp_timer_test.c
@@ -51,7 +51,7 @@ typedef struct {
 } test_globals_t;
 
 /** @private Timer set status ASCII strings */
-static const char *timerset2str(odp_timer_set_t val)
+static const char *timerset2str(odp_timer_retval_t val)
 {
 	switch (val) {
 	case ODP_TIMER_SUCCESS:
@@ -120,7 +120,7 @@ static void test_abs_timeouts(int thr, test_globals_t *gbls)
 	while (1) {
 		int wait = 0;
 		odp_event_t ev;
-		odp_timer_set_t rc;
+		odp_timer_retval_t rc;
 		odp_timer_start_t start_param;
 
 		if (ttp) {

--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -427,19 +427,22 @@ int ODP_DEPRECATE(odp_timer_set_rel)(odp_timer_t timer, uint64_t rel_tick, odp_e
 /**
  * Cancel a timer
  *
- * Cancels a previously started single shot timer. A successful operation prevents timer
- * expiration and returns the timeout event back to application. Application may use or free
- * the event normally.
+ * Cancels a previously started single shot timer. A successful operation (#ODP_TIMER_SUCCESS)
+ * prevents timer expiration and returns the timeout event back to application. Application may
+ * use or free the event normally.
  *
  * When the timer is close to expire or has expired already, the call may not be able cancel it
- * anymore. In this case, the call returns failure and the timeout is delivered to the destination
- * queue.
+ * anymore. In this case, the call returns #ODP_TIMER_TOO_NEAR and the timeout is delivered to
+ * the destination queue.
  *
  * @param      timer  Timer
- * @param[out] tmo_ev Pointer to an event handle for output
+ * @param[out] tmo_ev Pointer to an event handle for output. Event handle is written only
+ *                    on success.
  *
- * @retval 0  Success. Active timer cancelled, timeout returned in 'tmo_ev'
- * @retval <0 Failure. Timer inactive or already expired.
+ * @retval ODP_TIMER_SUCCESS  Timer was cancelled successfully. Timeout event returned in 'tmo_ev'.
+ * @retval ODP_TIMER_TOO_NEAR Timer cannot be cancelled. Timer has expired already, or cannot be
+ *                            cancelled due to close expiration time.
+ * @retval ODP_TIMER_FAIL     Other failure.
  */
 int odp_timer_cancel(odp_timer_t timer, odp_event_t *tmo_ev);
 

--- a/include/odp/api/spec/timer_types.h
+++ b/include/odp/api/spec/timer_types.h
@@ -515,24 +515,49 @@ typedef struct odp_timer_periodic_start_t {
 } odp_timer_periodic_start_t;
 
 /**
- * Return values of timer set calls.
+ * Return values for timer start, restart and cancel calls
  */
 typedef enum {
-	/** Timer set operation succeeded */
+	/**
+	 * Timer operation succeeded
+	 *
+	 * Timer start, restart and cancel operations may return this value.
+	 */
 	ODP_TIMER_SUCCESS = 0,
 
-	/** Timer set operation failed because expiration time is too near to
-	 *  the current time. */
+	/**
+	 * Timer operation failed, too near to the current time
+	 *
+	 * The operation failed because the requested time/timer has expired already, or is too
+	 * near to the current time. Timer start, restart and cancel operations may return this
+	 * value.
+	 */
 	ODP_TIMER_TOO_NEAR = -1,
 
-	/** Timer set operation failed because expiration time is too far from
-	 *  the current time. */
+	/**
+	 * Timer operation failed, too far from the current time
+	 *
+	 * The operation failed because the requested time is too far from the current time.
+	 * Only timer start and restart operations may return this value.
+	 */
 	ODP_TIMER_TOO_FAR = -2,
 
-	/** Timer set operation failed */
+	/**
+	 * Timer operation failed
+	 *
+	 * The operation failed due to some other reason than timing of the request. Timer start,
+	 * restart and cancel operations may return this value.
+	 */
 	ODP_TIMER_FAIL = -3
 
-} odp_timer_set_t;
+} odp_timer_retval_t;
+
+/**
+ * For backwards compatibility, odp_timer_set_t is synonym of odp_timer_retval_t
+ *
+ * @deprecated Use odp_timer_retval_t instead.
+ */
+typedef odp_timer_retval_t odp_timer_set_t;
 
 #if ODP_DEPRECATED_API
 /**

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1731,11 +1731,11 @@ int odp_timer_cancel(odp_timer_t hdl, odp_event_t *tmo_ev)
 	if (old_event != ODP_EVENT_INVALID) {
 		/* Active timer cancelled, timeout returned */
 		*tmo_ev = old_event;
-		return 0;
+		return ODP_TIMER_SUCCESS;
 	}
 
 	/* Timer already expired, no timeout returned */
-	return -1;
+	return ODP_TIMER_TOO_NEAR;
 }
 
 int odp_timer_periodic_cancel(odp_timer_t hdl)

--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -424,7 +424,7 @@ static int worker_thread_timers(void *arg)
 	odp_queue_t queue;
 	pktin_queue_context_t *queue_context;
 	odp_timer_t timer;
-	odp_timer_set_t ret;
+	odp_timer_retval_t ret;
 	odp_timer_start_t start_param;
 	worker_arg_t *worker_arg = arg;
 	test_global_t *test_global = worker_arg->test_global_ptr;
@@ -1326,7 +1326,7 @@ static int start_timers(test_global_t *test_global)
 	int i, j;
 	odp_timeout_t timeout;
 	odp_timer_t timer;
-	odp_timer_set_t ret;
+	odp_timer_retval_t ret;
 	odp_timer_start_t start_param;
 	uint64_t timeout_tick = test_global->timer.timeout_tick;
 	int num_pktio = test_global->opt.num_pktio;

--- a/test/performance/odp_timer_perf.c
+++ b/test/performance/odp_timer_perf.c
@@ -644,7 +644,7 @@ static void cancel_timers(test_global_t *global, uint32_t worker_idx)
 			if (timer == ODP_TIMER_INVALID)
 				continue;
 
-			if (odp_timer_cancel(timer, &ev) == 0)
+			if (odp_timer_cancel(timer, &ev) == ODP_TIMER_SUCCESS)
 				odp_event_free(ev);
 		}
 	}
@@ -753,8 +753,14 @@ static int set_cancel_mode_worker(void *arg)
 				status = odp_timer_cancel(timer, &ev);
 				num_cancel++;
 
-				if (status < 0)
+				if (odp_unlikely(status == ODP_TIMER_TOO_NEAR)) {
 					continue;
+				} else if (odp_unlikely(status != ODP_TIMER_SUCCESS)) {
+					ODPH_ERR("Timer (%u/%u) cancel failed (ret %i)\n", i, j,
+						 status);
+					ret = -1;
+					break;
+				}
 
 				start_param.tick_type = ODP_TIMER_TICK_ABS;
 				start_param.tick = tick + j * period_tick;

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -1595,7 +1595,7 @@ static void timer_test_cancel(void)
 	odp_timer_t tim;
 	odp_event_t ev;
 	odp_timeout_t tmo;
-	odp_timer_set_t rc;
+	odp_timer_retval_t rc;
 	int ret;
 
 	memset(&capa, 0, sizeof(capa));
@@ -1999,7 +1999,7 @@ static int worker_entrypoint(void *arg ODP_UNUSED)
 	odp_event_t ev;
 	struct timespec ts;
 	uint32_t nstale;
-	odp_timer_set_t timer_rc;
+	odp_timer_retval_t timer_rc;
 	odp_timer_start_t start_param;
 	odp_timer_pool_t tp = global_mem->tp;
 	odp_pool_t tbp = global_mem->tbp;
@@ -2119,7 +2119,7 @@ static int worker_entrypoint(void *arg ODP_UNUSED)
 				ncancel++;
 			}
 		} else {
-			odp_timer_set_t rc;
+			odp_timer_retval_t rc;
 			uint64_t cur_tick;
 			uint64_t tck;
 			int reset_timer = 0;


### PR DESCRIPTION
Use same return values between timer start and cancel calls. Separate cancel failure return values allow application to distinguish timing related failures (TOO_NEAR) from severe errors (that should never happen).

v2: Rebased
v3: Rebased
v4: Rebased