### PR TITLE
[PATCH v2] api: time: split header files

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -68,6 +68,7 @@ odpapiinclude_HEADERS = \
 	odp/api/thrmask.h \
 	odp/api/ticketlock.h \
 	odp/api/time.h \
+	odp/api/time_types.h \
 	odp/api/timer.h \
 	odp/api/timer_types.h \
 	odp/api/traffic_mngr.h \
@@ -134,6 +135,7 @@ odpapispecinclude_HEADERS = \
 		  odp/api/spec/thrmask.h \
 		  odp/api/spec/ticketlock.h \
 		  odp/api/spec/time.h \
+		  odp/api/spec/time_types.h \
 		  odp/api/spec/timer.h \
 		  odp/api/spec/timer_types.h \
 		  odp/api/spec/traffic_mngr.h
@@ -193,6 +195,7 @@ odpapiabidefaultinclude_HEADERS = \
 	odp/api/abi-default/thrmask.h \
 	odp/api/abi-default/ticketlock.h \
 	odp/api/abi-default/time.h \
+	odp/api/abi-default/time_types.h \
 	odp/api/abi-default/timer.h \
 	odp/api/abi-default/timer_types.h \
 	odp/api/abi-default/traffic_mngr.h \
@@ -253,6 +256,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm32-linux/odp/api/abi/thrmask.h \
 	odp/arch/arm32-linux/odp/api/abi/ticketlock.h \
 	odp/arch/arm32-linux/odp/api/abi/time.h \
+	odp/arch/arm32-linux/odp/api/abi/time_types.h \
 	odp/arch/arm32-linux/odp/api/abi/timer.h \
 	odp/arch/arm32-linux/odp/api/abi/timer_types.h \
 	odp/arch/arm32-linux/odp/api/abi/traffic_mngr.h \
@@ -309,6 +313,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm64-linux/odp/api/abi/thrmask.h \
 	odp/arch/arm64-linux/odp/api/abi/ticketlock.h \
 	odp/arch/arm64-linux/odp/api/abi/time.h \
+	odp/arch/arm64-linux/odp/api/abi/time_types.h \
 	odp/arch/arm64-linux/odp/api/abi/timer.h \
 	odp/arch/arm64-linux/odp/api/abi/timer_types.h \
 	odp/arch/arm64-linux/odp/api/abi/traffic_mngr.h \
@@ -365,6 +370,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/default-linux/odp/api/abi/thrmask.h \
 	odp/arch/default-linux/odp/api/abi/ticketlock.h \
 	odp/arch/default-linux/odp/api/abi/time.h \
+	odp/arch/default-linux/odp/api/abi/time_types.h \
 	odp/arch/default-linux/odp/api/abi/timer.h \
 	odp/arch/default-linux/odp/api/abi/timer_types.h \
 	odp/arch/default-linux/odp/api/abi/traffic_mngr.h \
@@ -421,6 +427,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/power64-linux/odp/api/abi/thrmask.h \
 	odp/arch/power64-linux/odp/api/abi/ticketlock.h \
 	odp/arch/power64-linux/odp/api/abi/time.h \
+	odp/arch/power64-linux/odp/api/abi/time_types.h \
 	odp/arch/power64-linux/odp/api/abi/timer.h \
 	odp/arch/power64-linux/odp/api/abi/timer_types.h \
 	odp/arch/power64-linux/odp/api/abi/traffic_mngr.h \
@@ -477,6 +484,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_32-linux/odp/api/abi/thrmask.h \
 	odp/arch/x86_32-linux/odp/api/abi/ticketlock.h \
 	odp/arch/x86_32-linux/odp/api/abi/time.h \
+	odp/arch/x86_32-linux/odp/api/abi/time_types.h \
 	odp/arch/x86_32-linux/odp/api/abi/timer.h \
 	odp/arch/x86_32-linux/odp/api/abi/timer_types.h \
 	odp/arch/x86_32-linux/odp/api/abi/traffic_mngr.h \
@@ -533,6 +541,7 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/x86_64-linux/odp/api/abi/thrmask.h \
 	odp/arch/x86_64-linux/odp/api/abi/ticketlock.h \
 	odp/arch/x86_64-linux/odp/api/abi/time.h \
+	odp/arch/x86_64-linux/odp/api/abi/time_types.h \
 	odp/arch/x86_64-linux/odp/api/abi/timer.h \
 	odp/arch/x86_64-linux/odp/api/abi/timer_types.h \
 	odp/arch/x86_64-linux/odp/api/abi/traffic_mngr.h \

--- a/include/odp/api/abi-default/time_types.h
+++ b/include/odp/api/abi-default/time_types.h
@@ -1,0 +1,49 @@
+/* Copyright (c) 2015-2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_ABI_TIME_TYPES_H_
+#define ODP_ABI_TIME_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/** @ingroup odp_time
+ *  @{
+ **/
+
+/**
+ * @internal Time structure used for both POSIX timespec and HW counter
+ * implementations.
+ */
+typedef struct odp_time_t {
+	/** @internal Variant mappings for time type */
+	union {
+		/** @internal Used with generic 64 bit operations */
+		uint64_t u64;
+
+		/** @internal Nanoseconds */
+		uint64_t nsec;
+
+		/** @internal HW timer counter value */
+		uint64_t count;
+
+	};
+} odp_time_t;
+
+#define ODP_TIME_NULL ((odp_time_t){.u64 = 0})
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -25,7 +25,7 @@ extern "C" {
 #include <odp/api/pool_types.h>
 #include <odp/api/proto_stats_types.h>
 #include <odp/api/std_types.h>
-#include <odp/api/time.h>
+#include <odp/api/time_types.h>
 
 /** @defgroup odp_packet ODP PACKET
  *  Packet event metadata and operations.

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -25,7 +25,7 @@ extern "C" {
 #include <odp/api/packet_io_types.h>
 #include <odp/api/queue_types.h>
 #include <odp/api/reassembly.h>
-#include <odp/api/time.h>
+#include <odp/api/time_types.h>
 
 /** @defgroup odp_packet_io ODP PACKET IO
  *  Packet IO interfaces.

--- a/include/odp/api/spec/time.h
+++ b/include/odp/api/spec/time.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2020-2021, Nokia
+ * Copyright (c) 2020-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -19,37 +19,12 @@
 extern "C" {
 #endif
 
+#include <odp/api/std_types.h>
+#include <odp/api/time_types.h>
+
 /** @defgroup odp_time ODP TIME
  *  Chip and CPU level wall clock time.
  *  @{
- */
-
-/** A microsecond in nanoseconds */
-#define ODP_TIME_USEC_IN_NS  1000ULL
-
-/** A millisecond in nanoseconds */
-#define ODP_TIME_MSEC_IN_NS  1000000ULL
-
-/** A second in nanoseconds */
-#define ODP_TIME_SEC_IN_NS   1000000000ULL
-
-/** A minute in nanoseconds */
-#define ODP_TIME_MIN_IN_NS   60000000000ULL
-
-/** An hour in nanoseconds */
-#define ODP_TIME_HOUR_IN_NS  3600000000000ULL
-
-/**
- * @typedef odp_time_t
- * ODP time stamp. Time stamp can represent a time stamp from local or global
- * time source. A local time stamp must not be shared between threads. API calls
- * work correctly only when all time stamps for input are from the same time
- * source.
- */
-
-/**
- * @def ODP_TIME_NULL
- * Zero time stamp
  */
 
 /**

--- a/include/odp/api/spec/time_types.h
+++ b/include/odp/api/spec/time_types.h
@@ -1,0 +1,63 @@
+/* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2020-2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP time
+ */
+
+#ifndef ODP_API_SPEC_TIME_TYPES_H_
+#define ODP_API_SPEC_TIME_TYPES_H_
+#include <odp/visibility_begin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup odp_time
+ *  @{
+ */
+
+/** A microsecond in nanoseconds */
+#define ODP_TIME_USEC_IN_NS  1000ULL
+
+/** A millisecond in nanoseconds */
+#define ODP_TIME_MSEC_IN_NS  1000000ULL
+
+/** A second in nanoseconds */
+#define ODP_TIME_SEC_IN_NS   1000000000ULL
+
+/** A minute in nanoseconds */
+#define ODP_TIME_MIN_IN_NS   60000000000ULL
+
+/** An hour in nanoseconds */
+#define ODP_TIME_HOUR_IN_NS  3600000000000ULL
+
+/**
+ * @typedef odp_time_t
+ * ODP time stamp. Time stamp can represent a time stamp from local or global
+ * time source. A local time stamp must not be shared between threads. API calls
+ * work correctly only when all time stamps for input are from the same time
+ * source.
+ */
+
+/**
+ * @def ODP_TIME_NULL
+ * Zero time stamp
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <odp/visibility_end.h>
+#endif

--- a/include/odp/api/time.h
+++ b/include/odp/api/time.h
@@ -17,7 +17,6 @@
 extern "C" {
 #endif
 
-#include <odp/api/std_types.h>
 #include <odp/api/abi/time.h>
 
 #include <odp/api/spec/time.h>

--- a/include/odp/api/time_types.h
+++ b/include/odp/api/time_types.h
@@ -4,14 +4,22 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#ifndef ODP_ABI_TIME_H_
-#define ODP_ABI_TIME_H_
+/**
+ * @file
+ *
+ * ODP time
+ */
+
+#ifndef ODP_API_TIME_TYPES_H_
+#define ODP_API_TIME_TYPES_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* Empty header required due to the inline functions */
+#include <odp/api/abi/time_types.h>
+
+#include <odp/api/spec/time_types.h>
 
 #ifdef __cplusplus
 }

--- a/include/odp/arch/arm32-linux/odp/api/abi/time_types.h
+++ b/include/odp/arch/arm32-linux/odp/api/abi/time_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/time_types.h>

--- a/include/odp/arch/arm64-linux/odp/api/abi/time_types.h
+++ b/include/odp/arch/arm64-linux/odp/api/abi/time_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/time_types.h>

--- a/include/odp/arch/default-linux/odp/api/abi/time_types.h
+++ b/include/odp/arch/default-linux/odp/api/abi/time_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/time_types.h>

--- a/include/odp/arch/power64-linux/odp/api/abi/time_types.h
+++ b/include/odp/arch/power64-linux/odp/api/abi/time_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/time_types.h>

--- a/include/odp/arch/x86_32-linux/odp/api/abi/time_types.h
+++ b/include/odp/arch/x86_32-linux/odp/api/abi/time_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/time_types.h>

--- a/include/odp/arch/x86_64-linux/odp/api/abi/time_types.h
+++ b/include/odp/arch/x86_64-linux/odp/api/abi/time_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/time_types.h>

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -115,6 +115,7 @@ odpapiabiarchinclude_HEADERS += \
 		  include-abi/odp/api/abi/thrmask.h \
 		  include-abi/odp/api/abi/ticketlock.h \
 		  include-abi/odp/api/abi/time.h \
+		  include-abi/odp/api/abi/time_types.h \
 		  include-abi/odp/api/abi/timer.h \
 		  include-abi/odp/api/abi/timer_types.h \
 		  include-abi/odp/api/abi/traffic_mngr.h \

--- a/platform/linux-generic/include-abi/odp/api/abi/time.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/time.h
@@ -4,7 +4,5 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#include <odp/api/abi-default/time.h>
-
-/* Inlined functions for non-ABI compat mode */
+/* Inlined API functions */
 #include <odp/api/plat/time_inlines.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/time_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/time_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2023, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/time_types.h>

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -18,7 +18,7 @@
 #include <odp/api/hints.h>
 #include <odp/api/packet_types.h>
 #include <odp/api/pool_types.h>
-#include <odp/api/time.h>
+#include <odp/api/time_types.h>
 
 #include <odp/api/plat/debug_inlines.h>
 #include <odp/api/plat/packet_io_inlines.h>

--- a/platform/linux-generic/include/odp/api/plat/time_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/time_inlines.h
@@ -8,11 +8,13 @@
 #ifndef ODP_PLAT_TIME_INLINES_H_
 #define ODP_PLAT_TIME_INLINES_H_
 
-#include <stdint.h>
 #include <odp/api/align.h>
 #include <odp/api/hints.h>
+#include <odp/api/time_types.h>
 
 #include <odp/api/abi/cpu_time.h>
+
+#include <stdint.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -22,6 +22,7 @@ extern "C" {
 #include <odp/api/packet_io.h>
 #include <odp/api/spinlock.h>
 #include <odp/api/ticketlock.h>
+#include <odp/api/time.h>
 
 #include <odp/api/plat/packet_io_inlines.h>
 


### PR DESCRIPTION
Split time API into separate header files for functions and types. This makes inlining API function implementations easier.