### PR TITLE
[PATCH v2] linux-gen: pktio: move tx completion capability to drivers

### DIFF
--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1612,12 +1612,8 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 	capa->lso.proto.custom           = 1;
 	capa->lso.mod_op.add_segment_num = 1;
 
-	capa->config.pktout.bit.tx_compl_ena = 1;
 	capa->tx_compl.queue_type_sched = 1;
 	capa->tx_compl.queue_type_plain = 1;
-	capa->tx_compl.mode_all = 1;
-	capa->tx_compl.mode_event = 1;
-	capa->tx_compl.mode_poll = 0;
 	capa->tx_compl.max_compl_id = 0;
 	capa->free_ctrl.dont_free = 0;
 

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -1816,6 +1816,13 @@ static int dpdk_init_capability(pktio_entry_t *pktio_entry,
 		capa->config.pktout.bit.tcp_chksum;
 	capa->config.pktout.bit.ts_ena = 1;
 
+	if (!_ODP_DPDK_ZERO_COPY) {
+		capa->config.pktout.bit.tx_compl_ena = 1;
+		capa->tx_compl.mode_all = 1;
+		capa->tx_compl.mode_event = 1;
+		capa->tx_compl.mode_poll = 0;
+	}
+
 	/* Copy for fast path access */
 	pkt_dpdk->pktout_capa = capa->config.pktout;
 

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -923,6 +923,10 @@ static int ipc_capability(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_capab
 
 	capa->max_input_queues  = 1;
 	capa->max_output_queues = 1;
+	capa->config.pktout.bit.tx_compl_ena = 1;
+	capa->tx_compl.mode_all = 1;
+	capa->tx_compl.mode_event = 1;
+	capa->tx_compl.mode_poll = 0;
 
 	return 0;
 }

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -674,6 +674,10 @@ static int loopback_init_capability(pktio_entry_t *pktio_entry)
 	capa->config.pktout.bit.udp_chksum = 1;
 	capa->config.pktout.bit.sctp_chksum = 1;
 	capa->config.pktout.bit.ts_ena = 1;
+	capa->config.pktout.bit.tx_compl_ena = 1;
+	capa->tx_compl.mode_all = 1;
+	capa->tx_compl.mode_event = 1;
+	capa->tx_compl.mode_poll = 0;
 
 	if (odp_global_ro.disable.ipsec == 0) {
 		capa->config.inbound_ipsec = 1;

--- a/platform/linux-generic/pktio/null.c
+++ b/platform/linux-generic/pktio/null.c
@@ -139,6 +139,10 @@ static int null_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 	capa->config.pktin.bit.ts_ptp = 1;
 
 	capa->config.pktout.bit.ts_ena = 1;
+	capa->config.pktout.bit.tx_compl_ena = 1;
+	capa->tx_compl.mode_all = 1;
+	capa->tx_compl.mode_event = 1;
+	capa->tx_compl.mode_poll = 0;
 
 	return 0;
 }

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -505,6 +505,10 @@ static int pcapif_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 	capa->config.pktin.bit.ts_ptp = 1;
 
 	capa->config.pktout.bit.ts_ena = 1;
+	capa->config.pktout.bit.tx_compl_ena = 1;
+	capa->tx_compl.mode_all = 1;
+	capa->tx_compl.mode_event = 1;
+	capa->tx_compl.mode_poll = 0;
 
 	capa->stats.pktio.counter.in_octets = 1;
 	capa->stats.pktio.counter.in_packets = 1;

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -587,6 +587,10 @@ static int sock_capability(pktio_entry_t *pktio_entry,
 	capa->config.pktin.bit.ts_ptp = 1;
 
 	capa->config.pktout.bit.ts_ena = 1;
+	capa->config.pktout.bit.tx_compl_ena = 1;
+	capa->tx_compl.mode_all = 1;
+	capa->tx_compl.mode_event = 1;
+	capa->tx_compl.mode_poll = 0;
 
 	/* Fill statistics capabilities */
 	_odp_sock_stats_capa(pktio_entry, capa);

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -891,6 +891,10 @@ static int sock_mmap_capability(pktio_entry_t *pktio_entry,
 	capa->config.pktin.bit.ts_ptp = 1;
 
 	capa->config.pktout.bit.ts_ena = 1;
+	capa->config.pktout.bit.tx_compl_ena = 1;
+	capa->tx_compl.mode_all = 1;
+	capa->tx_compl.mode_event = 1;
+	capa->tx_compl.mode_poll = 0;
 
 	/* Fill statistics capabilities */
 	_odp_sock_stats_capa(pktio_entry, capa);

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -536,6 +536,10 @@ static int tap_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 	capa->config.pktin.bit.ts_ptp = 1;
 
 	capa->config.pktout.bit.ts_ena = 1;
+	capa->config.pktout.bit.tx_compl_ena = 1;
+	capa->tx_compl.mode_all = 1;
+	capa->tx_compl.mode_event = 1;
+	capa->tx_compl.mode_poll = 0;
 
 	return 0;
 }


### PR DESCRIPTION
With zero-copy packet I/O drivers (i.e. DPDK and XDP) packet dispatching happens asynchronously in `odp_pktout_send()` context, meaning that memory areas related to packets are marked to be sent in the underlying machinery during the function execution, but the actual sending might occur after the function has returned. Because of this, current TX completion might signal packet TX completion before actual transmission.

To workaround this, TX completion capability filling is moved to individual drivers and currently not supported by zero-copy DPDK and XDP drivers.

v2:
- Rebased
- Added reviewed-by tags