### PR TITLE
[PATCH v6] api: queue: add queue create/destroy function multi variants

### DIFF
--- a/include/odp/api/spec/queue.h
+++ b/include/odp/api/spec/queue.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2023 Nokia
  */
 
 /**
@@ -42,6 +43,34 @@ extern "C" {
  * @retval ODP_QUEUE_INVALID on failure
  */
 odp_queue_t odp_queue_create(const char *name, const odp_queue_param_t *param);
+
+/**
+ * Create multiple queues
+ *
+ * Otherwise like odp_queue_create(), but creates multiple queues with a single
+ * call. The output queue handles are written in the same order as input
+ * parameters. A single odp_queue_create_multi() call is equivalent to calling
+ * odp_queue_create() 'num' times in row.
+ *
+ * If 'share_param' value is false, 'param' array must contain 'num' elements.
+ * If the value is true, only a single element is required and it's used as
+ * queue parameters for all created queues. If 'name' array is not NULL, the
+ * array must contain 'num' elements.
+ *
+ * @param      name         Array of queue name pointers or NULL. NULL is also
+ *                          valid queue name pointer value.
+ * @param      param        Array of queue parameters
+ * @param      share_param  If true, use same parameters ('param[0]') for all
+ *                          queues.
+ * @param[out] queue        Array of queue handles for output
+ * @param      num          Number of queues to create
+ *
+ * @return Number of queues actually created (0 ... num)
+ * @retval <0 on failure
+ */
+int odp_queue_create_multi(const char *name[], const odp_queue_param_t param[],
+			   odp_bool_t share_param, odp_queue_t queue[],
+			   int num);
 
 /**
  * Destroy ODP queue

--- a/include/odp/api/spec/queue.h
+++ b/include/odp/api/spec/queue.h
@@ -88,6 +88,20 @@ int odp_queue_create_multi(const char *name[], const odp_queue_param_t param[],
 int odp_queue_destroy(odp_queue_t queue);
 
 /**
+ * Destroy multiple queues
+ *
+ * Otherwise like odp_queue_destroy(), but destroys multiple queues with a
+ * single call.
+ *
+ * @param queue    Array of queue handles
+ * @param num      Number of queues to destroy
+ *
+ * @retval Number of queues actually destroyed (1 ... num)
+ * @retval <0 on failure
+ */
+int odp_queue_destroy_multi(odp_queue_t queue[], int num);
+
+/**
  * Find a queue by name
  *
  * @param name    Queue name

--- a/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2018, Linaro Limited
+ * Copyright (c) 2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -32,6 +33,10 @@ typedef struct _odp_queue_inline_offset_t {
 typedef struct {
 	odp_queue_t (*queue_create)(const char *name,
 				    const odp_queue_param_t *param);
+	int (*queue_create_multi)(const char *name[],
+				  const odp_queue_param_t param[],
+				  odp_bool_t share_param, odp_queue_t queue[],
+				  int num);
 	int (*queue_destroy)(odp_queue_t queue);
 	odp_queue_t (*queue_lookup)(const char *name);
 	int (*queue_capability)(odp_queue_capability_t *capa);

--- a/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
@@ -38,6 +38,7 @@ typedef struct {
 				  odp_bool_t share_param, odp_queue_t queue[],
 				  int num);
 	int (*queue_destroy)(odp_queue_t queue);
+	int (*queue_destroy_multi)(odp_queue_t queue[], int num);
 	odp_queue_t (*queue_lookup)(const char *name);
 	int (*queue_capability)(odp_queue_capability_t *capa);
 	int (*queue_context_set)(odp_queue_t queue, void *context,

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -463,6 +463,23 @@ static int queue_destroy(odp_queue_t handle)
 	return 0;
 }
 
+static int queue_destroy_multi(odp_queue_t handle[], int num)
+{
+	int i;
+
+	_ODP_ASSERT(handle != NULL);
+	_ODP_ASSERT(num > 0);
+
+	for (i = 0; i < num; i++) {
+		int ret = queue_destroy(handle[i]);
+
+		if (ret)
+			return (i == 0) ? ret : i;
+	}
+
+	return i;
+}
+
 static int queue_context_set(odp_queue_t handle, void *context,
 			     uint32_t len ODP_UNUSED)
 {
@@ -1246,6 +1263,7 @@ _odp_queue_api_fn_t _odp_queue_basic_api = {
 	.queue_create = queue_create,
 	.queue_create_multi = queue_create_multi,
 	.queue_destroy = queue_destroy,
+	.queue_destroy_multi = queue_destroy_multi,
 	.queue_lookup = queue_lookup,
 	.queue_capability = queue_capability,
 	.queue_context_set = queue_context_set,

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -370,6 +370,29 @@ static odp_queue_t queue_create(const char *name,
 	return handle;
 }
 
+static int queue_create_multi(const char *name[], const odp_queue_param_t param[],
+			      odp_bool_t share_param, odp_queue_t queue[], int num)
+{
+	int i;
+
+	_ODP_ASSERT(param != NULL);
+	_ODP_ASSERT(queue != NULL);
+	_ODP_ASSERT(num > 0);
+
+	for (i = 0; i < num; i++) {
+		odp_queue_t cur_queue;
+		const char *cur_name = name != NULL ? name[i] : NULL;
+		const odp_queue_param_t *cur_param = share_param ? &param[0] : &param[i];
+
+		cur_queue =  queue_create(cur_name, cur_param);
+		if (cur_queue == ODP_QUEUE_INVALID)
+			return (i == 0) ? -1 : i;
+
+		queue[i] = cur_queue;
+	}
+	return i;
+}
+
 void _odp_sched_queue_set_status(uint32_t queue_index, int status)
 {
 	queue_entry_t *queue = qentry_from_index(queue_index);
@@ -1221,6 +1244,7 @@ static odp_event_t queue_api_deq(odp_queue_t handle)
 /* API functions */
 _odp_queue_api_fn_t _odp_queue_basic_api = {
 	.queue_create = queue_create,
+	.queue_create_multi = queue_create_multi,
 	.queue_destroy = queue_destroy,
 	.queue_lookup = queue_lookup,
 	.queue_capability = queue_capability,

--- a/platform/linux-generic/odp_queue_if.c
+++ b/platform/linux-generic/odp_queue_if.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2017, ARM Limited
+ * Copyright (c) 2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -34,6 +35,13 @@ const queue_fn_t *_odp_queue_fn;
 odp_queue_t odp_queue_create(const char *name, const odp_queue_param_t *param)
 {
 	return _odp_queue_api->queue_create(name, param);
+}
+
+int odp_queue_create_multi(const char *name[], const odp_queue_param_t param[],
+			   odp_bool_t share_param, odp_queue_t queue[], int num)
+{
+	return _odp_queue_api->queue_create_multi(name, param, share_param,
+						  queue, num);
 }
 
 int odp_queue_destroy(odp_queue_t queue)

--- a/platform/linux-generic/odp_queue_if.c
+++ b/platform/linux-generic/odp_queue_if.c
@@ -49,6 +49,11 @@ int odp_queue_destroy(odp_queue_t queue)
 	return _odp_queue_api->queue_destroy(queue);
 }
 
+int odp_queue_destroy_multi(odp_queue_t queue[], int num)
+{
+	return _odp_queue_api->queue_destroy_multi(queue, num);
+}
+
 odp_queue_t odp_queue_lookup(const char *name)
 {
 	return _odp_queue_api->queue_lookup(name);

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -499,6 +499,23 @@ static int queue_destroy(odp_queue_t handle)
 	return 0;
 }
 
+static int queue_destroy_multi(odp_queue_t handle[], int num)
+{
+	int i;
+
+	_ODP_ASSERT(handle != NULL);
+	_ODP_ASSERT(num > 0);
+
+	for (i = 0; i < num; i++) {
+		int ret = queue_destroy(handle[i]);
+
+		if (ret)
+			return (i == 0) ? ret : i;
+	}
+
+	return i;
+}
+
 static int queue_context_set(odp_queue_t handle, void *context,
 			     uint32_t len ODP_UNUSED)
 {
@@ -1162,6 +1179,7 @@ _odp_queue_api_fn_t _odp_queue_scalable_api = {
 	.queue_create = queue_create,
 	.queue_create_multi = queue_create_multi,
 	.queue_destroy = queue_destroy,
+	.queue_destroy_multi = queue_destroy_multi,
 	.queue_lookup = queue_lookup,
 	.queue_capability = queue_capability,
 	.queue_context_set = queue_context_set,

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -399,6 +399,29 @@ static odp_queue_t queue_create(const char *name,
 	return handle;
 }
 
+static int queue_create_multi(const char *name[], const odp_queue_param_t param[],
+			      odp_bool_t share_param, odp_queue_t queue[], int num)
+{
+	int i;
+
+	_ODP_ASSERT(param != NULL);
+	_ODP_ASSERT(queue != NULL);
+	_ODP_ASSERT(num > 0);
+
+	for (i = 0; i < num; i++) {
+		odp_queue_t cur_queue;
+		const char *cur_name = name != NULL ? name[i] : NULL;
+		const odp_queue_param_t *cur_param = share_param ? &param[0] : &param[i];
+
+		cur_queue =  queue_create(cur_name, cur_param);
+		if (cur_queue == ODP_QUEUE_INVALID)
+			return (i == 0) ? -1 : i;
+
+		queue[i] = cur_queue;
+	}
+	return i;
+}
+
 static int queue_destroy(odp_queue_t handle)
 {
 	queue_entry_t *queue;
@@ -1137,6 +1160,7 @@ static void queue_timer_rem(odp_queue_t handle)
 /* API functions */
 _odp_queue_api_fn_t _odp_queue_scalable_api = {
 	.queue_create = queue_create,
+	.queue_create_multi = queue_create_multi,
 	.queue_destroy = queue_destroy,
 	.queue_lookup = queue_lookup,
 	.queue_capability = queue_capability,


### PR DESCRIPTION
Add new odp_queue_create_multi() function for creating multiple queues with a single call.

V2:
- Changed `odp_queue_create_multi()` parameter `const odp_queue_param_t *param[]` to `const odp_queue_param_t param[]`
- Added implementation and validation test

V3:
- Added `odp_queue_destroy_multi()` API