### PR TITLE
[PATCH v3] crypto: test that session creation fails when bit mode requested but not supported

### DIFF
--- a/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
+++ b/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
@@ -524,6 +524,16 @@ odp_crypto_session_create(const odp_crypto_session_param_t *param,
 		return -1;
 	}
 
+	if (param->cipher_range_in_bits) {
+		*status = ODP_CRYPTO_SES_ERR_CIPHER;
+		*session_out = ODP_CRYPTO_SESSION_INVALID;
+		return -1;
+	}
+	if (param->auth_range_in_bits) {
+		*status = ODP_CRYPTO_SES_ERR_AUTH;
+		*session_out = ODP_CRYPTO_SESSION_INVALID;
+		return -1;
+	}
 	if (param->op_type == ODP_CRYPTO_OP_TYPE_OOP) {
 		*status = ODP_CRYPTO_SES_ERR_PARAMS;
 		*session_out = ODP_CRYPTO_SESSION_INVALID;

--- a/platform/linux-generic/odp_crypto_ipsecmb.c
+++ b/platform/linux-generic/odp_crypto_ipsecmb.c
@@ -544,6 +544,16 @@ odp_crypto_session_create(const odp_crypto_session_param_t *param,
 		return -1;
 	}
 
+	if (param->cipher_range_in_bits) {
+		*status = ODP_CRYPTO_SES_ERR_CIPHER;
+		*session_out = ODP_CRYPTO_SESSION_INVALID;
+		return -1;
+	}
+	if (param->auth_range_in_bits) {
+		*status = ODP_CRYPTO_SES_ERR_AUTH;
+		*session_out = ODP_CRYPTO_SESSION_INVALID;
+		return -1;
+	}
 	if (param->op_type == ODP_CRYPTO_OP_TYPE_OOP) {
 		*status = ODP_CRYPTO_SES_ERR_PARAMS;
 		*session_out = ODP_CRYPTO_SESSION_INVALID;

--- a/platform/linux-generic/odp_crypto_null.c
+++ b/platform/linux-generic/odp_crypto_null.c
@@ -96,6 +96,9 @@ odp_crypto_generic_session_t *alloc_session(void)
 	}
 	odp_spinlock_unlock(&global->lock);
 
+	if (!session)
+		return NULL;
+
 	session->idx = session - global->sessions;
 
 	for (i = 0; i < ODP_THREAD_COUNT_MAX; i++)

--- a/platform/linux-generic/odp_crypto_null.c
+++ b/platform/linux-generic/odp_crypto_null.c
@@ -209,6 +209,16 @@ odp_crypto_session_create(const odp_crypto_session_param_t *param,
 		return -1;
 	}
 
+	if (param->cipher_range_in_bits) {
+		*status = ODP_CRYPTO_SES_ERR_CIPHER;
+		*session_out = ODP_CRYPTO_SESSION_INVALID;
+		return -1;
+	}
+	if (param->auth_range_in_bits) {
+		*status = ODP_CRYPTO_SES_ERR_AUTH;
+		*session_out = ODP_CRYPTO_SESSION_INVALID;
+		return -1;
+	}
 	if (param->op_type == ODP_CRYPTO_OP_TYPE_OOP) {
 		*status = ODP_CRYPTO_SES_ERR_PARAMS;
 		*session_out = ODP_CRYPTO_SESSION_INVALID;


### PR DESCRIPTION
linux-gen: crypto: null: fix session allocation when out of sessions
linux-gen: crypto: fail bit mode session creation when not supported
validation: crypto: test that session creation fails when it must
