### PR TITLE
[PATCH v4] validation: dma: fix max segment length

### DIFF
--- a/test/validation/api/dma/dma.c
+++ b/test/validation/api/dma/dma.c
@@ -1318,8 +1318,9 @@ static void test_dma_addr_to_addr_sync_res(void)
 
 static void get_seg_lens(uint32_t max_len, uint32_t *src, uint32_t *dst)
 {
-	uint32_t src_segs = *src, dst_segs = *dst;
+	uint32_t src_segs = *src, dst_segs = *dst, denom = MIN(src_segs, dst_segs);
 
+	max_len = MIN(max_len / denom, global.dma_capa.max_seg_len) * denom;
 	*src = max_len / src_segs;
 	*dst = *src * src_segs / dst_segs + *src * src_segs % dst_segs;
 }


### PR DESCRIPTION
Max segment length should be calculated based on the DMA device
capabilities such as max supported segments and segment length.

Fixes: 1aaf5cf55a0c ("validation: dma: add tests for maximum segment amount transfers")

Signed-off-by: Pavan Nikhilesh <pbhagavatula@marvell.com>
Reviewed-by: Tuomas Taipale <tuomas.taipale@nokia.com>
