### PR TITLE
[PATCH v6] api: pool: add user area initialization parameters

### DIFF
--- a/include/odp/api/spec/dma_types.h
+++ b/include/odp/api/spec/dma_types.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, Nokia
+/* Copyright (c) 2021-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -79,6 +79,12 @@ typedef struct odp_dma_pool_capability_t {
 
 	/** Maximum user area size in bytes */
 	uint32_t max_uarea_size;
+
+	/** Pool user area persistence
+	 *
+	 *  See buf.uarea_persistence of odp_pool_capability_t for details
+	 *  (odp_pool_capability_t::uarea_persistence). */
+	odp_bool_t uarea_persistence;
 
 	/** Minimum size of thread local cache */
 	uint32_t min_cache_size;

--- a/include/odp/api/spec/dma_types.h
+++ b/include/odp/api/spec/dma_types.h
@@ -110,6 +110,19 @@ typedef struct odp_dma_pool_param_t {
 	 */
 	uint32_t uarea_size;
 
+	/** Parameters for user area initialization */
+	struct {
+		/** See uarea_init.init_fn of odp_pool_param_t for details
+		 *  (odp_pool_param_t::init_fn). Function is called during
+		 *  odp_dma_pool_create(). */
+		void (*init_fn)(void *uarea, uint32_t size, void *args, uint32_t index);
+
+		/** See uarea_init.args of odp_pool_param_t for details
+		 *  (odp_pool_param_t::args). */
+		void *args;
+
+	} uarea_init;
+
 	/** Maximum number of events cached locally per thread
 	 *
 	 *  See odp_pool_param_t::cache_size documentation for details. Valid values range from

--- a/include/odp/api/spec/pool_types.h
+++ b/include/odp/api/spec/pool_types.h
@@ -609,6 +609,30 @@ typedef struct odp_pool_param_t {
 		uint32_t cache_size;
 	} vector;
 
+	/** Parameters for user area initialization */
+	struct {
+		/** User area initialization function
+		 *
+		 *  Application defined user area initialization function to be
+		 *  called for each event of the pool during odp_pool_create(). Ignored
+		 *  if user area persistence is not supported
+		 *  (odp_pool_capability_t::uarea_persistence) or pool will not have any
+		 *  user area. The default value is NULL.
+		 *
+		 *  @param uarea    Pointer to the user area of an event
+		 *  @param size     User area size
+		 *  @param args     Pointer to application defined arguments
+		 *  @param index    Index of the event (0..num events in pool - 1), not
+		 *                  necessarily in order
+		 */
+		void (*init_fn)(void *uarea, uint32_t size, void *args, uint32_t index);
+
+		/** Pointer to application defined arguments to be passed to every call
+		 *  of init_fn. The default value is NULL.
+		 */
+		void *args;
+	} uarea_init;
+
 	/**
 	 * Configure statistics counters
 	 *
@@ -757,6 +781,23 @@ typedef struct odp_pool_ext_capability_t {
 typedef struct odp_pool_ext_param_t {
 	/** Pool type */
 	odp_pool_type_t type;
+
+	/** Parameters for user area initialization */
+	struct {
+		/** See uarea_init.init_fn of odp_pool_param_t for details
+		 *  (odp_pool_param_t::init_fn). However, note that with external memory
+		 *  pools, this function is called during memory population and not during
+		 *  pool creation (odp_pool_ext_populate()). Depending on the implementation,
+		 *  the function may be called each time pool is being populated with
+		 *  odp_pool_ext_populate() or during the last population call
+		 *  (odp_pool_ext_populate() with #ODP_POOL_POPULATE_DONE). */
+		void (*init_fn)(void *uarea, uint32_t size, void *args, uint32_t index);
+
+		/** See uarea_init.args of odp_pool_param_t for details
+		 *  (odp_pool_param_t::args). */
+		void *args;
+
+	} uarea_init;
 
 	/** Maximum thread local cache size for the pool
 	 *

--- a/include/odp/api/spec/pool_types.h
+++ b/include/odp/api/spec/pool_types.h
@@ -209,6 +209,19 @@ typedef struct odp_pool_capability_t {
 		/** Maximum user area size in bytes */
 		uint32_t max_uarea_size;
 
+		/** Pool user area persistence
+		 *
+		 * When supported, implementation does not overwrite buffer user area
+		 * content at any point of buffer lifetime nor after freeing a buffer
+		 * back into pool.
+		 *
+		 * 0: User area content is maintained throughout regular buffer usage
+		 *    after allocation, but may be modified after free (default)
+		 * 1: User area content is maintained throughout regular buffer usage
+		 *    and additionally also after buffer is freed into the pool (between
+		 *    buffer free and allocation) */
+		odp_bool_t uarea_persistence;
+
 		/** Minimum size of thread local cache */
 		uint32_t min_cache_size;
 
@@ -288,6 +301,11 @@ typedef struct odp_pool_capability_t {
 		/** Maximum user area size in bytes */
 		uint32_t max_uarea_size;
 
+		/** Pool user area persistence
+		 *
+		 * See buf.uarea_persistence for details. */
+		odp_bool_t uarea_persistence;
+
 		/** Maximum number of subparameters
 		 *
 		 *  Maximum number of packet pool subparameters. Valid range is
@@ -318,6 +336,11 @@ typedef struct odp_pool_capability_t {
 		/** Maximum user area size in bytes */
 		uint32_t max_uarea_size;
 
+		/** Pool user area persistence
+		 *
+		 * See buf.uarea_persistence for details. */
+		odp_bool_t uarea_persistence;
+
 		/** Minimum size of thread local cache */
 		uint32_t min_cache_size;
 
@@ -344,6 +367,11 @@ typedef struct odp_pool_capability_t {
 
 		/** Maximum user area size in bytes */
 		uint32_t max_uarea_size;
+
+		/** Pool user area persistence
+		 *
+		 * See buf.uarea_persistence for details. */
+		odp_bool_t uarea_persistence;
 
 		/** Minimum size of thread local cache */
 		uint32_t min_cache_size;
@@ -712,6 +740,12 @@ typedef struct odp_pool_ext_capability_t {
 
 		/** Maximum user area size in bytes */
 		uint32_t max_uarea_size;
+
+		/** Pool user area persistence
+		 *
+		 *  See buf.uarea_persistence of odp_pool_capability_t for details
+		 *  (odp_pool_capability_t::uarea_persistence). */
+		odp_bool_t uarea_persistence;
 
 	} pkt;
 

--- a/platform/linux-generic/odp_dma.c
+++ b/platform/linux-generic/odp_dma.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, Nokia
+/* Copyright (c) 2021-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -99,11 +99,12 @@ int odp_dma_capability(odp_dma_capability_t *capa)
 	capa->queue_type_sched = 1;
 	capa->queue_type_plain = 1;
 
-	capa->pool.max_pools      = _odp_dma_glb->pool_capa.buf.max_pools;
-	capa->pool.max_num        = _odp_dma_glb->pool_capa.buf.max_num;
-	capa->pool.max_uarea_size = _odp_dma_glb->pool_capa.buf.max_uarea_size;
-	capa->pool.min_cache_size = _odp_dma_glb->pool_capa.buf.min_cache_size;
-	capa->pool.max_cache_size = _odp_dma_glb->pool_capa.buf.max_cache_size;
+	capa->pool.max_pools         = _odp_dma_glb->pool_capa.buf.max_pools;
+	capa->pool.max_num           = _odp_dma_glb->pool_capa.buf.max_num;
+	capa->pool.max_uarea_size    = _odp_dma_glb->pool_capa.buf.max_uarea_size;
+	capa->pool.uarea_persistence = _odp_dma_glb->pool_capa.buf.uarea_persistence;
+	capa->pool.min_cache_size    = _odp_dma_glb->pool_capa.buf.min_cache_size;
+	capa->pool.max_cache_size    = _odp_dma_glb->pool_capa.buf.max_cache_size;
 
 	return 0;
 }
@@ -738,11 +739,13 @@ odp_pool_t odp_dma_pool_create(const char *name, const odp_dma_pool_param_t *dma
 	}
 
 	odp_pool_param_init(&pool_param);
-	pool_param.type           = ODP_POOL_BUFFER;
-	pool_param.buf.num        = num;
-	pool_param.buf.uarea_size = uarea_size;
-	pool_param.buf.cache_size = cache_size;
-	pool_param.buf.size       = sizeof(odp_dma_result_t);
+	pool_param.type               = ODP_POOL_BUFFER;
+	pool_param.uarea_init.init_fn = dma_pool_param->uarea_init.init_fn;
+	pool_param.uarea_init.args    = dma_pool_param->uarea_init.args;
+	pool_param.buf.num            = num;
+	pool_param.buf.uarea_size     = uarea_size;
+	pool_param.buf.cache_size     = cache_size;
+	pool_param.buf.size           = sizeof(odp_dma_result_t);
 
 	pool = _odp_pool_create(name, &pool_param, ODP_POOL_DMA_COMPL);
 


### PR DESCRIPTION
This patchset adds possibility to initialize event user areas at pool creation time. Additionally, a user area persistence capability is added to signal if an implementation is able to maintain user area contents across event frees and allocations. 

v2:
- Petri's comments

v3:
- Petri's comments

v5:
- Rebased
- Ashwin's and Petri's comments

v6:
- Rebased
- Fixed checkpatch error
- Added reviewed-by tags