### PR TITLE
[PATCH v8] linux-gen: ticketlock: enable WFE on aarch64

### DIFF
--- a/include/odp/autoheader_external.h.in
+++ b/include/odp/autoheader_external.h.in
@@ -14,4 +14,7 @@
 /* Define to 1 or 2 to enable event validation */
 #undef _ODP_EVENT_VALIDATION
 
+/* Define to 1 to enable WFE based lock implementation on aarch64 */
+#undef _ODP_WFE_LOCKS
+
 #endif

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -340,7 +340,9 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/arm/odp/api/abi/cpu_inlines.h \
 				arch/arm/odp/api/abi/cpu.h \
 				arch/default/odp/api/abi/sync_inlines.h \
-				arch/default/odp/api/abi/time_inlines.h
+				arch/default/odp/api/abi/time_inlines.h \
+				arch/default/odp/api/abi/wait_until_generic.h \
+				arch/default/odp/api/abi/wait_until.h
 endif
 noinst_HEADERS += arch/arm/odp_atomic.h \
 		  arch/arm/odp_cpu.h \
@@ -370,7 +372,9 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/aarch64/odp/api/abi/cpu.h \
 				arch/aarch64/odp/api/abi/sync_inlines.h \
 				arch/common/odp/api/abi/time_cpu_inlines.h \
-				arch/aarch64/odp/api/abi/time_inlines.h
+				arch/aarch64/odp/api/abi/time_inlines.h \
+				arch/default/odp/api/abi/wait_until_generic.h \
+				arch/aarch64/odp/api/abi/wait_until.h
 endif
 noinst_HEADERS += arch/aarch64/odp_atomic.h \
 		  arch/aarch64/odp_cpu.h \
@@ -394,7 +398,9 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/default/odp/api/abi/cpu_inlines.h \
 				arch/default/odp/api/abi/cpu.h \
 				arch/default/odp/api/abi/sync_inlines.h \
-				arch/default/odp/api/abi/time_inlines.h
+				arch/default/odp/api/abi/time_inlines.h \
+				arch/default/odp/api/abi/wait_until_generic.h \
+				arch/default/odp/api/abi/wait_until.h
 endif
 noinst_HEADERS += arch/default/odp_atomic.h \
 		  arch/default/odp_cpu.h \
@@ -416,7 +422,9 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/default/odp/api/abi/cpu_inlines.h \
 				arch/powerpc/odp/api/abi/cpu.h \
 				arch/default/odp/api/abi/sync_inlines.h \
-				arch/default/odp/api/abi/time_inlines.h
+				arch/default/odp/api/abi/time_inlines.h \
+				arch/default/odp/api/abi/wait_until_generic.h \
+				arch/default/odp/api/abi/wait_until.h
 endif
 noinst_HEADERS += arch/default/odp_atomic.h \
 		  arch/default/odp_cpu.h \
@@ -442,7 +450,9 @@ odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/atomic_generic.h \
 				arch/x86/odp/api/abi/cpu.h \
 				arch/x86/odp/api/abi/sync_inlines.h \
 				arch/common/odp/api/abi/time_cpu_inlines.h \
-				arch/x86/odp/api/abi/time_inlines.h
+				arch/x86/odp/api/abi/time_inlines.h \
+				arch/default/odp/api/abi/wait_until_generic.h \
+				arch/default/odp/api/abi/wait_until.h
 endif
 noinst_HEADERS += arch/x86/cpu_flags.h \
 		  arch/x86/odp_cpu.h \

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/wait_until.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/wait_until.h
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 ARM Limited
+ */
+
+#ifndef ODP_API_ABI_WAIT_UNTIL_H_
+#define ODP_API_ABI_WAIT_UNTIL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/autoheader_external.h>
+
+#ifdef _ODP_WFE_LOCKS
+
+#include <stdint.h>
+
+#include <odp/api/atomic.h>
+
+static inline void
+_odp_wait_until_equal_acq_u32(odp_atomic_u32_t *addr, uint32_t expected)
+{
+	uint32_t value;
+	uint32_t *var = &addr->v;
+
+	__asm__ volatile("sevl" : : : "memory");
+	do {
+		__asm__ volatile("wfe" : : : "memory");
+		__asm__ volatile("ldaxr %w0, [%1]"
+					 : "=&r" (value)
+					 : "r" (var)
+					 : "memory");
+	} while (expected != value);
+}
+
+#else /* !_ODP_WFE_LOCKS*/
+
+/* Use generic implementation */
+#include <odp/api/abi/wait_until_generic.h>
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/arch/aarch64/odp_llsc.h
+++ b/platform/linux-generic/arch/aarch64/odp_llsc.h
@@ -150,15 +150,15 @@ static inline uint32_t scd(_odp_u128_t *var, _odp_u128_t neu, int mm)
 	if (mm == __ATOMIC_RELEASE)
 		__asm__ volatile("stlxp %w0, %1, %2, [%3]"
 				 : "=&r" (ret)
-				 : "r" (((union i128)neu).i64[0]),
-				   "r" (((union i128)neu).i64[1]),
+				 : "r" (((*(union i128 *)&neu)).i64[0]),
+				   "r" (((*(union i128 *)&neu)).i64[1]),
 				   "r" (var)
 				 : "memory");
 	else if (mm == __ATOMIC_RELAXED)
 		__asm__ volatile("stxp %w0, %1, %2, [%3]"
 				 : "=&r" (ret)
-				 : "r" (((union i128)neu).i64[0]),
-				   "r" (((union i128)neu).i64[1]),
+				 : "r" (((*(union i128 *)&neu)).i64[0]),
+				   "r" (((*(union i128 *)&neu)).i64[1]),
 				   "r" (var)
 				 : );
 	else

--- a/platform/linux-generic/arch/default/odp/api/abi/wait_until.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/wait_until.h
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 ARM Limited
+ */
+
+#include <odp/api/abi/wait_until_generic.h>

--- a/platform/linux-generic/arch/default/odp/api/abi/wait_until_generic.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/wait_until_generic.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 ARM Limited
+ */
+
+#ifndef ODP_API_ABI_WAIT_UNTIL_GENERIC_H_
+#define ODP_API_ABI_WAIT_UNTIL_GENERIC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/atomic.h>
+
+static inline void
+_odp_wait_until_equal_acq_u32(odp_atomic_u32_t *addr, uint32_t expected)
+{
+	while (odp_atomic_load_acq_u32(addr) != expected)
+		odp_cpu_pause();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp/api/plat/ticketlock_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/ticketlock_inlines.h
@@ -11,7 +11,7 @@
 #include <odp/api/cpu.h>
 
 #include <odp/api/abi/ticketlock.h>
-
+#include <odp/api/abi/wait_until.h>
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -47,8 +47,7 @@ _ODP_INLINE void odp_ticketlock_lock(odp_ticketlock_t *ticketlock)
 
 	/* Spin waiting for our turn. Use load-acquire so that we acquire
 	 * all stores from the previous lock owner */
-	while (ticket != odp_atomic_load_acq_u32(&ticketlock->cur_ticket))
-		odp_cpu_pause();
+	_odp_wait_until_equal_acq_u32(&ticketlock->cur_ticket, ticket);
 }
 
 _ODP_INLINE int odp_ticketlock_trylock(odp_ticketlock_t *tklock)

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -29,6 +29,7 @@ m4_include([platform/linux-generic/m4/odp_crypto.m4])
 m4_include([platform/linux-generic/m4/odp_ipsec_mb.m4])
 m4_include([platform/linux-generic/m4/odp_pcapng.m4])
 m4_include([platform/linux-generic/m4/odp_dpdk.m4])
+m4_include([platform/linux-generic/m4/odp_wfe.m4])
 m4_include([platform/linux-generic/m4/odp_xdp.m4])
 ODP_EVENT_VALIDATION
 ODP_SCHEDULER
@@ -42,9 +43,10 @@ AS_VAR_APPEND([PLAT_CFG_TEXT], ["
 	openssl:                ${with_openssl}
 	openssl_rand:           ${openssl_rand}
 	crypto:                 ${with_crypto}
-	pcap:			${have_pcap}
-	pcapng:			${have_pcapng}
-	default_config_path:	${default_config_path}"])
+	pcap:                   ${have_pcap}
+	pcapng:                 ${have_pcapng}
+	wfe_locks:              ${use_wfe_locks}
+	default_config_path:    ${default_config_path}"])
 
 # Ignore Clang specific errors about fields with variable sized type not at the
 # end of a struct. This style is used by e.g. odp_packet_hdr_t and

--- a/platform/linux-generic/m4/odp_wfe.m4
+++ b/platform/linux-generic/m4/odp_wfe.m4
@@ -1,0 +1,14 @@
+##########################################################################
+# Enable/disable WFE based lock implementations
+##########################################################################
+use_wfe_locks=no
+AC_ARG_ENABLE([wfe-locks],
+	      [AS_HELP_STRING([--enable-wfe-locks],
+			      [enable WFE based lock implementations on aarch64]
+			      [[default=disabled] (linux-generic)])],
+	      [use_wfe_locks=$enableval])
+
+if test x$use_wfe_locks = xyes; then
+    AC_DEFINE([_ODP_WFE_LOCKS], [1],
+    	      [Define to 1 to enable WFE based lock implementations on aarch64])
+fi


### PR DESCRIPTION
Fix casts to union type erros with CPP on aarch64. When "odp_cpu.h" is included in some head files, "odp_api_from_cpp.cpp" would include "odp_cpu.h" as well. Build failure and error of 'unknown conversion of types' show as going through this file with CPP.

Use WFE instruction on aarch64 to replace ISB instrution, making threads waiting for their turn into low-power state. Performance test with "odp_lock_perf" shows that it could reduce IPC while maintain similar performance.

**PLatform:arm-n1amp-01**
_Use 4 cores, test case ticketlock, run forever._ 
**1.ISB**
 2.971 GHz
IPC: 0.06 insn per cycle.
total rounds: 3.5-4.5 M rounds/sec
**2 WFE**
2.305 GHz
IPC: 0.02  insn per cycle.
total rounds: 4-4.5 M rounds/sec
_Use 8 cores, test case ticketlock, run forever._ 
**1.ISB**
 2.958 GHz
IPC: 0.07 insn per cycle.
total rounds: 2.5-3 M rounds/sec
**2 WFE**
2.069 GHz
IPC: 0.01  insn per cycle.
total rounds: 2.5-3 M rounds/sec

**- V5 update**

1. Add new configuration option '--enable-wfe-locks' for enabling  WFE based lock implementations on aarch64.
2. Change file name to wait_until.h
3. Functions updated