### PR TITLE
[PATCH v2] api: timer: clean up odp_timer_pool_param_t.num_timers description

### DIFF
--- a/include/odp/api/spec/timer_types.h
+++ b/include/odp/api/spec/timer_types.h
@@ -386,8 +386,7 @@ typedef struct {
 
 	} periodic;
 
-	/** Number of timers needed. Application will create in maximum this
-	 *  many concurrent timers from the timer pool. */
+	/** Number of timers in the pool. */
 	uint32_t num_timers;
 
 	/** Thread private timer pool. When zero, multiple thread may use the


### PR DESCRIPTION
Remove the limitation on application. This change implies that application may attempt to allocate more timers than there are in a timer pool. In that case, odp_timer_alloc() returns ODP_TIMER_INVALID.