### PR TITLE
[PATCH v7] api: init: add abnormal termination function

### DIFF
--- a/include/odp/api/spec/init.h
+++ b/include/odp/api/spec/init.h
@@ -91,11 +91,12 @@ int odp_override_log(odp_log_level_t level, const char *fmt, ...);
  * - By overriding the ODP implementation default abort function
  *   odp_override_abort().
  *
- * @warning The latter option is less portable and GNU linker dependent
- * (utilizes function attribute "weak"). If both are defined, the odp_init_t
- * function pointer has priority over the override function.
+ * The latter option is less portable and GNU linker dependent (utilizes function
+ * attribute "weak"). If both are defined, the odp_init_t function pointer has
+ * priority over the override function.
  *
- * @warning this function shall not return
+ * Note that no ODP calls should be called in the abort function and the function
+ * should not return.
  */
 void odp_override_abort(void) ODP_NORETURN;
 

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -692,6 +692,26 @@ int odp_term_local(void)
 	return term_local(ALL_INIT);
 }
 
+int odp_term_abnormal(odp_instance_t instance, uint64_t flags, void *data ODP_UNUSED)
+{
+	if (flags & ODP_TERM_FROM_SIGH)
+		/* Called from signal handler, not safe to terminate with local/global,
+		 * return with failure as not able to perform all actions */
+		return -1;
+
+	if (odp_term_local() < 0) {
+		_ODP_ERR("ODP local terminate failed.\n");
+		return -2;
+	}
+
+	if (odp_term_global(instance) < 0) {
+		_ODP_ERR("ODP global terminate failed.\n");
+		return -3;
+	}
+
+	return 0;
+}
+
 void odp_log_thread_fn_set(odp_log_func_t func)
 {
 	_odp_this_thread->log_fn = func;

--- a/test/validation/api/Makefile.am
+++ b/test/validation/api/Makefile.am
@@ -54,6 +54,7 @@ TESTS = \
 	init/init_feature_enabled$(EXEEXT) \
 	init/init_feature_disabled$(EXEEXT) \
 	init/init_test_param_init$(EXEEXT) \
+	init/init_test_term_abnormal$(EXEEXT) \
 	ipsec/ipsec_sync$(EXEEXT) \
 	ipsec/ipsec_async$(EXEEXT) \
 	ipsec/ipsec_inline_in$(EXEEXT) \

--- a/test/validation/api/init/.gitignore
+++ b/test/validation/api/init/.gitignore
@@ -6,3 +6,4 @@ init_num_thr
 init_feature_enabled
 init_feature_disabled
 init_test_param_init
+init_test_term_abnormal

--- a/test/validation/api/init/Makefile.am
+++ b/test/validation/api/init/Makefile.am
@@ -4,7 +4,7 @@ include ../Makefile.inc
 # the same application process to call odp_init_global() multiple times.
 test_PROGRAMS = init_defaults init_abort init_log init_num_thr \
 		init_feature_enabled init_feature_disabled init_log_thread \
-		init_test_param_init
+		init_test_param_init init_test_term_abnormal
 
 init_defaults_CPPFLAGS = -DINIT_TEST=0 $(AM_CPPFLAGS)
 init_abort_CPPFLAGS    = -DINIT_TEST=1 $(AM_CPPFLAGS)
@@ -14,6 +14,7 @@ init_feature_enabled_CPPFLAGS = -DINIT_TEST=4 $(AM_CPPFLAGS)
 init_feature_disabled_CPPFLAGS = -DINIT_TEST=5 $(AM_CPPFLAGS)
 init_log_thread_CPPFLAGS = -DINIT_TEST=6 $(AM_CPPFLAGS)
 init_test_param_init_CPPFLAGS = -DINIT_TEST=7 $(AM_CPPFLAGS)
+init_test_term_abnormal_CPPFLAGS = -DINIT_TEST=8 $(AM_CPPFLAGS)
 
 init_defaults_SOURCES = init_main.c
 init_abort_SOURCES = init_main.c
@@ -23,3 +24,4 @@ init_feature_enabled_SOURCES = init_main.c
 init_feature_disabled_SOURCES = init_main.c
 init_log_thread_SOURCES = init_main.c
 init_test_param_init_SOURCES = init_main.c
+init_test_term_abnormal_SOURCES = init_main.c

--- a/test/validation/api/init/init_main.c
+++ b/test/validation/api/init/init_main.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
+ * Copyright (c) 2019-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -242,6 +242,24 @@ static void init_test_feature_disabled(void)
 	init_test_feature(1);
 }
 
+static void init_test_term_abnormal(void)
+{
+	int ret;
+	odp_instance_t instance;
+
+	ret = odp_init_global(&instance, NULL, NULL);
+	CU_ASSERT_FATAL(ret == 0);
+
+	ret = odp_init_local(instance, ODP_THREAD_WORKER);
+	CU_ASSERT_FATAL(ret == 0);
+
+	/* odp_term_abnormal() is allowed to fail */
+	ret = odp_term_abnormal(instance, 0, NULL);
+
+	if (ret < 0)
+		ODPH_ERR("Failed to perform all abnormal termination actions: %d\n", ret);
+}
+
 odp_testinfo_t testinfo[] = {
 	ODP_TEST_INFO(init_test_defaults),
 	ODP_TEST_INFO(init_test_abort),
@@ -251,6 +269,7 @@ odp_testinfo_t testinfo[] = {
 	ODP_TEST_INFO(init_test_feature_disabled),
 	ODP_TEST_INFO(init_test_log_thread),
 	ODP_TEST_INFO(init_test_param_init),
+	ODP_TEST_INFO(init_test_term_abnormal)
 };
 
 odp_testinfo_t init_suite[] = {


### PR DESCRIPTION
New `odp_term_abnormal()` function can be used to abnormally terminate an ODP application. Application can utilize the new function to terminate ODP with additional debug data in error situations where regular local and global clean-up is not possible.

v2:
- Jerin's comments

v3:
- Petri's comments

v4:
- Added patches for ODP abort function usage clarification, `odp_term_abnormal()` linux-gen implementation and validation
- Changed `odp_term_abnormal()` `data` parameter type to `void *`
- Added a `ODP_TERM_LAST_FLAG` constant

v6:
- Added an explicit `uint64_t` cast to `ODP_TERM_FROM_SIGH`

v7:
- Rebased
- Added reviewed-by tags