### PR TITLE
[PATCH v2] linux-gen: dma: fix packet-type transfer segmentation

### DIFF
--- a/platform/linux-generic/odp_dma.c
+++ b/platform/linux-generic/odp_dma.c
@@ -396,7 +396,7 @@ static inline int segment_pkt(segment_t seg[], int num_seg, const odp_dma_seg_t 
 			offset  += len;
 			num++;
 
-			if (odp_unlikely(num >= MAX_SEGS)) {
+			if (odp_unlikely(num > MAX_SEGS)) {
 				_ODP_ERR("Too many packet segments\n");
 				return 0;
 			}


### PR DESCRIPTION
Correctly allow up to maximum capability of input segments in case of packet-type transfer.

v2:
- Added reviewed-by tag