### PR TITLE
[PATCH v3] github_ci: add github actions for build and run logging

### DIFF
--- a/.github/actions/build-failure-log/action.yml
+++ b/.github/actions/build-failure-log/action.yml
@@ -1,0 +1,7 @@
+name: 'Build Failure Logger'
+description: 'Log output of failing build'
+runs:
+  using: 'composite'
+  steps:
+    - run: find . -name config.log -exec cat {} \;
+      shell: bash

--- a/.github/actions/dump-log/action.yml
+++ b/.github/actions/dump-log/action.yml
@@ -1,0 +1,7 @@
+name: 'Dump Logs'
+description: 'Dump logs of successful run'
+runs:
+  using: 'composite'
+  steps:
+    - run: find . -name "*.log" -exec echo -e "\n\n        @@@@@ {} @@@@@\n\n" \; -exec cat {} \;
+      shell: bash

--- a/.github/actions/run-failure-log/action.yml
+++ b/.github/actions/run-failure-log/action.yml
@@ -1,0 +1,7 @@
+name: 'Run Failure Logger'
+description: 'Log output of failing run'
+runs:
+  using: 'composite'
+  steps:
+    - run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      shell: bash

--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -31,9 +31,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_static_u22:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -51,9 +50,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="gcc-${{matrix.cc_ver}}" -e CXX="g++-${{matrix.cc_ver}}"
                -e CONF="${CONF} ${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/build_static.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_OS:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -68,9 +66,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${{matrix.os}}-${ARCH}-native /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_gcc_u22:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -87,9 +84,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="gcc-${{matrix.cc_ver}}" -e CXX="g++-${{matrix.cc_ver}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_out-of-tree:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -99,9 +95,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/out_of_tree.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_XDP:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -118,9 +113,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Run_distcheck:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -134,9 +128,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/distcheck.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -155,9 +148,10 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}" -e ARCH="${ARCH}"
                -e CXX=g++-10 -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
+      - if: ${{ success() }}
+        uses: ./.github/actions/dump-log
 
   Run_CFLAGS:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -172,9 +166,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}" -e ARCH="${ARCH}"
                -e CXX=g++-10 -e CFLAGS="${{matrix.cflags}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_OS:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -188,9 +181,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${{matrix.os}}-${ARCH}-native /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_sched_config:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -200,9 +192,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/sched-basic.conf $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_stash_config:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -212,9 +203,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/stash-custom.conf $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_scheduler_sp:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -224,9 +214,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_SCHEDULER=sp $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_scheduler_scalable:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -236,9 +225,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_SCHEDULER=scalable -e CI_SKIP=pktio_test_pktin_event_sched $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_process_mode:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -249,9 +237,8 @@ jobs:
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/process-mode.conf
                -e ODPH_PROC_MODE=1 $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_inline_timer:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -262,9 +249,8 @@ jobs:
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/inline-timer.conf
                $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check_inline_timer.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_packet_align:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -275,9 +261,8 @@ jobs:
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/packet_align.conf
                $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native /odp/scripts/ci/check_pktio.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_dpdk-19_11:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -287,9 +272,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native-dpdk_19.11 /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_dpdk-20_11:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -299,9 +283,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native-dpdk_20.11 /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_dpdk-21_11:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
@@ -311,6 +294,5 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-native-dpdk_21.11 /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log

--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -11,7 +11,6 @@ env:
   OS: ubuntu_20.04
 
 jobs:
-
   Build:
     if: ${{ github.repository == 'OpenDataPlane/odp' }}
     runs-on: [self-hosted, ARM64]

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -78,9 +78,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_static_u20:
     runs-on: ubuntu-20.04
@@ -95,9 +94,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="gcc-${{matrix.cc_ver}}" -e CXX="g++-${{matrix.cc_ver}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_static.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_static_u22:
     runs-on: ubuntu-20.04
@@ -113,9 +111,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="gcc-${{matrix.cc_ver}}" -e CXX="g++-${{matrix.cc_ver}}"
                -e CONF="${CONF} ${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_static.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_arm64:
     runs-on: ubuntu-20.04
@@ -132,9 +129,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${CONF} ${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_arm64_u18:
     runs-on: ubuntu-20.04
@@ -149,9 +145,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_armhf:
     runs-on: ubuntu-20.04
@@ -166,9 +161,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_ppc64el:
     runs-on: ubuntu-20.04
@@ -184,9 +178,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${CONF} ${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_i386:
     runs-on: ubuntu-20.04
@@ -202,9 +195,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_riscv64:
     runs-on: ubuntu-20.04
@@ -219,9 +211,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_OS:
     runs-on: ubuntu-20.04
@@ -235,9 +226,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${{matrix.os}}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_gcc_u18:
     runs-on: ubuntu-20.04
@@ -252,9 +242,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="gcc-${{matrix.cc_ver}}" -e CXX="g++-${{matrix.cc_ver}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_gcc_u22:
     runs-on: ubuntu-20.04
@@ -269,9 +258,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="gcc-${{matrix.cc_ver}}" -e CXX="g++-${{matrix.cc_ver}}"
                -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_out-of-tree:
     runs-on: ubuntu-20.04
@@ -279,9 +267,8 @@ jobs:
     - uses: actions/checkout@v3
     - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}"
              -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/out_of_tree.sh
-    - name: Failure log
-      if: ${{ failure() }}
-      run: find . -name config.log -exec cat {} \;
+    - if: ${{ failure() }}
+      uses: ./.github/actions/build-failure-log
 
   Build_XDP:
     runs-on: ubuntu-20.04
@@ -296,9 +283,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name config.log -exec cat {} \;
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Run_distcheck:
     runs-on: ubuntu-20.04
@@ -310,9 +296,8 @@ jobs:
     - uses: actions/checkout@v3
     - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
              -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/distcheck.sh
-    - name: Failure log
-      if: ${{ failure() }}
-      run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+    - if: ${{ failure() }}
+      uses: ./.github/actions/run-failure-log
 
   Run:
     runs-on: ubuntu-20.04
@@ -329,9 +314,11 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}" -e ARCH="${ARCH}"
                -e CXX=g++-10 -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
+      - if: ${{ success() }}
+        uses: ./.github/actions/dump-log
+
 
   Run_OS:
     runs-on: ubuntu-20.04
@@ -344,9 +331,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${{matrix.os}}-${ARCH} /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_sched_config:
     runs-on: ubuntu-20.04
@@ -354,9 +340,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/sched-basic.conf $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_stash_config:
     runs-on: ubuntu-20.04
@@ -364,9 +349,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/stash-custom.conf $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_scheduler_sp:
     runs-on: ubuntu-20.04
@@ -374,9 +358,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_SCHEDULER=sp $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_scheduler_scalable:
     runs-on: ubuntu-20.04
@@ -384,9 +367,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_SCHEDULER=scalable -e CI_SKIP=pktio_test_pktin_event_sched $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_process_mode:
     runs-on: ubuntu-20.04
@@ -395,9 +377,8 @@ jobs:
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/process-mode.conf
                -e ODPH_PROC_MODE=1 $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_inline_timer:
     runs-on: ubuntu-20.04
@@ -406,9 +387,8 @@ jobs:
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/inline-timer.conf
                $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/check_inline_timer.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_packet_align:
     runs-on: ubuntu-20.04
@@ -417,9 +397,8 @@ jobs:
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/packet_align.conf
                $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/check_pktio.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_dpdk-19_11:
     runs-on: ubuntu-20.04
@@ -427,9 +406,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-dpdk_19.11 /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_dpdk-20_11:
     runs-on: ubuntu-20.04
@@ -437,9 +415,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-dpdk_20.11 /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run_dpdk-21_11:
     runs-on: ubuntu-20.04
@@ -447,6 +424,5 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH}-dpdk_21.11 /odp/scripts/ci/check.sh
-      - name: Failure log
-        if: ${{ failure() }}
-        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -11,55 +11,51 @@ jobs:
   Checkpatch:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: Install dependencies
-      run: |
-        sudo apt update
-        sudo apt install codespell
-
-    - name: Check pull request
-      if: github.event_name == 'pull_request'
-      env:
-        CHECKPATCH_COMMAND: ./scripts/checkpatch.pl
-      uses: webispy/checkpatch-action@v8
-
-    - name: Check push
-      if: github.event_name == 'push' && github.ref != 'refs/heads/master'
-      run: |
-        AFTER=${{ github.event.after }}
-        BEFORE=${{ github.event.before }}
-        if [ -z "${BEFORE//0}" ] || [ -z "${AFTER//0}" ]; then
-          COMMIT_RANGE=""
-        else
-          COMMIT_RANGE="${BEFORE}..${AFTER}"
-        fi
-        ./scripts/ci-checkpatches.sh ${COMMIT_RANGE}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install codespell
+      - name: Check pull request
+        if: github.event_name == 'pull_request'
+        env:
+          CHECKPATCH_COMMAND: ./scripts/checkpatch.pl
+        uses: webispy/checkpatch-action@v8
+      - name: Check push
+        if: github.event_name == 'push' && github.ref != 'refs/heads/master'
+        run: |
+          AFTER=${{ github.event.after }}
+          BEFORE=${{ github.event.before }}
+          if [ -z "${BEFORE//0}" ] || [ -z "${AFTER//0}" ]; then
+            COMMIT_RANGE=""
+          else
+            COMMIT_RANGE="${BEFORE}..${AFTER}"
+          fi
+          ./scripts/ci-checkpatches.sh ${COMMIT_RANGE}
 
   Documentation:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Install dependencies
-      run: |
-        sudo apt update
-        sudo apt install doxygen asciidoctor libconfig-dev libssl-dev mscgen cmake graphviz
-        sudo gem install asciidoctor
-    - name: Build
-      shell: bash
-      run: |
-        ./bootstrap
-        ./configure --enable-user-guides
-        pushd doc
-        make
-        popd
-        touch ./doxygen.log
-        # Doxygen does not trap on warnings, check for them here.
-        make doxygen-doc 2>&1 | tee ./doxygen.log
-        ! fgrep -rq warning ./doxygen.log
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install doxygen asciidoctor libconfig-dev libssl-dev mscgen cmake graphviz
+          sudo gem install asciidoctor
+      - name: Build
+        shell: bash
+        run: |
+          ./bootstrap
+          ./configure --enable-user-guides
+          pushd doc
+          make
+          popd
+          touch ./doxygen.log
+          # Doxygen does not trap on warnings, check for them here.
+          make doxygen-doc 2>&1 | tee ./doxygen.log
+          ! fgrep -rq warning ./doxygen.log
 
   Build:
     runs-on: ubuntu-20.04
@@ -264,11 +260,11 @@ jobs:
   Build_out-of-tree:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
-    - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}"
-             -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/out_of_tree.sh
-    - if: ${{ failure() }}
-      uses: ./.github/actions/build-failure-log
+      - uses: actions/checkout@v3
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}"
+              -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/out_of_tree.sh
+      - if: ${{ failure() }}
+        uses: ./.github/actions/build-failure-log
 
   Build_XDP:
     runs-on: ubuntu-20.04
@@ -293,11 +289,11 @@ jobs:
       matrix:
         conf: ['--enable-user-guides', '--enable-user-guides --enable-abi-compat']
     steps:
-    - uses: actions/checkout@v3
-    - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
-             -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/distcheck.sh
-    - if: ${{ failure() }}
-      uses: ./.github/actions/run-failure-log
+      - uses: actions/checkout@v3
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.cc}}"
+              -e CONF="${{matrix.conf}}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/distcheck.sh
+      - if: ${{ failure() }}
+        uses: ./.github/actions/run-failure-log
 
   Run:
     runs-on: ubuntu-20.04
@@ -318,7 +314,6 @@ jobs:
         uses: ./.github/actions/run-failure-log
       - if: ${{ success() }}
         uses: ./.github/actions/dump-log
-
 
   Run_OS:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This patchset introduces local github actions that replace current inline per-job failure logging commands. Additionally, a new logging action to display logs of successful runs is added. This enables inspection of e.g. validation test prints after a successful CI run.

v2:
- Renamed actions

v3:
- Added reviewed-by tags