### PR TITLE
[PATCH v2] api: timer: require an array of timeout events in odp_timer_periodic_start()

### DIFF
--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -317,6 +317,7 @@ int odp_timer_restart(odp_timer_t timer, const odp_timer_start_t *start_param);
  * provide in odp_timer_periodic_start(). Application must set the values of first_tick and
  * freq_multiplier in start_param before calling this function, the rest of the parameters are
  * ignored. On return, the value of num_tmo_ev is set and the other parameters are not modified.
+ * The value of num_tmo_ev is less than or equal to periodic.max_tmo_events in timer capability.
  *
  * @param timer_pool          Timer pool
  * @param start_param         Periodic timer start parameters

--- a/include/odp/api/spec/timer_types.h
+++ b/include/odp/api/spec/timer_types.h
@@ -213,6 +213,13 @@ typedef struct {
 		/** Maximum supported base frequency value */
 		odp_fract_u64_t max_base_freq_hz;
 
+		/** Maximum number of timeout events that may be needed
+		 *
+		 *  The number of timeout events per timer, as returned by
+		 *  odp_timer_periodic_events(), is less than or equal to this value.
+		 */
+		uint32_t max_tmo_events;
+
 	} periodic;
 
 } odp_timer_capability_t;


### PR DESCRIPTION
With a periodic timer, require application to provide an array of timeout events in odp_timer_periodic_start(). Add a new API function odp_timer_periodic_events(), which returns the number of events.