### PR TITLE
[PATCH v4] linux-gen: pool: fix odp_pool_ext_capability() return value

### DIFF
--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -1856,8 +1856,21 @@ int odp_pool_ext_capability(odp_pool_type_t type, odp_pool_ext_capability_t *cap
 {
 	odp_pool_stats_opt_t supported_stats;
 
-	if (type != ODP_POOL_PACKET)
+	_ODP_ASSERT(capa != NULL);
+
+	switch (type) {
+	case ODP_POOL_PACKET:
+		break;
+	case ODP_POOL_BUFFER:
+	case ODP_POOL_TIMEOUT:
+	case ODP_POOL_VECTOR:
+	case ODP_POOL_DMA_COMPL:
+		memset(capa, 0, sizeof(odp_pool_ext_capability_t));
+		return 0;
+	default:
+		_ODP_ERR("Invalid pool type: %d\n", type);
 		return -1;
+	}
 
 	supported_stats.all = 0;
 

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -1698,7 +1698,19 @@ static void pool_ext_init_packet_pool_param(odp_pool_ext_param_t *param)
 static void test_packet_pool_ext_capa(void)
 {
 	odp_pool_ext_capability_t capa;
-	odp_pool_type_t type = ODP_POOL_PACKET;
+	odp_pool_type_t type;
+	const odp_pool_type_t unsupported_types[] = {ODP_POOL_BUFFER, ODP_POOL_TIMEOUT,
+						     ODP_POOL_VECTOR, ODP_POOL_DMA_COMPL};
+	const int num_types = sizeof(unsupported_types) / sizeof(unsupported_types[0]);
+
+	/* Verify operation for unsupported pool types */
+	for (int i = 0; i < num_types; i++) {
+		type = unsupported_types[i];
+		CU_ASSERT_FATAL(odp_pool_ext_capability(type, &capa) == 0);
+		CU_ASSERT(capa.max_pools == 0);
+	}
+
+	type = ODP_POOL_PACKET;
 
 	CU_ASSERT_FATAL(odp_pool_ext_capability(type, &capa) == 0);
 


### PR DESCRIPTION
According to the specification, odp_pool_ext_capability() should set
'max_pools' to zero and return success if a valid but unsupported pool type
is used.

Add tests to validate that odp_pool_ext_capability() works according to the
specification when unsupported pool type is used.
