### PR TITLE
perf: timer: benchmark performance for timer functions

### DIFF
--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -638,6 +638,9 @@ uint64_t odp_timer_to_u64(odp_timer_t timer);
  */
 uint64_t odp_timeout_to_u64(odp_timeout_t tmo);
 
+uint64_t odp_timer_nsec(void);
+
+uint64_t odp_timer_rounds(void);
 /**
  * @}
  */

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -189,6 +189,12 @@ extern "C" {
  */
 #define CONFIG_TIMER_128BIT_ATOMICS 1
 
+/*
+ * Enable timer scan performance benchmark.
+ * This works with inline enabled.
+ */
+#define CONFIG_INLINE_PERF_BENCH 1
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Benchmark timer performance for the following timer functions: Set function: odp_timer_start()
Cancel function: odp_timer_cancel()
Scan function: odp_timer_scan_inline()