### PR TITLE
[PATCH v2] linux-gen: pktio: remove common capability function

### DIFF
--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1570,17 +1570,6 @@ int _odp_pktio_term_global(void)
 	return ret;
 }
 
-static
-int single_capability(odp_pktio_capability_t *capa)
-{
-	memset(capa, 0, sizeof(odp_pktio_capability_t));
-	capa->max_input_queues  = 1;
-	capa->max_output_queues = 1;
-	capa->set_op.op.promisc_mode = 1;
-
-	return 0;
-}
-
 int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 {
 	pktio_entry_t *entry;
@@ -1592,10 +1581,7 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 		return -1;
 	}
 
-	if (entry->ops->capability)
-		ret = entry->ops->capability(entry, capa);
-	else
-		ret = single_capability(capa);
+	ret = entry->ops->capability(entry, capa);
 
 	if (ret == 0) {
 		uint32_t mtu = pktio_maxlen(pktio);

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
+#include <odp/api/hints.h>
 #include <odp/api/system_info.h>
 
 #include <odp_debug_internal.h>
@@ -916,6 +917,16 @@ static int ipc_link_info(pktio_entry_t *pktio_entry, odp_pktio_link_info_t *info
 	return 0;
 }
 
+static int ipc_capability(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_capability_t *capa)
+{
+	memset(capa, 0, sizeof(odp_pktio_capability_t));
+
+	capa->max_input_queues  = 1;
+	capa->max_output_queues = 1;
+
+	return 0;
+}
+
 static int ipc_close(pktio_entry_t *pktio_entry)
 {
 	pkt_ipc_t *pktio_ipc = pkt_priv(pktio_entry);
@@ -965,6 +976,7 @@ const pktio_if_ops_t _odp_ipc_pktio_ops = {
 	.stop = ipc_stop,
 	.link_status = ipc_link_status,
 	.link_info = ipc_link_info,
+	.capability = ipc_capability,
 	.maxlen_get = ipc_mtu_get,
 	.promisc_mode_set = NULL,
 	.promisc_mode_get = NULL,


### PR DESCRIPTION
Remove pktio level single_capability() function which was only used by IPC pktio.