### PR TITLE
[PATCH v2] linux-gen: queue_lf: fix bogus 'maybe-uninitialized' warning

### DIFF
--- a/platform/linux-generic/odp_queue_lf.c
+++ b/platform/linux-generic/odp_queue_lf.c
@@ -176,7 +176,7 @@ static _odp_event_hdr_t *queue_lf_deq(odp_queue_t handle)
 {
 	queue_entry_t *queue;
 	queue_lf_t *queue_lf;
-	int i, j, i_lowest;
+	int i, j, i_lowest = 0;
 	int found;
 	ring_lf_node_t node_val, old_val, new_val;
 	ring_lf_node_t *node, *old;


### PR DESCRIPTION
GCC-13 warns that a variable may be used uninitialized. The warning is a false positive. Get rid of it by initializing the variable.