### PR TITLE
[PATCH v5] api: sync: new memory barriers

### DIFF
--- a/include/odp/api/spec/sync.h
+++ b/include/odp/api/spec/sync.h
@@ -1,7 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2023 Nokia
  */
 
 /**
@@ -23,15 +22,24 @@ extern "C" {
  * @details
  * <b> Memory barriers </b>
  *
- * Memory barriers enforce ordering of memory load and store operations
- * specified before and after the barrier. These barriers may affect both
- * compiler optimizations and CPU out-of-order execution. All ODP
- * synchronization mechanisms (e.g. execution barriers, locks, queues, etc )
- * include all necessary memory barriers, so these calls are not needed when
- * using those. Also ODP atomic operations have memory ordered versions. These
- * explicit barriers may be needed when thread synchronization is based on
- * a non-ODP defined mechanism. Depending on the HW platform, heavy usage of
- * memory barriers may cause significant performance degradation.
+ * A memory barrier enforces the order between memory accesses (loads and/or stores)
+ * specified (in program order) before the barrier with those specified after the barrier.
+ * A barrier may affect both compiler optimizations and CPU out-of-order execution. Depending
+ * on the used HW platform and barrier types, heavy usage of barriers may cause significant
+ * performance degradation.
+ *
+ * An application may use these memory barrier functions e.g. to build a synchronization
+ * mechanism between its threads in shared memory, or when it accesses memory mapped registers
+ * of a device.
+ *
+ * An application does not need to use these memory barriers when using other ODP APIs for thread
+ * synchronization (execution barriers, spinlocks, etc.), or when exchanging data through ODP API
+ * mechanisms (queues, stashes, etc.). Those ODP calls include necessary (acquire and release)
+ * memory barriers to maintain coherency between data producers and consumers.
+ *
+ * Some ODP atomic operations include a memory barrier - see for example odp_atomic_load_acq_u32()
+ * or odp_atomic_store_rel_u32(). Application may use also those (non-relaxed) atomic operations
+ * to enforce memory ordering while using atomic variables.
  *
  *  @{
  */
@@ -78,6 +86,39 @@ void odp_mb_acquire(void);
  * This call is not needed when using ODP defined synchronization mechanisms.
  */
 void odp_mb_full(void);
+
+/**
+ * Memory barrier for load and store synchronization
+ *
+ * This memory barrier ensures that all memory accesses (loads and stores) specified before the
+ * barrier (in program order) are complete prior to any memory access specified after the barrier
+ * begins execution.
+ *
+ * This is a stronger barrier than odp_mb_full(), as in addition to visibility order also memory
+ * access completion is ensured. The barrier may be useful e.g. when synchronizing loads and stores
+ * into memory mapped registers of a device.
+ */
+void odp_mb_sync(void);
+
+/**
+ * Memory barrier for load synchronization
+ *
+ * This memory barrier ensures that all memory loads specified before the barrier (in program
+ * order) are complete prior to any memory load specified after the barrier begins execution.
+ *
+ * The barrier may be useful e.g. when synchronizing loads from memory mapped registers of a device.
+ */
+void odp_mb_sync_load(void);
+
+/**
+ * Memory synchronization barrier for stores
+ *
+ * This memory barrier ensures that all memory stores specified before the barrier (in program
+ * order) are complete prior to any memory store specified after the barrier begins execution.
+ *
+ * The barrier may be useful e.g. when synchronizing stores to memory mapped registers of a device.
+ */
+void odp_mb_sync_store(void);
 
 /**
  * @}

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -339,6 +339,7 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/default/odp/api/abi/cpu_generic.h \
 				arch/arm/odp/api/abi/cpu_inlines.h \
 				arch/arm/odp/api/abi/cpu.h \
+				arch/default/odp/api/abi/sync_inlines.h \
 				arch/default/odp/api/abi/time_inlines.h
 endif
 noinst_HEADERS += arch/arm/odp_atomic.h \
@@ -367,6 +368,7 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/default/odp/api/abi/cpu_generic.h \
 				arch/aarch64/odp/api/abi/cpu_inlines.h \
 				arch/aarch64/odp/api/abi/cpu.h \
+				arch/aarch64/odp/api/abi/sync_inlines.h \
 				arch/common/odp/api/abi/time_cpu_inlines.h \
 				arch/aarch64/odp/api/abi/time_inlines.h
 endif
@@ -391,6 +393,7 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/default/odp/api/abi/cpu_generic.h \
 				arch/default/odp/api/abi/cpu_inlines.h \
 				arch/default/odp/api/abi/cpu.h \
+				arch/default/odp/api/abi/sync_inlines.h \
 				arch/default/odp/api/abi/time_inlines.h
 endif
 noinst_HEADERS += arch/default/odp_atomic.h \
@@ -412,6 +415,7 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/default/odp/api/abi/cpu_generic.h \
 				arch/default/odp/api/abi/cpu_inlines.h \
 				arch/powerpc/odp/api/abi/cpu.h \
+				arch/default/odp/api/abi/sync_inlines.h \
 				arch/default/odp/api/abi/time_inlines.h
 endif
 noinst_HEADERS += arch/default/odp_atomic.h \
@@ -436,6 +440,7 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/default/odp/api/abi/atomic_inlines.h \
 				arch/x86/odp/api/abi/cpu_inlines.h \
 				arch/x86/odp/api/abi/cpu.h \
+				arch/x86/odp/api/abi/sync_inlines.h \
 				arch/common/odp/api/abi/time_cpu_inlines.h \
 				arch/x86/odp/api/abi/time_inlines.h
 endif

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/sync_inlines.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/sync_inlines.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
+ */
+
+#ifndef ODP_ARCH_SYNC_INLINES_H_
+#define ODP_ARCH_SYNC_INLINES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline void _odp_mb_sync(void)
+{
+	__asm__ volatile("dsb sy" ::: "memory");
+}
+
+static inline void _odp_mb_sync_load(void)
+{
+	__asm__ volatile("dsb ld" ::: "memory");
+}
+
+static inline void _odp_mb_sync_store(void)
+{
+	__asm__ volatile("dsb st" ::: "memory");
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/arch/default/odp/api/abi/sync_inlines.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/sync_inlines.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
+ */
+
+#ifndef ODP_ARCH_SYNC_INLINES_H_
+#define ODP_ARCH_SYNC_INLINES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline void _odp_mb_sync(void)
+{
+	__sync_synchronize();
+}
+
+static inline void _odp_mb_sync_load(void)
+{
+	__sync_synchronize();
+}
+
+static inline void _odp_mb_sync_store(void)
+{
+	__sync_synchronize();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/arch/x86/odp/api/abi/sync_inlines.h
+++ b/platform/linux-generic/arch/x86/odp/api/abi/sync_inlines.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
+ */
+
+#ifndef ODP_ARCH_SYNC_INLINES_H_
+#define ODP_ARCH_SYNC_INLINES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline void _odp_mb_sync(void)
+{
+	__asm__ volatile("mfence" ::: "memory");
+}
+
+static inline void _odp_mb_sync_load(void)
+{
+	__asm__ volatile("lfence" ::: "memory");
+}
+
+static inline void _odp_mb_sync_store(void)
+{
+	__asm__ volatile("sfence" ::: "memory");
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp/api/plat/sync_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/sync_inlines.h
@@ -1,7 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2023 Nokia
  */
 
 /**
@@ -12,6 +11,8 @@
 
 #ifndef ODP_PLAT_SYNC_INLINE_H_
 #define ODP_PLAT_SYNC_INLINE_H_
+
+#include <odp/api/abi/sync_inlines.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,6 +26,9 @@ extern "C" {
 	#define odp_mb_release __odp_mb_release
 	#define odp_mb_acquire __odp_mb_acquire
 	#define odp_mb_full __odp_mb_full
+	#define odp_mb_sync __odp_mb_sync
+	#define odp_mb_sync_load __odp_mb_sync_load
+	#define odp_mb_sync_store __odp_mb_sync_store
 #else
 	#define _ODP_INLINE
 #endif
@@ -42,6 +46,21 @@ _ODP_INLINE void odp_mb_acquire(void)
 _ODP_INLINE void odp_mb_full(void)
 {
 	__atomic_thread_fence(__ATOMIC_SEQ_CST);
+}
+
+_ODP_INLINE void odp_mb_sync(void)
+{
+	_odp_mb_sync();
+}
+
+_ODP_INLINE void odp_mb_sync_load(void)
+{
+	_odp_mb_sync_load();
+}
+
+_ODP_INLINE void odp_mb_sync_store(void)
+{
+	_odp_mb_sync_store();
 }
 
 /** @endcond */

--- a/test/validation/api/barrier/barrier.c
+++ b/test/validation/api/barrier/barrier.c
@@ -283,6 +283,9 @@ static void barrier_test_memory_barrier(void)
 	volatile int b = 0;
 	volatile int c = 0;
 	volatile int d = 0;
+	volatile int e = 0;
+	volatile int f = 0;
+	volatile int g = 0;
 
 	/* Call all memory barriers to verify that those are implemented */
 	a = 1;
@@ -292,9 +295,15 @@ static void barrier_test_memory_barrier(void)
 	c = 1;
 	odp_mb_full();
 	d = 1;
+	odp_mb_sync();
+	e = 1;
+	odp_mb_sync_load();
+	f = 1;
+	odp_mb_sync_store();
+	g = 1;
 
 	/* Avoid "variable set but not used" warning */
-	temp_result = a + b + c + d;
+	temp_result = a + b + c + d + e + f + g;
 }
 
 static int barrier_init(odp_instance_t *inst)


### PR DESCRIPTION
Added data synchronizing memory barriers that are stronger than the current barriers, and can be used also when accessing memory mapped device registers.

v4: rebased