### PR TITLE
[PATCH v6] api: dma: add completion event pool user area

### DIFF
--- a/include/odp/api/spec/dma.h
+++ b/include/odp/api/spec/dma.h
@@ -285,6 +285,19 @@ odp_event_t odp_dma_compl_to_event(odp_dma_compl_t dma_compl);
 uint64_t odp_dma_compl_to_u64(odp_dma_compl_t dma_compl);
 
 /**
+ * DMA completion event user area
+ *
+ * Returns pointer to the user area associated with the completion event. Size of the area is fixed
+ * and defined in completion event pool parameters.
+ *
+ * @param dma_compl    DMA completion event handle
+ *
+ * @return Pointer to the user area of the completion event
+ * @retval NULL  The completion event does not have user area
+ */
+void *odp_dma_compl_user_area(odp_dma_compl_t dma_compl);
+
+/**
  * Allocate DMA completion event
  *
  * Allocates a DMA completion event from a pool. The pool must have been created with

--- a/include/odp/api/spec/dma_types.h
+++ b/include/odp/api/spec/dma_types.h
@@ -77,6 +77,9 @@ typedef struct odp_dma_pool_capability_t {
 	/** Maximum number of DMA completion events in a pool */
 	uint32_t max_num;
 
+	/** Maximum user area size in bytes */
+	uint32_t max_uarea_size;
+
 	/** Minimum size of thread local cache */
 	uint32_t min_cache_size;
 
@@ -93,6 +96,13 @@ typedef struct odp_dma_pool_param_t {
 	 *
 	 *  Maximum value is defined by 'max_num' pool capability */
 	uint32_t num;
+
+	/** User area size in bytes
+	 *
+	 *  Maximum value is defined by 'max_uarea_size' pool capability. Specify as 0 if no user
+	 *  area is needed. The default value is 0.
+	 */
+	uint32_t uarea_size;
 
 	/** Maximum number of events cached locally per thread
 	 *

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -1230,6 +1230,7 @@ int odp_pool_info(odp_pool_t pool_hdl, odp_pool_info_t *info)
 
 	} else if (pool->type_2 == ODP_POOL_DMA_COMPL) {
 		info->dma_pool_param.num        = pool->params.buf.num;
+		info->dma_pool_param.uarea_size = pool->params.buf.uarea_size;
 		info->dma_pool_param.cache_size = pool->params.buf.cache_size;
 
 	} else {

--- a/test/validation/api/dma/dma.c
+++ b/test/validation/api/dma/dma.c
@@ -173,7 +173,7 @@ static int dma_suite_term(void)
 		return -1;
 	}
 
-	return 0;
+	return odp_cunit_print_inactive();
 }
 
 static void test_dma_capability(void)


### PR DESCRIPTION
This patchset introduces user area for DMA event-completion pools.

v2:
- Dropped "minimum" in `odp_dma_pool_param_t` user area parameter spec

v3:
- Rebased
- Added a function to query completion event user area

v4:
- Matias' comments
- Added a patch that prints inactive tests at the end of DMA suite

v5:
- Added reviewed-by tag

v6:
- Rebased
- Added reviewed-by tags