### PR TITLE
[PATCH v3] helper: test: harmonize main function signatures

### DIFF
--- a/example/ipfragreass/odp_ipfragreass.c
+++ b/example/ipfragreass/odp_ipfragreass.c
@@ -228,7 +228,7 @@ static int run_worker(void *arg ODP_UNUSED)
 /**
  * ODP fragmentation and reassembly example main function
  */
-int main(void)
+int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 {
 	odp_instance_t instance;
 	odp_pool_t fragment_pool;

--- a/helper/test/debug.c
+++ b/helper/test/debug.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int main(void)
+int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 {
 	printf("\nHelper library version is: %s\n\n", odph_version_str());
 

--- a/helper/test/macros.c
+++ b/helper/test/macros.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int main(void)
+int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 {
 	int a, b;
 	int ret = 0;

--- a/helper/test/parse.c
+++ b/helper/test/parse.c
@@ -342,7 +342,7 @@ static int test_ipv4(void)
 	return 0;
 }
 
-int main(void)
+int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 {
 	int ret = 0;
 

--- a/helper/test/version.c
+++ b/helper/test/version.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int main(void)
+int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 {
 	printf("\nHelper library versions is: %s\n\n", odph_version_str());
 

--- a/test/miscellaneous/odp_api_headers.c
+++ b/test/miscellaneous/odp_api_headers.c
@@ -8,7 +8,7 @@
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
 
-int main(void)
+int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 {
 	odp_instance_t inst;
 


### PR DESCRIPTION
Use ODP_UNUSED for intentionally unused variables of functions. Thereby, harmonizing the main function signatures across multiple files.