### PR TITLE
[PATCH v3] test: dma_perf: add new verify option

### DIFF
--- a/test/performance/odp_dma_perf_run.sh
+++ b/test/performance/odp_dma_perf_run.sh
@@ -28,42 +28,42 @@ check_result()
 echo "odp_dma_perf: synchronous DMA transfer 1"
 echo "===================================="
 
-${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 0 -i $SEGC -o $SEGC -s $SEGS -S 0 -f $INFL -T $TIME
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 0 -i $SEGC -o $SEGC -s $SEGS -S 0 -f $INFL -T $TIME -v
 
 check_result $?
 
 echo "odp_dma_perf: synchronous DMA transfer 2"
 echo "===================================="
 
-${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 0 -i $SEGC -o $SEGC -s $SEGS -S 1 -f $INFL -T $TIME
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 0 -i $SEGC -o $SEGC -s $SEGS -S 1 -f $INFL -T $TIME -v
 
 check_result $?
 
 echo "odp_dma_perf: asynchronous DMA transfer 1"
 echo "====================================="
 
-${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -i $SEGC -o $SEGC -s $SEGS -S 2 -m 0 -f $INFL -T $TIME
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -i $SEGC -o $SEGC -s $SEGS -S 2 -m 0 -f $INFL -T $TIME -v
 
 check_result $?
 
 echo "odp_dma_perf: asynchronous DMA transfer 2"
 echo "====================================="
 
-${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -i $SEGC -o $SEGC -s $SEGS -S 3 -m 1 -f $INFL -T $TIME
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 1 -i $SEGC -o $SEGC -s $SEGS -S 3 -m 1 -f $INFL -T $TIME -v
 
 check_result $?
 
 echo "odp_dma_perf: SW transfer 1"
 echo "====================================="
 
-${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 2 -i $SEGC -o $SEGC -s $SEGS -S 0 -f $INFL -T $TIME
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 2 -i $SEGC -o $SEGC -s $SEGS -S 0 -f $INFL -T $TIME -v
 
 check_result $?
 
 echo "odp_dma_perf: SW transfer 2"
 echo "====================================="
 
-${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 2 -i $SEGC -o $SEGC -s $SEGS -S 2 -f $INFL -T $TIME
+${TEST_DIR}/${BIN_NAME}${EXEEXT} -t 2 -i $SEGC -o $SEGC -s $SEGS -S 2 -f $INFL -T $TIME -v
 
 check_result $?
 


### PR DESCRIPTION
Add new option to verify correctness of successfully transferred data. This can be useful in the unlikely occurences of data corruption caused by a DMA subsystem.

v2:
- Fixed a commit message typo

v3:
- Rebased
- Added reviewed-by tag