### PR TITLE
[PATCH v5] api: timer: explicitly deprecate odp_timer_set_t

### DIFF
--- a/include/odp/api/spec/timer_types.h
+++ b/include/odp/api/spec/timer_types.h
@@ -17,6 +17,7 @@
 extern "C" {
 #endif
 
+#include <odp/api/deprecated.h>
 #include <odp/api/event_types.h>
 #include <odp/api/std_types.h>
 
@@ -536,7 +537,7 @@ typedef enum {
  *
  * @deprecated Use odp_timer_retval_t instead.
  */
-typedef odp_timer_retval_t odp_timer_set_t;
+typedef odp_timer_retval_t ODP_DEPRECATE(odp_timer_set_t);
 
 /**
  * Timer tick information


### PR DESCRIPTION
Explicitly deprecate `odp_timer_set_t` with `ODP_DEPRECATE()` macro.

v2:
- Added reviewed-by tag

v3:
- Rebased

v5:
- Rebased