### PR TITLE
[PATCH v6] api: timer: only inactive timers can be freed

### DIFF
--- a/example/timer/odp_timer_accuracy.c
+++ b/example/timer/odp_timer_accuracy.c
@@ -806,7 +806,6 @@ static int destroy_timers(test_global_t *test_global)
 {
 	uint64_t i, alloc_timers;
 	odp_timer_t timer;
-	odp_event_t ev;
 	int ret = 0;
 
 	alloc_timers = test_global->opt.alloc_timers;
@@ -817,10 +816,10 @@ static int destroy_timers(test_global_t *test_global)
 		if (timer == ODP_TIMER_INVALID)
 			break;
 
-		ev = odp_timer_free(timer);
-
-		if (ev != ODP_EVENT_INVALID)
-			odp_event_free(ev);
+		if (odp_timer_free(timer)) {
+			printf("Timer free failed: %" PRIu64 "\n", i);
+			ret = -1;
+		}
 	}
 
 	if (test_global->timer_pool != ODP_TIMER_POOL_INVALID)

--- a/example/timer/odp_timer_simple.c
+++ b/example/timer/odp_timer_simple.c
@@ -159,18 +159,24 @@ int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 	}
 
 	/* Destroy created resources */
-	rc += odp_timer_cancel(tim, &ev);
-	rc += -(odp_timer_free(tim) == ODP_EVENT_INVALID);
 	odp_event_free(ev);
 
-	ret += odp_queue_destroy(queue);
+	if (odp_timer_free(tim))
+		ret++;
+
+	if (odp_queue_destroy(queue))
+		ret++;
 err:
 	odp_timer_pool_destroy(timer_pool);
 err_tp:
-	ret += odp_pool_destroy(timeout_pool);
-	ret += odp_term_local();
+	if (odp_pool_destroy(timeout_pool))
+		ret++;
+
+	if (odp_term_local())
+		ret++;
 err_local:
-	ret += odp_term_global(instance);
+	if (odp_term_global(instance))
+		ret++;
 err_global:
 	return ret;
 }

--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -246,19 +246,21 @@ odp_timer_t odp_timer_alloc(odp_timer_pool_t timer_pool, odp_queue_t queue, cons
 /**
  * Free a timer
  *
- * Free (destroy) a timer, reclaiming associated resources.
- * The timeout event for an active timer will be returned.
- * The timeout event for an expired timer will not be returned. It is the
- * responsibility of the application to handle this timeout when it is received.
+ * Frees a previously allocated timer. The timer must be inactive when calling this function.
+ * In other words, the application must cancel an active single shot timer (odp_timer_cancel())
+ * successfully or wait it to expire before freeing it. Similarly for an active periodic timer, the
+ * application must cancel it (odp_timer_periodic_cancel()) and receive the last event from
+ * the timer (odp_timer_periodic_ack()) before freeing it.
  *
- * A periodic timer must be cancelled successfully before freeing it.
+ * The call returns failure only on non-recoverable errors. Application must not use the timer
+ * handle anymore after the call, regardless of the return value.
  *
- * @param timer      Timer
+ * @param timer       Timer
  *
- * @return Event handle of timeout event
- * @retval ODP_EVENT_INVALID on failure
+ * @retval 0 on success
+ * @retval <0 on failure
  */
-odp_event_t odp_timer_free(odp_timer_t timer);
+int odp_timer_free(odp_timer_t timer);
 
 /**
  * Start a timer

--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -1081,10 +1081,10 @@ static int stop_pktios(test_global_t *test_global)
 	return ret;
 }
 
-static void empty_queues(void)
+static void empty_queues(uint64_t wait_ns)
 {
 	odp_event_t ev;
-	uint64_t wait_time = odp_schedule_wait_time(ODP_TIME_SEC_IN_NS / 2);
+	uint64_t wait_time = odp_schedule_wait_time(wait_ns);
 
 	/* Drop all events from all queues */
 	while (1) {
@@ -1365,7 +1365,6 @@ static int start_timers(test_global_t *test_global)
 static void destroy_timers(test_global_t *test_global)
 {
 	int i, j;
-	odp_event_t event;
 	odp_timer_t timer;
 	int num_pktio = test_global->opt.num_pktio;
 	int num_queue = test_global->opt.num_pktio_queue;
@@ -1375,6 +1374,9 @@ static void destroy_timers(test_global_t *test_global)
 	if (timer_pool == ODP_TIMER_POOL_INVALID)
 		return;
 
+	/* Wait any remaining timers to expire */
+	empty_queues(2000 * test_global->opt.timeout_us);
+
 	for (i = 0; i < num_pktio; i++) {
 		for (j = 0; j < num_queue; j++) {
 			timer = test_global->timer.timer[i][j];
@@ -1382,10 +1384,8 @@ static void destroy_timers(test_global_t *test_global)
 			if (timer == ODP_TIMER_INVALID)
 				break;
 
-			event = odp_timer_free(timer);
-
-			if (event != ODP_EVENT_INVALID)
-				odp_event_free(event);
+			if (odp_timer_free(timer))
+				printf("Timer free failed: %i, %i\n", i, j);
 		}
 	}
 
@@ -1552,7 +1552,7 @@ int main(int argc, char *argv[])
 
 quit:
 	stop_pktios(test_global);
-	empty_queues();
+	empty_queues(ODP_TIME_SEC_IN_NS / 2);
 	close_pktios(test_global);
 	destroy_pipeline_queues(test_global);
 	destroy_timers(test_global);

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -707,7 +707,7 @@ static void timer_pool_create_destroy(void)
 
 	tim = odp_timer_alloc(tp[0], queue, USER_PTR);
 	CU_ASSERT(tim != ODP_TIMER_INVALID);
-	CU_ASSERT(odp_timer_free(tim) == ODP_EVENT_INVALID);
+	CU_ASSERT(odp_timer_free(tim) == 0);
 
 	odp_timer_pool_destroy(tp[0]);
 
@@ -731,7 +731,7 @@ static void timer_pool_create_destroy(void)
 
 	tim = odp_timer_alloc(tp[1], queue, USER_PTR);
 	CU_ASSERT(tim != ODP_TIMER_INVALID);
-	CU_ASSERT(odp_timer_free(tim) == ODP_EVENT_INVALID);
+	CU_ASSERT(odp_timer_free(tim) == 0);
 
 	odp_timer_pool_destroy(tp[1]);
 
@@ -741,7 +741,7 @@ static void timer_pool_create_destroy(void)
 
 	tim = odp_timer_alloc(tp[0], queue, USER_PTR);
 	CU_ASSERT(tim != ODP_TIMER_INVALID);
-	CU_ASSERT(odp_timer_free(tim) == ODP_EVENT_INVALID);
+	CU_ASSERT(odp_timer_free(tim) == 0);
 
 	odp_timer_pool_destroy(tp[0]);
 
@@ -816,7 +816,7 @@ static void timer_pool_create_max(void)
 	}
 
 	for (i = 0; i < num; i++)
-		CU_ASSERT(odp_timer_free(timer[i]) == ODP_EVENT_INVALID);
+		CU_ASSERT(odp_timer_free(timer[i]) == 0);
 
 	for (i = 0; i < num; i++)
 		odp_timer_pool_destroy(tp[i]);
@@ -912,7 +912,7 @@ static void timer_pool_max_res(void)
 			odp_event_free(ev);
 		}
 
-		CU_ASSERT(odp_timer_free(timer) == ODP_EVENT_INVALID);
+		CU_ASSERT(odp_timer_free(timer) == 0);
 		odp_timer_pool_destroy(tp);
 	}
 
@@ -1122,7 +1122,7 @@ static void timer_single_shot(odp_queue_type_t queue_type, odp_timer_tick_type_t
 
 	free_schedule_context(queue_type);
 
-	CU_ASSERT(odp_timer_free(timer) == ODP_EVENT_INVALID);
+	CU_ASSERT(odp_timer_free(timer) == 0);
 	odp_timer_pool_destroy(tp);
 
 	CU_ASSERT(odp_queue_destroy(queue) == 0);
@@ -1585,7 +1585,7 @@ static void timer_test_event_type(odp_queue_type_t queue_type,
 	}
 
 	for (i = 0; i < num; i++)
-		CU_ASSERT(odp_timer_free(timer[i]) == ODP_EVENT_INVALID);
+		CU_ASSERT(odp_timer_free(timer[i]) == 0);
 
 	odp_timer_pool_destroy(timer_pool);
 	CU_ASSERT(odp_queue_destroy(queue) == 0);
@@ -1791,7 +1791,7 @@ static void timer_test_queue_type(odp_queue_type_t queue_type, int priv, int exp
 				 tick, nsec, target, (int64_t)(nsec - target));
 
 			odp_timeout_free(tmo);
-			CU_ASSERT(odp_timer_free(tim) == ODP_EVENT_INVALID);
+			CU_ASSERT(odp_timer_free(tim) == 0);
 
 			num_tmo++;
 		}
@@ -1947,9 +1947,7 @@ static void timer_test_cancel(void)
 
 	odp_timeout_free(tmo);
 
-	ev = odp_timer_free(tim);
-	if (ev != ODP_EVENT_INVALID)
-		CU_FAIL_FATAL("Free returned event");
+	CU_ASSERT_FATAL(odp_timer_free(tim) == 0);
 
 	odp_timer_pool_destroy(tp);
 
@@ -2135,7 +2133,7 @@ static void timer_test_tmo_limit(odp_queue_type_t queue_type,
 		CU_ASSERT(num_tmo == num);
 
 	for (i = 0; i < num; i++)
-		CU_ASSERT(odp_timer_free(timer[i]) == ODP_EVENT_INVALID);
+		CU_ASSERT(odp_timer_free(timer[i]) == 0);
 
 	odp_timer_pool_destroy(timer_pool);
 	CU_ASSERT(odp_queue_destroy(queue) == 0);
@@ -2507,7 +2505,7 @@ sleep:
 	}
 
 	for (i = 0; i < allocated; i++) {
-		if (odp_timer_free(tt[i].tim) != ODP_EVENT_INVALID)
+		if (odp_timer_free(tt[i].tim))
 			CU_FAIL("odp_timer_free");
 	}
 
@@ -3108,7 +3106,7 @@ static void timer_test_periodic(odp_queue_type_t queue_type, int use_first, int 
 		CU_ASSERT(ret == 2);
 	}
 
-	CU_ASSERT(odp_timer_free(timer) == ODP_EVENT_INVALID);
+	CU_ASSERT(odp_timer_free(timer) == 0);
 	odp_timer_pool_destroy(timer_pool);
 	CU_ASSERT(odp_queue_destroy(queue) == 0);
 	CU_ASSERT(odp_pool_destroy(pool) == 0);


### PR DESCRIPTION
Remove possibility to free a timer that is running. When timer free call returns, the timer handle cannot be referenced any more. Expiration and event delivery of an already destroyed timer is an error prone corner case.