### PR TITLE
[PATCH v5] api: pktio: add ODP_PKTIO_MAX_INDEX define

### DIFF
--- a/example/ping/odp_ping.c
+++ b/example/ping/odp_ping.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019-2022, Nokia
+/* Copyright (c) 2019-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -16,7 +16,6 @@
 #include <odp/helper/odph_api.h>
 
 #define MAX_PKTIOS        32
-#define MAX_PKTIO_INDEXES 1024
 #define MAX_PKTIO_NAME    255
 #define MAX_PKT_NUM       1024
 
@@ -48,7 +47,7 @@ typedef struct test_global_t {
 	} pktio[MAX_PKTIOS];
 
 	/* Pktio index lookup table */
-	uint8_t pktio_from_idx[MAX_PKTIO_INDEXES];
+	uint8_t pktio_from_idx[ODP_PKTIO_MAX_INDEX + 1];
 
 } test_global_t;
 
@@ -196,9 +195,6 @@ static int open_pktios(test_global_t *global)
 		return -1;
 	}
 
-	if (odp_pktio_max_index() >= MAX_PKTIO_INDEXES)
-		printf("Warning: max pktio index (%u) is too large\n", odp_pktio_max_index());
-
 	odp_pktio_param_init(&pktio_param);
 	pktio_param.in_mode  = ODP_PKTIN_MODE_SCHED;
 	pktio_param.out_mode = ODP_PKTOUT_MODE_DIRECT;
@@ -287,8 +283,8 @@ static int init_pktio_lookup_tbl(test_global_t *global)
 		odp_pktio_t pktio = global->pktio[i].pktio;
 		int pktio_idx = odp_pktio_index(pktio);
 
-		if (pktio_idx < 0 || pktio_idx >= MAX_PKTIO_INDEXES) {
-			ODPH_ERR("Bad pktio index: %i\n", pktio_idx);
+		if (pktio_idx < 0) {
+			ODPH_ERR("odp_pktio_index() failed: %s\n", global->opt.pktio_name[i]);
 			return -1;
 		}
 

--- a/include/odp/api/abi-default/packet_io_types.h
+++ b/include/odp/api/abi-default/packet_io_types.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2015-2018 Linaro Limited
- * Copyright (c) 2020-2022 Nokia
+ * Copyright (c) 2020-2023 Nokia
  */
 
 /**
@@ -46,6 +46,8 @@ typedef struct odp_pktout_queue_t {
 
 #define ODP_PKTIO_INVALID ((odp_pktio_t)0)
 #define ODP_LSO_PROFILE_INVALID ((odp_lso_profile_t)0)
+
+#define ODP_PKTIO_MAX_INDEX 63
 
 #define ODP_PKTIO_MACADDR_MAXSIZE 16
 

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2020-2022 Nokia
+ * Copyright (c) 2020-2023 Nokia
  */
 
 /**
@@ -126,6 +126,7 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa);
  *
  * Return the maximum packet IO interface index. Interface indexes
  * (e.g. returned by odp_pktio_index()) range from zero to this maximum value.
+ * The return value does not exceed #ODP_PKTIO_MAX_INDEX.
  *
  * @return Maximum packet IO interface index
  */

--- a/include/odp/api/spec/packet_io_types.h
+++ b/include/odp/api/spec/packet_io_types.h
@@ -59,6 +59,12 @@ extern "C" {
  */
 
 /**
+ * @def ODP_PKTIO_MAX_INDEX
+ * Maximum packet IO interface index. Use odp_pktio_max_index() to check the
+ * runtime maximum value, which may be smaller than this value.
+ */
+
+/**
  * @def ODP_PKTIO_MACADDR_MAXSIZE
  * Minimum size of output buffer for odp_pktio_mac_addr()
  * Actual MAC address sizes may be different.

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_io_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_io_types.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2020-2022, Nokia
+ * Copyright (c) 2020-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -42,6 +42,8 @@ typedef struct odp_pktout_queue_t {
 
 #define ODP_PKTIO_INVALID _odp_cast_scalar(odp_pktio_t, 0)
 #define ODP_LSO_PROFILE_INVALID _odp_cast_scalar(odp_lso_profile_t, 0)
+
+#define ODP_PKTIO_MAX_INDEX 63
 
 #define ODP_PKTIO_MACADDR_MAXSIZE 16
 

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -8,6 +8,7 @@
 #include <odp_posix_extensions.h>
 
 #include <odp/api/buffer.h>
+#include <odp/api/debug.h>
 #include <odp/api/packet.h>
 #include <odp/api/packet_io.h>
 #include <odp/api/proto_stats.h>
@@ -1624,6 +1625,9 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 
 	return 0;
 }
+
+ODP_STATIC_ASSERT(ODP_CONFIG_PKTIO_ENTRIES - 1 <= ODP_PKTIO_MAX_INDEX,
+		  "ODP_CONFIG_PKTIO_ENTRIES larger than ODP_PKTIO_MAX_INDEX");
 
 unsigned int odp_pktio_max_index(void)
 {

--- a/test/performance/odp_dmafwd.c
+++ b/test/performance/odp_dmafwd.c
@@ -44,7 +44,6 @@ enum {
 #define MAX_OUT_QS 32U
 #define MAX_BURST 32U
 #define MAX_WORKERS (ODP_THREAD_COUNT_MAX - 1)
-#define MAX_PKTIO_INDEXES 1024U
 
 #define MIN(a, b) (((a) <= (b)) ? (a) : (b))
 #define MAX(a, b) (((a) >= (b)) ? (a) : (b))
@@ -126,7 +125,7 @@ typedef void (*pkt_fn_t)(odp_packet_t pkts[], int num, pktio_t *pktio, init_fn_t
 typedef void (*drain_fn_t)(thread_config_t *config);
 
 typedef struct prog_config_s {
-	uint8_t pktio_idx_map[MAX_PKTIO_INDEXES];
+	uint8_t pktio_idx_map[ODP_PKTIO_MAX_INDEX + 1];
 	odph_thread_t thread_tbl[MAX_WORKERS];
 	thread_config_t thread_config[MAX_WORKERS];
 	pktio_t pktios[MAX_IFS];
@@ -298,7 +297,6 @@ static odp_bool_t get_stash_capa(odp_stash_capability_t *stash_capa, odp_stash_t
 
 static parse_result_t check_options(prog_config_t *config)
 {
-	const unsigned int idx = odp_pktio_max_index();
 	odp_dma_capability_t dma_capa;
 	uint32_t burst_size;
 	odp_stash_capability_t stash_capa;
@@ -310,11 +308,6 @@ static parse_result_t check_options(prog_config_t *config)
 		ODPH_ERR("Invalid number of interfaces: %u (min: 1, max: %u)\n", config->num_ifs,
 			 MAX_IFS);
 		return PRS_NOK;
-	}
-
-	if (idx >= MAX_PKTIO_INDEXES) {
-		ODPH_ERR("Invalid packet I/O maximum index: %u (max: %u)\n", idx,
-			 MAX_PKTIO_INDEXES);
 	}
 
 	if (config->copy_type != SW_COPY && config->copy_type != DMA_COPY_EV &&

--- a/test/performance/odp_l2fwd.c
+++ b/test/performance/odp_l2fwd.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
+ * Copyright (c) 2019-2023, Nokia
  * Copyright (c) 2020-2021, Marvell
  * All rights reserved.
  *
@@ -41,9 +41,6 @@
 
 /* Maximum number of pktio interfaces */
 #define MAX_PKTIOS             8
-
-/* Maximum pktio index table size */
-#define MAX_PKTIO_INDEXES      1024
 
 /* Default vector size */
 #define DEFAULT_VEC_SIZE       MAX_PKT_BURST
@@ -200,7 +197,7 @@ typedef struct {
 	/* Destination port lookup table.
 	 * Table index is pktio_index of the API. This is used by the sched
 	 * mode. */
-	uint8_t dst_port_from_idx[MAX_PKTIO_INDEXES];
+	uint8_t dst_port_from_idx[ODP_PKTIO_MAX_INDEX + 1];
 	/* Break workers loop if set to 1 */
 	odp_atomic_u32_t exit_threads;
 
@@ -1411,8 +1408,10 @@ static void init_port_lookup_tbl(void)
 		int pktio_idx     = odp_pktio_index(pktio);
 		int dst_port      = find_dest_port(rx_idx);
 
-		if (pktio_idx < 0 || pktio_idx >= MAX_PKTIO_INDEXES) {
-			ODPH_ERR("Bad pktio index %i\n", pktio_idx);
+		if (pktio_idx < 0) {
+			ODPH_ERR("Reading pktio (%s) index failed: %i\n",
+				 gbl_args->appl.if_names[rx_idx], pktio_idx);
+
 			exit(EXIT_FAILURE);
 		}
 
@@ -2215,10 +2214,6 @@ int main(int argc, char *argv[])
 				odp_pool_print(vec_pool_tbl[i]);
 		}
 	}
-
-	if (odp_pktio_max_index() >= MAX_PKTIO_INDEXES)
-		ODPH_DBG("Warning: max pktio index (%u) is too large\n",
-			 odp_pktio_max_index());
 
 	bind_workers();
 

--- a/test/performance/odp_packet_gen.c
+++ b/test/performance/odp_packet_gen.c
@@ -48,8 +48,6 @@ ODP_STATIC_ASSERT(MAX_WORKERS >= 2, "Too few threads");
 #define RAND_16BIT_WORDS  128
 /* Max retries to generate random data */
 #define MAX_RAND_RETRIES  1000
-/* Maximum pktio index table size */
-#define MAX_PKTIO_INDEXES 1024
 
 /* Used don't free */
 #define TX_MODE_DF        0
@@ -174,7 +172,7 @@ typedef struct test_global_t {
 	} pktio[MAX_PKTIOS];
 
 	/* Interface lookup table. Table index is pktio_index of the API. */
-	uint8_t if_from_pktio_idx[MAX_PKTIO_INDEXES];
+	uint8_t if_from_pktio_idx[ODP_PKTIO_MAX_INDEX + 1];
 
 	uint32_t num_tx_pkt;
 	uint32_t num_bins;
@@ -883,9 +881,6 @@ static int open_pktios(test_global_t *global)
 
 	global->pool = pool;
 
-	if (odp_pktio_max_index() >= MAX_PKTIO_INDEXES)
-		ODPH_ERR("Warning: max pktio index (%u) is too large\n", odp_pktio_max_index());
-
 	odp_pktio_param_init(&pktio_param);
 
 	if (test_options->direct_rx)
@@ -913,8 +908,8 @@ static int open_pktios(test_global_t *global)
 		odp_pktio_print(pktio);
 
 		pktio_idx = odp_pktio_index(pktio);
-		if (pktio_idx < 0 || pktio_idx >= MAX_PKTIO_INDEXES) {
-			ODPH_ERR("Error (%s): Bad pktio index: %i\n", name, pktio_idx);
+		if (pktio_idx < 0) {
+			ODPH_ERR("Error (%s): Reading pktio index failed: %i\n", name, pktio_idx);
 			return -1;
 		}
 		global->if_from_pktio_idx[pktio_idx] = i;

--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -16,7 +16,7 @@
 
 #define DEBUG_PRINT       0
 #define MAX_WORKERS       64
-#define MAX_PKTIOS        32
+#define MAX_PKTIOS        (ODP_PKTIO_MAX_INDEX + 1)
 #define MAX_PKTIO_NAME    31
 #define MAX_PKTIO_QUEUES  MAX_WORKERS
 #define MAX_PIPE_STAGES   64

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1705,6 +1705,9 @@ static void pktio_test_index(void)
 	ndx = odp_pktio_index(pktio);
 	CU_ASSERT(ndx >= 0);
 
+	CU_ASSERT(ODP_PKTIO_MAX_INDEX >= odp_pktio_max_index());
+	CU_ASSERT(ODP_PKTIO_MAX_INDEX >= 0 && ODP_PKTIO_MAX_INDEX <= 1024);
+
 	CU_ASSERT(odp_pktio_close(pktio) == 0);
 }
 


### PR DESCRIPTION
Add new API define ODP_PKTIO_MAX_INDEX for maximum packet IO interface
index. The value of ODP_PKTIO_MAX_INDEX is always greater or equal to
odp_pktio_max_index(), so the new define can be used for example when
defining static length arrays.


V3:
- Fixed rebase failure