### PR TITLE
[PATCH v9] validation: ipsec: disable anti-replay with null authentication

### DIFF
--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -395,7 +395,10 @@ void ipsec_sa_param_fill(odp_ipsec_sa_param_t *param,
 	param->dir = dir;
 	if (dir == ODP_IPSEC_DIR_INBOUND) {
 		param->inbound.lookup_mode = ODP_IPSEC_LOOKUP_SPI;
-		param->inbound.antireplay_ws = capa.max_antireplay_ws;
+		if (auth_alg == ODP_AUTH_ALG_NULL)
+			param->inbound.antireplay_ws = 0;
+		else
+			param->inbound.antireplay_ws = capa.max_antireplay_ws;
 	}
 	param->proto = proto;
 


### PR DESCRIPTION
validation: ipsec: disable anti-replay with null authentication

Set antireplay_ws to zero to disable anti-replay service when an inbound SA
without integrity protection is created.
The anti-replay service is not used in IPsec without integrity protection
and therefore some ODP implementations may not support SAs that have null
auth algorithm but anti-replay enabled. This change also enables a future
API change that would require zero antireplay_ws with null authentication.
