### PR TITLE
[PATCH v5] quell GCC 13.1 bound check warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,6 +120,7 @@ AS_IF([test "$GCC" == yes],
       AS_IF([test `$CC -dumpversion | cut -d '.' -f 1` -ge 10],
 	    ODP_CHECK_CFLAG([-Wno-error=array-bounds])
 	    ODP_CHECK_CFLAG([-Wno-error=stringop-overflow])
+	    ODP_CHECK_CXXFLAG([-Wno-error=stringop-overflow])
       )
 )
 

--- a/example/packet/odp_pktio.c
+++ b/example/packet/odp_pktio.c
@@ -521,7 +521,10 @@ static int drop_err_pkts(odp_packet_t pkt_tbl[], unsigned len)
 			odp_packet_free(pkt); /* Drop */
 			pkt_cnt--;
 		} else if (odp_unlikely(i != j++)) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
 			pkt_tbl[j-1] = pkt;
+#pragma GCC diagnostic pop
 		}
 	}
 

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -799,6 +799,11 @@ static odp_schedule_group_t schedule_group_create(const char *name,
 		if (!sched_group->s.group[i].allocated) {
 			char *grp_name = sched_group->s.group[i].name;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#if __GNUC__ >= 13
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 			if (name == NULL) {
 				grp_name[0] = 0;
 			} else {
@@ -806,6 +811,7 @@ static odp_schedule_group_t schedule_group_create(const char *name,
 					ODP_SCHED_GROUP_NAME_LEN - 1);
 				grp_name[ODP_SCHED_GROUP_NAME_LEN - 1] = 0;
 			}
+#pragma GCC diagnostic pop
 
 			odp_thrmask_copy(&sched_group->s.group[i].mask, thrmask);
 			sched_group->s.group[i].allocated = 1;

--- a/platform/linux-generic/pktio/stats/ethtool_stats.c
+++ b/platform/linux-generic/pktio/stats/ethtool_stats.c
@@ -29,9 +29,11 @@
 
 static struct ethtool_gstrings *get_stringset(int fd, struct ifreq *ifr)
 {
-	struct {
+	union {
 		struct ethtool_sset_info hdr;
-		uint32_t buf[1]; /* overlaps with hdr.data[] */
+		/* Reserve space for hdr.data. */
+		uint8_t buf[sizeof(struct ethtool_sset_info) +
+			    sizeof(((struct ethtool_sset_info *)0)->data[0])];
 	} sset_info;
 	struct ethtool_drvinfo drvinfo;
 	uint32_t len;


### PR DESCRIPTION
Quell a few -Warray-bounds and -Wstringop-overflow warnings with GCC 13.1, with and without -Wpedantic.

The question here is do we keep adding these pragmas to the code or do we just disable -Warray-bounds and -Wstringop-overflow?