### PR TITLE
[PATCH v2] validation: crypto: reduce duplicate testing in different op modes

### DIFF
--- a/test/validation/api/crypto/util.h
+++ b/test/validation/api/crypto/util.h
@@ -20,6 +20,7 @@ struct suite_context_s {
 	odp_queue_t queue;
 	odp_queue_type_t q_type;
 	odp_event_t (*compl_queue_deq)(void);
+	int partial_test;
 };
 
 extern struct suite_context_s suite_context;


### PR DESCRIPTION
Run time consuming algorithm combination tests only once, in async-sched, async-plain or sync mode (in that preference order) instead of in all the three modes, unless FULL_TEST is requested. We assume that the actual crypto implementation being tested is the same in all the three modes so test coverage should not suffer much.