### PR TITLE
[PATCH v4] test: dmafwd: implement DMA poll mode

### DIFF
--- a/test/performance/odp_dmafwd.c
+++ b/test/performance/odp_dmafwd.c
@@ -1064,12 +1064,12 @@ int main(int argc, char **argv)
 	init_param.mem_model = odph_opts.mem_model;
 
 	if (odp_init_global(&odp_instance, NULL, NULL)) {
-		ODPH_ERR("ODP global init failed, exiting.\n");
+		ODPH_ERR("ODP global init failed, exiting\n");
 		exit(EXIT_FAILURE);
 	}
 
 	if (odp_init_local(odp_instance, ODP_THREAD_CONTROL)) {
-		ODPH_ERR("ODP local init failed, exiting.\n");
+		ODPH_ERR("ODP local init failed, exiting\n");
 		exit(EXIT_FAILURE);
 	}
 
@@ -1140,12 +1140,12 @@ out:
 		(void)odp_shm_free(shm_cfg);
 
 	if (odp_term_local()) {
-		ODPH_ERR("ODP local terminate failed, exiting.\n");
+		ODPH_ERR("ODP local terminate failed, exiting\n");
 		exit(EXIT_FAILURE);
 	}
 
 	if (odp_term_global(odp_instance)) {
-		ODPH_ERR("ODP global terminate failed, exiting.\n");
+		ODPH_ERR("ODP global terminate failed, exiting\n");
 		exit(EXIT_FAILURE);
 	}
 

--- a/test/performance/odp_dmafwd.c
+++ b/test/performance/odp_dmafwd.c
@@ -290,7 +290,7 @@ static parse_result_t check_options(prog_config_t *config)
 	}
 
 	if ((uint32_t)config->num_thrs > dma_capa.max_sessions) {
-		ODPH_ERR("Not enough DMA sessions supported: %d (max: %u)\n", config->num_thrs,
+		ODPH_ERR("Unsupported DMA session count: %d (max: %u)\n", config->num_thrs,
 			 dma_capa.max_sessions);
 		return PRS_NOT_SUP;
 	}
@@ -299,13 +299,13 @@ static parse_result_t check_options(prog_config_t *config)
 	burst_size = MIN(burst_size, MAX_BURST);
 
 	if (config->burst_size == 0U || config->burst_size > burst_size) {
-		ODPH_ERR("Unsupported segment count for DMA: %u (min: 1, max: %u)\n",
+		ODPH_ERR("Invalid segment count for DMA: %u (min: 1, max: %u)\n",
 			 config->burst_size, burst_size);
 		return PRS_NOK;
 	}
 
 	if (config->pkt_len > dma_capa.max_seg_len) {
-		ODPH_ERR("Unsupported packet length for DMA: %u (max: %u)\n", config->pkt_len,
+		ODPH_ERR("Invalid packet length for DMA: %u (max: %u)\n", config->pkt_len,
 			 dma_capa.max_seg_len);
 		return PRS_NOK;
 	}
@@ -317,7 +317,7 @@ static parse_result_t check_options(prog_config_t *config)
 	}
 
 	if ((uint32_t)config->num_thrs > dma_capa.pool.max_pools) {
-		ODPH_ERR("Unsupported amount of completion pools: %d (max: %u)\n",
+		ODPH_ERR("Invalid amount of completion pools: %d (max: %u)\n",
 			 config->num_thrs, dma_capa.pool.max_pools);
 		return PRS_NOK;
 	}

--- a/test/performance/odp_dmafwd_run.sh
+++ b/test/performance/odp_dmafwd_run.sh
@@ -60,9 +60,13 @@ echo "${BIN_NAME}: SW copy"
 echo "==================="
 ./${BIN_NAME}${EXEEXT} -i ${IF0} -b ${BATCH} -T ${TIME} -t 0
 check_result $?
-echo "${BIN_NAME}: DMA copy"
+echo "${BIN_NAME}: DMA copy event"
 echo "===================="
 ./${BIN_NAME}${EXEEXT} -i ${IF0} -b ${BATCH} -T ${TIME} -t 1
+check_result $?
+echo "${BIN_NAME}: DMA copy poll"
+echo "===================="
+./${BIN_NAME}${EXEEXT} -i ${IF0} -b ${BATCH} -T ${TIME} -t 2
 check_result $?
 cleanup_interfaces
 check_exit


### PR DESCRIPTION
This patchset implements DMA poll mode support to `odp_dmafwd`.

Additionally, a few improvements related to pool cache and element count configuration are introduced which may improve performance when DMA copy scenarios are used.

v2:
- Matias' comments

v3:
- Refactored stash capability checking

v4:
- Added reviewed-by tag