### PR TITLE
[PATCH v2] LICENSE: update project owner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,20 @@
-Copyright (c) 2013-2018, Linaro Limited
-All rights reserved.
-
-SPDX-License-Identifier:	BSD-3-Clause
+SPDX-License-Identifier: BSD-3-Clause
+Copyright (c) 2013-2019 Linaro Limited
+Copyright (c) 2019-2023 OpenFastPath Foundation
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-Redistributions of source code must retain the above copyright notice, this
+1. Redistributions of source code must retain the above copyright notice, this
 list of conditions and the following disclaimer.
 
-Redistributions in binary form must reproduce the above copyright notice, this
-list of conditions and the following disclaimer in the documentation and/or
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
 other materials provided with the distribution.
 
-Neither the name of Linaro Limited nor the names of its contributors may be
-used to endorse or promote products derived from this software without specific
-prior written permission.
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/README
+++ b/README
@@ -1,7 +1,6 @@
-Copyright (c) 2013-2019, Linaro Limited
-All rights reserved.
-
-SPDX-License-Identifier:        BSD-3-Clause
+SPDX-License-Identifier: BSD-3-Clause
+Copyright (c) 2013-2019 Linaro Limited
+Copyright (c) 2019-2023 OpenFastPath Foundation
 
 OpenDataPlane (ODP) project web page:
     https://www.opendataplane.org
@@ -40,8 +39,10 @@ How to build:
         make
 
 Licensing:
-    ODP project uses BSD-3-Clause license as the default license. See LICENSE
-    file for details.
+    The default license for ODP project is BSD-3-Clause (see LICENSE file).
+    SPDX short-form identifiers (https://spdx.dev/ids/) are used in project
+    source files to identify the used license. The SPDX license list can be
+    found from https://spdx.org/licenses/.
 
 Mailing list:
     odp@lists.opendataplane.org


### PR DESCRIPTION
Change current project owner to OpenFastPath Foundation and update license text to match the standard BSD-3-Clause format. The default copyright message has been shortened and reformatted:

```
/* SPDX-License-Identifier: BSD-3-Clause
 * Copyright (c) <YEAR> <COPYRIGHT HOLDER>
 */
```

The rest of project files will be updated later to follow this new format.