### PR TITLE
[PATCH v1] test: timer_perf: fix thread activity check

### DIFF
--- a/test/performance/odp_timer_perf.c
+++ b/test/performance/odp_timer_perf.c
@@ -1095,7 +1095,7 @@ static void print_stat_set_cancel_mode(test_global_t *global)
 	printf("        1      2      3      4      5      6      7      8      9     10");
 
 	for (i = 0; i < ODP_THREAD_COUNT_MAX; i++) {
-		if (global->stat[i].rounds) {
+		if (global->stat[i].sets) {
 			if ((num % 10) == 0)
 				printf("\n   ");
 
@@ -1152,7 +1152,7 @@ static void print_stat_expire_mode(test_global_t *global)
 	printf("        1      2      3      4      5      6      7      8      9     10");
 
 	for (i = 0; i < ODP_THREAD_COUNT_MAX; i++) {
-		if (global->stat[i].rounds) {
+		if (global->stat[i].events) {
 			if ((num % 10) == 0)
 				printf("\n   ");
 


### PR DESCRIPTION
To avoid division by zero in result print, check the value used in division instead of number of rounds.
