### PR TITLE
[PATCH v2] linux-gen: pktio: move packet vector cast helper

### DIFF
--- a/platform/linux-generic/include/odp_event_vector_internal.h
+++ b/platform/linux-generic/include/odp_event_vector_internal.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Nokia
+/* Copyright (c) 2020-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -55,6 +55,14 @@ ODP_STATIC_ASSERT(sizeof(odp_event_vector_hdr_t) <= ODP_CACHE_LINE_SIZE,
 static inline odp_event_vector_hdr_t *_odp_packet_vector_hdr(odp_packet_vector_t pktv)
 {
 	return (odp_event_vector_hdr_t *)(uintptr_t)pktv;
+}
+
+/**
+ * Return the event header
+ */
+static inline _odp_event_hdr_t *_odp_packet_vector_to_event_hdr(odp_packet_vector_t pktv)
+{
+	return (_odp_event_hdr_t *)(uintptr_t)&_odp_packet_vector_hdr(pktv)->event_hdr;
 }
 
 /**

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -72,11 +72,6 @@ static inline pktio_entry_t *pktio_entry_by_index(int index)
 	return _odp_pktio_entry_ptr[index];
 }
 
-static inline _odp_event_hdr_t *packet_vector_to_event_hdr(odp_packet_vector_t pktv)
-{
-	return (_odp_event_hdr_t *)(uintptr_t)&_odp_packet_vector_hdr(pktv)->event_hdr;
-}
-
 static int read_config_file(pktio_global_t *pktio_glb)
 {
 	const char *str;
@@ -826,7 +821,7 @@ static inline int pktin_recv_buf(pktio_entry_t *entry, int pktin_index,
 	if (odp_unlikely(pktv == ODP_PACKET_VECTOR_INVALID))
 		return 0;
 
-	event_hdrs[0] = packet_vector_to_event_hdr(pktv);
+	event_hdrs[0] = _odp_packet_vector_to_event_hdr(pktv);
 	return 1;
 }
 


### PR DESCRIPTION
Move `packet_vector_to_event_hdr()` to `odp_event_vector_internal.h` where it is reusable also elsewhere. Rename it accordingly.

v2:
- Rebased
- Added reviewed-by tag