### PR TITLE
[PATCH v3] api: timer: deprecate timeout fresh

### DIFF
--- a/doc/users-guide/users-guide-timer.adoc
+++ b/doc/users-guide/users-guide-timer.adoc
@@ -113,11 +113,6 @@ while (1) {
 		void *userptr = odp_timeout_user_ptr(timeout);
 		uint64_t expiration = odp_timeout_tick(timeout);
 
-		if (!odp_timeout_fresh(timeout)) {
-			odp_timeout_free(timeout);
-			continue;
-		}
-
 		...process the timeout event
 		break;
 
@@ -125,16 +120,3 @@ while (1) {
 	}
 }
 -----
-When a worker thread receives a timeout event via `odp_schedule()`, it needs
-to determine whether the event is still relevant. A timeout event that is still
-relevant is said to be _fresh_ while one that is no longer relevant is said to
-be _stale_. Timeouts may be stale for any number of reasons, most of which are
-known only to the application itself. However, there are a few cases where the
-ODP implementation may be able to assist in this determination and for those
-cases the `odp_timeout_fresh()` API is provided.
-
-ODP defines a fresh timeout simply as one that has not been reset or
-canceled since it expired. So if `odp_timeout_fresh()` returns 0 then it is
-likely that the application should ignore this event, however if it returns 1
-then it remains an application responsibility to handle the event appropriate
-to its needs.

--- a/example/timer/odp_timer_test.c
+++ b/example/timer/odp_timer_test.c
@@ -165,13 +165,7 @@ static void test_abs_timeouts(int thr, test_globals_t *gbls)
 		tick = odp_timeout_tick(tmo);
 		ttp = odp_timeout_user_ptr(tmo);
 		ttp->ev = ev;
-		if (!odp_timeout_fresh(tmo)) {
-			/* Not the expected expiration tick, timer has
-			 * been reset or cancelled or freed */
-			ODPH_ABORT("Unexpected timeout received (timer "
-				   "%" PRIu64 ", tick %" PRIu64 ")\n",
-				   odp_timer_to_u64(ttp->tim), tick);
-		}
+
 		ODPH_DBG("  [%i] timeout, tick %" PRIu64 "\n", thr, tick);
 
 		uint32_t rx_num = odp_atomic_fetch_dec_u32(&gbls->remain);

--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -474,8 +474,10 @@ odp_event_t odp_timeout_to_event(odp_timeout_t tmo);
  * @param tmo Timeout handle
  * @retval 1 Timeout is fresh
  * @retval 0 Timeout is stale
+ *
+ * @deprecated The function will be removed in a future API version.
  */
-int odp_timeout_fresh(odp_timeout_t tmo);
+int ODP_DEPRECATE(odp_timeout_fresh)(odp_timeout_t tmo);
 
 /**
  * Return timer handle for the timeout

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1799,7 +1799,7 @@ uint64_t odp_timeout_to_u64(odp_timeout_t tmo)
 	return _odp_pri(tmo);
 }
 
-int odp_timeout_fresh(odp_timeout_t tmo)
+int ODP_DEPRECATE(odp_timeout_fresh)(odp_timeout_t tmo)
 {
 	const odp_timeout_hdr_t *hdr = timeout_hdr(tmo);
 	odp_timer_t hdl = hdr->timer;

--- a/test/performance/odp_bench_timer.c
+++ b/test/performance/odp_bench_timer.c
@@ -170,18 +170,6 @@ static int timeout_from_event(void)
 	return i;
 }
 
-static int timeout_fresh(void)
-{
-	int i;
-	odp_timeout_t timeout = gbl_args->timeout;
-	uint64_t *a1 = gbl_args->a1;
-
-	for (i = 0; i < REPEAT_COUNT; i++)
-		a1[i] = odp_timeout_fresh(timeout);
-
-	return i;
-}
-
 static int timeout_timer(void)
 {
 	int i;
@@ -274,7 +262,6 @@ bench_info_t test_suite[] = {
 	BENCH_INFO(timer_ns_to_tick, 0, NULL),
 	BENCH_INFO(timeout_to_event, 0, NULL),
 	BENCH_INFO(timeout_from_event, 0, NULL),
-	BENCH_INFO(timeout_fresh, 0, NULL),
 	BENCH_INFO(timeout_timer, 0, NULL),
 	BENCH_INFO(timeout_tick, 0, NULL),
 	BENCH_INFO(timeout_user_ptr, 0, NULL),

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -2232,9 +2232,10 @@ static void handle_tmo(odp_event_t ev, bool stale, uint64_t prev_tick)
 		CU_FAIL("odp_timeout_timer() wrong timer");
 
 	if (!stale) {
+#if ODP_DEPRECATED_API
 		if (!odp_timeout_fresh(tmo))
 			CU_FAIL("Wrong status (stale) for fresh timeout");
-
+#endif
 		/* tmo tick cannot be smaller than pre-calculated tick */
 		if (tick < ttp->tick) {
 			ODPH_DBG("Too small tick: pre-calculated %" PRIu64 " "


### PR DESCRIPTION
The feature is not very useful to applications, since freshness result depends on timing of cancel/restart API calls vs the freshness check point.