### PR TITLE
[PATCH v2] api: queue: clarify odp_queue_param_t default value specification

### DIFF
--- a/include/odp/api/spec/queue.h
+++ b/include/odp/api/spec/queue.h
@@ -28,12 +28,11 @@ extern "C" {
 /**
  * Queue create
  *
- * Create a queue according to the queue parameters. Queue type is specified by
- * queue parameter 'type'. Use odp_queue_param_init() to initialize parameters
- * into their default values. Default values are also used when 'param' pointer
- * is NULL. The default queue type is ODP_QUEUE_TYPE_PLAIN. The use of queue
- * name is optional. Unique names are not required. However, odp_queue_lookup()
- * returns only a single matching queue.
+ * Create a queue according to the queue parameters. The use of queue name is
+ * optional. Unique names are not required. However, odp_queue_lookup() returns
+ * only a single matching queue. Use odp_queue_param_init() to initialize
+ * parameters into their default values. Default values are also used when
+ * 'param' pointer is NULL.
  *
  * @param name    Name of the queue or NULL. Maximum string length is
  *                ODP_QUEUE_NAME_LEN.

--- a/include/odp/api/spec/queue_types.h
+++ b/include/odp/api/spec/queue_types.h
@@ -225,7 +225,7 @@ typedef struct odp_queue_param_t {
 	/** Queue type
 	  *
 	  * Valid values for other parameters in this structure depend on
-	  * the queue type. */
+	  * the queue type. The default value is ODP_QUEUE_TYPE_PLAIN. */
 	odp_queue_type_t type;
 
 	/** Enqueue mode
@@ -288,7 +288,7 @@ typedef struct odp_queue_param_t {
 	  * The queue must be able to store at minimum this many events
 	  * simultaneously. The value must not exceed 'max_size' queue
 	  * capability. The value of zero means implementation specific
-	  * default size. */
+	  * default size. The default value is 0. */
 	uint32_t size;
 
 } odp_queue_param_t;


### PR DESCRIPTION
Move default queue type specification from odp_queue_create() to odp_queue_param_t to make it conform with the other parameters.

Also, explicitly state that queue size default value is zero. This was already tested by the validation test.