### PR TITLE
[PATCH v10] api: crypto: copy the ranges of null algorithms in OOP op type & change bit mode semantics

### DIFF
--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -255,9 +255,7 @@ int odp_crypto_result(odp_crypto_packet_result_t *result,
  * input packet to the output packet and then the crypto operation
  * was applied to the output packet.
  *
- * Crypto range and auth range of null cipher and auth algorithms are
- * ignored, i.e. not copied in the output packet. Auth range of (AEAD)
- * algorithms that ignore auth range is not copied.
+ * Auth range of (AEAD) algorithms that ignore auth range is not copied.
  *
  * The offset of the crypto range and auth range in the output packet is
  * the same as in the input packet, adjusted by dst_offset_shift operation

--- a/include/odp/api/spec/crypto_types.h
+++ b/include/odp/api/spec/crypto_types.h
@@ -560,6 +560,30 @@ typedef struct odp_crypto_session_param_t {
 	 */
 	odp_crypto_op_type_t op_type;
 
+	/** Cipher range unit
+	 *
+	 *  When this flag is true, cipher range offset and length are in bits.
+	 *  Otherwise the offset and length are in bytes.
+	 *
+	 *  If cipher capabilities do not include bit_mode, setting this to
+	 *  true causes a session creation failure.
+	 *
+	 *  The default value is false.
+	 */
+	odp_bool_t cipher_range_in_bits;
+
+	/** Auth range unit
+	 *
+	 *  When this flag is true, auth range offset and length are in bits.
+	 *  Otherwise the offset and length are in bytes.
+	 *
+	 *  If auth capabilities do not include bit_mode, setting this to
+	 *  true causes a session creation failure.
+	 *
+	 *  The default value is false.
+	 */
+	odp_bool_t auth_range_in_bits;
+
 	/** Authenticate cipher vs. plain text
 	 *
 	 *  Controls ordering of authentication and cipher operations,
@@ -725,6 +749,9 @@ typedef struct odp_crypto_packet_op_param_t {
 
 	/** Data range to be ciphered.
 	 *
+	 *  The range is given in bits or bytes as configured at session
+	 *  creation.
+	 *
 	 *  Ignored by the null cipher with operation types other than
 	 *  ODP_CRYPTO_OP_TYPE_OOP. Must be set to zero range (zero offset
 	 *  and zero length) with the null cipher used with the out-of-place
@@ -733,6 +760,9 @@ typedef struct odp_crypto_packet_op_param_t {
 	odp_packet_data_range_t cipher_range;
 
 	/** Data range to be authenticated
+	 *
+	 *  The range is given in bits or bytes as configured at session
+	 *  creation.
 	 *
 	 *  The value is ignored with authenticated encryption algorithms,
 	 *  such as AES-GCM, which authenticate data in the cipher range
@@ -937,22 +967,23 @@ typedef struct odp_crypto_cipher_capability_t {
 	/** IV length in bytes */
 	uint32_t iv_len;
 
-	/** Cipher is operating in bitwise mode
+	/** Cipher supports bit mode
 	 *
-	 * This cipher works on series of bits, rather than sequences of bytes:
-	 * cipher_range in odp_crypto_op_param_t and
-	 * odp_crypto_packet_op_param_t will use bits, rather than bytes.
+	 * This cipher can work on a range of bits in addition to a range of
+	 * bytes. When this capability is not present, only byte ranges are
+	 * supported. The unit of cipher range is selected at session creation
+	 * through the cipher_range_in_bits session parameter.
 	 *
-	 * Note: data buffer MUST start on the byte boundary, using offset
-	 * which is not divisible by 8 is unsupported and will result in
-	 * unspecified behaviour.
+	 * Note: In bit mode the cipher range must start on a byte boundary.
+	 * Using an offset which is not divisible by 8 will result in
+	 * undefined behaviour.
 	 *
-	 * Note2: If the data length is not a multiple of 8, the remaining
-	 * bits of the data in the last byte of the input/output will be the
-	 * most significant bits, i.e. the most significant bit is considered
-	 * to be the first bit of a byte for the purpose of input and output
-	 * data range. The output bits that fall out of the output range are
-	 * undefined.
+	 * Note2: If the range length in bit mode is not a multiple of 8,
+	 * the remaining bits of the data in the last byte of the input/output
+	 * will be the most significant bits, i.e. the most significant bit is
+	 * considered to be the first bit of a byte for the purpose of input
+	 * and output data range. The output bits that fall out of the output
+	 * range are undefined.
 	 */
 	odp_bool_t bit_mode;
 
@@ -984,22 +1015,23 @@ typedef struct odp_crypto_auth_capability_t {
 		uint32_t inc;
 	} aad_len;
 
-	/** Auth is operating in bitstring mode
+	/** Auth algorithm supports bit mode
 	 *
-	 * This auth works on series of bits, rather than sequences of bytes:
-	 * auth_range in odp_crypto_op_param_t and
-	 * odp_crypto_packet_op_param_t will use bits, rather than bytes.
+	 * This auth algorithm can work on a range of bits in addition to
+	 * a range of bytes. When this capability is not present, only byte
+	 * ranges are supported. The unit of auth range is selected at session
+	 * creation through the auth_range_in_bits session parameter.
 	 *
-	 * Note: data buffer MUST start on the byte boundary, using offset
-	 * which is not divisible by 8 is unsupported and will result in
-	 * unpredictable behaviour.
+	 * Note: In bit mode the auth range must start on a byte boundary.
+	 * Using an offset which is not divisible by 8 will result in
+	 * undefined behaviour.
 	 *
-	 * Note2: If the data length is not a multiple of 8, the remaining
-	 * bits of the data in the last byte of the input/output will be the
-	 * most significant bits, i.e. the most significant bit is considered
-	 * to be the first bit of a byte for the purpose of input and output
-	 * data range. The output bits that fall out of the output range are
-	 * undefined.
+	 * Note2: If the range length in bit mode is not a multiple of 8,
+	 * the remaining bits of the data in the last byte of the input/output
+	 * will be the most significant bits, i.e. the most significant bit is
+	 * considered to be the first bit of a byte for the purpose of input
+	 * and output data range. The output bits that fall out of the output
+	 * range are undefined.
 	 */
 	odp_bool_t bit_mode;
 

--- a/include/odp/api/spec/crypto_types.h
+++ b/include/odp/api/spec/crypto_types.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021-2022, Nokia
+ * Copyright (c) 2021-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -509,7 +509,7 @@ typedef struct odp_crypto_key {
  */
 typedef enum odp_crypto_op_type_t {
 	/**
-	 * Input packet data and metadata are copied in the output packet
+	 * Input packet data and metadata are copied to the output packet
 	 * and then processed. Output packet is allocated by the caller
 	 * or by ODP.
 	 *
@@ -518,7 +518,7 @@ typedef enum odp_crypto_op_type_t {
 	ODP_CRYPTO_OP_TYPE_LEGACY,
 
 	/**
-	 * Input packet data and metadata are copied in the output packet
+	 * Input packet data and metadata are copied to the output packet
 	 * and then processed. Output packet is allocated by ODP.
 	 */
 	ODP_CRYPTO_OP_TYPE_BASIC,
@@ -753,9 +753,15 @@ typedef struct odp_crypto_packet_op_param_t {
 	 *  creation.
 	 *
 	 *  Ignored by the null cipher with operation types other than
-	 *  ODP_CRYPTO_OP_TYPE_OOP. Must be set to zero range (zero offset
-	 *  and zero length) with the null cipher used with the out-of-place
-	 *  operation type.
+	 *  ODP_CRYPTO_OP_TYPE_OOP.
+	 *
+	 *  With the OOP operation type the cipher range is copied to the
+	 *  output packet even with the null cipher. Non-zero-length ranges
+	 *  are not necessarily supported with the null cipher and the OOP
+	 *  operation type. If the requested range is not supported, the
+	 *  crypto operation will fail. The failure is indicated through
+	 *  odp_crypto_result() or through a negative return value of
+	 *  odp_crypto_op()/odp_crypto_op_enq().
 	 **/
 	odp_packet_data_range_t cipher_range;
 
@@ -769,9 +775,15 @@ typedef struct odp_crypto_packet_op_param_t {
 	 *  and the AAD.
 	 *
 	 *  Ignored by the null auth algorithm with operation types other than
-	 *  ODP_CRYPTO_OP_TYPE_OOP. Must be set to zero range (zero offset
-	 *  and zero length) with the null cipher used with the out-of-place
-	 *  operation type.
+	 *  ODP_CRYPTO_OP_TYPE_OOP.
+	 *
+	 *  With the OOP operation type the auth range is copied to the
+	 *  output packet even with the null auth algorithm. Non-zero-length
+	 *  ranges are not necessarily supported with the null algorithm and
+	 *  the OOP operation type. If the requested range is not supported,
+	 *  the crypto operation will fail. The failure is indicated through
+	 *  odp_crypto_result() or through a negative return value of
+	 *  odp_crypto_op()/odp_crypto_op_enq().
 	 *
 	 *  As a special case AES-GMAC uses this field instead of aad_ptr
 	 *  for the data bytes to be authenticated.

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -55,7 +55,7 @@
  * Keep sorted: first by key length, then by IV length
  */
 static const odp_crypto_cipher_capability_t cipher_capa_null[] = {
-{.key_len = 0, .iv_len = 0, .bit_mode = 0} };
+{.key_len = 0, .iv_len = 0, .bit_mode = 1} };
 
 static const odp_crypto_cipher_capability_t cipher_capa_trides_cbc[] = {
 {.key_len = 24, .iv_len = 8} };
@@ -106,7 +106,7 @@ static const odp_crypto_cipher_capability_t cipher_capa_chacha20_poly1305[] = {
 #endif
 
 static const odp_crypto_cipher_capability_t cipher_capa_aes_eea2[] = {
-{.key_len = 16, .iv_len = 16, .bit_mode = 0} };
+{.key_len = 16, .iv_len = 16, .bit_mode = 1} };
 
 /*
  * Authentication algorithm capabilities
@@ -114,7 +114,7 @@ static const odp_crypto_cipher_capability_t cipher_capa_aes_eea2[] = {
  * Keep sorted: first by digest length, then by key length
  */
 static const odp_crypto_auth_capability_t auth_capa_null[] = {
-{.digest_len = 0, .key_len = 0, .aad_len = {.min = 0, .max = 0, .inc = 0}, .bit_mode = 0} };
+{.digest_len = 0, .key_len = 0, .aad_len = {.min = 0, .max = 0, .inc = 0}, .bit_mode = 1} };
 
 static const odp_crypto_auth_capability_t auth_capa_md5_hmac[] = {
 {.digest_len = 12, .key_len = 16, .aad_len = {.min = 0, .max = 0, .inc = 0} },
@@ -1815,7 +1815,7 @@ int odp_crypto_capability(odp_crypto_capability_t *capa)
 #if _ODP_HAVE_CHACHA20_POLY1305
 	capa->ciphers.bit.chacha20_poly1305 = 1;
 #endif
-	capa->ciphers.bit.aes_eea2 = 0;
+	capa->ciphers.bit.aes_eea2   = 1;
 
 	capa->auths.bit.null         = 1;
 	capa->auths.bit.md5_hmac     = 1;

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -55,8 +55,7 @@
  * Keep sorted: first by key length, then by IV length
  */
 static const odp_crypto_cipher_capability_t cipher_capa_null[] = {
-{.key_len = 0, .iv_len = 0},
-{.key_len = 0, .iv_len = 0, .bit_mode = 1} };
+{.key_len = 0, .iv_len = 0, .bit_mode = 0} };
 
 static const odp_crypto_cipher_capability_t cipher_capa_trides_cbc[] = {
 {.key_len = 24, .iv_len = 8} };
@@ -107,7 +106,7 @@ static const odp_crypto_cipher_capability_t cipher_capa_chacha20_poly1305[] = {
 #endif
 
 static const odp_crypto_cipher_capability_t cipher_capa_aes_eea2[] = {
-{.key_len = 16, .iv_len = 16, .bit_mode = 1} };
+{.key_len = 16, .iv_len = 16, .bit_mode = 0} };
 
 /*
  * Authentication algorithm capabilities
@@ -115,9 +114,7 @@ static const odp_crypto_cipher_capability_t cipher_capa_aes_eea2[] = {
  * Keep sorted: first by digest length, then by key length
  */
 static const odp_crypto_auth_capability_t auth_capa_null[] = {
-{.digest_len = 0, .key_len = 0, .aad_len = {.min = 0, .max = 0, .inc = 0},
-	.bit_mode = 1},
-{.digest_len = 0, .key_len = 0, .aad_len = {.min = 0, .max = 0, .inc = 0} } };
+{.digest_len = 0, .key_len = 0, .aad_len = {.min = 0, .max = 0, .inc = 0}, .bit_mode = 0} };
 
 static const odp_crypto_auth_capability_t auth_capa_md5_hmac[] = {
 {.digest_len = 12, .key_len = 16, .aad_len = {.min = 0, .max = 0, .inc = 0} },
@@ -1813,7 +1810,7 @@ int odp_crypto_capability(odp_crypto_capability_t *capa)
 #if _ODP_HAVE_CHACHA20_POLY1305
 	capa->ciphers.bit.chacha20_poly1305 = 1;
 #endif
-	capa->ciphers.bit.aes_eea2 = 1;
+	capa->ciphers.bit.aes_eea2 = 0;
 
 	capa->auths.bit.null         = 1;
 	capa->auths.bit.md5_hmac     = 1;

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
+ * Copyright (c) 2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:	BSD-3-Clause
@@ -1169,6 +1169,12 @@ static int run_measure_one_config(test_run_arg_t *arg)
 		printf("    Auth algorithm not supported\n");
 		rc = 1;
 	}
+
+#if ODP_VERSION_API >= ODP_VERSION_API_NUM(1, 42, 0)
+	/* Bit mode ciphers can now be used in byte mode. */
+	config->cipher_in_bit_mode = 0;
+	config->auth_in_bit_mode = 0;
+#endif
 
 	if (rc == 0)
 		rc = create_session_from_config(&session, config, cargs);

--- a/test/validation/api/crypto/crypto_op_test.c
+++ b/test/validation/api/crypto/crypto_op_test.c
@@ -178,7 +178,6 @@ static void prepare_crypto_ranges(const crypto_op_test_param_t *param,
 				  odp_packet_data_range_t *cipher_range,
 				  odp_packet_data_range_t *auth_range)
 {
-	odp_packet_data_range_t zero_range = {.offset = 0, .length = 0};
 	uint32_t c_scale = param->session.cipher_range_in_bits ? 8 : 1;
 	uint32_t a_scale = param->session.auth_range_in_bits ? 8 : 1;
 
@@ -186,11 +185,6 @@ static void prepare_crypto_ranges(const crypto_op_test_param_t *param,
 	*auth_range = param->auth_range;
 	cipher_range->offset += c_scale * param->header_len;
 	auth_range->offset += a_scale * param->header_len;
-
-	if (param->ref->cipher == ODP_CIPHER_ALG_NULL)
-		*cipher_range = zero_range;
-	if (param->ref->auth == ODP_AUTH_ALG_NULL)
-		*auth_range = zero_range;
 }
 
 static int prepare_input_packet(const crypto_op_test_param_t *param,
@@ -391,13 +385,10 @@ static void prepare_expected_data(const crypto_op_test_param_t *param,
 		auth_offset /= 8;
 		auth_len = (auth_len + 7) / 8;
 	}
-	if (param->ref->cipher == ODP_CIPHER_ALG_NULL)
-		cipher_len = 0;
-	if (param->ref->auth == ODP_AUTH_ALG_NULL ||
-	    param->ref->auth == ODP_AUTH_ALG_AES_GCM ||
+	if (param->ref->auth == ODP_AUTH_ALG_AES_GCM ||
 	    param->ref->auth == ODP_AUTH_ALG_AES_CCM ||
 	    param->ref->auth == ODP_AUTH_ALG_CHACHA20_POLY1305) {
-		/* auth range is ignored with null and AEAD algorithms */
+		/* auth range is ignored with AEAD algorithms */
 		auth_len = 0;
 	}
 

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -36,6 +36,8 @@ static void test_defaults(uint8_t fill)
 
 	CU_ASSERT_EQUAL(param.op, ODP_CRYPTO_OP_ENCODE);
 	CU_ASSERT_EQUAL(param.op_type, ODP_CRYPTO_OP_TYPE_LEGACY);
+	CU_ASSERT_EQUAL(param.cipher_range_in_bits, false);
+	CU_ASSERT_EQUAL(param.auth_range_in_bits, false);
 	CU_ASSERT_EQUAL(param.auth_cipher_text, false);
 	CU_ASSERT_EQUAL(param.op_mode, ODP_CRYPTO_SYNC);
 	CU_ASSERT_EQUAL(param.cipher_alg, ODP_CIPHER_ALG_NULL);
@@ -145,13 +147,11 @@ typedef enum {
 	AUTH_PLAINTEXT
 } alg_order_t;
 
-static odp_crypto_session_t session_create(odp_crypto_op_t op,
-					   odp_crypto_op_type_t op_type,
-					   alg_order_t order,
-					   crypto_test_reference_t *ref,
-					   hash_test_mode_t hash_mode)
+static int session_create(crypto_session_t *session,
+			  alg_order_t order,
+			  crypto_test_reference_t *ref,
+			  hash_test_mode_t hash_mode)
 {
-	odp_crypto_session_t session = ODP_CRYPTO_SESSION_INVALID;
 	int rc;
 	odp_crypto_ses_create_err_t status;
 	odp_crypto_session_param_t ses_params;
@@ -171,8 +171,10 @@ static odp_crypto_session_t session_create(odp_crypto_op_t op,
 
 	/* Create a crypto session */
 	odp_crypto_session_param_init(&ses_params);
-	ses_params.op = op;
-	ses_params.op_type = op_type;
+	ses_params.op = session->op;
+	ses_params.op_type = session->op_type;
+	ses_params.cipher_range_in_bits = session->cipher_range_in_bits;
+	ses_params.auth_range_in_bits = session->auth_range_in_bits;
 	ses_params.auth_cipher_text = (order == AUTH_CIPHERTEXT);
 	ses_params.op_mode = suite_context.op_mode;
 	ses_params.cipher_alg = ref->cipher;
@@ -186,7 +188,7 @@ static odp_crypto_session_t session_create(odp_crypto_op_t op,
 	ses_params.auth_digest_len = ref->digest_length;
 	ses_params.auth_aad_len = ref->aad_length;
 	ses_params.hash_result_in_auth_range = (hash_mode == HASH_OVERLAP);
-	rc = odp_crypto_session_create(&ses_params, &session, &status);
+	rc = odp_crypto_session_create(&ses_params, &session->session, &status);
 
 	if (rc < 0 && status == ODP_CRYPTO_SES_ERR_ALG_COMBO) {
 		if (!combo_warning_shown) {
@@ -195,7 +197,7 @@ static odp_crypto_session_t session_create(odp_crypto_op_t op,
 			       cipher_alg_name(ref->cipher),
 			       auth_alg_name(ref->auth));
 		}
-		return ODP_CRYPTO_SESSION_INVALID;
+		return -1;
 	}
 
 	/*
@@ -209,21 +211,21 @@ static odp_crypto_session_t session_create(odp_crypto_op_t op,
 		       cipher_alg_name(ref->cipher),
 		       auth_alg_name(ref->auth),
 		       ses_params.auth_cipher_text);
-		return ODP_CRYPTO_SESSION_INVALID;
+		return -1;
 	}
 
 	/* For now, allow out-of-place sessions not to be supported. */
 	if (rc < 0 && status == ODP_CRYPTO_SES_ERR_PARAMS &&
-	    op_type == ODP_CRYPTO_OP_TYPE_OOP) {
+	    ses_params.op_type == ODP_CRYPTO_OP_TYPE_OOP) {
 		if (!oop_warning_shown)
 			printf("\n    Skipping ODP_CRYPTO_OP_TYPE_OOP tests\n");
 		oop_warning_shown = 1;
-		return ODP_CRYPTO_SESSION_INVALID;
+		return -1;
 	}
 
 	CU_ASSERT_FATAL(!rc);
 	CU_ASSERT(status == ODP_CRYPTO_SES_ERR_NONE);
-	CU_ASSERT(odp_crypto_session_to_u64(session) !=
+	CU_ASSERT(odp_crypto_session_to_u64(session->session) !=
 		  odp_crypto_session_to_u64(ODP_CRYPTO_SESSION_INVALID));
 
 	/*
@@ -234,7 +236,7 @@ static odp_crypto_session_t session_create(odp_crypto_op_t op,
 	memset(auth_key_data, 0, sizeof(auth_key_data));
 	memset(&ses_params, 0, sizeof(ses_params));
 
-	return session;
+	return 0;
 }
 
 static void alg_test_ses(odp_crypto_op_t op,
@@ -244,14 +246,13 @@ static void alg_test_ses(odp_crypto_op_t op,
 			 odp_packet_data_range_t cipher_range,
 			 odp_packet_data_range_t auth_range,
 			 uint32_t digest_offset,
-			 odp_bool_t is_bit_mode_cipher,
-			 odp_bool_t is_bit_mode_auth)
+			 odp_bool_t cipher_range_in_bits,
+			 odp_bool_t auth_range_in_bits)
 {
 	unsigned int initial_num_failures = CU_get_number_of_failures();
 	const uint32_t reflength = ref_length_in_bytes(ref);
-	const uint32_t auth_scale = is_bit_mode_auth ? 8 : 1;
+	const uint32_t auth_scale = auth_range_in_bits ? 8 : 1;
 	hash_test_mode_t hash_mode = HASH_NO_OVERLAP;
-	odp_crypto_session_t session;
 	int rc;
 	uint32_t seg_len;
 	uint32_t max_shift;
@@ -261,16 +262,13 @@ static void alg_test_ses(odp_crypto_op_t op,
 	    digest_offset * auth_scale < auth_range.offset + auth_range.length)
 		hash_mode = HASH_OVERLAP;
 
-	session = session_create(op, op_type, order, ref, hash_mode);
-	if (session == ODP_CRYPTO_SESSION_INVALID)
-		return;
-
 	memset(&test_param, 0, sizeof(test_param));
-	test_param.session.session = session;
 	test_param.session.op = op;
 	test_param.session.op_type = op_type;
-	test_param.session.cipher_range_in_bits = is_bit_mode_cipher;
-	test_param.session.auth_range_in_bits = is_bit_mode_auth;
+	test_param.session.cipher_range_in_bits = cipher_range_in_bits;
+	test_param.session.auth_range_in_bits = auth_range_in_bits;
+	if (session_create(&test_param.session, order, ref, hash_mode))
+		return;
 	test_param.ref = ref;
 	test_param.cipher_range = cipher_range;
 	test_param.auth_range = auth_range;
@@ -315,18 +313,18 @@ static void alg_test_ses(odp_crypto_op_t op,
 		alg_test_op(&test_param);
 	}
 
-	rc = odp_crypto_session_destroy(session);
+	rc = odp_crypto_session_destroy(test_param.session.session);
 	CU_ASSERT(!rc);
 }
 
-static void alg_test(odp_crypto_op_t op,
-		     alg_order_t order,
-		     crypto_test_reference_t *ref,
-		     odp_packet_data_range_t cipher_range,
-		     odp_packet_data_range_t auth_range,
-		     uint32_t digest_offset,
-		     odp_bool_t is_bit_mode_cipher,
-		     odp_bool_t is_bit_mode_auth)
+static void alg_test_op_types(odp_crypto_op_t op,
+			      alg_order_t order,
+			      crypto_test_reference_t *ref,
+			      odp_packet_data_range_t cipher_range,
+			      odp_packet_data_range_t auth_range,
+			      uint32_t digest_offset,
+			      odp_bool_t cipher_range_in_bits,
+			      odp_bool_t auth_range_in_bits)
 {
 	odp_crypto_op_type_t op_types[] = {
 		ODP_CRYPTO_OP_TYPE_LEGACY,
@@ -342,8 +340,47 @@ static void alg_test(odp_crypto_op_t op,
 			     cipher_range,
 			     auth_range,
 			     digest_offset,
-			     is_bit_mode_cipher,
-			     is_bit_mode_auth);
+			     cipher_range_in_bits,
+			     auth_range_in_bits);
+	}
+}
+
+static void alg_test(odp_crypto_op_t op,
+		     alg_order_t order,
+		     crypto_test_reference_t *ref,
+		     odp_packet_data_range_t cipher_bit_range,
+		     odp_packet_data_range_t auth_bit_range,
+		     uint32_t digest_offset,
+		     odp_bool_t is_bit_mode_cipher,
+		     odp_bool_t is_bit_mode_auth)
+{
+	odp_packet_data_range_t cipher_range;
+	odp_packet_data_range_t auth_range;
+
+	for (int cr_in_bits = 0; cr_in_bits <= 1; cr_in_bits++) {
+		if (!cr_in_bits && cipher_bit_range.length % 8 != 0)
+			continue;
+		if (cr_in_bits && !is_bit_mode_cipher)
+			continue;
+		for (int ar_in_bits = 0; ar_in_bits <= 1; ar_in_bits++) {
+			if (!ar_in_bits && auth_bit_range.length % 8 != 0)
+				continue;
+			if (ar_in_bits && !is_bit_mode_auth)
+				continue;
+
+			cipher_range = cipher_bit_range;
+			auth_range = auth_bit_range;
+			if (!cr_in_bits) {
+				cipher_range.offset /= 8;
+				cipher_range.length /= 8;
+			}
+			if (!ar_in_bits) {
+				auth_range.offset /= 8;
+				auth_range.length /= 8;
+			}
+			alg_test_op_types(op, order, ref, cipher_range, auth_range,
+					  digest_offset, cr_in_bits, ar_in_bits);
+		}
 	}
 }
 
@@ -400,8 +437,8 @@ static void check_alg(odp_crypto_op_t op,
 		odp_bool_t is_bit_mode_cipher = false;
 		odp_bool_t is_bit_mode_auth = false;
 		uint32_t digest_offs = ref_length_in_bytes(&ref[idx]);
-		odp_packet_data_range_t cipher_range = {.offset = 0};
-		odp_packet_data_range_t auth_range = {.offset = 0};
+		odp_packet_data_range_t cipher_bit_range = {.offset = 0};
+		odp_packet_data_range_t auth_bit_range = {.offset = 0};
 
 		if (ref_length_in_bits(&ref[idx]) % 8 != 0)
 			bit_mode_needed = true;
@@ -461,18 +498,14 @@ static void check_alg(odp_crypto_op_t op,
 			continue;
 		}
 
-		cipher_range.length = is_bit_mode_cipher ?
-			ref_length_in_bits(&ref[idx]) :
-			ref_length_in_bytes(&ref[idx]);
-		auth_range.length = is_bit_mode_auth ?
-			ref_length_in_bits(&ref[idx]) :
-			ref_length_in_bytes(&ref[idx]);
+		cipher_bit_range.length = ref_length_in_bits(&ref[idx]);
+		auth_bit_range.length = ref_length_in_bits(&ref[idx]);
 
 		alg_test(op, AUTH_PLAINTEXT, &ref[idx],
-			 cipher_range, auth_range, digest_offs,
+			 cipher_bit_range, auth_bit_range, digest_offs,
 			 is_bit_mode_cipher, is_bit_mode_auth);
 		alg_test(op, AUTH_CIPHERTEXT, &ref[idx],
-			 cipher_range, auth_range, digest_offs,
+			 cipher_bit_range, auth_bit_range, digest_offs,
 			 is_bit_mode_cipher, is_bit_mode_auth);
 
 		cipher_tested[cipher_idx] = true;
@@ -533,7 +566,7 @@ static int create_hash_test_reference(odp_auth_alg_t auth,
 				      uint32_t digest_offset,
 				      uint8_t digest_fill)
 {
-	odp_crypto_session_t session;
+	crypto_session_t session;
 	int rc;
 	odp_packet_t pkt;
 	odp_bool_t ok;
@@ -566,33 +599,33 @@ static int create_hash_test_reference(odp_auth_alg_t auth,
 	rc = odp_packet_copy_from_mem(pkt, 0, auth_bytes, ref->plaintext);
 	CU_ASSERT(rc == 0);
 
-	session = session_create(ODP_CRYPTO_OP_ENCODE,
-				 ODP_CRYPTO_OP_TYPE_LEGACY,
-				 AUTH_PLAINTEXT, ref, HASH_NO_OVERLAP);
-	if (session == ODP_CRYPTO_SESSION_INVALID)
+	session.op = ODP_CRYPTO_OP_ENCODE;
+	session.op_type = ODP_CRYPTO_OP_TYPE_LEGACY;
+	session.cipher_range_in_bits = false;
+	session.auth_range_in_bits = false;
+	if (session_create(&session, AUTH_PLAINTEXT, ref, HASH_NO_OVERLAP))
 		return -1;
 
 	odp_crypto_packet_op_param_t op_params = {
-		.session = session,
+		.session = session.session,
 		.cipher_iv_ptr = ref->cipher_iv,
 		.auth_iv_ptr = ref->auth_iv,
 		.hash_result_offset = enc_digest_offset,
 		.aad_ptr = ref->aad,
 		.cipher_range = {.offset = 0, .length = 0},
-		.auth_range = { .offset = 0,
-				.length = capa->bit_mode ? auth_bytes * 8 : auth_bytes },
+		.auth_range = { .offset = 0, .length = auth_bytes },
 		.dst_offset_shift = 0,
 	};
 	rc = crypto_op(pkt, &pkt, &ok, &op_params, ODP_CRYPTO_OP_TYPE_LEGACY);
 
 	CU_ASSERT(rc == 0);
 	if (rc) {
-		(void)odp_crypto_session_destroy(session);
+		(void)odp_crypto_session_destroy(session.session);
 		return -1;
 	}
 	CU_ASSERT(ok);
 
-	rc = odp_crypto_session_destroy(session);
+	rc = odp_crypto_session_destroy(session.session);
 	CU_ASSERT(rc == 0);
 
 	/* copy the processed packet to the ciphertext packet in ref */
@@ -620,8 +653,8 @@ static void test_auth_hash_in_auth_range(odp_auth_alg_t auth,
 {
 	static crypto_test_reference_t ref = {.length = 0};
 	uint32_t digest_offset = 13;
-	const odp_packet_data_range_t cipher_range = {.offset = 0, .length = 0};
-	odp_packet_data_range_t auth_range;
+	const odp_packet_data_range_t cipher_bit_range = {.offset = 0, .length = 0};
+	odp_packet_data_range_t auth_bit_range;
 
 	if (!full_test && capa->digest_len % 4 != 0)
 		return;
@@ -633,10 +666,8 @@ static void test_auth_hash_in_auth_range(odp_auth_alg_t auth,
 	if (create_hash_test_reference(auth, capa, &ref, digest_offset, 0))
 		return;
 
-	auth_range.offset = 0;
-	auth_range.length = capa->bit_mode ?
-		ref_length_in_bits(&ref) :
-		ref_length_in_bytes(&ref);
+	auth_bit_range.offset = 0;
+	auth_bit_range.length = ref_length_in_bits(&ref);
 
 	/*
 	 * Decode the ciphertext packet.
@@ -648,7 +679,7 @@ static void test_auth_hash_in_auth_range(odp_auth_alg_t auth,
 	alg_test(ODP_CRYPTO_OP_DECODE,
 		 order,
 		 &ref,
-		 cipher_range, auth_range,
+		 cipher_bit_range, auth_bit_range,
 		 digest_offset,
 		 false,
 		 capa->bit_mode);
@@ -660,10 +691,8 @@ static void test_auth_hash_in_auth_range(odp_auth_alg_t auth,
 	if (create_hash_test_reference(auth, capa, &ref, digest_offset, 1))
 		return;
 
-	auth_range.offset = 0;
-	auth_range.length = capa->bit_mode ?
-		ref_length_in_bits(&ref) :
-		ref_length_in_bytes(&ref);
+	auth_bit_range.offset = 0;
+	auth_bit_range.length = ref_length_in_bits(&ref);
 
 	/*
 	 * Encode the plaintext packet.
@@ -675,7 +704,7 @@ static void test_auth_hash_in_auth_range(odp_auth_alg_t auth,
 	alg_test(ODP_CRYPTO_OP_ENCODE,
 		 order,
 		 &ref,
-		 cipher_range, auth_range,
+		 cipher_bit_range, auth_bit_range,
 		 digest_offset,
 		 false,
 		 capa->bit_mode);
@@ -759,7 +788,7 @@ static int crypto_encode_ref(crypto_test_reference_t *ref,
 	odp_packet_data_range_t zero_range = {.offset = 0, .length = 0};
 	odp_packet_t pkt;
 	int rc;
-	odp_crypto_session_t session;
+	crypto_session_t session;
 	odp_bool_t ok;
 
 	pkt = odp_packet_alloc(suite_context.pool, ref->length);
@@ -768,13 +797,11 @@ static int crypto_encode_ref(crypto_test_reference_t *ref,
 	rc = odp_packet_copy_from_mem(pkt, 0, ref->length, ref->plaintext);
 	CU_ASSERT(rc == 0);
 
-	session = session_create(ODP_CRYPTO_OP_ENCODE,
-				 ODP_CRYPTO_OP_TYPE_LEGACY,
-				 AUTH_PLAINTEXT,
-				 ref,
-				 HASH_OVERLAP);
-
-	if (session == ODP_CRYPTO_SESSION_INVALID) {
+	session.op = ODP_CRYPTO_OP_ENCODE;
+	session.op_type = ODP_CRYPTO_OP_TYPE_LEGACY;
+	session.cipher_range_in_bits = false;
+	session.auth_range_in_bits = false;
+	if (session_create(&session, AUTH_PLAINTEXT, ref, HASH_OVERLAP)) {
 		odp_packet_free(pkt);
 		return 1;
 	}
@@ -789,7 +816,7 @@ static int crypto_encode_ref(crypto_test_reference_t *ref,
 	CU_ASSERT_FATAL(hash_result_offset + ref->digest_length <= ref->length);
 
 	odp_crypto_packet_op_param_t op_params = {
-		.session = session,
+		.session = session.session,
 		.cipher_iv_ptr = ref->cipher_iv,
 		.auth_iv_ptr = ref->auth_iv,
 		.hash_result_offset = hash_result_offset,
@@ -801,12 +828,12 @@ static int crypto_encode_ref(crypto_test_reference_t *ref,
 	rc = crypto_op(pkt, &pkt, &ok, &op_params, ODP_CRYPTO_OP_TYPE_LEGACY);
 	CU_ASSERT(rc == 0);
 	if (rc) {
-		(void)odp_crypto_session_destroy(session);
+		(void)odp_crypto_session_destroy(session.session);
 		return -1;
 	}
 	CU_ASSERT(ok);
 
-	rc = odp_crypto_session_destroy(session);
+	rc = odp_crypto_session_destroy(session.session);
 	CU_ASSERT(rc == 0);
 
 	rc = odp_packet_copy_to_mem(pkt, 0, ref->length, ref->ciphertext);
@@ -830,8 +857,8 @@ typedef struct crypto_suite_t {
  */
 static int create_combined_ref(const crypto_suite_t *suite,
 			       crypto_test_reference_t *ref,
-			       odp_packet_data_range_t *cipher_range,
-			       odp_packet_data_range_t *auth_range,
+			       const odp_packet_data_range_t *cipher_range,
+			       const odp_packet_data_range_t *auth_range,
 			       uint32_t digest_offset)
 {
 	uint32_t total_len;
@@ -856,15 +883,6 @@ static int create_combined_ref(const crypto_suite_t *suite,
 	ref->aad_length = 0;
 	ref->is_length_in_bits = false;
 	ref->length = total_len;
-
-	if (suite->cipher_capa->bit_mode) {
-		cipher_range->offset *= 8;
-		cipher_range->length *= 8;
-	}
-	if (suite->auth_capa->bit_mode) {
-		auth_range->offset *= 8;
-		auth_range->length *= 8;
-	}
 
 	if (ref->auth_key_length > MAX_KEY_LEN ||
 	    ref->auth_iv_length > MAX_IV_LEN ||
@@ -1184,6 +1202,11 @@ static void test_combo(const crypto_suite_t *suite,
 				 digest_offset);
 	if (rc)
 		return;
+
+	cipher_range.offset *= 8;
+	cipher_range.length *= 8;
+	auth_range.offset *= 8;
+	auth_range.length *= 8;
 
 	alg_test(ODP_CRYPTO_OP_ENCODE,
 		 suite->order,

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -714,6 +714,7 @@ static void test_auth_hash_in_auth_range(odp_auth_alg_t auth,
  * Cipher algorithms that are not AEAD algorithms
  */
 static odp_cipher_alg_t cipher_algs[] = {
+	ODP_CIPHER_ALG_NULL,
 	ODP_CIPHER_ALG_DES,
 	ODP_CIPHER_ALG_3DES_CBC,
 	ODP_CIPHER_ALG_3DES_ECB,
@@ -729,10 +730,11 @@ static odp_cipher_alg_t cipher_algs[] = {
 };
 
 /*
- * Authentication algorithms and hashes that use auth_range
+ * Authentication algorithms and hashes that may use auth_range
  * parameter. AEAD algorithms are excluded.
  */
 static odp_auth_alg_t auth_algs[] = {
+	ODP_AUTH_ALG_NULL,
 	ODP_AUTH_ALG_MD5_HMAC,
 	ODP_AUTH_ALG_SHA1_HMAC,
 	ODP_AUTH_ALG_SHA224_HMAC,


### PR DESCRIPTION
Allow non-zero-length cipher and auth ranges for the null cipher and auth algoriths in the OOP operation type. Copy the ranges to the output packet as with non-null algorithms. Allow implementations to not fully support non-zero-length ranges by explicitly mentioning that a crypto operation with such a range may fail if not supported.

This changes makes null algorithms behave as non-null algorithms with respect to packet data copying in the OOP operation type. When both the cipher and the auth algorithms are null, a crypto operation reduces to a´packet data copying operation (if supported by the underlying ODP implementation). Such copying may be useful for applications that wish to process crypto and non-crypto packets in the same way using the OOP crypto operation type.