### PR TITLE
[PATCH v2] test: ipsecfwd: fix potential memory leak

### DIFF
--- a/test/performance/odp_ipsecfwd.c
+++ b/test/performance/odp_ipsecfwd.c
@@ -1933,11 +1933,12 @@ static void teardown_test(const prog_config_t *config)
 {
 	(void)odph_iplookup_table_destroy(config->fwd_tbl);
 
-	for (uint32_t i = 0U; i < config->num_ifs; ++i)
-		if (config->pktios[i].handle != ODP_PKTIO_INVALID) {
+	for (uint32_t i = 0U; i < config->num_ifs; ++i) {
+		free(config->pktios[i].name);
+
+		if (config->pktios[i].handle != ODP_PKTIO_INVALID)
 			(void)odp_pktio_close(config->pktios[i].handle);
-			free(config->pktios[i].name);
-		}
+	}
 
 	if (config->pktio_pool != ODP_POOL_INVALID)
 		(void)odp_pool_destroy(config->pktio_pool);


### PR DESCRIPTION
When tearing down resources, free interface string unconditionally as teardown logic could be reached before packet I/Os have been opened.

v2:
- Added reviewed-by tag