### PR TITLE
[PATCH v3] api: hints: fix type conversion problem in odp_unlikely()

### DIFF
--- a/include/odp/api/spec/hints.h
+++ b/include/odp/api/spec/hints.h
@@ -61,7 +61,7 @@ extern "C" {
 /**
  * Branch unlikely taken
  */
-#define odp_unlikely(x) __builtin_expect((x), 0)
+#define odp_unlikely(x) __builtin_expect(!!(x), 0)
 
 /*
  * __builtin_prefetch (const void *addr, rw, locality)


### PR DESCRIPTION
Convert the argument of odp_unlikely() to boolean before passing it to __builtin_expect() which takes a long int argument. This prevents implementation-defined behaviour when the argument of odp_unlikely() does not fit in a long int. In certain systems with 32-bit long, odp_unlikely() currently turns certain non-zero 64-bit values to zero, breaking the code that is using odp_unlikely().