### PR TITLE
[PATCH v5] api: cls: add new packet matching rule capabilities

### DIFF
--- a/example/sysinfo/odp_sysinfo.c
+++ b/example/sysinfo/odp_sysinfo.c
@@ -990,7 +990,6 @@ int main(int argc, char **argv)
 	printf("    max_pmr:                %u\n", cls_capa.max_pmr);
 	printf("    max_pmr_per_cos:        %u\n", cls_capa.max_pmr_per_cos);
 	printf("    max_terms_per_pmr:      %u\n", cls_capa.max_terms_per_pmr);
-	printf("    available_pmr_terms:    %u\n", cls_capa.available_pmr_terms);
 	printf("    max_cos:                %u\n", cls_capa.max_cos);
 	printf("    max_hash_queues:        %u\n", cls_capa.max_hash_queues);
 	printf("    hash_protocols:         0x%x\n", cls_capa.hash_protocols.all_bits);

--- a/example/sysinfo/odp_sysinfo.c
+++ b/example/sysinfo/odp_sysinfo.c
@@ -989,7 +989,7 @@ int main(int argc, char **argv)
 	printf("    supported_terms:        0x%" PRIx64 "\n", cls_capa.supported_terms.all_bits);
 	printf("    max_pmr:                %u\n", cls_capa.max_pmr);
 	printf("    max_pmr_per_cos:        %u\n", cls_capa.max_pmr_per_cos);
-	printf("    max_pmr_terms:          %u\n", cls_capa.max_pmr_terms);
+	printf("    max_terms_per_pmr:      %u\n", cls_capa.max_terms_per_pmr);
 	printf("    available_pmr_terms:    %u\n", cls_capa.available_pmr_terms);
 	printf("    max_cos:                %u\n", cls_capa.max_cos);
 	printf("    max_hash_queues:        %u\n", cls_capa.max_hash_queues);

--- a/example/sysinfo/odp_sysinfo.c
+++ b/example/sysinfo/odp_sysinfo.c
@@ -987,6 +987,8 @@ int main(int argc, char **argv)
 	printf("\n");
 	printf("  CLASSIFIER\n");
 	printf("    supported_terms:        0x%" PRIx64 "\n", cls_capa.supported_terms.all_bits);
+	printf("    max_pmr:                %u\n", cls_capa.max_pmr);
+	printf("    max_pmr_per_cos:        %u\n", cls_capa.max_pmr_per_cos);
 	printf("    max_pmr_terms:          %u\n", cls_capa.max_pmr_terms);
 	printf("    available_pmr_terms:    %u\n", cls_capa.available_pmr_terms);
 	printf("    max_cos:                %u\n", cls_capa.max_cos);

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -546,9 +546,6 @@ typedef struct odp_cls_capability_t {
 	/** Maximum number of terms per composite PMR */
 	uint32_t max_terms_per_pmr;
 
-	/** Number of PMR terms available for use now */
-	uint32_t available_pmr_terms;
-
 	/** Maximum number of CoS supported */
 	uint32_t max_cos;
 

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -544,7 +544,7 @@ typedef struct odp_cls_capability_t {
 	uint32_t max_pmr_per_cos;
 
 	/** Maximum number of terms per composite PMR */
-	uint32_t max_pmr_terms;
+	uint32_t max_terms_per_pmr;
 
 	/** Number of PMR terms available for use now */
 	uint32_t available_pmr_terms;
@@ -919,8 +919,8 @@ void odp_cls_pmr_create_opt_init(odp_pmr_create_opt_t *opt);
  * considered to match only if a packet matches with all its terms. It is implementation specific
  * which term combinations are supported as composite PMRs. When creating a composite PMR,
  * application should check the return value and perform appropriate fallback actions if the create
- * call returns failure. See odp_cls_capability_t::max_pmr and odp_cls_capability_t::max_pmr_terms
- * for related capabilities.
+ * call returns failure. See odp_cls_capability_t::max_pmr and
+ * odp_cls_capability_t::max_terms_per_pmr for related capabilities.
  *
  * Use odp_cls_pmr_param_init() to initialize parameters into their default values.
  *

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -529,11 +529,21 @@ typedef struct odp_cls_stats_capability_t {
  */
 typedef struct odp_cls_capability_t {
 	/** PMR terms supported by the classifier
-	 * A bit mask of one bit for each of odp_pmr_term_t
-	 */
+	 *
+	 * A bit mask of one bit for each of odp_pmr_term_t. */
 	odp_cls_pmr_terms_t supported_terms;
 
-	/** Maximum number of PMR terms */
+	/** Maximum number of single-term PMRs
+	 *
+	 * Depending on the implementation, using several/composite terms for a
+	 * single PMR may end up incurring more than one PMR element from this
+	 * total capacity. */
+	uint32_t max_pmr;
+
+	/** Maximum number of PMRs per CoS */
+	uint32_t max_pmr_per_cos;
+
+	/** Maximum number of terms per composite PMR */
 	uint32_t max_pmr_terms;
 
 	/** Number of PMR terms available for use now */
@@ -542,13 +552,16 @@ typedef struct odp_cls_capability_t {
 	/** Maximum number of CoS supported */
 	uint32_t max_cos;
 
-	/** Maximum number of CoSes that can have statistics enabled at the same
+	/** Maximum number of concurrent CoS stats
+	 *
+	 * Maximum number of CoSes that can have statistics enabled at the same
 	 * time. If this value is zero, then CoS level statistics are not
 	 * supported. */
 	uint32_t max_cos_stats;
 
 	/** Maximum number of queues supported per CoS
-	 * if the value is 1, then hashing is not supported*/
+	 *
+	 * If the value is 1, then hashing is not supported. */
 	uint32_t max_hash_queues;
 
 	/** Protocol header combination supported for Hashing */
@@ -906,7 +919,8 @@ void odp_cls_pmr_create_opt_init(odp_pmr_create_opt_t *opt);
  * considered to match only if a packet matches with all its terms. It is implementation specific
  * which term combinations are supported as composite PMRs. When creating a composite PMR,
  * application should check the return value and perform appropriate fallback actions if the create
- * call returns failure.
+ * call returns failure. See odp_cls_capability_t::max_pmr and odp_cls_capability_t::max_pmr_terms
+ * for related capabilities.
  *
  * Use odp_cls_pmr_param_init() to initialize parameters into their default values.
  *

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -151,18 +151,10 @@ void odp_cls_pmr_param_init(odp_pmr_param_t *param)
 
 int odp_cls_capability(odp_cls_capability_t *capability)
 {
-	uint32_t count = 0;
-
 	memset(capability, 0, sizeof(odp_cls_capability_t));
-
-	for (int i = 0; i < CLS_PMR_MAX_ENTRY; i++)
-		if (!pmr_tbl->pmr[i].valid)
-			count++;
-
 	capability->max_pmr = CLS_PMR_MAX_ENTRY;
 	capability->max_pmr_per_cos = CLS_PMR_PER_COS_MAX;
 	capability->max_terms_per_pmr = CLS_PMRTERM_MAX;
-	capability->available_pmr_terms = count;
 	capability->max_cos = CLS_COS_MAX_ENTRY;
 	capability->max_cos_stats = capability->max_cos;
 	capability->pmr_range_supported = false;

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -161,7 +161,7 @@ int odp_cls_capability(odp_cls_capability_t *capability)
 
 	capability->max_pmr = CLS_PMR_MAX_ENTRY;
 	capability->max_pmr_per_cos = CLS_PMR_PER_COS_MAX;
-	capability->max_pmr_terms = CLS_PMRTERM_MAX;
+	capability->max_terms_per_pmr = CLS_PMRTERM_MAX;
 	capability->available_pmr_terms = count;
 	capability->max_cos = CLS_COS_MAX_ENTRY;
 	capability->max_cos_stats = capability->max_cos;

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -159,7 +159,9 @@ int odp_cls_capability(odp_cls_capability_t *capability)
 		if (!pmr_tbl->pmr[i].valid)
 			count++;
 
-	capability->max_pmr_terms = CLS_PMR_MAX_ENTRY;
+	capability->max_pmr = CLS_PMR_MAX_ENTRY;
+	capability->max_pmr_per_cos = CLS_PMR_PER_COS_MAX;
+	capability->max_pmr_terms = CLS_PMRTERM_MAX;
 	capability->available_pmr_terms = count;
 	capability->max_cos = CLS_COS_MAX_ENTRY;
 	capability->max_cos_stats = capability->max_cos;

--- a/test/validation/api/classification/odp_classification_basic.c
+++ b/test/validation/api/classification/odp_classification_basic.c
@@ -630,7 +630,7 @@ static void cls_pmr_composite_create(void)
 	odp_pool_t pkt_pool;
 	odp_cls_cos_param_t cls_param;
 	odp_pktio_t pktio;
-	uint32_t max_pmr_terms;
+	uint32_t max_terms_per_pmr;
 	uint16_t val = 1024;
 	uint16_t mask = 0xffff;
 
@@ -658,10 +658,10 @@ static void cls_pmr_composite_create(void)
 	cos = odp_cls_cos_create("pmr_match", &cls_param);
 	CU_ASSERT(cos != ODP_COS_INVALID);
 
-	max_pmr_terms = capa.max_pmr_terms;
-	odp_pmr_param_t pmr_terms[max_pmr_terms];
+	max_terms_per_pmr = capa.max_terms_per_pmr;
+	odp_pmr_param_t pmr_terms[max_terms_per_pmr];
 
-	for (uint32_t i = 0; i < max_pmr_terms; i++) {
+	for (uint32_t i = 0; i < max_terms_per_pmr; i++) {
 		odp_cls_pmr_param_init(&pmr_terms[i]);
 		pmr_terms[i].term = ODP_PMR_TCP_DPORT;
 		pmr_terms[i].match.value = &val;
@@ -670,7 +670,7 @@ static void cls_pmr_composite_create(void)
 		pmr_terms[i].val_sz = sizeof(val);
 	}
 
-	pmr_composite = odp_cls_pmr_create(pmr_terms, max_pmr_terms, default_cos, cos);
+	pmr_composite = odp_cls_pmr_create(pmr_terms, max_terms_per_pmr, default_cos, cos);
 	CU_ASSERT(odp_pmr_to_u64(pmr_composite) !=
 		  odp_pmr_to_u64(ODP_PMR_INVALID));
 


### PR DESCRIPTION
Add new `max_pmr` and `max_pmr_per_cos` packet matching rule capabilities to `odp_cls_capability_t` to signal maximum amount of PMRs and maximum amount of PMRs per class of service, respectively, that an implementation is able to support.

v2:
- Spec text reworded

v3:
- Spec text reworded
- Renamed `max_pmr_terms` field
- Removed `available_pmr_terms` field

v4:
- Added reviewed-by tags

v5:
- Added reviewed-by tags