### PR TITLE
[PATCH v2] test: bench_pktio_sp: add new test for creating pmr rules

### DIFF
--- a/test/performance/bench_common.h
+++ b/test/performance/bench_common.h
@@ -140,6 +140,9 @@ typedef struct bench_tm_results_s {
 		/* Maximum duration */
 		odp_time_t max;
 
+		/* Number of measurements */
+		uint64_t num;
+
 	} func[BENCH_TM_MAX_FUNC];
 
 	/* Number of registered test functions */
@@ -158,6 +161,9 @@ typedef int (*bench_tm_run_fn_t)(bench_tm_result_t *res, int repeat_count);
 typedef struct {
 	/* Test case name */
 	const char *name;
+
+	/* Optional precondition to run test */
+	bench_cond_fn_t cond;
 
 	/* Optional test initializer function */
 	bench_init_fn_t init;


### PR DESCRIPTION
Add new test case 'cls_create_pmr', which creates a selected number ('-p') of PMRs.

bench_tm_func_record() saves now also the number of measurements, which makes the usage more flexible. Optional precondition check function 'cond' was added to bench_tm_info_t to enable skipping unsupported tests.