### PR TITLE
[PATCH v4] test: dma_perf: add memory copy and sparse segment type options

### DIFF
--- a/test/performance/odp_dma_perf.c
+++ b/test/performance/odp_dma_perf.c
@@ -1658,8 +1658,10 @@ static void print_stats(const prog_config_t *config)
 				config->trs_type == ASYNC_DMA && config->compl_mode == EVENT ?
 					"DMA asynchronous-event" : "SW", config->num_in_segs,
 	       config->num_out_segs, config->src_seg_len,
-	       config->seg_type == DENSE_PACKET ? "packet" : "memory", config->num_inflight,
-	       config->policy == SINGLE ? "shared" : "per-worker");
+	       config->seg_type == DENSE_PACKET ? "dense packet" :
+		config->seg_type == SPARSE_PACKET ? "sparse packet" :
+			config->seg_type == DENSE_MEMORY ? "dense memory" : "sparse memory",
+	       config->num_inflight, config->policy == SINGLE ? "shared" : "per-worker");
 
 	for (int i = 0; i < config->num_workers; ++i) {
 		stats = &config->thread_config[i].stats;

--- a/test/performance/odp_dma_perf.c
+++ b/test/performance/odp_dma_perf.c
@@ -675,7 +675,7 @@ static odp_bool_t setup_packet_segments(sd_t *sd)
 	return configure_packets(sd) && allocate_packets(sd);
 }
 
-static void configure_packet_dma_transfer(sd_t *sd)
+static void configure_packet_transfer(sd_t *sd)
 {
 	odp_dma_seg_t *start_src_seg, *start_dst_seg, *seg;
 	uint32_t k = 0U, z = 0U, len;
@@ -758,7 +758,7 @@ static odp_bool_t setup_memory_segments(sd_t *sd)
 	return allocate_memory(sd);
 }
 
-static void configure_address_dma_transfer(sd_t *sd)
+static void configure_address_transfer(sd_t *sd)
 {
 	odp_dma_seg_t *start_src_seg, *start_dst_seg, *seg;
 	uint32_t k = 0U, z = 0U, len;
@@ -1156,11 +1156,11 @@ static void setup_api(prog_config_t *config)
 {
 	if (config->seg_type == PACKET) {
 		config->api.setup_fn = setup_packet_segments;
-		config->api.trs_fn = configure_packet_dma_transfer;
+		config->api.trs_fn = configure_packet_transfer;
 		config->api.free_fn = free_packets;
 	} else {
 		config->api.setup_fn = setup_memory_segments;
-		config->api.trs_fn = configure_address_dma_transfer;
+		config->api.trs_fn = configure_address_transfer;
 		config->api.free_fn = free_memory;
 	}
 

--- a/test/performance/odp_dma_perf.c
+++ b/test/performance/odp_dma_perf.c
@@ -717,12 +717,11 @@ static void free_packets(const sd_t *sd)
 
 static odp_bool_t allocate_memory(sd_t *sd)
 {
-	const uint64_t num_segs = (uint64_t)sd->dma.num_in_segs * sd->dma.num_inflight;
+	const uint64_t shm_size = (uint64_t)sd->dma.dst_seg_len * sd->dma.num_out_segs *
+				  sd->dma.num_inflight;
 
-	sd->seg.src_shm = odp_shm_reserve(PROG_NAME "_src_shm", sd->dma.src_seg_len * num_segs,
-					  ODP_CACHE_LINE_SIZE, 0U);
-	sd->seg.dst_shm = odp_shm_reserve(PROG_NAME "_dst_shm", sd->dma.dst_seg_len * num_segs,
-					  ODP_CACHE_LINE_SIZE, 0U);
+	sd->seg.src_shm = odp_shm_reserve(PROG_NAME "_src_shm", shm_size, ODP_CACHE_LINE_SIZE, 0U);
+	sd->seg.dst_shm = odp_shm_reserve(PROG_NAME "_dst_shm", shm_size, ODP_CACHE_LINE_SIZE, 0U);
 
 	if (sd->seg.src_shm == ODP_SHM_INVALID || sd->seg.dst_shm == ODP_SHM_INVALID) {
 		ODPH_ERR("Error allocating SHM block\n");

--- a/test/performance/odp_dma_perf.c
+++ b/test/performance/odp_dma_perf.c
@@ -315,11 +315,6 @@ static parse_result_t check_options(prog_config_t *config)
 		return PRS_NOK;
 	}
 
-	if (config->trs_type == SW_COPY) {
-		ODPH_ERR("SW memory copy transfer type not yet implemented\n");
-		return PRS_NOT_SUP;
-	}
-
 	if (config->seg_type != PACKET && config->seg_type != MEMORY) {
 		ODPH_ERR("Invalid segment type: %u\n", config->seg_type);
 		return PRS_NOK;

--- a/test/performance/odp_dma_perf.c
+++ b/test/performance/odp_dma_perf.c
@@ -344,11 +344,6 @@ static parse_result_t check_options(prog_config_t *config)
 		return PRS_NOK;
 	}
 
-	if (config->seg_type == SPARSE_PACKET || config->seg_type == SPARSE_MEMORY) {
-		ODPH_ERR("Sparse segment types not yet implemented\n");
-		return PRS_NOT_SUP;
-	}
-
 	max_workers = ODPH_MIN(odp_thread_count_max() - 1, MAX_WORKERS);
 
 	if (config->num_workers <= 0 || config->num_workers > max_workers) {

--- a/test/performance/odp_dma_perf.c
+++ b/test/performance/odp_dma_perf.c
@@ -1,8 +1,14 @@
-/* Copyright (c) 2021-2023, Nokia
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021-2023 Nokia
+ */
+
+/**
+ * DMA performance tester
  *
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+ * This tester application can be used to profile the performance of an ODP DMA implementation.
+ * Tester workflow is simple and consists of issuing as many back-to-back DMA transfers as the
+ * implementation allows and then recording key performance statistics (such as function overhead,
+ * latencies etc.).
  */
 
 #ifndef _GNU_SOURCE

--- a/test/performance/odp_dma_perf_run.sh
+++ b/test/performance/odp_dma_perf_run.sh
@@ -25,24 +25,45 @@ check_result()
 	fi
 }
 
-echo "odp_dma_perf: synchronous transfer"
+echo "odp_dma_perf: synchronous DMA transfer 1"
 echo "===================================="
 
 ${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 0 -i $SEGC -o $SEGC -s $SEGS -S 0 -f $INFL -T $TIME
 
 check_result $?
 
-echo "odp_dma_perf: asynchronous transfer 1"
-echo "====================================="
+echo "odp_dma_perf: synchronous DMA transfer 2"
+echo "===================================="
 
-${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -i $SEGC -o $SEGC -s $SEGS -S 1 -m 0 -f $INFL -T $TIME
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 0 -i $SEGC -o $SEGC -s $SEGS -S 1 -f $INFL -T $TIME
 
 check_result $?
 
-echo "odp_dma_perf: asynchronous transfer 2"
+echo "odp_dma_perf: asynchronous DMA transfer 1"
 echo "====================================="
 
-${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -i $SEGC -o $SEGC -s $SEGS -S 1 -m 1 -f $INFL -T $TIME
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -i $SEGC -o $SEGC -s $SEGS -S 2 -m 0 -f $INFL -T $TIME
+
+check_result $?
+
+echo "odp_dma_perf: asynchronous DMA transfer 2"
+echo "====================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -i $SEGC -o $SEGC -s $SEGS -S 3 -m 1 -f $INFL -T $TIME
+
+check_result $?
+
+echo "odp_dma_perf: SW transfer 1"
+echo "====================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 2 -i $SEGC -o $SEGC -s $SEGS -S 0 -f $INFL -T $TIME
+
+check_result $?
+
+echo "odp_dma_perf: SW transfer 2"
+echo "====================================="
+
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 2 -i $SEGC -o $SEGC -s $SEGS -S 2 -f $INFL -T $TIME
 
 check_result $?
 


### PR DESCRIPTION
This patchset introduces a new SW packet copy transfer mode. This is useful for comparing the performance of DMA subsystem and copying on CPU. Additionally, new sparse segment type variants are introduced: 'sparse packet' and 'sparse memory'. These configure scenarios which might be a more realistic usecase for some applications due to potentially incurred cache misses and allocation overheads. The old existing segment type options are renamed to 'dense packet' and 'dense memory'.

v2:
- Simplified memory copy transfer with transfer being done now only with a single function instead of separate for packets and addresses

v3:
- Matias' comments

v4:
- Fixed an issue when preparing transfers for poll mode
- Dropped ticketlock return value check
- Added reviewed-by tags
