### PR TITLE
[PATCH v1] github_ci: add selective successful job logging

### DIFF
--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Failure log
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - name: Success log
+        if: ${{ success() }}
+        run: find . -name "*.log" -exec echo -e "\n\n        @@@@@ {} @@@@@\n\n" \; -exec cat {} \;
 
   Run_CFLAGS:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -344,6 +344,9 @@ jobs:
       - name: Failure log
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - name: Success log
+        if: ${{ success() }}
+        run: find . -name "*.log" -exec echo -e "\n\n        @@@@@ {} @@@@@\n\n" \; -exec cat {} \;
 
   Run_OS:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Add test log dump after a basic successful make check run. All `.log` files are searched and dumped.

This enables e.g. validation test output inspection in CI after a successfully ran job.