### PR TITLE
[PATCH v5] helper: add new macros for min/max comparison operations

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -9,7 +9,6 @@
 --ignore=VOLATILE
 --ignore=AVOID_EXTERNS
 --ignore=CONST_STRUCT
---ignore=ARRAY_SIZE
 --ignore=PREFER_KERNEL_TYPES
 --ignore=CONSTANT_COMPARISON
 --ignore=BLOCK_COMMENT_STYLE

--- a/example/generator/odp_generator.c
+++ b/example/generator/odp_generator.c
@@ -35,7 +35,6 @@
 #define APPL_MODE_UDP    0			/**< UDP mode */
 #define APPL_MODE_PING   1			/**< ping mode */
 #define APPL_MODE_RCV    2			/**< receive mode */
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 #define PING_THR_TX 0
 #define PING_THR_RX 1

--- a/example/timer/odp_timer_accuracy.c
+++ b/example/timer/odp_timer_accuracy.c
@@ -21,8 +21,6 @@
 #define MAX_QUEUES 1024
 #define MAX_FILENAME 128
 
-#define ABS(v) ((v) < 0 ? -(v) : (v))
-
 enum mode_e {
 	MODE_ONESHOT = 0,
 	MODE_RESTART_ABS,
@@ -973,7 +971,7 @@ static void print_stat(test_global_t *test_global)
 			timer_ctx_t *t = &test_global->timer_ctx[i];
 			int64_t v = t->first_tmo_diff;
 
-			if (ABS(v) > ABS(max)) {
+			if (ODPH_ABS(v) > ODPH_ABS(max)) {
 				max = v;
 				idx = i;
 			}
@@ -990,7 +988,7 @@ static void print_stat(test_global_t *test_global)
 		timer_ctx_t *t = &test_global->timer_ctx[i];
 		int64_t v = t->nsec_final;
 
-		if (ABS(v) > ABS(max))
+		if (ODPH_ABS(v) > ODPH_ABS(max))
 			max = v;
 	}
 

--- a/example/timer/odp_timer_simple.c
+++ b/example/timer/odp_timer_simple.c
@@ -19,8 +19,6 @@
 
 #include <odp/helper/odph_api.h>
 
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-
 int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 {
 	odp_instance_t instance;
@@ -71,8 +69,8 @@ int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 	}
 
 	odp_timer_pool_param_init(&tparams);
-	tparams.res_ns = MAX(10 * ODP_TIME_MSEC_IN_NS,
-			     timer_capa.highest_res_ns);
+	tparams.res_ns = ODPH_MAX(10 * ODP_TIME_MSEC_IN_NS,
+				  timer_capa.highest_res_ns);
 	tparams.min_tmo = 10 * ODP_TIME_MSEC_IN_NS;
 	tparams.max_tmo = 1 * ODP_TIME_SEC_IN_NS;
 	tparams.num_timers = 1; /* One timer per worker */

--- a/example/timer/odp_timer_test.c
+++ b/example/timer/odp_timer_test.c
@@ -21,7 +21,6 @@
 #define MAX_WORKERS           (ODP_THREAD_COUNT_MAX - 1)
 #define NUM_TMOS              10000         /**< Number of timers */
 #define WAIT_NUM	      10    /**< Max tries to rx last tmo per worker */
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 /** Test arguments */
 typedef struct {
@@ -282,9 +281,7 @@ static int parse_args(int argc, char *argv[], test_args_t *args)
 		return -1;
 
 	args->cpu_count     = 1;
-	args->resolution_us = MAX(10000,
-				  timer_capa.highest_res_ns /
-					ODP_TIME_USEC_IN_NS);
+	args->resolution_us = ODPH_MAX(10000u, timer_capa.highest_res_ns / ODP_TIME_USEC_IN_NS);
 	args->min_us        = 0;
 	args->max_us        = 10000000;
 	args->period_us     = 1000000;

--- a/example/traffic_mgmt/odp_traffic_mgmt.c
+++ b/example/traffic_mgmt/odp_traffic_mgmt.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 
 #define NUM_SVC_CLASSES     4
 #define USERS_PER_SVC_CLASS 2
@@ -38,9 +39,6 @@
 
 #define FALSE  0
 #define TRUE   1
-
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
 #define RANDOM_BUF_LEN  1024
 
@@ -302,7 +300,7 @@ static uint32_t tm_shaper_max_burst;
 static uint64_t
 clamp_rate(uint64_t rate)
 {
-	uint64_t val = MIN(MAX(rate, tm_shaper_min_rate), tm_shaper_max_rate);
+	uint64_t val = ODPH_MIN(ODPH_MAX(rate, tm_shaper_min_rate), tm_shaper_max_rate);
 
 	if (!rate)
 		return 0;
@@ -316,7 +314,7 @@ clamp_rate(uint64_t rate)
 static uint32_t
 clamp_burst(uint32_t burst)
 {
-	uint32_t val = MIN(MAX(burst, tm_shaper_min_burst), tm_shaper_max_burst);
+	uint32_t val = ODPH_MIN(ODPH_MAX(burst, tm_shaper_min_burst), tm_shaper_max_burst);
 
 	if (!burst)
 		return 0;
@@ -765,7 +763,7 @@ static int traffic_generator(uint32_t pkts_to_send)
 		queue_num = random_16() & (TM_QUEUES_PER_CLASS - 1);
 		tm_queue  = queue_num_tbls[svc_class][queue_num];
 		pkt_len   = ((uint32_t)((random_8() & 0x7F) + 2)) * 32;
-		pkt_len   = MIN(pkt_len, 1500);
+		pkt_len   = ODPH_MIN(pkt_len, 1500u);
 		pkt       = make_odp_packet(pkt_len);
 
 		pkt_cnt++;

--- a/helper/Makefile.am
+++ b/helper/Makefile.am
@@ -23,6 +23,7 @@ helperinclude_HEADERS = \
 		  include/odp/helper/igmp.h\
 		  include/odp/helper/ip.h\
 		  include/odp/helper/ipsec.h\
+		  include/odp/helper/macros.h\
 		  include/odp/helper/odph_api.h\
 		  include/odp/helper/odph_cuckootable.h\
 		  include/odp/helper/odph_hashtable.h\

--- a/helper/include/odp/helper/macros.h
+++ b/helper/include/odp/helper/macros.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2023 Nokia
+ */
+
+/**
+ * @file
+ *
+ * Common helper macros
+ */
+
+#ifndef ODPH_MACROS_H_
+#define ODPH_MACROS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup odph_macros ODPH MACROS
+ * Helper macros
+ *
+ * @{
+ */
+
+/**
+ * Return minimum of two numbers
+ */
+#define ODPH_MIN(a, b)				\
+	__extension__ ({			\
+		__typeof__(a) tmp_a = (a);	\
+		__typeof__(b) tmp_b = (b);	\
+		tmp_a < tmp_b ? tmp_a : tmp_b;	\
+	})
+
+/**
+ * Return maximum of two numbers
+ */
+#define ODPH_MAX(a, b)				\
+	__extension__ ({			\
+		__typeof__(a) tmp_a = (a);	\
+		__typeof__(b) tmp_b = (b);	\
+		tmp_a > tmp_b ? tmp_a : tmp_b;	\
+	})
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ODPH_MACROS_H_ */

--- a/helper/include/odp/helper/macros.h
+++ b/helper/include/odp/helper/macros.h
@@ -23,6 +23,11 @@ extern "C" {
  */
 
 /**
+ * Return number of elements in array
+ */
+#define ODPH_ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
+/**
  * Return minimum of two numbers
  */
 #define ODPH_MIN(a, b)				\

--- a/helper/include/odp/helper/macros.h
+++ b/helper/include/odp/helper/macros.h
@@ -48,6 +48,15 @@ extern "C" {
 	})
 
 /**
+ * Return absolute value of signed variable
+ */
+#define ODPH_ABS(v)				\
+	__extension__ ({			\
+		__typeof__(v) tmp_v = (v);	\
+		tmp_v < 0 ? -tmp_v : tmp_v;	\
+	})
+
+/**
  * @}
  */
 

--- a/helper/include/odp/helper/odph_api.h
+++ b/helper/include/odp/helper/odph_api.h
@@ -28,6 +28,7 @@ extern "C" {
 #include <odp/helper/igmp.h>
 #include <odp/helper/ip.h>
 #include <odp/helper/ipsec.h>
+#include <odp/helper/macros.h>
 #include <odp/helper/odph_lineartable.h>
 #include <odp/helper/odph_iplookuptable.h>
 #include <odp/helper/sctp.h>

--- a/helper/test/.gitignore
+++ b/helper/test/.gitignore
@@ -4,6 +4,7 @@ chksum
 cli
 cuckootable
 iplookuptable
+macros
 odpthreads
 parse
 process

--- a/helper/test/Makefile.am
+++ b/helper/test/Makefile.am
@@ -3,10 +3,11 @@ include $(top_srcdir)/test/Makefile.inc
 EXECUTABLES = version \
 	      debug \
 	      chksum \
-              cuckootable \
-              parse\
-              table \
-              iplookuptable
+	      cuckootable \
+	      macros \
+	      parse\
+	      table \
+	      iplookuptable
 
 #These are platform specific extensions that are not portable
 #They are a convenience to app writers who have chosen to
@@ -39,6 +40,7 @@ dist_check_SCRIPTS = odpthreads_as_processes odpthreads_as_pthreads
 
 chksum_SOURCES = chksum.c
 cuckootable_SOURCES = cuckootable.c
+macros_SOURCES = macros.c
 odpthreads_SOURCES = odpthreads.c
 parse_SOURCES = parse.c
 table_SOURCES = table.c

--- a/helper/test/macros.c
+++ b/helper/test/macros.c
@@ -12,6 +12,8 @@ int main(void)
 {
 	int a, b;
 	int ret = 0;
+	int arr_1[1];
+	int arr_10[10];
 
 	printf("Running helper macro tests\n");
 
@@ -35,6 +37,12 @@ int main(void)
 	a = 0;
 	b = 10;
 	if (ODPH_MAX(++a, ++b) != 11)
+		ret++;
+
+	if (ODPH_ARRAY_SIZE(arr_1) != 1)
+		ret++;
+
+	if (ODPH_ARRAY_SIZE(arr_10) != 10)
 		ret++;
 
 	if (!ret)

--- a/helper/test/macros.c
+++ b/helper/test/macros.c
@@ -45,6 +45,23 @@ int main(void)
 	if (ODPH_ARRAY_SIZE(arr_10) != 10)
 		ret++;
 
+	if (ODPH_ABS(-1) != 1)
+		ret++;
+
+	if (ODPH_ABS(1) != 1)
+		ret++;
+
+	if (ODPH_ABS(0) != 0)
+		ret++;
+
+	a = -1;
+	if (ODPH_ABS(a++) != 1)
+		ret++;
+
+	a = -1;
+	if (ODPH_ABS(--a) != 2)
+		ret++;
+
 	if (!ret)
 		printf("All tests passed\n");
 	else

--- a/helper/test/macros.c
+++ b/helper/test/macros.c
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2023 Nokia
+ */
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void)
+{
+	int a, b;
+	int ret = 0;
+
+	printf("Running helper macro tests\n");
+
+	if (ODPH_MIN(0, 10) != 0)
+		ret++;
+
+	if (ODPH_MAX(0, 10) != 10)
+		ret++;
+
+	if (ODPH_MIN(-1, 10) != -1)
+		ret++;
+
+	if (ODPH_MAX(-1, 10) != 10)
+		ret++;
+
+	a = 0;
+	b = 10;
+	if (ODPH_MIN(a--, b--) != 0)
+		ret++;
+
+	a = 0;
+	b = 10;
+	if (ODPH_MAX(++a, ++b) != 11)
+		ret++;
+
+	if (!ret)
+		printf("All tests passed\n");
+	else
+		printf("%d tests failed\n", ret);
+
+	return ret ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/common/mask_common.c
+++ b/test/common/mask_common.c
@@ -5,6 +5,7 @@
  */
 
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 
 #include "odp_cunit_common.h"
 #include "mask_common.h"
@@ -457,7 +458,7 @@ MASK_TESTFUNC(next)
 
 	_odp_mask_from_str(&mask1, TEST_MASK_1_3);
 
-	for (i = 0; i < sizeof(expected) / sizeof(int); i++)
+	for (i = 0; i < ODPH_ARRAY_SIZE(expected); i++)
 		CU_ASSERT(_odp_mask_next(&mask1, i) == expected[i]);
 }
 

--- a/test/performance/odp_atomic_perf.c
+++ b/test/performance/odp_atomic_perf.c
@@ -1354,7 +1354,7 @@ int main(int argc, char **argv)
 	print_info(&test_global->test_options);
 
 	/* Loop all test cases */
-	num_tests = sizeof(test_suite) / sizeof(test_suite[0]);
+	num_tests = ODPH_ARRAY_SIZE(test_suite);
 
 	for (i = 0; i < num_tests; i++) {
 		/* Initialize test variables */

--- a/test/performance/odp_bench_buffer.c
+++ b/test/performance/odp_bench_buffer.c
@@ -658,7 +658,7 @@ int main(int argc, char *argv[])
 
 	bench_suite_init(&gbl_args->suite);
 	gbl_args->suite.bench = test_suite;
-	gbl_args->suite.num_bench = sizeof(test_suite) / sizeof(test_suite[0]);
+	gbl_args->suite.num_bench = ODPH_ARRAY_SIZE(test_suite);
 	gbl_args->suite.indef_idx = gbl_args->appl.bench_idx;
 	gbl_args->suite.rounds = gbl_args->appl.rounds;
 	gbl_args->suite.repeat_count = TEST_REPEAT_COUNT;

--- a/test/performance/odp_bench_misc.c
+++ b/test/performance/odp_bench_misc.c
@@ -800,8 +800,7 @@ static int parse_args(int argc, char *argv[])
 		return -1;
 	}
 
-	if (appl_args->bench_idx < 0 ||
-	    appl_args->bench_idx > (int)(sizeof(test_suite) / sizeof(test_suite[0]))) {
+	if (appl_args->bench_idx < 0 || appl_args->bench_idx > (int)ODPH_ARRAY_SIZE(test_suite)) {
 		ODPH_ERR("Bad bench index %i\n", appl_args->bench_idx);
 		return -1;
 	}
@@ -900,7 +899,7 @@ int main(int argc, char *argv[])
 
 	bench_suite_init(&gbl_args->suite);
 	gbl_args->suite.bench = test_suite;
-	gbl_args->suite.num_bench = sizeof(test_suite) / sizeof(test_suite[0]);
+	gbl_args->suite.num_bench = ODPH_ARRAY_SIZE(test_suite);
 	gbl_args->suite.measure_time = !!gbl_args->appl.time;
 	gbl_args->suite.indef_idx = gbl_args->appl.bench_idx;
 	gbl_args->suite.rounds = gbl_args->appl.rounds;

--- a/test/performance/odp_bench_packet.c
+++ b/test/performance/odp_bench_packet.c
@@ -146,7 +146,7 @@ static int run_benchmarks(void *arg)
 	int i;
 	args_t *args = arg;
 	bench_suite_t *suite = &args->suite;
-	int num_sizes = sizeof(test_packet_len) / sizeof(test_packet_len[0]);
+	int num_sizes = ODPH_ARRAY_SIZE(test_packet_len);
 	double results[num_sizes][suite->num_bench];
 
 	memset(results, 0, sizeof(results));
@@ -1613,7 +1613,7 @@ int main(int argc, char *argv[])
 
 	bench_suite_init(&gbl_args->suite);
 	gbl_args->suite.bench = test_suite;
-	gbl_args->suite.num_bench = sizeof(test_suite) / sizeof(test_suite[0]);
+	gbl_args->suite.num_bench = ODPH_ARRAY_SIZE(test_suite);
 	gbl_args->suite.indef_idx = gbl_args->appl.bench_idx;
 	gbl_args->suite.rounds = gbl_args->appl.rounds;
 	gbl_args->suite.repeat_count = TEST_REPEAT_COUNT;

--- a/test/performance/odp_bench_pktio_sp.c
+++ b/test/performance/odp_bench_pktio_sp.c
@@ -914,7 +914,7 @@ static int check_args(appl_args_t *appl_args)
 		return -1;
 	}
 
-	if (gbl_args->opt.case_idx > sizeof(test_suite) / sizeof(test_suite[0])) {
+	if (gbl_args->opt.case_idx > ODPH_ARRAY_SIZE(test_suite)) {
 		ODPH_ERR("Invalid test case index: %u\n", gbl_args->opt.case_idx);
 		return -1;
 	}
@@ -1069,7 +1069,7 @@ int main(int argc, char *argv[])
 
 	bench_tm_suite_init(&gbl_args->suite);
 	gbl_args->suite.bench = test_suite;
-	gbl_args->suite.num_bench = sizeof(test_suite) / sizeof(test_suite[0]);
+	gbl_args->suite.num_bench = ODPH_ARRAY_SIZE(test_suite);
 	gbl_args->suite.rounds = gbl_args->opt.rounds;
 	gbl_args->suite.bench_idx = gbl_args->opt.case_idx;
 

--- a/test/performance/odp_bench_timer.c
+++ b/test/performance/odp_bench_timer.c
@@ -356,7 +356,7 @@ static int parse_args(int argc, char *argv[])
 	}
 
 	if (gbl_args->opt.bench_idx < 0 ||
-	    gbl_args->opt.bench_idx > (int)(sizeof(test_suite) / sizeof(test_suite[0]))) {
+	    gbl_args->opt.bench_idx > (int)ODPH_ARRAY_SIZE(test_suite)) {
 		ODPH_ERR("Bad bench index %i\n", gbl_args->opt.bench_idx);
 		return -1;
 	}
@@ -645,7 +645,7 @@ int main(int argc, char *argv[])
 
 	bench_suite_init(&gbl_args->suite);
 	gbl_args->suite.bench = test_suite;
-	gbl_args->suite.num_bench = sizeof(test_suite) / sizeof(test_suite[0]);
+	gbl_args->suite.num_bench = ODPH_ARRAY_SIZE(test_suite);
 	gbl_args->suite.measure_time = !!gbl_args->opt.time;
 	gbl_args->suite.indef_idx = gbl_args->opt.bench_idx;
 	gbl_args->suite.rounds = gbl_args->opt.rounds;

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -505,8 +505,7 @@ find_config_by_name(const char *name) {
 	unsigned int i;
 	crypto_alg_config_t *ret = NULL;
 
-	for (i = 0; i < (sizeof(algs_config) / sizeof(crypto_alg_config_t));
-	     i++) {
+	for (i = 0; i < ODPH_ARRAY_SIZE(algs_config); i++) {
 		if (strcmp(algs_config[i].name, name) == 0) {
 			ret = algs_config + i;
 			break;
@@ -523,10 +522,8 @@ static void
 print_config_names(const char *prefix) {
 	unsigned int i;
 
-	for (i = 0; i < (sizeof(algs_config) / sizeof(crypto_alg_config_t));
-	     i++) {
+	for (i = 0; i < ODPH_ARRAY_SIZE(algs_config); i++)
 		printf("%s %s\n", prefix, algs_config[i].name);
-	}
 }
 
 /**
@@ -1287,7 +1284,7 @@ int main(int argc, char *argv[])
 
 	max_seg_len = pool_capa.pkt.max_seg_len;
 
-	for (i = 0; i < sizeof(payloads) / sizeof(unsigned int); i++) {
+	for (i = 0; i < ODPH_ARRAY_SIZE(payloads); i++) {
 		if (payloads[i] + MAX_AUTH_DIGEST_LEN > max_seg_len)
 			break;
 	}
@@ -1371,9 +1368,7 @@ int main(int argc, char *argv[])
 	} else {
 		unsigned int i;
 
-		for (i = 0;
-		     i < (sizeof(algs_config) / sizeof(crypto_alg_config_t));
-		     i++) {
+		for (i = 0; i < ODPH_ARRAY_SIZE(algs_config); i++) {
 			test_run_arg.crypto_alg_config = algs_config + i;
 			run_measure_one_config(&test_run_arg);
 		}

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -413,8 +413,7 @@ find_config_by_name(const char *name)
 	unsigned int i;
 	ipsec_alg_config_t *ret = NULL;
 
-	for (i = 0; i < (sizeof(algs_config) / sizeof(ipsec_alg_config_t));
-	     i++) {
+	for (i = 0; i < ODPH_ARRAY_SIZE(algs_config); i++) {
 		if (strcmp(algs_config[i].name, name) == 0) {
 			ret = algs_config + i;
 			break;
@@ -432,10 +431,8 @@ print_config_names(const char *prefix)
 {
 	unsigned int i;
 
-	for (i = 0; i < (sizeof(algs_config) / sizeof(ipsec_alg_config_t));
-	     i++) {
+	for (i = 0; i < ODPH_ARRAY_SIZE(algs_config); i++)
 		printf("%s %s\n", prefix, algs_config[i].name);
-	}
 }
 
 /**
@@ -1223,7 +1220,7 @@ int main(int argc, char *argv[])
 
 	max_seg_len = capa.pkt.max_seg_len;
 
-	for (i = 0; i < sizeof(global_payloads) / sizeof(unsigned int); i++) {
+	for (i = 0; i < ODPH_ARRAY_SIZE(global_payloads); i++) {
 		if (global_payloads[i] > max_seg_len)
 			break;
 	}
@@ -1380,9 +1377,7 @@ int main(int argc, char *argv[])
 	} else {
 		unsigned int i;
 
-		for (i = 0;
-		     i < (sizeof(algs_config) / sizeof(ipsec_alg_config_t));
-		     i++) {
+		for (i = 0; i < ODPH_ARRAY_SIZE(algs_config); i++) {
 			if (cargs.ah &&
 			    algs_config[i].crypto.cipher_alg !=
 			    ODP_CIPHER_ALG_NULL)

--- a/test/performance/odp_ipsecfwd.c
+++ b/test/performance/odp_ipsecfwd.c
@@ -249,7 +249,7 @@ static void parse_interfaces(prog_config_t *config, const char *optarg)
 static void print_supported_algos(const odp_ipsec_capability_t *ipsec_capa)
 {
 	int c_cnt, a_cnt;
-	const size_t len = sizeof(exposed_algs) / sizeof(exposed_algs[0]);
+	const size_t len = ODPH_ARRAY_SIZE(exposed_algs);
 
 	printf("                          Cipher algorithms:\n");
 

--- a/test/performance/odp_ipsecfwd.c
+++ b/test/performance/odp_ipsecfwd.c
@@ -22,8 +22,6 @@
 #define SHORT_PROG_NAME "ipsfwd"
 #define DELIMITER ","
 
-#define MIN(a, b)  (((a) <= (b)) ? (a) : (b))
-
 #define MAX_IFS 2U
 #define MAX_SAS 4000U
 #define MAX_FWDS 64U
@@ -416,8 +414,9 @@ static void print_usage(void)
 	       "                      options are ignored, input and output queue counts will\n"
 	       "                      match worker count.\n"
 	       "  -h, --help          This help.\n"
-	       "\n", pool_capa.pkt.max_num > 0U ? MIN(pool_capa.pkt.max_num, PKT_CNT) : PKT_CNT,
-	       pool_capa.pkt.max_len > 0U ? MIN(pool_capa.pkt.max_len, PKT_SIZE) : PKT_SIZE);
+	       "\n", pool_capa.pkt.max_num > 0U ? ODPH_MIN(pool_capa.pkt.max_num, PKT_CNT) :
+	       PKT_CNT, pool_capa.pkt.max_len > 0U ? ODPH_MIN(pool_capa.pkt.max_len, PKT_SIZE) :
+	       PKT_SIZE);
 }
 
 static inline odp_ipsec_sa_t *get_in_sa(odp_packet_t pkt)
@@ -965,7 +964,7 @@ static odp_bool_t create_sa_dest_queues(odp_ipsec_capability_t *ipsec_capa,
 					prog_config_t *config)
 {
 	odp_queue_param_t q_param;
-	const uint32_t max_sa_qs = MIN(MAX_SA_QUEUES, ipsec_capa->max_queues);
+	const uint32_t max_sa_qs = ODPH_MIN(MAX_SA_QUEUES, ipsec_capa->max_queues);
 
 	if (config->num_sa_qs == 0U || config->num_sa_qs > max_sa_qs) {
 		ODPH_ERR("Invalid number of SA queues: %u (min: 1, max: %u)\n", config->num_sa_qs,
@@ -1276,7 +1275,7 @@ static void parse_sas(config_t *cfg, prog_config_t *config)
 	if (!config->is_dir_rx && !create_sa_dest_queues(&ipsec_capa, config))
 		return;
 
-	max_num_sa = MIN(MAX_SAS, ipsec_capa.max_num_sa);
+	max_num_sa = ODPH_MIN(MAX_SAS, ipsec_capa.max_num_sa);
 	parse_and_create_sa_entries(cfg, config, max_num_sa);
 }
 
@@ -1400,7 +1399,7 @@ static parse_result_t check_options(prog_config_t *config)
 
 	if (config->num_pkts == 0U)
 		config->num_pkts = pool_capa.pkt.max_num > 0U ?
-					MIN(pool_capa.pkt.max_num, PKT_CNT) : PKT_CNT;
+					ODPH_MIN(pool_capa.pkt.max_num, PKT_CNT) : PKT_CNT;
 
 	if (pool_capa.pkt.max_len > 0U && config->pkt_len > pool_capa.pkt.max_len) {
 		ODPH_ERR("Invalid pool packet length: %u (max: %u)\n", config->pkt_len,
@@ -1410,7 +1409,7 @@ static parse_result_t check_options(prog_config_t *config)
 
 	if (config->pkt_len == 0U)
 		config->pkt_len = pool_capa.pkt.max_len > 0U ?
-					MIN(pool_capa.pkt.max_len, PKT_SIZE) : PKT_SIZE;
+					ODPH_MIN(pool_capa.pkt.max_len, PKT_SIZE) : PKT_SIZE;
 
 	if (config->num_thrs <= 0 || config->num_thrs > MAX_WORKERS) {
 		ODPH_ERR("Invalid thread count: %d (min: 1, max: %d)\n", config->num_thrs,
@@ -1620,7 +1619,7 @@ static odp_bool_t setup_pktios(prog_config_t *config)
 			return false;
 		}
 
-		max_output_qs = MIN(MAX_QUEUES, capa.max_output_queues);
+		max_output_qs = ODPH_MIN(MAX_QUEUES, capa.max_output_queues);
 
 		if (config->num_output_qs == 0U || config->num_output_qs > max_output_qs) {
 			ODPH_ERR("Invalid number of output queues for packet I/O: %u (min: 1, "

--- a/test/performance/odp_lock_perf.c
+++ b/test/performance/odp_lock_perf.c
@@ -634,7 +634,7 @@ int main(int argc, char **argv)
 	print_info(&test_global->test_options);
 
 	/* Loop all test cases */
-	num_tests = sizeof(test_suite) / sizeof(test_suite[0]);
+	num_tests = ODPH_ARRAY_SIZE(test_suite);
 
 	while (1) {
 		for (i = 0; i < num_tests; i++) {

--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -25,9 +25,6 @@
 
 #define UNUSED			__attribute__((__unused__))
 
-#define min(a, b) (a < b ? a : b)
-#define max(a, b) (a > b ? a : b)
-
 typedef __volatile uint32_t volatile_u32_t;
 typedef __volatile uint64_t volatile_u64_t;
 
@@ -929,7 +926,7 @@ static void test_atomic_validate_max_min(void)
 	 * a long test, counter may overflow, in which case max is saturated at
 	 * UINT32_MAX, and min at 0.
 	 */
-	const uint32_t a32u_max = min(U32_INIT_VAL + total_count - 1, UINT32_MAX);
+	const uint32_t a32u_max = ODPH_MIN(U32_INIT_VAL + total_count - 1, UINT32_MAX);
 	const uint32_t a32u_min = U32_INIT_VAL + total_count - 1 > UINT32_MAX ? 0 : U32_INIT_VAL;
 
 	CU_ASSERT(odp_atomic_load_u32(&global_mem->a32u_max) == a32u_max);
@@ -1546,7 +1543,7 @@ static void test_atomic_validate_max(void)
 {
 	const uint64_t total_count = CNT * global_mem->g_num_threads - 1;
 	/* In a long test, counter may overflow, in which case max is saturated at UINT32_MAX. */
-	const uint32_t a32u_max = min(U32_INIT_VAL + total_count, UINT32_MAX);
+	const uint32_t a32u_max = ODPH_MIN(U32_INIT_VAL + total_count, UINT32_MAX);
 
 	CU_ASSERT(a32u_max == odp_atomic_load_u32(&global_mem->a32u_max));
 	CU_ASSERT(U64_INIT_VAL + total_count == odp_atomic_load_u64(&global_mem->a64u_max));
@@ -1561,7 +1558,7 @@ static void test_atomic_validate_min(void)
 {
 	const uint64_t total_count = CNT * global_mem->g_num_threads - 1;
 	/* In a long test, counter may underflow, in which case min is saturated at 0. */
-	const uint32_t a32u_min = max((int64_t)U32_INIT_VAL - (int64_t)total_count, 0);
+	const uint32_t a32u_min = ODPH_MAX((int64_t)U32_INIT_VAL - (int64_t)total_count, 0);
 
 	CU_ASSERT(a32u_min == odp_atomic_load_u32(&global_mem->a32u_min));
 	CU_ASSERT(U64_INIT_VAL - total_count == odp_atomic_load_u64(&global_mem->a64u_min));

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -129,7 +129,7 @@ static void alg_test_op2(crypto_op_test_param_t *param)
 {
 	int32_t oop_shifts[] = {0, 3, 130, -10};
 
-	for (uint32_t n = 0; n < ARRAY_SIZE(oop_shifts); n++) {
+	for (uint32_t n = 0; n < ODPH_ARRAY_SIZE(oop_shifts); n++) {
 		if (oop_shifts[n] != 0 &&
 		    param->op_type != ODP_CRYPTO_OP_TYPE_OOP)
 			continue;
@@ -388,7 +388,7 @@ static void alg_test_op_types(odp_crypto_op_t op,
 		ODP_CRYPTO_OP_TYPE_BASIC_AND_OOP,
 	};
 
-	for (unsigned int n = 0; n < ARRAY_SIZE(op_types); n++) {
+	for (unsigned int n = 0; n < ODPH_ARRAY_SIZE(op_types); n++) {
 		for (unsigned int null_crypto = 0 ; null_crypto <= 1; null_crypto++)
 			alg_test_ses(op,
 				     op_types[n],
@@ -807,7 +807,7 @@ static odp_auth_alg_t auth_algs[] = {
 
 static void test_auth_hashes_in_auth_range(void)
 {
-	for (size_t n = 0; n < ARRAY_SIZE(auth_algs); n++) {
+	for (size_t n = 0; n < ODPH_ARRAY_SIZE(auth_algs); n++) {
 		odp_auth_alg_t auth = auth_algs[n];
 		odp_crypto_cipher_capability_t c_capa;
 		int num;
@@ -1359,8 +1359,8 @@ static void test_all_combinations(void)
 	}
 
 	printf("\n");
-	for (size_t n = 0; n < ARRAY_SIZE(cipher_algs); n++)
-		for (size_t i = 0; i < ARRAY_SIZE(auth_algs); i++)
+	for (size_t n = 0; n < ODPH_ARRAY_SIZE(cipher_algs); n++)
+		for (size_t i = 0; i < ODPH_ARRAY_SIZE(auth_algs); i++)
 			test_combo_variants(cipher_algs[n], auth_algs[i]);
 }
 
@@ -1373,14 +1373,14 @@ static void crypto_test_enc_alg_null(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  null_reference,
-		  ARRAY_SIZE(null_reference));
+		  ODPH_ARRAY_SIZE(null_reference));
 }
 
 static void crypto_test_dec_alg_null(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  null_reference,
-		  ARRAY_SIZE(null_reference));
+		  ODPH_ARRAY_SIZE(null_reference));
 }
 
 static int check_alg_3des_cbc(void)
@@ -1392,14 +1392,14 @@ static void crypto_test_enc_alg_3des_cbc(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  tdes_cbc_reference,
-		  ARRAY_SIZE(tdes_cbc_reference));
+		  ODPH_ARRAY_SIZE(tdes_cbc_reference));
 }
 
 static void crypto_test_dec_alg_3des_cbc(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  tdes_cbc_reference,
-		  ARRAY_SIZE(tdes_cbc_reference));
+		  ODPH_ARRAY_SIZE(tdes_cbc_reference));
 }
 
 static int check_alg_3des_ecb(void)
@@ -1411,14 +1411,14 @@ static void crypto_test_enc_alg_3des_ecb(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  tdes_ecb_reference,
-		  ARRAY_SIZE(tdes_ecb_reference));
+		  ODPH_ARRAY_SIZE(tdes_ecb_reference));
 }
 
 static void crypto_test_dec_alg_3des_ecb(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  tdes_ecb_reference,
-		  ARRAY_SIZE(tdes_ecb_reference));
+		  ODPH_ARRAY_SIZE(tdes_ecb_reference));
 }
 
 static int check_alg_chacha20_poly1305(void)
@@ -1431,14 +1431,14 @@ static void crypto_test_enc_alg_chacha20_poly1305(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  chacha20_poly1305_reference,
-		  ARRAY_SIZE(chacha20_poly1305_reference));
+		  ODPH_ARRAY_SIZE(chacha20_poly1305_reference));
 }
 
 static void crypto_test_dec_alg_chacha20_poly1305(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  chacha20_poly1305_reference,
-		  ARRAY_SIZE(chacha20_poly1305_reference));
+		  ODPH_ARRAY_SIZE(chacha20_poly1305_reference));
 }
 
 static int check_alg_aes_gcm(void)
@@ -1450,14 +1450,14 @@ static void crypto_test_enc_alg_aes_gcm(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  aes_gcm_reference,
-		  ARRAY_SIZE(aes_gcm_reference));
+		  ODPH_ARRAY_SIZE(aes_gcm_reference));
 }
 
 static void crypto_test_dec_alg_aes_gcm(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  aes_gcm_reference,
-		  ARRAY_SIZE(aes_gcm_reference));
+		  ODPH_ARRAY_SIZE(aes_gcm_reference));
 }
 
 static int check_alg_aes_ccm(void)
@@ -1469,14 +1469,14 @@ static void crypto_test_enc_alg_aes_ccm(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  aes_ccm_reference,
-		  ARRAY_SIZE(aes_ccm_reference));
+		  ODPH_ARRAY_SIZE(aes_ccm_reference));
 }
 
 static void crypto_test_dec_alg_aes_ccm(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  aes_ccm_reference,
-		  ARRAY_SIZE(aes_ccm_reference));
+		  ODPH_ARRAY_SIZE(aes_ccm_reference));
 }
 
 static int check_alg_aes_cbc(void)
@@ -1488,14 +1488,14 @@ static void crypto_test_enc_alg_aes_cbc(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  aes_cbc_reference,
-		  ARRAY_SIZE(aes_cbc_reference));
+		  ODPH_ARRAY_SIZE(aes_cbc_reference));
 }
 
 static void crypto_test_dec_alg_aes_cbc(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  aes_cbc_reference,
-		  ARRAY_SIZE(aes_cbc_reference));
+		  ODPH_ARRAY_SIZE(aes_cbc_reference));
 }
 
 static int check_alg_aes_ctr(void)
@@ -1507,14 +1507,14 @@ static void crypto_test_enc_alg_aes_ctr(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  aes_ctr_reference,
-		  ARRAY_SIZE(aes_ctr_reference));
+		  ODPH_ARRAY_SIZE(aes_ctr_reference));
 }
 
 static void crypto_test_dec_alg_aes_ctr(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  aes_ctr_reference,
-		  ARRAY_SIZE(aes_ctr_reference));
+		  ODPH_ARRAY_SIZE(aes_ctr_reference));
 }
 
 static int check_alg_aes_ecb(void)
@@ -1526,14 +1526,14 @@ static void crypto_test_enc_alg_aes_ecb(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  aes_ecb_reference,
-		  ARRAY_SIZE(aes_ecb_reference));
+		  ODPH_ARRAY_SIZE(aes_ecb_reference));
 }
 
 static void crypto_test_dec_alg_aes_ecb(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  aes_ecb_reference,
-		  ARRAY_SIZE(aes_ecb_reference));
+		  ODPH_ARRAY_SIZE(aes_ecb_reference));
 }
 
 static int check_alg_aes_cfb128(void)
@@ -1545,14 +1545,14 @@ static void crypto_test_enc_alg_aes_cfb128(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  aes_cfb128_reference,
-		  ARRAY_SIZE(aes_cfb128_reference));
+		  ODPH_ARRAY_SIZE(aes_cfb128_reference));
 }
 
 static void crypto_test_dec_alg_aes_cfb128(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  aes_cfb128_reference,
-		  ARRAY_SIZE(aes_cfb128_reference));
+		  ODPH_ARRAY_SIZE(aes_cfb128_reference));
 }
 
 static int check_alg_aes_xts(void)
@@ -1564,14 +1564,14 @@ static void crypto_test_enc_alg_aes_xts(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  aes_xts_reference,
-		  ARRAY_SIZE(aes_xts_reference));
+		  ODPH_ARRAY_SIZE(aes_xts_reference));
 }
 
 static void crypto_test_dec_alg_aes_xts(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  aes_xts_reference,
-		  ARRAY_SIZE(aes_xts_reference));
+		  ODPH_ARRAY_SIZE(aes_xts_reference));
 }
 
 static int check_alg_kasumi_f8(void)
@@ -1583,14 +1583,14 @@ static void crypto_test_enc_alg_kasumi_f8(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  kasumi_f8_reference,
-		  ARRAY_SIZE(kasumi_f8_reference));
+		  ODPH_ARRAY_SIZE(kasumi_f8_reference));
 }
 
 static void crypto_test_dec_alg_kasumi_f8(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  kasumi_f8_reference,
-		  ARRAY_SIZE(kasumi_f8_reference));
+		  ODPH_ARRAY_SIZE(kasumi_f8_reference));
 }
 
 static int check_alg_snow3g_uea2(void)
@@ -1602,14 +1602,14 @@ static void crypto_test_enc_alg_snow3g_uea2(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  snow3g_uea2_reference,
-		  ARRAY_SIZE(snow3g_uea2_reference));
+		  ODPH_ARRAY_SIZE(snow3g_uea2_reference));
 }
 
 static void crypto_test_dec_alg_snow3g_uea2(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  snow3g_uea2_reference,
-		  ARRAY_SIZE(snow3g_uea2_reference));
+		  ODPH_ARRAY_SIZE(snow3g_uea2_reference));
 }
 
 static int check_alg_aes_eea2(void)
@@ -1622,14 +1622,14 @@ static void crypto_test_enc_alg_aes_eea2(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  aes_eea2_reference,
-		  ARRAY_SIZE(aes_eea2_reference));
+		  ODPH_ARRAY_SIZE(aes_eea2_reference));
 }
 
 static void crypto_test_dec_alg_aes_eea2(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  aes_eea2_reference,
-		  ARRAY_SIZE(aes_eea2_reference));
+		  ODPH_ARRAY_SIZE(aes_eea2_reference));
 }
 
 static int check_alg_zuc_eea3(void)
@@ -1641,14 +1641,14 @@ static void crypto_test_enc_alg_zuc_eea3(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  zuc_eea3_reference,
-		  ARRAY_SIZE(zuc_eea3_reference));
+		  ODPH_ARRAY_SIZE(zuc_eea3_reference));
 }
 
 static void crypto_test_dec_alg_zuc_eea3(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  zuc_eea3_reference,
-		  ARRAY_SIZE(zuc_eea3_reference));
+		  ODPH_ARRAY_SIZE(zuc_eea3_reference));
 }
 
 static int check_alg_hmac_md5(void)
@@ -1660,14 +1660,14 @@ static void crypto_test_gen_alg_hmac_md5(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  hmac_md5_reference,
-		  ARRAY_SIZE(hmac_md5_reference));
+		  ODPH_ARRAY_SIZE(hmac_md5_reference));
 }
 
 static void crypto_test_check_alg_hmac_md5(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  hmac_md5_reference,
-		  ARRAY_SIZE(hmac_md5_reference));
+		  ODPH_ARRAY_SIZE(hmac_md5_reference));
 }
 
 static int check_alg_hmac_sha1(void)
@@ -1679,14 +1679,14 @@ static void crypto_test_gen_alg_hmac_sha1(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  hmac_sha1_reference,
-		  ARRAY_SIZE(hmac_sha1_reference));
+		  ODPH_ARRAY_SIZE(hmac_sha1_reference));
 }
 
 static void crypto_test_check_alg_hmac_sha1(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  hmac_sha1_reference,
-		  ARRAY_SIZE(hmac_sha1_reference));
+		  ODPH_ARRAY_SIZE(hmac_sha1_reference));
 }
 
 static int check_alg_hmac_sha224(void)
@@ -1698,14 +1698,14 @@ static void crypto_test_gen_alg_hmac_sha224(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  hmac_sha224_reference,
-		  ARRAY_SIZE(hmac_sha224_reference));
+		  ODPH_ARRAY_SIZE(hmac_sha224_reference));
 }
 
 static void crypto_test_check_alg_hmac_sha224(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  hmac_sha224_reference,
-		  ARRAY_SIZE(hmac_sha224_reference));
+		  ODPH_ARRAY_SIZE(hmac_sha224_reference));
 }
 
 static int check_alg_hmac_sha256(void)
@@ -1717,14 +1717,14 @@ static void crypto_test_gen_alg_hmac_sha256(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  hmac_sha256_reference,
-		  ARRAY_SIZE(hmac_sha256_reference));
+		  ODPH_ARRAY_SIZE(hmac_sha256_reference));
 }
 
 static void crypto_test_check_alg_hmac_sha256(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  hmac_sha256_reference,
-		  ARRAY_SIZE(hmac_sha256_reference));
+		  ODPH_ARRAY_SIZE(hmac_sha256_reference));
 }
 
 static int check_alg_hmac_sha384(void)
@@ -1736,14 +1736,14 @@ static void crypto_test_gen_alg_hmac_sha384(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  hmac_sha384_reference,
-		  ARRAY_SIZE(hmac_sha384_reference));
+		  ODPH_ARRAY_SIZE(hmac_sha384_reference));
 }
 
 static void crypto_test_check_alg_hmac_sha384(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  hmac_sha384_reference,
-		  ARRAY_SIZE(hmac_sha384_reference));
+		  ODPH_ARRAY_SIZE(hmac_sha384_reference));
 }
 
 static int check_alg_hmac_sha512(void)
@@ -1755,14 +1755,14 @@ static void crypto_test_gen_alg_hmac_sha512(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  hmac_sha512_reference,
-		  ARRAY_SIZE(hmac_sha512_reference));
+		  ODPH_ARRAY_SIZE(hmac_sha512_reference));
 }
 
 static void crypto_test_check_alg_hmac_sha512(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  hmac_sha512_reference,
-		  ARRAY_SIZE(hmac_sha512_reference));
+		  ODPH_ARRAY_SIZE(hmac_sha512_reference));
 }
 
 static int check_alg_aes_xcbc(void)
@@ -1775,14 +1775,14 @@ static void crypto_test_gen_alg_aes_xcbc(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  aes_xcbc_reference,
-		  ARRAY_SIZE(aes_xcbc_reference));
+		  ODPH_ARRAY_SIZE(aes_xcbc_reference));
 }
 
 static void crypto_test_check_alg_aes_xcbc(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  aes_xcbc_reference,
-		  ARRAY_SIZE(aes_xcbc_reference));
+		  ODPH_ARRAY_SIZE(aes_xcbc_reference));
 }
 
 static int check_alg_aes_gmac(void)
@@ -1794,14 +1794,14 @@ static void crypto_test_gen_alg_aes_gmac(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  aes_gmac_reference,
-		  ARRAY_SIZE(aes_gmac_reference));
+		  ODPH_ARRAY_SIZE(aes_gmac_reference));
 }
 
 static void crypto_test_check_alg_aes_gmac(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  aes_gmac_reference,
-		  ARRAY_SIZE(aes_gmac_reference));
+		  ODPH_ARRAY_SIZE(aes_gmac_reference));
 }
 
 static int check_alg_aes_cmac(void)
@@ -1813,14 +1813,14 @@ static void crypto_test_gen_alg_aes_cmac(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  aes_cmac_reference,
-		  ARRAY_SIZE(aes_cmac_reference));
+		  ODPH_ARRAY_SIZE(aes_cmac_reference));
 }
 
 static void crypto_test_check_alg_aes_cmac(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  aes_cmac_reference,
-		  ARRAY_SIZE(aes_cmac_reference));
+		  ODPH_ARRAY_SIZE(aes_cmac_reference));
 }
 
 static int check_alg_kasumi_f9(void)
@@ -1832,14 +1832,14 @@ static void crypto_test_gen_alg_kasumi_f9(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  kasumi_f9_reference,
-		  ARRAY_SIZE(kasumi_f9_reference));
+		  ODPH_ARRAY_SIZE(kasumi_f9_reference));
 }
 
 static void crypto_test_check_alg_kasumi_f9(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  kasumi_f9_reference,
-		  ARRAY_SIZE(kasumi_f9_reference));
+		  ODPH_ARRAY_SIZE(kasumi_f9_reference));
 }
 
 static int check_alg_snow3g_uia2(void)
@@ -1851,14 +1851,14 @@ static void crypto_test_gen_alg_snow3g_uia2(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  snow3g_uia2_reference,
-		  ARRAY_SIZE(snow3g_uia2_reference));
+		  ODPH_ARRAY_SIZE(snow3g_uia2_reference));
 }
 
 static void crypto_test_check_alg_snow3g_uia2(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  snow3g_uia2_reference,
-		  ARRAY_SIZE(snow3g_uia2_reference));
+		  ODPH_ARRAY_SIZE(snow3g_uia2_reference));
 }
 
 static int check_alg_aes_eia2(void)
@@ -1871,14 +1871,14 @@ static void crypto_test_gen_alg_aes_eia2(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  aes_eia2_reference,
-		  ARRAY_SIZE(aes_eia2_reference));
+		  ODPH_ARRAY_SIZE(aes_eia2_reference));
 }
 
 static void crypto_test_check_alg_aes_eia2(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  aes_eia2_reference,
-		  ARRAY_SIZE(aes_eia2_reference));
+		  ODPH_ARRAY_SIZE(aes_eia2_reference));
 }
 
 static int check_alg_zuc_eia3(void)
@@ -1890,14 +1890,14 @@ static void crypto_test_gen_alg_zuc_eia3(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  zuc_eia3_reference,
-		  ARRAY_SIZE(zuc_eia3_reference));
+		  ODPH_ARRAY_SIZE(zuc_eia3_reference));
 }
 
 static void crypto_test_check_alg_zuc_eia3(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  zuc_eia3_reference,
-		  ARRAY_SIZE(zuc_eia3_reference));
+		  ODPH_ARRAY_SIZE(zuc_eia3_reference));
 }
 
 static int check_alg_md5(void)
@@ -1909,14 +1909,14 @@ static void crypto_test_gen_alg_md5(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  md5_reference,
-		  ARRAY_SIZE(md5_reference));
+		  ODPH_ARRAY_SIZE(md5_reference));
 }
 
 static void crypto_test_check_alg_md5(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  md5_reference,
-		  ARRAY_SIZE(md5_reference));
+		  ODPH_ARRAY_SIZE(md5_reference));
 }
 
 static int check_alg_sha1(void)
@@ -1928,14 +1928,14 @@ static void crypto_test_gen_alg_sha1(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  sha1_reference,
-		  ARRAY_SIZE(sha1_reference));
+		  ODPH_ARRAY_SIZE(sha1_reference));
 }
 
 static void crypto_test_check_alg_sha1(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  sha1_reference,
-		  ARRAY_SIZE(sha1_reference));
+		  ODPH_ARRAY_SIZE(sha1_reference));
 }
 
 static int check_alg_sha224(void)
@@ -1947,14 +1947,14 @@ static void crypto_test_gen_alg_sha224(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  sha224_reference,
-		  ARRAY_SIZE(sha224_reference));
+		  ODPH_ARRAY_SIZE(sha224_reference));
 }
 
 static void crypto_test_check_alg_sha224(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  sha224_reference,
-		  ARRAY_SIZE(sha224_reference));
+		  ODPH_ARRAY_SIZE(sha224_reference));
 }
 
 static int check_alg_sha256(void)
@@ -1966,14 +1966,14 @@ static void crypto_test_gen_alg_sha256(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  sha256_reference,
-		  ARRAY_SIZE(sha256_reference));
+		  ODPH_ARRAY_SIZE(sha256_reference));
 }
 
 static void crypto_test_check_alg_sha256(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  sha256_reference,
-		  ARRAY_SIZE(sha256_reference));
+		  ODPH_ARRAY_SIZE(sha256_reference));
 }
 
 static int check_alg_sha384(void)
@@ -1985,14 +1985,14 @@ static void crypto_test_gen_alg_sha384(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  sha384_reference,
-		  ARRAY_SIZE(sha384_reference));
+		  ODPH_ARRAY_SIZE(sha384_reference));
 }
 
 static void crypto_test_check_alg_sha384(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  sha384_reference,
-		  ARRAY_SIZE(sha384_reference));
+		  ODPH_ARRAY_SIZE(sha384_reference));
 }
 
 static int check_alg_sha512(void)
@@ -2004,14 +2004,14 @@ static void crypto_test_gen_alg_sha512(void)
 {
 	check_alg(ODP_CRYPTO_OP_ENCODE,
 		  sha512_reference,
-		  ARRAY_SIZE(sha512_reference));
+		  ODPH_ARRAY_SIZE(sha512_reference));
 }
 
 static void crypto_test_check_alg_sha512(void)
 {
 	check_alg(ODP_CRYPTO_OP_DECODE,
 		  sha512_reference,
-		  ARRAY_SIZE(sha512_reference));
+		  ODPH_ARRAY_SIZE(sha512_reference));
 }
 
 static odp_queue_t sched_compl_queue_create(void)

--- a/test/validation/api/crypto/util.h
+++ b/test/validation/api/crypto/util.h
@@ -12,8 +12,6 @@
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
-
 struct suite_context_s {
 	odp_crypto_op_mode_t op_mode;
 	odp_pool_t pool;

--- a/test/validation/api/dma/dma.c
+++ b/test/validation/api/dma/dma.c
@@ -19,10 +19,8 @@
 #define MULTI        1
 #define RESULT       1
 #define USER_DATA    0xdeadbeef
-#define ELEM_NUM     10
+#define ELEM_NUM     10u
 #define UAREA        0xaa
-
-#define MIN(a, b) (a < b ? a : b)
 
 typedef struct global_t {
 	odp_dma_capability_t dma_capa;
@@ -105,7 +103,7 @@ static int dma_suite_init(void)
 	if (pkt_len == 0)
 		pkt_len = 4000;
 
-	pkt_len = MIN(pkt_len, global.dma_capa.max_seg_len);
+	pkt_len = ODPH_MIN(pkt_len, global.dma_capa.max_seg_len);
 	odp_pool_param_init(&pool_param);
 	pool_param.type = ODP_POOL_PACKET;
 	pool_param.pkt.num = global.dma_capa.max_src_segs + global.dma_capa.max_dst_segs;
@@ -426,7 +424,7 @@ static void test_dma_compl_pool_max_pools(void)
 static void test_dma_compl_user_area(void)
 {
 	odp_dma_pool_param_t dma_pool_param;
-	uint32_t num = MIN(ELEM_NUM, global.dma_capa.pool.max_num),
+	uint32_t num = ODPH_MIN(ELEM_NUM, global.dma_capa.pool.max_num),
 	size = global.dma_capa.pool.max_uarea_size, i;
 	odp_pool_t pool;
 	odp_dma_compl_t compl_evs[num];
@@ -482,7 +480,7 @@ static void init_event_uarea(void *uarea, uint32_t size, void *args, uint32_t in
 static void test_dma_compl_user_area_init(void)
 {
 	odp_dma_pool_param_t dma_pool_param;
-	uint32_t num = MIN(ELEM_NUM, global.dma_capa.pool.max_num), i;
+	uint32_t num = ODPH_MIN(ELEM_NUM, global.dma_capa.pool.max_num), i;
 	odp_pool_t pool;
 	uarea_init_t data;
 	odp_dma_compl_t compl_evs[num];
@@ -721,7 +719,7 @@ static void test_dma_addr_to_addr(odp_dma_compl_mode_t compl_mode_mask, uint32_t
 	uint32_t i, cur_len;
 	uint8_t *src = global.src_addr + OFFSET;
 	uint8_t *dst = global.dst_addr + OFFSET;
-	uint32_t seg_len = MIN(global.len / num, global.dma_capa.max_seg_len);
+	uint32_t seg_len = ODPH_MIN(global.len / num, global.dma_capa.max_seg_len);
 	uint32_t len = seg_len * num;
 	uint32_t offset = 0;
 
@@ -781,7 +779,7 @@ static void test_dma_addr_to_addr_trs(odp_dma_compl_mode_t compl_mode_mask, uint
 	odp_dma_compl_mode_t compl_mode;
 	uint8_t *src = global.src_addr + OFFSET;
 	uint8_t *dst = global.dst_addr + OFFSET;
-	uint32_t trs_len = MIN(global.len / num_trs, global.dma_capa.max_seg_len);
+	uint32_t trs_len = ODPH_MIN(global.len / num_trs, global.dma_capa.max_seg_len);
 	uint32_t len = trs_len * num_trs;
 	uint32_t offset = 0;
 	int ret = -1;
@@ -852,7 +850,7 @@ static void test_dma_addr_to_addr_max_trs(odp_dma_compl_mode_t compl_mode_mask)
 	uint32_t i, cur_len;
 	uint8_t *src = global.src_addr + OFFSET;
 	uint8_t *dst = global.dst_addr + OFFSET;
-	uint32_t seg_len = MIN(global.len / num_trs, global.dma_capa.max_seg_len);
+	uint32_t seg_len = ODPH_MIN(global.len / num_trs, global.dma_capa.max_seg_len);
 	uint32_t len = seg_len * num_trs;
 	uint32_t offset = 0;
 
@@ -1315,9 +1313,9 @@ static void test_dma_addr_to_addr_sync_res(void)
 
 static void get_seg_lens(uint32_t max_len, uint32_t *src, uint32_t *dst)
 {
-	uint32_t src_segs = *src, dst_segs = *dst, denom = MIN(src_segs, dst_segs);
+	uint32_t src_segs = *src, dst_segs = *dst, denom = ODPH_MIN(src_segs, dst_segs);
 
-	max_len = MIN(max_len / denom, global.dma_capa.max_seg_len) * denom;
+	max_len = ODPH_MIN(max_len / denom, global.dma_capa.max_seg_len) * denom;
 	*src = max_len / src_segs;
 	*dst = *src * src_segs / dst_segs + *src * src_segs % dst_segs;
 }
@@ -1358,7 +1356,7 @@ static void test_dma_addr_to_addr_sync_max_seg(void)
 
 		memset(&dst_seg[i], 0, sizeof(odp_dma_seg_t));
 		dst_seg[i].addr = addr;
-		dst_seg[i].len = MIN(len, dst_len);
+		dst_seg[i].len = ODPH_MIN(len, dst_len);
 		len -= dst_len;
 	}
 
@@ -1441,7 +1439,7 @@ static void test_dma_pkt_to_pkt_sync_max_seg(void)
 		memset(odp_packet_data(pkt), 0, dst_len);
 		memset(&dst_seg[i], 0, sizeof(odp_dma_seg_t));
 		dst_seg[i].packet = pkt;
-		dst_seg[i].len = MIN(len, dst_len);
+		dst_seg[i].len = ODPH_MIN(len, dst_len);
 		len -= dst_len;
 	}
 

--- a/test/validation/api/hash/hash.c
+++ b/test/validation/api/hash/hash.c
@@ -6,6 +6,8 @@
  */
 
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
 #include <odp_cunit_common.h>
 #include <test_packet_ipv4_with_crc.h>
 
@@ -216,7 +218,7 @@ static void hash_test_crc32c(void)
 {
 	uint32_t ret, result;
 	int i;
-	int num = sizeof(crc32c_test_vector) / sizeof(hash_test_vector_t);
+	int num = ODPH_ARRAY_SIZE(crc32c_test_vector);
 
 	for (i = 0; i < num; i++) {
 		ret = odp_hash_crc32c(crc32c_test_vector[i].data,
@@ -232,7 +234,7 @@ static void hash_test_crc32(void)
 {
 	uint32_t ret, result;
 	int i;
-	int num = sizeof(crc32_test_vector) / sizeof(hash_test_vector_t);
+	int num = ODPH_ARRAY_SIZE(crc32_test_vector);
 
 	for (i = 0; i < num; i++) {
 		ret = odp_hash_crc32(crc32_test_vector[i].data,
@@ -341,7 +343,7 @@ static void hash_test_crc32_generic(void)
 	crc_param.poly        = 0x04c11db7;
 	crc_param.reflect_in  = 1;
 	crc_param.reflect_out = 1;
-	num = sizeof(crc32_test_vector) / sizeof(hash_test_vector_t);
+	num = ODPH_ARRAY_SIZE(crc32_test_vector);
 
 	for (i = 0; i < num; i++) {
 		if (odp_hash_crc_gen64(crc32_test_vector[i].data,
@@ -360,7 +362,7 @@ static void hash_test_crc32_generic(void)
 	crc_param.poly        = 0x1edc6f41;
 	crc_param.reflect_in  = 1;
 	crc_param.reflect_out = 1;
-	num = sizeof(crc32c_test_vector) / sizeof(hash_test_vector_t);
+	num = ODPH_ARRAY_SIZE(crc32c_test_vector);
 
 	for (i = 0; i < num; i++) {
 		if (odp_hash_crc_gen64(crc32c_test_vector[i].data,

--- a/test/validation/api/init/init_main.c
+++ b/test/validation/api/init/init_main.c
@@ -284,7 +284,7 @@ odp_suiteinfo_t init_suites[] = {
 
 static int fill_testinfo(odp_testinfo_t *info, unsigned int test_case)
 {
-	if (test_case >= (sizeof(testinfo) / sizeof(odp_testinfo_t))) {
+	if (test_case >= ODPH_ARRAY_SIZE(testinfo)) {
 		ODPH_ERR("Bad test case number %u\n", test_case);
 		return -1;
 	}

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -16,8 +16,6 @@
 					      ((c) << 8) | \
 					      ((d) << 0))
 
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
-
 /* test arrays: */
 extern odp_testinfo_t ipsec_in_suite[];
 extern odp_testinfo_t ipsec_out_suite[];

--- a/test/validation/api/ipsec/ipsec_test_in.c
+++ b/test/validation/api/ipsec/ipsec_test_in.c
@@ -1847,7 +1847,7 @@ static void test_in_ipv4_esp_reass_success_two_frags(odp_ipsec_sa_t out_sa,
 	ipsec_test_packet *result_packet = &pkt_ipv4_udp_p1;
 
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV4,
-			  ARRAY_SIZE(input_packets),
+			  ODPH_ARRAY_SIZE(input_packets),
 			  input_packets,
 			  result_packet,
 			  ODP_PACKET_REASS_COMPLETE);
@@ -1865,7 +1865,7 @@ static void test_in_ipv4_esp_reass_success_four_frags(odp_ipsec_sa_t out_sa,
 	ipsec_test_packet *result_packet = &pkt_ipv4_udp_p2;
 
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV4,
-			  ARRAY_SIZE(input_packets),
+			  ODPH_ARRAY_SIZE(input_packets),
 			  input_packets,
 			  result_packet,
 			  ODP_PACKET_REASS_COMPLETE);
@@ -1881,7 +1881,7 @@ static void test_in_ipv4_esp_reass_success_two_frags_ooo(odp_ipsec_sa_t out_sa,
 	ipsec_test_packet *result_packet = &pkt_ipv4_udp_p1;
 
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV4,
-			  ARRAY_SIZE(input_packets),
+			  ODPH_ARRAY_SIZE(input_packets),
 			  input_packets,
 			  result_packet,
 			  ODP_PACKET_REASS_COMPLETE);
@@ -1899,7 +1899,7 @@ static void test_in_ipv4_esp_reass_success_four_frags_ooo(odp_ipsec_sa_t out_sa,
 	ipsec_test_packet *result_packet = &pkt_ipv4_udp_p2;
 
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV4,
-			  ARRAY_SIZE(input_packets),
+			  ODPH_ARRAY_SIZE(input_packets),
 			  input_packets,
 			  result_packet,
 			  ODP_PACKET_REASS_COMPLETE);
@@ -1914,7 +1914,7 @@ static void test_in_ipv4_esp_reass_incomp_missing(odp_ipsec_sa_t out_sa,
 	ipsec_test_packet *result_packet = &pkt_ipv4_udp_p1_f1;
 
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV4,
-			  ARRAY_SIZE(input_packets),
+			  ODPH_ARRAY_SIZE(input_packets),
 			  input_packets,
 			  result_packet,
 			  ODP_PACKET_REASS_INCOMPLETE);
@@ -2031,7 +2031,7 @@ static void test_in_ipv6_esp_reass_success_two_frags(odp_ipsec_sa_t out_sa,
 	ipsec_test_packet *result_packet = &pkt_ipv6_udp_p1;
 
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV6,
-			  ARRAY_SIZE(input_packets),
+			  ODPH_ARRAY_SIZE(input_packets),
 			  input_packets,
 			  result_packet,
 			  ODP_PACKET_REASS_COMPLETE);
@@ -2049,7 +2049,7 @@ static void test_in_ipv6_esp_reass_success_four_frags(odp_ipsec_sa_t out_sa,
 	ipsec_test_packet *result_packet = &pkt_ipv6_udp_p2;
 
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV6,
-			  ARRAY_SIZE(input_packets),
+			  ODPH_ARRAY_SIZE(input_packets),
 			  input_packets,
 			  result_packet,
 			  ODP_PACKET_REASS_COMPLETE);
@@ -2065,7 +2065,7 @@ static void test_in_ipv6_esp_reass_success_two_frags_ooo(odp_ipsec_sa_t out_sa,
 	ipsec_test_packet *result_packet = &pkt_ipv6_udp_p1;
 
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV6,
-			  ARRAY_SIZE(input_packets),
+			  ODPH_ARRAY_SIZE(input_packets),
 			  input_packets,
 			  result_packet,
 			  ODP_PACKET_REASS_COMPLETE);
@@ -2083,7 +2083,7 @@ static void test_in_ipv6_esp_reass_success_four_frags_ooo(odp_ipsec_sa_t out_sa,
 	ipsec_test_packet *result_packet = &pkt_ipv6_udp_p2;
 
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV6,
-			  ARRAY_SIZE(input_packets),
+			  ODPH_ARRAY_SIZE(input_packets),
 			  input_packets,
 			  result_packet,
 			  ODP_PACKET_REASS_COMPLETE);
@@ -2098,7 +2098,7 @@ static void test_in_ipv6_esp_reass_incomp_missing(odp_ipsec_sa_t out_sa,
 	ipsec_test_packet *result_packet = &pkt_ipv6_udp_p1_f1;
 
 	test_multi_out_in(out_sa, in_sa, ODPH_IPV6,
-			  ARRAY_SIZE(input_packets),
+			  ODPH_ARRAY_SIZE(input_packets),
 			  input_packets,
 			  result_packet,
 			  ODP_PACKET_REASS_INCOMPLETE);

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -715,11 +715,11 @@ static void test_esp_out_in_all(const ipsec_test_flags *flags_in)
 
 	flags.ah = false;
 
-	for (c = 0; c < ARRAY_SIZE(ciphers); c++)
-		for (a = 0; a < ARRAY_SIZE(auths); a++)
+	for (c = 0; c < ODPH_ARRAY_SIZE(ciphers); c++)
+		for (a = 0; a < ODPH_ARRAY_SIZE(auths); a++)
 			test_esp_out_in(&ciphers[c], &auths[a], &flags);
 
-	for (c = 0; c < ARRAY_SIZE(cipher_auth_comb); c++)
+	for (c = 0; c < ODPH_ARRAY_SIZE(cipher_auth_comb); c++)
 		test_esp_out_in(&cipher_auth_comb[c].cipher,
 				&cipher_auth_comb[c].auth,
 				&flags);
@@ -777,9 +777,9 @@ static void test_ah_out_in_all(const ipsec_test_flags *flags)
 {
 	uint32_t a;
 
-	for (a = 0; a < ARRAY_SIZE(auths); a++)
+	for (a = 0; a < ODPH_ARRAY_SIZE(auths); a++)
 		test_ah_out_in(&auths[a], flags);
-	for (a = 0; a < ARRAY_SIZE(ah_auths); a++)
+	for (a = 0; a < ODPH_ARRAY_SIZE(ah_auths); a++)
 		test_ah_out_in(&ah_auths[a], flags);
 }
 

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -3531,7 +3531,7 @@ static int packet_parse_suite_init(void)
 		return -1;
 	}
 
-	num_test_pkt = sizeof(parse_test_pkt_len) / sizeof(uint32_t);
+	num_test_pkt = ODPH_ARRAY_SIZE(parse_test_pkt_len);
 	max_len = 0;
 
 	for (i = 0; i < num_test_pkt; i++) {

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -1699,7 +1699,7 @@ static void test_packet_pool_ext_capa(void)
 	odp_pool_type_t type;
 	const odp_pool_type_t unsupported_types[] = {ODP_POOL_BUFFER, ODP_POOL_TIMEOUT,
 						     ODP_POOL_VECTOR, ODP_POOL_DMA_COMPL};
-	const int num_types = sizeof(unsupported_types) / sizeof(unsupported_types[0]);
+	const int num_types = ODPH_ARRAY_SIZE(unsupported_types);
 
 	/* Verify operation for unsupported pool types */
 	for (int i = 0; i < num_types; i++) {

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -20,8 +20,8 @@
 #define VEC_LEN  32
 #define PKT_LEN  400
 #define PKT_NUM  500
-#define ELEM_NUM 10
-#define ELEM_SIZE 128
+#define ELEM_NUM 10u
+#define ELEM_SIZE 128u
 #define CACHE_SIZE 32
 #define MAX_NUM_DEFAULT (10 * 1024 * 1024)
 #define UAREA    0xaa
@@ -33,8 +33,6 @@
 #define EXT_UAREA_SIZE     32
 #define EXT_HEADROOM       16
 #define MAGIC_U8           0x7a
-
-#define MIN(a, b)  (((a) < (b)) ? (a) : (b))
 
 typedef struct {
 	odp_barrier_t init_barrier;
@@ -204,8 +202,8 @@ static void init_event_uarea(void *uarea, uint32_t size, void *args, uint32_t in
 static void pool_test_buffer_uarea_init(void)
 {
 	odp_pool_param_t param;
-	uint32_t num = MIN(global_pool_capa.buf.max_num, ELEM_NUM),
-	size = MIN(global_pool_capa.buf.max_size, ELEM_SIZE), i;
+	uint32_t num = ODPH_MIN(global_pool_capa.buf.max_num, ELEM_NUM),
+	size = ODPH_MIN(global_pool_capa.buf.max_size, ELEM_SIZE), i;
 	odp_pool_t pool;
 	uarea_init_t data;
 	odp_buffer_t bufs[num];
@@ -246,8 +244,8 @@ static void pool_test_buffer_uarea_init(void)
 static void pool_test_packet_uarea_init(void)
 {
 	odp_pool_param_t param;
-	uint32_t num = MIN(global_pool_capa.pkt.max_num, ELEM_NUM),
-	size = MIN(global_pool_capa.pkt.max_len, ELEM_SIZE), i;
+	uint32_t num = ODPH_MIN(global_pool_capa.pkt.max_num, ELEM_NUM),
+	size = ODPH_MIN(global_pool_capa.pkt.max_len, ELEM_SIZE), i;
 	odp_pool_t pool;
 	uarea_init_t data;
 	odp_packet_t pkts[num];
@@ -288,8 +286,8 @@ static void pool_test_packet_uarea_init(void)
 static void pool_test_vector_uarea_init(void)
 {
 	odp_pool_param_t param;
-	uint32_t num = MIN(global_pool_capa.vector.max_num, ELEM_NUM),
-	size = MIN(global_pool_capa.vector.max_size, ELEM_NUM), i;
+	uint32_t num = ODPH_MIN(global_pool_capa.vector.max_num, ELEM_NUM),
+	size = ODPH_MIN(global_pool_capa.vector.max_size, ELEM_NUM), i;
 	odp_pool_t pool;
 	uarea_init_t data;
 	odp_packet_vector_t vecs[num];
@@ -332,7 +330,7 @@ static void pool_test_vector_uarea_init(void)
 static void pool_test_timeout_uarea_init(void)
 {
 	odp_pool_param_t param;
-	uint32_t num = MIN(global_pool_capa.tmo.max_num, ELEM_NUM), i;
+	uint32_t num = ODPH_MIN(global_pool_capa.tmo.max_num, ELEM_NUM), i;
 	odp_pool_t pool;
 	uarea_init_t data;
 	odp_timeout_t tmos[num];
@@ -2047,7 +2045,7 @@ static void test_packet_pool_ext_uarea_init(void)
 	pool_ext_init_packet_pool_param(&param);
 	param.uarea_init.init_fn = init_event_uarea;
 	param.uarea_init.args = &data;
-	num = MIN(num, param.pkt.num_buf);
+	num = ODPH_MIN(num, param.pkt.num_buf);
 	param.pkt.num_buf = num;
 	param.pkt.uarea_size = 1;
 	pool = odp_pool_ext_create(NULL, &param);

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -1360,7 +1360,7 @@ static void chaos_run(unsigned int qtype)
 	odp_schedule_sync_t sync[] = {ODP_SCHED_SYNC_PARALLEL,
 				      ODP_SCHED_SYNC_ATOMIC,
 				      ODP_SCHED_SYNC_ORDERED};
-	const unsigned num_sync = (sizeof(sync) / sizeof(odp_schedule_sync_t));
+	const unsigned int num_sync = ODPH_ARRAY_SIZE(sync);
 	const char *const qtypes[] = {"parallel", "atomic", "ordered"};
 
 	/* Set up the scheduling environment */

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -21,8 +21,6 @@
 
 #define GLOBAL_SHM_NAME	"GlobalTimerTest"
 
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-
 #define MAX_TIMER_POOLS  1024
 
 /* Timeout range in milliseconds (ms) */

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -111,8 +111,6 @@
 
 #define TM_PERCENT(percent) ((uint32_t)(100 * percent))
 
-#define ARRAY_SIZE(a) (sizeof((a)) / sizeof((a)[0]))
-
 typedef enum {
 	SHAPER_PROFILE, SCHED_PROFILE, THRESHOLD_PROFILE, WRED_PROFILE
 } profile_kind_t;
@@ -3542,7 +3540,7 @@ static wred_pkt_cnts_t *search_expected_pkt_rcv_tbl(odp_tm_percent_t confidence,
 	uint32_t         idx, table_size;
 
 	/* Search the EXPECTED_PKT_RCVD table to find a matching entry */
-	table_size = sizeof(EXPECTED_PKT_RCVD) / sizeof(wred_pkt_cnts_t);
+	table_size = ODPH_ARRAY_SIZE(EXPECTED_PKT_RCVD);
 	for (idx = 0; idx < table_size; idx++) {
 		wred_pkt_cnts = &EXPECTED_PKT_RCVD[idx];
 		if ((wred_pkt_cnts->confidence_percent == confidence) &&
@@ -5036,7 +5034,7 @@ int main(int argc, char *argv[])
 		ret = odp_cunit_run();
 
 	/* Exit with 77 in order to indicate that test is skipped completely */
-	if (!ret && suite_inactive == (ARRAY_SIZE(traffic_mngr_suites) - 1))
+	if (!ret && suite_inactive == (ODPH_ARRAY_SIZE(traffic_mngr_suites) - 1))
 		return 77;
 	return ret;
 }

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -27,7 +27,7 @@
 #define NUM_LEVELS               3
 #define NUM_PRIORITIES           4
 #define NUM_QUEUES_PER_NODE      NUM_PRIORITIES
-#define FANIN_RATIO              8
+#define FANIN_RATIO              8u
 #define NUM_LEVEL0_TM_NODES      1
 #define NUM_LEVEL1_TM_NODES      FANIN_RATIO
 #define NUM_LEVEL2_TM_NODES      (FANIN_RATIO * FANIN_RATIO)
@@ -65,7 +65,7 @@
 #define MED_DROP_PROB            4
 #define MAX_DROP_PROB            8
 
-#define MAX_PKTS                 1000
+#define MAX_PKTS                 1000u
 #define PKT_BUF_SIZE             1460
 #define MAX_PAYLOAD              1400
 #define USE_IPV4                 false
@@ -108,9 +108,6 @@
 #define MS                       1000000  /* Millisecond in units of NS */
 #define MBPS                     1000000
 #define GBPS                     1000000000
-
-#define MIN(a, b)  (((a) <= (b)) ? (a) : (b))
-#define MAX(a, b)  (((a) <= (b)) ? (b) : (a))
 
 #define TM_PERCENT(percent) ((uint32_t)(100 * percent))
 
@@ -400,13 +397,13 @@ static odp_bool_t approx_eq64(uint64_t val, uint64_t correct)
 static uint64_t
 clamp_rate(uint64_t rate)
 {
-	return MIN(MAX(rate, tm_shaper_min_rate), tm_shaper_max_rate);
+	return ODPH_MIN(ODPH_MAX(rate, tm_shaper_min_rate), tm_shaper_max_rate);
 }
 
 static uint32_t
 clamp_burst(uint32_t burst)
 {
-	return MIN(MAX(burst, tm_shaper_min_burst), tm_shaper_max_burst);
+	return ODPH_MIN(ODPH_MAX(burst, tm_shaper_min_burst), tm_shaper_max_burst);
 }
 
 static int test_overall_capabilities(void)
@@ -1464,8 +1461,8 @@ static inline void calc_rcv_stats(rcv_stats_t *rcv_stats,
 	last_rcv_gap_idx  = (rcv_gap_cnt * (100 - ending_drop_percent)) / 100;
 	for (idx = first_rcv_gap_idx; idx <= last_rcv_gap_idx; idx++) {
 		rcv_gap                = rcv_gaps[idx];
-		rcv_stats->min_rcv_gap = MIN(rcv_stats->min_rcv_gap, rcv_gap);
-		rcv_stats->max_rcv_gap = MAX(rcv_stats->max_rcv_gap, rcv_gap);
+		rcv_stats->min_rcv_gap = ODPH_MIN(rcv_stats->min_rcv_gap, rcv_gap);
+		rcv_stats->max_rcv_gap = ODPH_MAX(rcv_stats->max_rcv_gap, rcv_gap);
 		rcv_stats->total_rcv_gap         += rcv_gap;
 		rcv_stats->total_rcv_gap_squared += rcv_gap * rcv_gap;
 		rcv_stats->num_samples++;
@@ -2365,7 +2362,7 @@ static int traffic_mngr_suite_init(void)
 
 	payload_len = 0;
 	while (payload_len < MAX_PAYLOAD) {
-		copy_len = MIN(MAX_PAYLOAD - payload_len, sizeof(ALPHABET));
+		copy_len = ODPH_MIN(MAX_PAYLOAD - payload_len, sizeof(ALPHABET));
 		memcpy(&payload_data[payload_len], ALPHABET, copy_len);
 		payload_len += copy_len;
 	}
@@ -3087,7 +3084,7 @@ static int set_sched_fanin(const char         *node_name,
 		CU_ASSERT_FATAL(odp_tm_stop(odp_tm_systems[0]) == 0);
 	}
 
-	fanin_cnt = MIN(node_desc->num_children, FANIN_RATIO);
+	fanin_cnt = ODPH_MIN(node_desc->num_children, FANIN_RATIO);
 	for (fanin = 0; fanin < fanin_cnt; fanin++) {
 		odp_tm_sched_params_init(&sched_params);
 		sched_weight = sched_weights[fanin];
@@ -3352,7 +3349,7 @@ static int test_sched_wfq(const char         *sched_base_name,
 	/* Now determine at least one tm_queue that feeds into each fanin/
 	 * child node. */
 	priority  = 0;
-	fanin_cnt = MIN(node_desc->num_children, FANIN_RATIO);
+	fanin_cnt = ODPH_MIN(node_desc->num_children, FANIN_RATIO);
 	for (fanin = 0; fanin < fanin_cnt; fanin++) {
 		child_desc = node_desc->children[fanin];
 		num_queues = find_child_queues(0, child_desc, priority,
@@ -3482,7 +3479,7 @@ static int test_threshold(const char *threshold_name,
 
 	odp_tm_threshold_params_init(&threshold_params);
 	if (max_pkts != 0) {
-		max_pkts = MIN(max_pkts, MAX_PKTS / 3);
+		max_pkts = ODPH_MIN(max_pkts, MAX_PKTS / 3);
 		threshold_params.max_pkts        = max_pkts;
 		threshold_params.enable_max_pkts = true;
 		num_pkts = 2 * max_pkts;
@@ -3490,7 +3487,7 @@ static int test_threshold(const char *threshold_name,
 	}
 
 	if (max_bytes != 0) {
-		max_bytes = MIN(max_bytes, MAX_PKTS * MAX_PAYLOAD / 3);
+		max_bytes = ODPH_MIN(max_bytes, MAX_PKTS * MAX_PAYLOAD / 3);
 		threshold_params.max_bytes        = max_bytes;
 		threshold_params.enable_max_bytes = true;
 		num_pkts = 2 * max_bytes / MAX_PAYLOAD;
@@ -4662,7 +4659,7 @@ static void traffic_mngr_test_queue_stats(void)
 	odp_tm_capabilities_t capa;
 	pkt_info_t pkt_info;
 	uint32_t pkts_sent;
-	uint32_t num_pkts = MIN(50, MAX_PKTS);
+	uint32_t num_pkts = ODPH_MIN(50u, MAX_PKTS);
 	uint32_t pkt_len = 256;
 
 	CU_ASSERT_FATAL(odp_tm_capability(odp_tm_systems[0], &capa) == 0);


### PR DESCRIPTION
Add new ODPH_MIN() and ODPH_MAX() helper macros.

V2:
- Added `ODPH_ARRAY_SIZE()` macro

V3:
- Rebase
- Added `ODPH_ABS()` macro spec, implementation, and tests