### PR TITLE
[PATCH v8] api: pool: add new function for reading only selected statistics

### DIFF
--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -158,8 +158,9 @@ int odp_pool_index(odp_pool_t pool);
 /**
  * Get statistics for pool handle
  *
- * Read the statistics counters enabled using odp_pool_stats_opt_t during pool
- * creation. The inactive counters are set to zero by the implementation.
+ * Read the statistics counters enabled using odp_pool_stats_opt_t during pool creation. The
+ * inactive counters are set to zero by the implementation. Depending on the implementation, there
+ * may be some delay until performed pool operations are visible in the statistics.
  *
  * A single call may read statistics from one to ODP_POOL_MAX_THREAD_STATS
  * threads. Set 'stats.thread.first' and 'stats.thread.last' to select the

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2020-2022, Nokia
+ * Copyright (c) 2020-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -156,7 +156,7 @@ unsigned int odp_pool_max_index(void);
 int odp_pool_index(odp_pool_t pool);
 
 /**
- * Get statistics for pool handle
+ * Get statistics for pool
  *
  * Read the statistics counters enabled using odp_pool_stats_opt_t during pool creation. The
  * inactive counters are set to zero by the implementation. Depending on the implementation, there
@@ -177,7 +177,29 @@ int odp_pool_index(odp_pool_t pool);
 int odp_pool_stats(odp_pool_t pool, odp_pool_stats_t *stats);
 
 /**
- * Reset statistics for pool handle
+ * Get selected pool statistics
+ *
+ * Read the selected counters given in odp_pool_stats_opt_t bit field structure. Only counters
+ * included in odp_pool_stats_selected_t can be read and the selected counters must have been
+ * enabled during pool creation. Values of the unselected counters are undefined. Depending on the
+ * implementation, there may be some delay until performed pool operations are visible in the
+ * statistics.
+ *
+ * Depending on the implementation, this function may have higher performance compared to
+ * odp_pool_stats(), as only the selected set of counters is read.
+ *
+ * @param         pool   Pool handle
+ * @param[out]    stats  Output buffer for counters
+ * @param         opt    Bit field for selecting the counters to be read
+ *
+ * @retval  0 on success
+ * @retval <0 on failure
+ */
+int odp_pool_stats_selected(odp_pool_t pool, odp_pool_stats_selected_t *stats,
+			    const odp_pool_stats_opt_t *opt);
+
+/**
+ * Reset statistics for pool
  *
  * Reset all statistics counters to zero except: odp_pool_stats_t::available,
  * odp_pool_stats_t::cache_available, odp_pool_stats_t::thread::cache_available

--- a/include/odp/api/spec/pool_types.h
+++ b/include/odp/api/spec/pool_types.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, Nokia
+/* Copyright (c) 2021-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -146,6 +146,38 @@ typedef struct odp_pool_stats_t {
 	} thread;
 
 } odp_pool_stats_t;
+
+/**
+ * Pool statistics counters
+ *
+ * Same as odp_pool_stats_t excluding per thread counters.
+ */
+typedef struct odp_pool_stats_selected_t {
+	/** See odp_pool_stats_t::available */
+	uint64_t available;
+
+	/** See odp_pool_stats_t::alloc_ops */
+	uint64_t alloc_ops;
+
+	/** See odp_pool_stats_t::alloc_fails */
+	uint64_t alloc_fails;
+
+	/** See odp_pool_stats_t::free_ops */
+	uint64_t free_ops;
+
+	/** See odp_pool_stats_t::total_ops */
+	uint64_t total_ops;
+
+	/** See odp_pool_stats_t::cache_available */
+	uint64_t cache_available;
+
+	/** See odp_pool_stats_t::cache_alloc_ops */
+	uint64_t cache_alloc_ops;
+
+	/** See odp_pool_stats_t::cache_free_ops */
+	uint64_t cache_free_ops;
+
+} odp_pool_stats_selected_t;
 
 /**
  * Pool capabilities

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -1264,6 +1264,9 @@ static void pool_test_pool_statistics(odp_pool_type_t pool_type)
 		CU_ASSERT(num_events == num_obj);
 		num_event[i] = num_events;
 
+		/* Allow implementation some time to update counters */
+		odp_time_wait_ns(ODP_TIME_MSEC_IN_NS);
+
 		stats.thread.first = first;
 		stats.thread.last = last;
 		CU_ASSERT_FATAL(odp_pool_stats(pool[i], &stats) == 0);
@@ -1287,6 +1290,9 @@ static void pool_test_pool_statistics(odp_pool_type_t pool_type)
 
 	for (i = 0; i < num_pool; i++) {
 		odp_event_free_multi(event[i], num_event[i]);
+
+		/* Allow implementation some time to update counters */
+		odp_time_wait_ns(ODP_TIME_MSEC_IN_NS);
 
 		stats.thread.first = odp_thread_id();
 		stats.thread.last = odp_thread_id();


### PR DESCRIPTION
Add new function `odp_pool_stats_selected()` for reading only selected pool
statistic(s). This can minimize function overhead compared to original
`odp_pool_stats()` function, which always returns all enabled counters.

Also, relax `odp_pool_stats()` specification to allow implementations to have some
delay until pool statistics are updated. This is required by some HW
statistics counters.