### PR TITLE
[PATCH v2] validation: use ODPH_ERR() macro for error prints

### DIFF
--- a/platform/linux-generic/test/validation/api/shmem/shmem_odp2.c
+++ b/platform/linux-generic/test/validation/api/shmem/shmem_odp2.c
@@ -5,6 +5,8 @@
  */
 
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
 #include <linux/limits.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -33,11 +35,11 @@ int main(int argc, char *argv[])
 
 	/* odp init: */
 	if (0 != odp_init_global(&odp2, NULL, NULL)) {
-		fprintf(stderr, "error: odp_init_global() failed.\n");
+		ODPH_ERR("odp_init_global() failed\n");
 		return 1;
 	}
 	if (0 != odp_init_local(odp2, ODP_THREAD_CONTROL)) {
-		fprintf(stderr, "error: odp_init_local() failed.\n");
+		ODPH_ERR("odp_init_local() failed\n");
 		return 1;
 	}
 
@@ -46,8 +48,7 @@ int main(int argc, char *argv[])
 	 * is given as first arg. In linux-generic ODP, this pid is actually
 	 * the ODP instance */
 	if (argc != 2) {
-		fprintf(stderr, "One single parameter expected, %d found.\n",
-			argc);
+		ODPH_ERR("One single parameter expected, %d found\n", argc);
 		return 1;
 	}
 	odp1 = (odp_instance_t)atoi(argv[1]);
@@ -56,46 +57,46 @@ int main(int argc, char *argv[])
 	       SHM_NAME, (int)odp1);
 	shm = odp_shm_import(SHM_NAME, odp1, SHM_NAME);
 	if (shm == ODP_SHM_INVALID) {
-		fprintf(stderr, "error: odp_shm_lookup_external failed.\n");
+		ODPH_ERR("odp_shm_import() failed\n");
 		return 1;
 	}
 
 	/* check that the read size matches the allocated size (in other ODP):*/
 	if ((odp_shm_info(shm, &info)) ||
 	    (info.size != sizeof(*test_shared_data))) {
-		fprintf(stderr, "error: odp_shm_info failed.\n");
+		ODPH_ERR("odp_shm_info() failed\n");
 		return 1;
 	}
 
 	test_shared_data = odp_shm_addr(shm);
 	if (test_shared_data == NULL) {
-		fprintf(stderr, "error: odp_shm_addr failed.\n");
+		ODPH_ERR("odp_shm_addr() failed\n");
 		return 1;
 	}
 
 	if (test_shared_data->foo != TEST_SHARE_FOO) {
-		fprintf(stderr, "error: Invalid data TEST_SHARE_FOO.\n");
+		ODPH_ERR("Invalid data TEST_SHARE_FOO\n");
 		return 1;
 	}
 
 	if (test_shared_data->bar != TEST_SHARE_BAR) {
-		fprintf(stderr, "error: Invalid data TEST_SHARE_BAR.\n");
+		ODPH_ERR("Invalid data TEST_SHARE_BAR\n");
 		return 1;
 	}
 
 	if (odp_shm_free(shm) != 0) {
-		fprintf(stderr, "error: odp_shm_free() failed.\n");
+		ODPH_ERR("odp_shm_free() failed\n");
 		return 1;
 	}
 
 	/* odp term: */
 	if (0 != odp_term_local()) {
-		fprintf(stderr, "error: odp_term_local() failed.\n");
+		ODPH_ERR("odp_term_local() failed\n");
 		return 1;
 	}
 
 	if (0 != odp_term_global(odp2)) {
-		fprintf(stderr, "error: odp_term_global() failed.\n");
+		ODPH_ERR("odp_term_global() failed\n");
 		return 1;
 	}
 

--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -974,7 +974,7 @@ static int atomic_init(odp_instance_t *inst)
 	odph_helper_options_t helper_options;
 
 	if (odph_options(&helper_options)) {
-		fprintf(stderr, "error: odph_options() failed.\n");
+		ODPH_ERR("odph_options() failed\n");
 		return -1;
 	}
 
@@ -982,18 +982,18 @@ static int atomic_init(odp_instance_t *inst)
 	init_param.mem_model = helper_options.mem_model;
 
 	if (0 != odp_init_global(inst, &init_param, NULL)) {
-		fprintf(stderr, "error: odp_init_global() failed.\n");
+		ODPH_ERR("odp_init_global() failed\n");
 		return -1;
 	}
 	if (0 != odp_init_local(*inst, ODP_THREAD_CONTROL)) {
-		fprintf(stderr, "error: odp_init_local() failed.\n");
+		ODPH_ERR("odp_init_local() failed\n");
 		return -1;
 	}
 
 	global_shm = odp_shm_reserve(GLOBAL_SHM_NAME,
 				     sizeof(global_shared_mem_t), 64, 0);
 	if (ODP_SHM_INVALID == global_shm) {
-		fprintf(stderr, "Unable reserve memory for global_shm\n");
+		ODPH_ERR("Unable to reserve memory for global_shm\n");
 		return -1;
 	}
 
@@ -1029,17 +1029,17 @@ static int atomic_term(odp_instance_t inst)
 
 	shm = odp_shm_lookup(GLOBAL_SHM_NAME);
 	if (0 != odp_shm_free(shm)) {
-		fprintf(stderr, "error: odp_shm_free() failed.\n");
+		ODPH_ERR("odp_shm_free() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_local()) {
-		fprintf(stderr, "error: odp_term_local() failed.\n");
+		ODPH_ERR("odp_term_local() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_global(inst)) {
-		fprintf(stderr, "error: odp_term_global() failed.\n");
+		ODPH_ERR("odp_term_global() failed\n");
 		return -1;
 	}
 

--- a/test/validation/api/barrier/barrier.c
+++ b/test/validation/api/barrier/barrier.c
@@ -305,7 +305,7 @@ static int barrier_init(odp_instance_t *inst)
 	odph_helper_options_t helper_options;
 
 	if (odph_options(&helper_options)) {
-		fprintf(stderr, "error: odph_options() failed.\n");
+		ODPH_ERR("odph_options() failed\n");
 		return -1;
 	}
 
@@ -313,18 +313,18 @@ static int barrier_init(odp_instance_t *inst)
 	init_param.mem_model = helper_options.mem_model;
 
 	if (0 != odp_init_global(inst, &init_param, NULL)) {
-		fprintf(stderr, "error: odp_init_global() failed.\n");
+		ODPH_ERR("odp_init_global() failed\n");
 		return -1;
 	}
 	if (0 != odp_init_local(*inst, ODP_THREAD_CONTROL)) {
-		fprintf(stderr, "error: odp_init_local() failed.\n");
+		ODPH_ERR("odp_init_local() failed\n");
 		return -1;
 	}
 
 	global_shm = odp_shm_reserve(GLOBAL_SHM_NAME,
 				     sizeof(global_shared_mem_t), 64, 0);
 	if (ODP_SHM_INVALID == global_shm) {
-		fprintf(stderr, "Unable reserve memory for global_shm\n");
+		ODPH_ERR("Unable to reserve memory for global_shm\n");
 		return -1;
 	}
 
@@ -360,17 +360,17 @@ static int barrier_term(odp_instance_t inst)
 
 	shm = odp_shm_lookup(GLOBAL_SHM_NAME);
 	if (0 != odp_shm_free(shm)) {
-		fprintf(stderr, "error: odp_shm_free() failed.\n");
+		ODPH_ERR("odp_shm_free() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_local()) {
-		fprintf(stderr, "error: odp_term_local() failed.\n");
+		ODPH_ERR("odp_term_local() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_global(inst)) {
-		fprintf(stderr, "error: odp_term_global() failed.\n");
+		ODPH_ERR("odp_term_global() failed\n");
 		return -1;
 	}
 

--- a/test/validation/api/buffer/buffer.c
+++ b/test/validation/api/buffer/buffer.c
@@ -23,7 +23,7 @@ static int buffer_suite_init(void)
 	uint32_t size, num, align;
 
 	if (odp_pool_capability(&pool_capa)) {
-		printf("pool capability failed\n");
+		ODPH_ERR("Pool capability failed\n");
 		return -1;
 	}
 
@@ -111,7 +111,7 @@ static void test_pool_alloc_free(const odp_pool_param_t *param)
 			wrong_align = true;
 
 		if (wrong_type || wrong_subtype || wrong_size || wrong_align) {
-			printf("Buffer has error\n");
+			ODPH_ERR("Buffer has error\n");
 			odp_buffer_print(buffer[i]);
 			break;
 		}
@@ -200,7 +200,7 @@ static void test_pool_alloc_free_multi(const odp_pool_param_t *param)
 			wrong_align = true;
 
 		if (wrong_type || wrong_subtype || wrong_size || wrong_align) {
-			printf("Buffer has error\n");
+			ODPH_ERR("Buffer has error\n");
 			odp_buffer_print(buffer[i]);
 			break;
 		}
@@ -351,7 +351,7 @@ static void test_pool_max_pools(odp_pool_param_t *param)
 
 	CU_ASSERT(num_pool == max_pools);
 	if (num_pool != max_pools)
-		printf("Error: created only %u pools\n", num_pool);
+		ODPH_ERR("Created only %u pools\n", num_pool);
 
 	for (i = 0; i < num_pool; i++) {
 		buffer[i] = odp_buffer_alloc(pool[i]);

--- a/test/validation/api/classification/odp_classification_tests.c
+++ b/test/validation/api/classification/odp_classification_tests.c
@@ -70,7 +70,7 @@ static int classification_suite_common_init(odp_bool_t enable_pktv)
 
 	ret = odp_pktio_capability(pktio_loop, &pktio_capa);
 	if (ret) {
-		fprintf(stderr, "unable to get pktio capability.\n");
+		ODPH_ERR("Unable to get pktio capability\n");
 		return -1;
 	}
 

--- a/test/validation/api/comp/comp.c
+++ b/test/validation/api/comp/comp.c
@@ -5,6 +5,8 @@
  */
 
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
 #include <odp_cunit_common.h>
 #include "test_vectors.h"
 
@@ -68,7 +70,7 @@ static int check_comp_alg_support(odp_comp_alg_t comp,
 			return ODP_TEST_INACTIVE;
 		break;
 	default:
-		fprintf(stderr, "Unsupported compression algorithm\n");
+		ODPH_ERR("Unsupported compression algorithm\n");
 		return ODP_TEST_INACTIVE;
 	}
 
@@ -87,7 +89,7 @@ static int check_comp_alg_support(odp_comp_alg_t comp,
 			return ODP_TEST_INACTIVE;
 		break;
 	default:
-		fprintf(stderr, "Unsupported hash algorithm\n");
+		ODPH_ERR("Unsupported hash algorithm\n");
 		return ODP_TEST_INACTIVE;
 	}
 
@@ -475,17 +477,17 @@ static int comp_init(odp_instance_t *inst)
 	odp_pool_capability_t pool_capa;
 
 	if (0 != odp_init_global(inst, NULL, NULL)) {
-		fprintf(stderr, "error: odp_init_global() failed.\n");
+		ODPH_ERR("odp_init_global() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_init_local(*inst, ODP_THREAD_CONTROL)) {
-		fprintf(stderr, "error: odp_init_local() failed.\n");
+		ODPH_ERR("odp_init_local() failed\n");
 		return -1;
 	}
 
 	if (odp_pool_capability(&pool_capa) < 0) {
-		fprintf(stderr, "error: odp_pool_capability() failed.\n");
+		ODPH_ERR("odp_pool_capability() failed\n");
 		return -1;
 	}
 
@@ -497,20 +499,20 @@ static int comp_init(odp_instance_t *inst)
 
 	if (pool_capa.pkt.max_seg_len &&
 	    TEST_PKT_LEN > pool_capa.pkt.max_seg_len) {
-		fprintf(stderr, "Warning: small packet segment length\n");
+		ODPH_ERR("Warning: small packet segment length\n");
 		params.pkt.seg_len = pool_capa.pkt.max_seg_len;
 	}
 
 	pool = odp_pool_create(COMP_PACKET_POOL, &params);
 	if (ODP_POOL_INVALID == pool) {
-		fprintf(stderr, "Packet pool creation failed.\n");
+		ODPH_ERR("Packet pool creation failed\n");
 		return -1;
 	}
 
 	/* Queue to store compression/decompression events */
 	out_queue = odp_queue_create(COMP_OUT_QUEUE, NULL);
 	if (ODP_QUEUE_INVALID == out_queue) {
-		fprintf(stderr, "Comp outq creation failed.\n");
+		ODPH_ERR("Comp outq creation failed\n");
 		return -1;
 	}
 
@@ -525,26 +527,26 @@ static int comp_term(odp_instance_t inst)
 	out_queue = odp_queue_lookup(COMP_OUT_QUEUE);
 	if (ODP_QUEUE_INVALID != out_queue) {
 		if (odp_queue_destroy(out_queue))
-			fprintf(stderr, "Comp outq destroy failed.\n");
+			ODPH_ERR("Comp outq destroy failed\n");
 	} else {
-		fprintf(stderr, "Comp outq not found.\n");
+		ODPH_ERR("Comp outq not found\n");
 	}
 
 	pool = odp_pool_lookup(COMP_PACKET_POOL);
 	if (ODP_POOL_INVALID != pool) {
 		if (odp_pool_destroy(pool))
-			fprintf(stderr, "Packet pool destroy failed.\n");
+			ODPH_ERR("Packet pool destroy failed\n");
 	} else {
-		fprintf(stderr, "Packet pool not found.\n");
+		ODPH_ERR("Packet pool not found\n");
 	}
 
 	if (0 != odp_term_local()) {
-		fprintf(stderr, "error: odp_term_local() failed.\n");
+		ODPH_ERR("odp_term_local() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_global(inst)) {
-		fprintf(stderr, "error: odp_term_global() failed.\n");
+		ODPH_ERR("odp_term_global() failed\n");
 		return -1;
 	}
 

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -1264,7 +1264,7 @@ static int check_alg_support(odp_cipher_alg_t cipher, odp_auth_alg_t auth)
 
 	memset(&capability, 0, sizeof(odp_crypto_capability_t));
 	if (odp_crypto_capability(&capability)) {
-		fprintf(stderr, "odp_crypto_capability() failed\n");
+		ODPH_ERR("odp_crypto_capability() failed\n");
 		return ODP_TEST_INACTIVE;
 	}
 
@@ -1351,7 +1351,7 @@ static int check_alg_support(odp_cipher_alg_t cipher, odp_auth_alg_t auth)
 			return ODP_TEST_INACTIVE;
 		break;
 	default:
-		fprintf(stderr, "Unsupported cipher algorithm\n");
+		ODPH_ERR("Unsupported cipher algorithm\n");
 		return ODP_TEST_INACTIVE;
 	}
 
@@ -1450,7 +1450,7 @@ static int check_alg_support(odp_cipher_alg_t cipher, odp_auth_alg_t auth)
 			return ODP_TEST_INACTIVE;
 		break;
 	default:
-		fprintf(stderr, "Unsupported authentication algorithm\n");
+		ODPH_ERR("Unsupported authentication algorithm\n");
 		return ODP_TEST_INACTIVE;
 	}
 
@@ -3071,7 +3071,7 @@ static int crypto_suite_packet_async_plain_init(void)
 
 	out_queue = plain_compl_queue_create();
 	if (ODP_QUEUE_INVALID == out_queue) {
-		fprintf(stderr, "Crypto outq creation failed.\n");
+		ODPH_ERR("Crypto outq creation failed\n");
 		return -1;
 	}
 	suite_context.queue = out_queue;
@@ -3093,7 +3093,7 @@ static int crypto_suite_packet_async_sched_init(void)
 
 	out_queue = sched_compl_queue_create();
 	if (ODP_QUEUE_INVALID == out_queue) {
-		fprintf(stderr, "Crypto outq creation failed.\n");
+		ODPH_ERR("Crypto outq creation failed\n");
 		return -1;
 	}
 	suite_context.queue = out_queue;
@@ -3107,9 +3107,9 @@ static int crypto_suite_term(void)
 {
 	if (ODP_QUEUE_INVALID != suite_context.queue) {
 		if (odp_queue_destroy(suite_context.queue))
-			fprintf(stderr, "Crypto outq destroy failed.\n");
+			ODPH_ERR("Crypto outq destroy failed\n");
 	} else {
-		fprintf(stderr, "Crypto outq not found.\n");
+		ODPH_ERR("Crypto outq not found\n");
 	}
 
 	return odp_cunit_print_inactive();
@@ -3280,7 +3280,7 @@ static int crypto_init(odp_instance_t *inst)
 	odph_helper_options_t helper_options;
 
 	if (odph_options(&helper_options)) {
-		fprintf(stderr, "error: odph_options() failed.\n");
+		ODPH_ERR("odph_options() failed\n");
 		return -1;
 	}
 
@@ -3288,23 +3288,23 @@ static int crypto_init(odp_instance_t *inst)
 	init_param.mem_model = helper_options.mem_model;
 
 	if (0 != odp_init_global(inst, &init_param, NULL)) {
-		fprintf(stderr, "error: odp_init_global() failed.\n");
+		ODPH_ERR("odp_init_global() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_init_local(*inst, ODP_THREAD_CONTROL)) {
-		fprintf(stderr, "error: odp_init_local() failed.\n");
+		ODPH_ERR("odp_init_local() failed\n");
 		return -1;
 	}
 
 	/* Configure the scheduler. */
 	if (odp_schedule_config(NULL)) {
-		fprintf(stderr, "odp_schedule_config() failed.\n");
+		ODPH_ERR("odp_schedule_config() failed\n");
 		return -1;
 	}
 
 	if (odp_pool_capability(&pool_capa) < 0) {
-		fprintf(stderr, "error: odp_pool_capability() failed.\n");
+		ODPH_ERR("odp_pool_capability() failed\n");
 		return -1;
 	}
 
@@ -3325,20 +3325,20 @@ static int crypto_init(odp_instance_t *inst)
 
 	if (pool_capa.pkt.max_seg_len &&
 	    PKT_POOL_LEN > pool_capa.pkt.max_seg_len) {
-		fprintf(stderr, "Warning: small packet segment length\n");
+		ODPH_ERR("Warning: small packet segment length\n");
 		params.pkt.seg_len = pool_capa.pkt.max_seg_len;
 	}
 
 	if (pool_capa.pkt.max_len &&
 	    PKT_POOL_LEN > pool_capa.pkt.max_len) {
-		fprintf(stderr, "Pool max packet length too small\n");
+		ODPH_ERR("Pool max packet length too small\n");
 		return -1;
 	}
 
 	pool = odp_pool_create("packet_pool", &params);
 
 	if (ODP_POOL_INVALID == pool) {
-		fprintf(stderr, "Packet pool creation failed.\n");
+		ODPH_ERR("Packet pool creation failed\n");
 		return -1;
 	}
 
@@ -3352,18 +3352,18 @@ static int crypto_term(odp_instance_t inst)
 	pool = odp_pool_lookup("packet_pool");
 	if (ODP_POOL_INVALID != pool) {
 		if (odp_pool_destroy(pool))
-			fprintf(stderr, "Packet pool destroy failed.\n");
+			ODPH_ERR("Packet pool destroy failed\n");
 	} else {
-		fprintf(stderr, "Packet pool not found.\n");
+		ODPH_ERR("Packet pool not found\n");
 	}
 
 	if (0 != odp_term_local()) {
-		fprintf(stderr, "error: odp_term_local() failed.\n");
+		ODPH_ERR("odp_term_local() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_global(inst)) {
-		fprintf(stderr, "error: odp_term_global() failed.\n");
+		ODPH_ERR("odp_term_global() failed\n");
 		return -1;
 	}
 

--- a/test/validation/api/init/init_main.c
+++ b/test/validation/api/init/init_main.c
@@ -6,6 +6,7 @@
  */
 
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 #include <odp_cunit_common.h>
 
 #include <stdarg.h>
@@ -265,7 +266,7 @@ odp_suiteinfo_t init_suites[] = {
 static int fill_testinfo(odp_testinfo_t *info, unsigned int test_case)
 {
 	if (test_case >= (sizeof(testinfo) / sizeof(odp_testinfo_t))) {
-		printf("Bad test case number %u\n", test_case);
+		ODPH_ERR("Bad test case number %u\n", test_case);
 		return -1;
 	}
 

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -57,12 +57,12 @@ static odp_pktio_t pktio_create(odp_pool_t pool)
 	if (pktio == ODP_PKTIO_INVALID) {
 		ret = odp_pool_destroy(pool);
 		if (ret)
-			fprintf(stderr, "unable to destroy pool.\n");
+			ODPH_ERR("Unable to destroy pool\n");
 		return ODP_PKTIO_INVALID;
 	}
 
 	if (odp_pktio_capability(pktio, &capa)) {
-		fprintf(stderr, "pktio capabilities failed.\n");
+		ODPH_ERR("Pktio capabilities failed\n");
 		return ODP_PKTIO_INVALID;
 	}
 
@@ -70,12 +70,12 @@ static odp_pktio_t pktio_create(odp_pool_t pool)
 	pktin_param.queue_param.sched.sync = ODP_SCHED_SYNC_ATOMIC;
 
 	if (odp_pktin_queue_config(pktio, &pktin_param)) {
-		fprintf(stderr, "pktin queue config failed.\n");
+		ODPH_ERR("Pktin queue config failed\n");
 		return ODP_PKTIO_INVALID;
 	}
 
 	if (odp_pktout_queue_config(pktio, NULL)) {
-		fprintf(stderr, "pktout queue config failed.\n");
+		ODPH_ERR("Pktout queue config failed\n");
 		return ODP_PKTIO_INVALID;
 	}
 
@@ -213,7 +213,7 @@ static void pktio_stop(odp_pktio_t pktio)
 	odp_pktin_event_queue(pktio, &queue, 1);
 
 	if (odp_pktio_stop(pktio))
-		fprintf(stderr, "IPsec pktio stop failed.\n");
+		ODPH_ERR("IPsec pktio stop failed\n");
 
 	while (1) {
 		odp_event_t ev = recv_event(queue, 0);
@@ -1279,7 +1279,7 @@ int ipsec_suite_term(void)
 
 	if (ODP_QUEUE_INVALID != suite_context.queue) {
 		if (odp_queue_destroy(suite_context.queue))
-			fprintf(stderr, "IPsec destq destroy failed.\n");
+			ODPH_ERR("IPsec destq destroy failed\n");
 	}
 
 	if (odp_cunit_print_inactive())
@@ -1332,7 +1332,7 @@ int ipsec_suite_plain_init(void)
 
 	dest_queue = plain_queue_create("ipsec-out");
 	if (ODP_QUEUE_INVALID == dest_queue) {
-		fprintf(stderr, "IPsec destq creation failed.\n");
+		ODPH_ERR("IPsec destq creation failed\n");
 		return -1;
 	}
 
@@ -1348,7 +1348,7 @@ int ipsec_suite_sched_init(void)
 
 	dest_queue = sched_queue_create("ipsec-out");
 	if (ODP_QUEUE_INVALID == dest_queue) {
-		fprintf(stderr, "IPsec destq creation failed.\n");
+		ODPH_ERR("IPsec destq creation failed\n");
 		return -1;
 	}
 
@@ -1374,7 +1374,7 @@ int ipsec_init(odp_instance_t *inst, odp_ipsec_op_mode_t mode)
 	suite_context.default_queue = ODP_QUEUE_INVALID;
 
 	if (odph_options(&helper_options)) {
-		fprintf(stderr, "error: odph_options() failed.\n");
+		ODPH_ERR("odph_options() failed\n");
 		return -1;
 	}
 
@@ -1382,22 +1382,22 @@ int ipsec_init(odp_instance_t *inst, odp_ipsec_op_mode_t mode)
 	init_param.mem_model = helper_options.mem_model;
 
 	if (0 != odp_init_global(inst, &init_param, NULL)) {
-		fprintf(stderr, "error: odp_init_global() failed.\n");
+		ODPH_ERR("odp_init_global() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_init_local(*inst, ODP_THREAD_CONTROL)) {
-		fprintf(stderr, "error: odp_init_local() failed.\n");
+		ODPH_ERR("odp_init_local() failed\n");
 		return -1;
 	}
 
 	if (odp_schedule_config(NULL)) {
-		fprintf(stderr, "odp_schedule_config() failed.\n");
+		ODPH_ERR("odp_schedule_config() failed\n");
 		return -1;
 	}
 
 	if (odp_pool_capability(&pool_capa) < 0) {
-		fprintf(stderr, "error: odp_pool_capability() failed.\n");
+		ODPH_ERR("odp_pool_capability() failed\n");
 		return -1;
 	}
 
@@ -1409,27 +1409,27 @@ int ipsec_init(odp_instance_t *inst, odp_ipsec_op_mode_t mode)
 
 	if (pool_capa.pkt.max_seg_len &&
 	    MAX_PKT_LEN > pool_capa.pkt.max_seg_len) {
-		fprintf(stderr, "Warning: small packet segment length\n");
+		ODPH_ERR("Warning: small packet segment length\n");
 		params.pkt.seg_len = pool_capa.pkt.max_seg_len;
 	}
 
 	if (pool_capa.pkt.max_len &&
 	    MAX_PKT_LEN > pool_capa.pkt.max_len) {
-		fprintf(stderr, "Pool max packet length too small\n");
+		ODPH_ERR("Pool max packet length too small\n");
 		return -1;
 	}
 
 	pool = odp_pool_create("packet_pool", &params);
 
 	if (ODP_POOL_INVALID == pool) {
-		fprintf(stderr, "Packet pool creation failed.\n");
+		ODPH_ERR("Packet pool creation failed\n");
 		return -1;
 	}
 
 	if (mode == ODP_IPSEC_OP_MODE_INLINE) {
 		pktio = pktio_create(pool);
 		if (ODP_PKTIO_INVALID == pktio) {
-			fprintf(stderr, "IPsec pktio creation failed.\n");
+			ODPH_ERR("IPsec pktio creation failed\n");
 			return -1;
 		}
 	}
@@ -1469,7 +1469,7 @@ int ipsec_config(odp_instance_t ODP_UNUSED inst)
 			suite_context.default_queue = sched_queue_create("ipsec-default");
 
 		if (ODP_QUEUE_INVALID == suite_context.default_queue) {
-			fprintf(stderr, "IPsec defaultq creation failed.\n");
+			ODPH_ERR("IPsec defaultq creation failed\n");
 			return -1;
 		}
 	}
@@ -1564,26 +1564,26 @@ int ipsec_term(odp_instance_t inst)
 
 	if (ODP_PKTIO_INVALID != pktio) {
 		if (odp_pktio_close(pktio))
-			fprintf(stderr, "IPsec pktio close failed.\n");
+			ODPH_ERR("IPsec pktio close failed\n");
 	}
 
 	if (ODP_QUEUE_INVALID != default_queue) {
 		if (odp_queue_destroy(default_queue))
-			fprintf(stderr, "IPsec defaultq destroy failed.\n");
+			ODPH_ERR("IPsec defaultq destroy failed\n");
 	}
 
 	if (ODP_POOL_INVALID != pool) {
 		if (odp_pool_destroy(pool))
-			fprintf(stderr, "Packet pool destroy failed.\n");
+			ODPH_ERR("Packet pool destroy failed\n");
 	}
 
 	if (0 != odp_term_local()) {
-		fprintf(stderr, "error: odp_term_local() failed.\n");
+		ODPH_ERR("odp_term_local() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_global(inst)) {
-		fprintf(stderr, "error: odp_term_global() failed.\n");
+		ODPH_ERR("odp_term_global() failed\n");
 		return -1;
 	}
 

--- a/test/validation/api/lock/lock.c
+++ b/test/validation/api/lock/lock.c
@@ -569,12 +569,12 @@ static int spinlock_functional_test(void *arg UNUSED)
 
 	if ((global_mem->g_verbose) &&
 	    ((sync_failures != 0) || (is_locked_errs != 0)))
-		printf("\nThread %" PRIu32 " (id=%d core=%d) had %" PRIu32
-		       " sync_failures and %" PRIu32
-		       " is_locked_errs in %" PRIu32
-		       " iterations\n", thread_num,
-		       per_thread_mem->thread_id, per_thread_mem->thread_core,
-		       sync_failures, is_locked_errs, iterations);
+		ODPH_ERR("Thread %" PRIu32 " (id=%d core=%d) had %" PRIu32
+			 " sync_failures and %" PRIu32
+			 " is_locked_errs in %" PRIu32
+			 " iterations\n", thread_num,
+			 per_thread_mem->thread_id, per_thread_mem->thread_core,
+			 sync_failures, is_locked_errs, iterations);
 
 	CU_ASSERT(sync_failures == 0);
 	CU_ASSERT(is_locked_errs == 0);
@@ -675,14 +675,14 @@ static int spinlock_recursive_functional_test(void *arg UNUSED)
 
 	if ((global_mem->g_verbose) &&
 	    (sync_failures != 0 || recursive_errs != 0 || is_locked_errs != 0))
-		printf("\nThread %" PRIu32 " (id=%d core=%d) had %" PRIu32
-		       " sync_failures and %" PRIu32
-		       " recursive_errs and %" PRIu32
-		       " is_locked_errs in %" PRIu32
-		       " iterations\n", thread_num,
-		       per_thread_mem->thread_id, per_thread_mem->thread_core,
-		       sync_failures, recursive_errs, is_locked_errs,
-		       iterations);
+		ODPH_ERR("Thread %" PRIu32 " (id=%d core=%d) had %" PRIu32
+			 " sync_failures and %" PRIu32
+			 " recursive_errs and %" PRIu32
+			 " is_locked_errs in %" PRIu32
+			 " iterations\n", thread_num,
+			 per_thread_mem->thread_id, per_thread_mem->thread_core,
+			 sync_failures, recursive_errs, is_locked_errs,
+			 iterations);
 
 	CU_ASSERT(sync_failures == 0);
 	CU_ASSERT(recursive_errs == 0);
@@ -765,12 +765,12 @@ static int ticketlock_functional_test(void *arg UNUSED)
 
 	if ((global_mem->g_verbose) &&
 	    ((sync_failures != 0) || (is_locked_errs != 0)))
-		printf("\nThread %" PRIu32 " (id=%d core=%d) had %" PRIu32
-		       " sync_failures and %" PRIu32
-		       " is_locked_errs in %" PRIu32 " iterations\n",
-		       thread_num,
-		       per_thread_mem->thread_id, per_thread_mem->thread_core,
-		       sync_failures, is_locked_errs, iterations);
+		ODPH_ERR("Thread %" PRIu32 " (id=%d core=%d) had %" PRIu32
+			 " sync_failures and %" PRIu32
+			 " is_locked_errs in %" PRIu32 " iterations\n",
+			 thread_num,
+			 per_thread_mem->thread_id, per_thread_mem->thread_core,
+			 sync_failures, is_locked_errs, iterations);
 
 	CU_ASSERT(sync_failures == 0);
 	CU_ASSERT(is_locked_errs == 0);
@@ -858,11 +858,11 @@ static int rwlock_functional_test(void *arg UNUSED)
 	}
 
 	if ((global_mem->g_verbose) && (sync_failures != 0))
-		printf("\nThread %" PRIu32 " (id=%d core=%d) had %" PRIu32
-		       " sync_failures in %" PRIu32 " iterations\n", thread_num,
-		       per_thread_mem->thread_id,
-		       per_thread_mem->thread_core,
-		       sync_failures, iterations);
+		ODPH_ERR("Thread %" PRIu32 " (id=%d core=%d) had %" PRIu32
+			 " sync_failures in %" PRIu32 " iterations\n", thread_num,
+			 per_thread_mem->thread_id,
+			 per_thread_mem->thread_core,
+			 sync_failures, iterations);
 
 	CU_ASSERT(sync_failures == 0);
 
@@ -985,13 +985,13 @@ static int rwlock_recursive_functional_test(void *arg UNUSED)
 	}
 
 	if ((global_mem->g_verbose) && (sync_failures != 0))
-		printf("\nThread %" PRIu32 " (id=%d core=%d) had %" PRIu32
-		       " sync_failures and %" PRIu32
-		       " recursive_errs in %" PRIu32
-		       " iterations\n", thread_num,
-		       per_thread_mem->thread_id,
-		       per_thread_mem->thread_core,
-		       sync_failures, recursive_errs, iterations);
+		ODPH_ERR("Thread %" PRIu32 " (id=%d core=%d) had %" PRIu32
+			 " sync_failures and %" PRIu32
+			 " recursive_errs in %" PRIu32
+			 " iterations\n", thread_num,
+			 per_thread_mem->thread_id,
+			 per_thread_mem->thread_core,
+			 sync_failures, recursive_errs, iterations);
 
 	CU_ASSERT(sync_failures == 0);
 	CU_ASSERT(recursive_errs == 0);
@@ -1153,7 +1153,7 @@ static int lock_init(odp_instance_t *inst)
 	odph_helper_options_t helper_options;
 
 	if (odph_options(&helper_options)) {
-		fprintf(stderr, "error: odph_options() failed.\n");
+		ODPH_ERR("odph_options() failed\n");
 		return -1;
 	}
 
@@ -1161,18 +1161,18 @@ static int lock_init(odp_instance_t *inst)
 	init_param.mem_model = helper_options.mem_model;
 
 	if (0 != odp_init_global(inst, &init_param, NULL)) {
-		fprintf(stderr, "error: odp_init_global() failed.\n");
+		ODPH_ERR("odp_init_global() failed\n");
 		return -1;
 	}
 	if (0 != odp_init_local(*inst, ODP_THREAD_CONTROL)) {
-		fprintf(stderr, "error: odp_init_local() failed.\n");
+		ODPH_ERR("odp_init_local() failed\n");
 		return -1;
 	}
 
 	global_shm = odp_shm_reserve(GLOBAL_SHM_NAME,
 				     sizeof(global_shared_mem_t), 64, 0);
 	if (ODP_SHM_INVALID == global_shm) {
-		fprintf(stderr, "Unable reserve memory for global_shm\n");
+		ODPH_ERR("Unable to reserve memory for global_shm\n");
 		return -1;
 	}
 
@@ -1208,17 +1208,17 @@ static int lock_term(odp_instance_t inst)
 
 	shm = odp_shm_lookup(GLOBAL_SHM_NAME);
 	if (0 != odp_shm_free(shm)) {
-		fprintf(stderr, "error: odp_shm_free() failed.\n");
+		ODPH_ERR("odp_shm_free() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_local()) {
-		fprintf(stderr, "error: odp_term_local() failed.\n");
+		ODPH_ERR("odp_term_local() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_global(inst)) {
-		fprintf(stderr, "error: odp_term_global() failed.\n");
+		ODPH_ERR("odp_term_global() failed\n");
 		return -1;
 	}
 

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -200,7 +200,7 @@ static int packet_suite_init(void)
 	memset(&pool_capa, 0, sizeof(odp_pool_capability_t));
 
 	if (odp_pool_capability(&pool_capa) < 0) {
-		printf("pool_capability failed\n");
+		ODPH_ERR("odp_pool_capability() failed\n");
 		return -1;
 	}
 
@@ -246,14 +246,14 @@ static int packet_suite_init(void)
 
 	default_pool = odp_pool_create("default_pool", &params);
 	if (default_pool == ODP_POOL_INVALID) {
-		printf("default pool create failed\n");
+		ODPH_ERR("Default pool create failed\n");
 		return -1;
 	}
 
 	test_packet = odp_packet_alloc(default_pool, packet_len);
 
 	if (test_packet == ODP_PACKET_INVALID) {
-		printf("test_packet alloc failed\n");
+		ODPH_ERR("Packet alloc failed\n");
 		return -1;
 	}
 
@@ -277,7 +277,7 @@ static int packet_suite_init(void)
 		 segmented_packet_len > pool_capa.pkt.min_seg_len);
 
 	if (ret != PACKET_POOL_NUM_SEG) {
-		printf("packet alloc failed\n");
+		ODPH_ERR("Packet alloc failed\n");
 		return -1;
 	}
 	segmented_test_packet = pkt_tbl[0];
@@ -285,7 +285,7 @@ static int packet_suite_init(void)
 
 	if (odp_packet_is_valid(test_packet) == 0 ||
 	    odp_packet_is_valid(segmented_test_packet) == 0) {
-		printf("packet_is_valid failed\n");
+		ODPH_ERR("odp_packet_is_valid() failed\n");
 		return -1;
 	}
 
@@ -299,7 +299,7 @@ static int packet_suite_init(void)
 
 	udat = odp_packet_user_area(test_packet);
 	if (odp_packet_user_area_size(test_packet) < uarea_size) {
-		printf("Bad packet user area size %u\n", odp_packet_user_area_size(test_packet));
+		ODPH_ERR("Bad packet user area size %u\n", odp_packet_user_area_size(test_packet));
 		return -1;
 	}
 
@@ -308,8 +308,8 @@ static int packet_suite_init(void)
 
 	udat = odp_packet_user_area(segmented_test_packet);
 	if (odp_packet_user_area_size(segmented_test_packet) < uarea_size) {
-		printf("Bad segmented packet user area size %u\n",
-		       odp_packet_user_area_size(segmented_test_packet));
+		ODPH_ERR("Bad segmented packet user area size %u\n",
+			 odp_packet_user_area_size(segmented_test_packet));
 		return -1;
 	}
 
@@ -3343,14 +3343,14 @@ static int packet_vector_suite_init(void)
 	vector_default_pool = odp_pool_create("vector_default_pool", &params);
 
 	if (vector_default_pool == ODP_POOL_INVALID) {
-		ODPH_ERR("default vector pool create failed\n");
+		ODPH_ERR("Default vector pool create failed\n");
 		goto err1;
 	}
 
 	/* Allocating a default vector */
 	pktv_default = odp_packet_vector_alloc(vector_default_pool);
 	if (pktv_default == ODP_PACKET_VECTOR_INVALID) {
-		ODPH_ERR("default vector packet allocation failed\n");
+		ODPH_ERR("Default vector packet allocation failed\n");
 		goto err2;
 	}
 	return 0;
@@ -3406,7 +3406,7 @@ static void packet_test_max_pools(void)
 
 	CU_ASSERT(num_pool == max_pools);
 	if (num_pool != max_pools)
-		printf("Error: created only %u pools\n", num_pool);
+		ODPH_ERR("Created only %u pools\n", num_pool);
 
 	for (i = 0; i < num_pool; i++) {
 		packet[i] = odp_packet_alloc(pool[i], len);
@@ -3498,7 +3498,7 @@ static int packet_parse_suite_init(void)
 	memset(&pool_capa, 0, sizeof(odp_pool_capability_t));
 
 	if (odp_pool_capability(&pool_capa) < 0) {
-		printf("pool_capability failed\n");
+		ODPH_ERR("odp_pool_capability() failed\n");
 		return -1;
 	}
 

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -1859,7 +1859,7 @@ static int pool_suite_init(void)
 	memset(&default_pool_param, 0, sizeof(odp_pool_param_t));
 
 	if (odp_pool_capability(&global_pool_capa) < 0) {
-		printf("pool_capability failed in suite init\n");
+		ODPH_ERR("odp_pool_capability() failed in suite init\n");
 		return -1;
 	}
 
@@ -1873,12 +1873,12 @@ static int pool_ext_suite_init(void)
 	memset(&global_pool_ext_capa, 0, sizeof(odp_pool_ext_capability_t));
 
 	if (odp_pool_ext_capability(ODP_POOL_PACKET, &global_pool_ext_capa)) {
-		printf("Pool ext capa failed in suite init\n");
+		ODPH_ERR("Pool ext capa failed in suite init\n");
 		return -1;
 	}
 
 	if (global_pool_ext_capa.type != ODP_POOL_PACKET) {
-		printf("Bad type from pool ext capa in suite init\n");
+		ODPH_ERR("Bad type from pool ext capa in suite init\n");
 		return -1;
 	}
 

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -6,6 +6,7 @@
  */
 
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 #include <odp_cunit_common.h>
 
 #define MAX_WORKERS             32
@@ -65,7 +66,7 @@ static int queue_suite_init(void)
 			      ODP_CACHE_LINE_SIZE, 0);
 
 	if (shm == ODP_SHM_INVALID) {
-		printf("Shared memory reserve failed\n");
+		ODPH_ERR("Shared memory reserve failed\n");
 		return -1;
 	}
 
@@ -91,7 +92,7 @@ static int queue_suite_init(void)
 	pool = odp_pool_create("msg_pool", &params);
 
 	if (ODP_POOL_INVALID == pool) {
-		printf("Pool create failed.\n");
+		ODPH_ERR("Pool create failed\n");
 		return -1;
 	}
 	return 0;
@@ -103,17 +104,17 @@ static int queue_suite_term(void)
 
 	shm = odp_shm_lookup(GLOBALS_NAME);
 	if (shm == ODP_SHM_INVALID) {
-		printf("SHM lookup failed.\n");
+		ODPH_ERR("SHM lookup failed\n");
 		return -1;
 	}
 
 	if (odp_shm_free(shm)) {
-		printf("SHM free failed.\n");
+		ODPH_ERR("SHM free failed\n");
 		return -1;
 	}
 
 	if (odp_pool_destroy(pool)) {
-		printf("Pool destroy failed.\n");
+		ODPH_ERR("Pool destroy failed\n");
 		return -1;
 	}
 
@@ -455,7 +456,7 @@ static int queue_pair_work_loop(void *arg)
 		buf = odp_buffer_from_event(ev);
 		data = odp_buffer_addr(buf);
 		if (*data != i) {
-			printf("Seq error: expected %u, recv %u\n", i, *data);
+			ODPH_ERR("Seq error: expected %u, recv %u\n", i, *data);
 			CU_FAIL("Sequence number error");
 		}
 

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -3155,12 +3155,12 @@ static int create_queues(test_globals_t *globals)
 	int sched_types;
 
 	if (odp_queue_capability(&queue_capa) < 0) {
-		printf("Queue capability query failed\n");
+		ODPH_ERR("Queue capability query failed\n");
 		return -1;
 	}
 
 	if (odp_schedule_capability(&sched_capa) < 0) {
-		printf("Queue capability query failed\n");
+		ODPH_ERR("Queue capability query failed\n");
 		return -1;
 	}
 
@@ -3196,9 +3196,9 @@ static int create_queues(test_globals_t *globals)
 		num_plain = (prios * queues_per_prio);
 	}
 	if (!queues_per_prio) {
-		printf("Not enough queues. At least %d scheduled queues and "
-		       "%d plain queus required.\n",
-		       ((prios * sched_types) + CHAOS_NUM_QUEUES), prios);
+		ODPH_ERR("Not enough queues. At least %d scheduled queues and "
+			 "%d plain queues required.\n",
+			 ((prios * sched_types) + CHAOS_NUM_QUEUES), prios);
 		return -1;
 	}
 	globals->queues_per_prio = queues_per_prio;
@@ -3211,7 +3211,7 @@ static int create_queues(test_globals_t *globals)
 	queue_ctx_pool = odp_pool_create(QUEUE_CTX_POOL_NAME, &params);
 
 	if (queue_ctx_pool == ODP_POOL_INVALID) {
-		printf("Pool creation failed (queue ctx).\n");
+		ODPH_ERR("Pool creation failed (queue ctx)\n");
 		return -1;
 	}
 	globals->queue_ctx_pool = queue_ctx_pool;
@@ -3231,7 +3231,7 @@ static int create_queues(test_globals_t *globals)
 			q = odp_queue_create(name, &p);
 
 			if (q == ODP_QUEUE_INVALID) {
-				printf("Parallel queue create failed.\n");
+				ODPH_ERR("Parallel queue create failed\n");
 				return -1;
 			}
 
@@ -3241,21 +3241,21 @@ static int create_queues(test_globals_t *globals)
 			q = odp_queue_create(name, &p);
 
 			if (q == ODP_QUEUE_INVALID) {
-				printf("Atomic queue create failed.\n");
+				ODPH_ERR("Atomic queue create failed\n");
 				return -1;
 			}
 
 			snprintf(name, sizeof(name), "plain_%d_%d_o", i, j);
 			pq = odp_queue_create(name, NULL);
 			if (pq == ODP_QUEUE_INVALID) {
-				printf("Plain queue create failed.\n");
+				ODPH_ERR("Plain queue create failed\n");
 				return -1;
 			}
 
 			queue_ctx_buf = odp_buffer_alloc(queue_ctx_pool);
 
 			if (queue_ctx_buf == ODP_BUFFER_INVALID) {
-				printf("Cannot allocate plain queue ctx buf\n");
+				ODPH_ERR("Cannot allocate plain queue ctx buf\n");
 				return -1;
 			}
 
@@ -3266,7 +3266,7 @@ static int create_queues(test_globals_t *globals)
 			rc = odp_queue_context_set(pq, pqctx, 0);
 
 			if (rc != 0) {
-				printf("Cannot set plain queue context\n");
+				ODPH_ERR("Cannot set plain queue context\n");
 				return -1;
 			}
 
@@ -3277,7 +3277,7 @@ static int create_queues(test_globals_t *globals)
 			q = odp_queue_create(name, &p);
 
 			if (q == ODP_QUEUE_INVALID) {
-				printf("Ordered queue create failed.\n");
+				ODPH_ERR("Ordered queue create failed\n");
 				return -1;
 			}
 			if (odp_queue_lock_count(q) !=
@@ -3293,7 +3293,7 @@ static int create_queues(test_globals_t *globals)
 			queue_ctx_buf = odp_buffer_alloc(queue_ctx_pool);
 
 			if (queue_ctx_buf == ODP_BUFFER_INVALID) {
-				printf("Cannot allocate queue ctx buf\n");
+				ODPH_ERR("Cannot allocate queue ctx buf\n");
 				return -1;
 			}
 
@@ -3311,7 +3311,7 @@ static int create_queues(test_globals_t *globals)
 			rc = odp_queue_context_set(q, qctx, 0);
 
 			if (rc != 0) {
-				printf("Cannot set queue context\n");
+				ODPH_ERR("Cannot set queue context\n");
 				return -1;
 			}
 		}
@@ -3522,14 +3522,14 @@ static int scheduler_test_global_init(void)
 			      sizeof(test_globals_t), ODP_CACHE_LINE_SIZE, 0);
 
 	if (shm == ODP_SHM_INVALID) {
-		printf("Shared memory reserve failed (globals).\n");
+		ODPH_ERR("Shared memory reserve failed (globals)\n");
 		return -1;
 	}
 
 	globals = odp_shm_addr(shm);
 
 	if (!globals) {
-		printf("Shared memory reserve failed (globals).\n");
+		ODPH_ERR("Shared memory reserve failed (globals)\n");
 		return -1;
 	}
 
@@ -3544,7 +3544,7 @@ static int scheduler_test_global_init(void)
 			      ODP_CACHE_LINE_SIZE, 0);
 
 	if (shm == ODP_SHM_INVALID) {
-		printf("Shared memory reserve failed (args).\n");
+		ODPH_ERR("Shared memory reserve failed (args)\n");
 		return -1;
 	}
 
@@ -3552,7 +3552,7 @@ static int scheduler_test_global_init(void)
 	globals->shm_args = shm;
 
 	if (!args) {
-		printf("Shared memory reserve failed (args).\n");
+		ODPH_ERR("Shared memory reserve failed (args)\n");
 		return -1;
 	}
 
@@ -3572,14 +3572,14 @@ static int scheduler_test_global_init(void)
 	pool = odp_pool_create(MSG_POOL_NAME, &params);
 
 	if (pool == ODP_POOL_INVALID) {
-		printf("Pool creation failed (msg).\n");
+		ODPH_ERR("Pool creation failed (msg)\n");
 		return -1;
 	}
 
 	globals->pool = pool;
 
 	if (odp_schedule_capability(&sched_capa)) {
-		printf("odp_schedule_capability() failed\n");
+		ODPH_ERR("odp_schedule_capability() failed\n");
 		return -1;
 	}
 
@@ -3599,7 +3599,7 @@ static int scheduler_test_global_init(void)
 
 	/* Configure the scheduler. All test cases share the config. */
 	if (odp_schedule_config(&sched_config)) {
-		printf("odp_schedule_config() failed.\n");
+		ODPH_ERR("odp_schedule_config() failed\n");
 		return -1;
 	}
 

--- a/test/validation/api/scheduler/scheduler_no_predef_groups.c
+++ b/test/validation/api/scheduler/scheduler_no_predef_groups.c
@@ -139,7 +139,7 @@ static int scheduler_suite_init(void)
 	odp_schedule_config_t sched_config;
 
 	if (odp_schedule_capability(&sched_capa)) {
-		printf("odp_schedule_capability() failed\n");
+		ODPH_ERR("odp_schedule_capability() failed\n");
 		return -1;
 	}
 
@@ -152,7 +152,7 @@ static int scheduler_suite_init(void)
 
 	/* Configure the scheduler. All test cases share the config. */
 	if (odp_schedule_config(&sched_config)) {
-		printf("odp_schedule_config() failed.\n");
+		ODPH_ERR("odp_schedule_config() failed\n");
 		return -1;
 	}
 

--- a/test/validation/api/stash/stash.c
+++ b/test/validation/api/stash/stash.c
@@ -5,6 +5,8 @@
  */
 
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
 #include "odp_cunit_common.h"
 
 #include <string.h>
@@ -63,7 +65,7 @@ static int stash_suite_init(void)
 	odp_stash_capability_t *capa_fifo = &global.capa_fifo;
 
 	if (odp_stash_capability(capa_default, ODP_STASH_TYPE_DEFAULT)) {
-		printf("stash capability failed for the default type\n");
+		ODPH_ERR("Stash capability failed for the default type\n");
 		return -1;
 	}
 

--- a/test/validation/api/thread/thread.c
+++ b/test/validation/api/thread/thread.c
@@ -30,7 +30,7 @@ static int thread_global_init(odp_instance_t *inst)
 	odph_helper_options_t helper_options;
 
 	if (odph_options(&helper_options)) {
-		fprintf(stderr, "error: odph_options() failed.\n");
+		ODPH_ERR("odph_options() failed\n");
 		return -1;
 	}
 
@@ -38,11 +38,11 @@ static int thread_global_init(odp_instance_t *inst)
 	init_param.mem_model = helper_options.mem_model;
 
 	if (0 != odp_init_global(inst, &init_param, NULL)) {
-		fprintf(stderr, "error: odp_init_global() failed.\n");
+		ODPH_ERR("odp_init_global() failed\n");
 		return -1;
 	}
 	if (0 != odp_init_local(*inst, ODP_THREAD_CONTROL)) {
-		fprintf(stderr, "error: odp_init_local() failed.\n");
+		ODPH_ERR("odp_init_local() failed\n");
 		return -1;
 	}
 
@@ -50,7 +50,7 @@ static int thread_global_init(odp_instance_t *inst)
 				     sizeof(global_shared_mem_t),
 				     ODP_CACHE_LINE_SIZE, 0);
 	if (global_shm == ODP_SHM_INVALID) {
-		fprintf(stderr, "Unable reserve memory for global_shm\n");
+		ODPH_ERR("Unable to reserve memory for global_shm\n");
 		return -1;
 	}
 
@@ -66,17 +66,17 @@ static int thread_global_term(odp_instance_t inst)
 
 	shm = odp_shm_lookup(GLOBAL_SHM_NAME);
 	if (0 != odp_shm_free(shm)) {
-		fprintf(stderr, "error: odp_shm_free() failed.\n");
+		ODPH_ERR("odp_shm_free() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_local()) {
-		fprintf(stderr, "error: odp_term_local() failed.\n");
+		ODPH_ERR("odp_term_local() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_global(inst)) {
-		fprintf(stderr, "error: odp_term_global() failed.\n");
+		ODPH_ERR("odp_term_global() failed\n");
 		return -1;
 	}
 

--- a/test/validation/api/time/time.c
+++ b/test/validation/api/time/time.c
@@ -519,15 +519,13 @@ static void time_test_wait_until(time_cb time_cur, time_from_ns_cb time_from_ns)
 				   DELAY_TOLERANCE);
 
 	if (odp_time_cmp(wait, lower_limit) < 0) {
-		ODPH_ERR("Exceed lower limit: "
-			 "wait is %" PRIu64 ", lower_limit %" PRIu64 "\n",
+		ODPH_ERR("Exceed lower limit: wait is %" PRIu64 ", lower_limit %" PRIu64 "\n",
 			 odp_time_to_ns(wait), odp_time_to_ns(lower_limit));
 		CU_FAIL("Exceed lower limit\n");
 	}
 
 	if (odp_time_cmp(wait, upper_limit) > 0) {
-		ODPH_ERR("Exceed upper limit: "
-			 "wait is %" PRIu64 ", upper_limit %" PRIu64 "\n",
+		ODPH_ERR("Exceed upper limit: wait is %" PRIu64 ", upper_limit %" PRIu64 "\n",
 			 odp_time_to_ns(wait), odp_time_to_ns(lower_limit));
 		CU_FAIL("Exceed upper limit\n");
 	}
@@ -562,15 +560,13 @@ static void time_test_wait_ns(void)
 					     DELAY_TOLERANCE);
 
 	if (odp_time_cmp(diff, lower_limit) < 0) {
-		ODPH_ERR("Exceed lower limit: "
-			 "diff is %" PRIu64 ", lower_limit %" PRIu64 "\n",
+		ODPH_ERR("Exceed lower limit: diff is %" PRIu64 ", lower_limit %" PRIu64 "\n",
 			 odp_time_to_ns(diff), odp_time_to_ns(lower_limit));
 		CU_FAIL("Exceed lower limit\n");
 	}
 
 	if (odp_time_cmp(diff, upper_limit) > 0) {
-		ODPH_ERR("Exceed upper limit: "
-			 "diff is %" PRIu64 ", upper_limit %" PRIu64 "\n",
+		ODPH_ERR("Exceed upper limit: diff is %" PRIu64 ", upper_limit %" PRIu64 "\n",
 			 odp_time_to_ns(diff), odp_time_to_ns(upper_limit));
 		CU_FAIL("Exceed upper limit\n");
 	}

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -117,7 +117,7 @@ static int timer_global_init(odp_instance_t *inst)
 	int i;
 
 	if (odph_options(&helper_options)) {
-		fprintf(stderr, "error: odph_options() failed.\n");
+		ODPH_ERR("odph_options() failed\n");
 		return -1;
 	}
 
@@ -125,11 +125,11 @@ static int timer_global_init(odp_instance_t *inst)
 	init_param.mem_model = helper_options.mem_model;
 
 	if (0 != odp_init_global(inst, &init_param, NULL)) {
-		fprintf(stderr, "error: odp_init_global() failed.\n");
+		ODPH_ERR("odp_init_global() failed\n");
 		return -1;
 	}
 	if (0 != odp_init_local(*inst, ODP_THREAD_CONTROL)) {
-		fprintf(stderr, "error: odp_init_local() failed.\n");
+		ODPH_ERR("odp_init_local() failed\n");
 		return -1;
 	}
 
@@ -137,7 +137,7 @@ static int timer_global_init(odp_instance_t *inst)
 				     sizeof(global_shared_mem_t),
 				     ODP_CACHE_LINE_SIZE, 0);
 	if (global_shm == ODP_SHM_INVALID) {
-		fprintf(stderr, "Unable reserve memory for global_shm\n");
+		ODPH_ERR("Unable to reserve memory for global_shm\n");
 		return -1;
 	}
 
@@ -149,7 +149,7 @@ static int timer_global_init(odp_instance_t *inst)
 
 	memset(&capa, 0, sizeof(capa));
 	if (odp_timer_capability(ODP_CLOCK_DEFAULT, &capa)) {
-		fprintf(stderr, "Timer capability failed\n");
+		ODPH_ERR("Timer capability failed\n");
 		return -1;
 	}
 
@@ -162,7 +162,7 @@ static int timer_global_init(odp_instance_t *inst)
 	res_capa.res_ns = res_ns;
 
 	if (odp_timer_res_capability(ODP_CLOCK_DEFAULT, &res_capa)) {
-		fprintf(stderr, "Timer resolution capability failed\n");
+		ODPH_ERR("Timer resolution capability failed\n");
 		return -1;
 	}
 
@@ -178,7 +178,7 @@ static int timer_global_init(odp_instance_t *inst)
 
 	range = (RANGE_MS * 1000) + THREE_POINT_THREE_MSEC;
 	if ((max_tmo - min_tmo) < range) {
-		fprintf(stderr, "Validation test needs %u msec range\n", range);
+		ODPH_ERR("Validation test needs %u msec range\n", range);
 		return -1;
 	}
 
@@ -209,17 +209,17 @@ static int timer_global_term(odp_instance_t inst)
 
 	shm = odp_shm_lookup(GLOBAL_SHM_NAME);
 	if (0 != odp_shm_free(shm)) {
-		fprintf(stderr, "error: odp_shm_free() failed.\n");
+		ODPH_ERR("odp_shm_free() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_local()) {
-		fprintf(stderr, "error: odp_term_local() failed.\n");
+		ODPH_ERR("odp_term_local() failed\n");
 		return -1;
 	}
 
 	if (0 != odp_term_global(inst)) {
-		fprintf(stderr, "error: odp_term_global() failed.\n");
+		ODPH_ERR("odp_term_global() failed\n");
 		return -1;
 	}
 


### PR DESCRIPTION
Use ODPH_ERR() macro for all error prints in the validation tests and make error messages more consistent. The helper macro adds additional debug information (filename, line number, function name) to the error messages, which can help debugging.