### PR TITLE
[PATCH v2] test: ipsecfwd: update CFLAGS with libconfig

### DIFF
--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -84,6 +84,7 @@ odp_timer_perf_SOURCES = odp_timer_perf.c
 
 if LIBCONFIG
 odp_ipsecfwd_SOURCES = odp_ipsecfwd.c
+AM_CFLAGS += $(LIBCONFIG_CFLAGS)
 endif
 
 # l2fwd test depends on generator example


### PR DESCRIPTION
Update CFLAGS with libconfig CFLAGS. The app has dependency on libconfig and CFLAGS should be updated.

Fixes: 249739742fcf ("test: ipsecfwd: utilize libconfig")
Cc: tuomas.taipale@nokia.com