### PR TITLE
[PATCH v7] api: timer: add tick sample function

### DIFF
--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -191,6 +191,28 @@ uint64_t odp_timer_ns_to_tick(odp_timer_pool_t timer_pool, uint64_t ns);
 uint64_t odp_timer_current_tick(odp_timer_pool_t timer_pool);
 
 /**
+ * Sample tick values of timer pools
+ *
+ * Reads timer pool tick values simultaneously (or closely back-to-back) from all requested timer
+ * pools, and outputs those on success. Optionally, outputs corresponding source clock (HW) counter
+ * values, which are implementation specific and may be used for debugging. When a timer pool does
+ * not support reading of the source clock value, zero is written instead. Values are written into
+ * the output arrays in the same order which timer pools were defined. Nothing is written on
+ * failure.
+ *
+ * @param      timer_pool  Timer pools to sample
+ * @param[out] tick        Tick value array for output (one element per timer pool)
+ * @param[out] clk_count   Source clock counter value array for output (one element per
+ *                         timer pool), or NULL when counter values are not requested.
+ * @param      num         Number of timer pools to sample
+ *
+ * @retval  0 All requested timer pools sampled successfully
+ * @retval -1 Failure
+ */
+int odp_timer_sample_ticks(odp_timer_pool_t timer_pool[], uint64_t tick[], uint64_t clk_count[],
+			   int num);
+
+/**
  * Query timer pool configuration and current state
  *
  * @param      timer_pool  Timer pool

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1453,6 +1453,39 @@ uint64_t odp_timer_current_tick(odp_timer_pool_t tpid)
 	return current_nsec(tp);
 }
 
+int odp_timer_sample_ticks(odp_timer_pool_t timer_pool[], uint64_t tick[], uint64_t clk_count[],
+			   int num)
+{
+	timer_pool_t *tp[MAX_TIMER_POOLS];
+	odp_time_t now;
+	int i;
+
+	if (num <= 0 || num > MAX_TIMER_POOLS) {
+		_ODP_ERR("Bad number of timer pools: %i\n", num);
+		return -1;
+	}
+
+	for (i = 0; i < num; i++) {
+		if (odp_unlikely(timer_pool[i] == ODP_TIMER_POOL_INVALID)) {
+			_ODP_ERR("Invalid timer pool\n");
+			return -1;
+		}
+
+		tp[i] = timer_pool_from_hdl(timer_pool[i]);
+	}
+
+	now = odp_time_global();
+
+	for (i = 0; i < num; i++) {
+		tick[i] = time_nsec(tp[i], now);
+
+		if (clk_count)
+			clk_count[i] = tick[i];
+	}
+
+	return 0;
+}
+
 int odp_timer_pool_info(odp_timer_pool_t tpid, odp_timer_pool_info_t *tp_info)
 {
 	timer_pool_t *tp;


### PR DESCRIPTION
Added a new function that samples tick value of multiple timer pools simultaneously. This helps application to calculate tick offset between timer pools with minimum error.

v3: Fixed comments, rebased
v4: Fixed comment
v6: Rebased