### PR TITLE
[PATCH v3] linux-gen: timer: enhance timer expire scalability

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -270,7 +270,7 @@ stash: {
 	#
 	# The value may be rounded up by the implementation. For optimal memory
 	# usage set value to a power of two - 1.
-	max_num_obj = 4095
+	max_num_obj = 65535
 }
 
 timer: {

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -189,6 +189,9 @@ extern "C" {
  */
 #define CONFIG_TIMER_128BIT_ATOMICS 1
 
+/* Better scalability for timer expires. It works with inline timer enabled. */
+#define CONFIG_TIMER_EXPIRE_ENHANCE 0
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Use stash and pre-allocated memory to store tick_buf index, so timer_expire can find expire tick_buf index with hash function without walk through all tick_buf.

Addtional overhead introduced to timer start and cancel operation. Expire operation cost remain constant.

Timer set and cancel operation cycles
Base     69
Current 139

Expire operation cycles
Timer num.     10   100   1000
Base           37    38    190
Current        40    39     37