### PR TITLE
[PATCH v6] Speed up testing slightly

### DIFF
--- a/example/packet/odp_pktio.c
+++ b/example/packet/odp_pktio.c
@@ -72,7 +72,7 @@ typedef struct {
 	char **if_names;	/**< Array of pointers to interface names */
 	int mode;		/**< Packet IO mode */
 	char *if_str;		/**< Storage for interface names */
-	int time;		/**< Time to run app */
+	double time;		/**< Time to run app */
 } appl_args_t;
 
 /**
@@ -479,7 +479,7 @@ int main(int argc, char *argv[])
 			odp_pktio_stop(pktio);
 		}
 		/* use delay to let workers clean up queues */
-		odp_time_wait_ns(ODP_TIME_SEC_IN_NS);
+		odp_time_wait_ns(100 * ODP_TIME_MSEC_IN_NS);
 		odp_atomic_store_u32(&args->exit_threads, 1);
 	}
 
@@ -615,7 +615,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 			appl_args->cpu_count = atoi(optarg);
 			break;
 		case 't':
-			appl_args->time = atoi(optarg);
+			appl_args->time = atof(optarg);
 			break;
 			/* parse packet-io interface names */
 		case 'i':
@@ -742,7 +742,7 @@ static void usage(char *progname)
 	       "\n"
 	       "Optional OPTIONS\n"
 	       "  -c, --count <number> CPU count, 0=all available, default=1\n"
-	       "  -t, --time <seconds> Number of seconds to run.\n"
+	       "  -t, --time <seconds> Number of seconds to run (e.g. 0.1).\n"
 	       "  -m, --mode      0: Receive and send directly (no queues)\n"
 	       "                  1: Receive and send via queues.\n"
 	       "                  2: Receive via scheduler, send via queues.\n"

--- a/example/packet/pktio_run.sh
+++ b/example/packet/pktio_run.sh
@@ -4,6 +4,8 @@
 # Copyright (c) 2016-2018 Linaro Limited
 #
 
+TEST_TIME=0.1
+
 if  [ -f ./pktio_env ]; then
 	. ./pktio_env
 else
@@ -15,7 +17,7 @@ fi
 setup_interfaces
 
 # burst mode
-./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 0
+./odp_pktio${EXEEXT} -i $IF1 -t $TEST_TIME -m 0
 STATUS=$?
 if [ ${STATUS} -ne 0 ]; then
 	echo "Error: status ${STATUS}"
@@ -26,7 +28,7 @@ validate_result
 echo "Pass -m 0: status ${STATUS}"
 
 # queue mode
-./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 1
+./odp_pktio${EXEEXT} -i $IF1 -t $TEST_TIME -m 1
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then
@@ -38,7 +40,7 @@ validate_result
 echo "Pass -m 1: status ${STATUS}"
 
 # sched/queue mode
-./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 2
+./odp_pktio${EXEEXT} -i $IF1 -t $TEST_TIME -m 2
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then
@@ -50,7 +52,7 @@ validate_result
 echo "Pass -m 2: status ${STATUS}"
 
 # cpu number option test 1
-./odp_pktio${EXEEXT} -i $IF1 -t 1 -m 0 -c 1
+./odp_pktio${EXEEXT} -i $IF1 -t $TEST_TIME -m 0 -c 1
 STATUS=$?
 
 if [ ${STATUS} -ne 0 ]; then

--- a/example/timer/odp_timer_simple.c
+++ b/example/timer/odp_timer_simple.c
@@ -121,9 +121,8 @@ int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 
 	ev = odp_timeout_to_event(tmo);
 
-	/* Calculate period for timer in uint64_t value, in current case
-	 * we will schedule timer for 1 second */
-	period = odp_timer_ns_to_tick(timer_pool, 1 * ODP_TIME_SEC_IN_NS);
+	/* Calculate timer period in ticks */
+	period = odp_timer_ns_to_tick(timer_pool, 100 * ODP_TIME_MSEC_IN_NS);
 
 	/* Wait time to return from odp_schedule() if there are no
 	 * events
@@ -159,7 +158,7 @@ int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 		       i, odp_time_to_ns(time));
 
 		/* Do not free current event, just go back to loop and program
-		 * timeout to next second.
+		 * the next timeout.
 		 */
 	}
 

--- a/example/traffic_mgmt/odp_traffic_mgmt.c
+++ b/example/traffic_mgmt/odp_traffic_mgmt.c
@@ -292,7 +292,7 @@ static uint32_t next_rand_byte;
 static odp_atomic_u32_t atomic_pkts_into_tm;
 static odp_atomic_u32_t atomic_pkts_from_tm;
 
-static uint32_t g_num_pkts_to_send = 1000;
+static uint32_t g_num_pkts_to_send = 100;
 static uint8_t  g_print_tm_stats   = TRUE;
 
 static void tester_egress_fcn(odp_packet_t odp_pkt);

--- a/platform/linux-generic/test/pktio_ipc/ipc_common.c
+++ b/platform/linux-generic/test/pktio_ipc/ipc_common.c
@@ -151,15 +151,13 @@ void usage(char *progname)
 {
 	printf("\n"
 	       "Usage: %s OPTIONS\n"
-	       "  E.g. -n ipc_name_space %s -t seconds\n"
 	       "\n"
 	       "OpenDataPlane odp-linux ipc test application.\n"
 	       "\n"
-		"Mandatory OPTIONS:\n"
-	       "  -n, --ns           IPC name space ID /dev/shm/odp-<ns>-objname.\n"
 	       "Optional OPTIONS\n"
 	       "  -h, --help           Display help and exit.\n"
+	       "  -p, --pid            PID of the master process.\n"
 	       "  -t, --time           Time to run in seconds.\n"
-	       "\n", NO_PATH(progname), NO_PATH(progname)
+	       "\n", NO_PATH(progname)
 	    );
 }

--- a/platform/linux-generic/test/pktio_ipc/ipc_common.c
+++ b/platform/linux-generic/test/pktio_ipc/ipc_common.c
@@ -1,11 +1,12 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/*  SPDX-License-Identifier: BSD-3-Clause
+ *  Copyright (c) 2015-2018 Linaro Limited
+ *  Copyright (c) 2023 Nokia
  */
 
 #include "ipc_common.h"
 
+/** Start time in seconds */
+int start_time_sec;
 /** Run time in seconds */
 int run_time_sec;
 /** Pid of the master process */
@@ -97,23 +98,28 @@ void parse_args(int argc, char *argv[])
 	int opt;
 	int long_index;
 	static struct option longopts[] = {
-		{"time", required_argument, NULL, 't'},
+		{"start-timeout", required_argument, NULL, 's'},
+		{"run-time", required_argument, NULL, 't'},
 		{"pid", required_argument, NULL, 'p'}, /* master process pid */
 		{"help", no_argument, NULL, 'h'},     /* return 'h' */
 		{NULL, 0, NULL, 0}
 	};
 
+	start_time_sec = 0; /* wait forever if time is 0 */
 	run_time_sec = 0; /* loop forever if time to run is 0 */
 	master_pid = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, "+t:p:h",
+		opt = getopt_long(argc, argv, "+s:t:p:h",
 				  longopts, &long_index);
 
 		if (opt == -1)
 			break;	/* No more options */
 
 		switch (opt) {
+		case 's':
+			start_time_sec = atoi(optarg);
+			break;
 		case 't':
 			run_time_sec = atoi(optarg);
 			break;
@@ -157,7 +163,8 @@ void usage(char *progname)
 	       "Optional OPTIONS\n"
 	       "  -h, --help           Display help and exit.\n"
 	       "  -p, --pid            PID of the master process.\n"
-	       "  -t, --time           Time to run in seconds.\n"
+	       "  -t, --run-time       Time to run in seconds.\n"
+	       "  -s, --start-timeout  Maximum time for pktio startup.\n"
 	       "\n", NO_PATH(progname)
 	    );
 }

--- a/platform/linux-generic/test/pktio_ipc/ipc_common.h
+++ b/platform/linux-generic/test/pktio_ipc/ipc_common.h
@@ -1,7 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/*  SPDX-License-Identifier: BSD-3-Clause
+ *  Copyright (c) 2015-2018 Linaro Limited
+ *  Copyright (c) 2023 Nokia
  */
 
 #define _POSIX_C_SOURCE 200809L
@@ -63,6 +62,9 @@ typedef struct ODP_PACKED {
 typedef struct ODP_PACKED {
 	odp_u32be_t magic;
 } pkt_tail_t;
+
+/** Start time in seconds */
+extern int start_time_sec;
 
 /** Run time in seconds */
 extern int run_time_sec;

--- a/platform/linux-generic/test/pktio_ipc/pktio_ipc1.c
+++ b/platform/linux-generic/test/pktio_ipc/pktio_ipc1.c
@@ -1,7 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/*  SPDX-License-Identifier: BSD-3-Clause
+ *  Copyright (c) 2015-2018 Linaro Limited
+ *  Copyright (c) 2023 Nokia
  */
 
 #include "ipc_common.h"
@@ -49,17 +48,17 @@ static int pktio_run_loop(odp_pool_t pool)
 	else
 		sprintf(name, TEST_IPC_PKTIO_NAME);
 
-	wait = odp_time_local_from_ns(run_time_sec * ODP_TIME_SEC_IN_NS);
+	wait = odp_time_local_from_ns(start_time_sec * ODP_TIME_SEC_IN_NS);
 	start_cycle = odp_time_local();
 	current_cycle = start_cycle;
 
 	for (;;) {
-		if (run_time_sec) {
+		if (start_time_sec) {
 			cycle = odp_time_local();
 			diff = odp_time_diff(cycle, start_cycle);
 			if (odp_time_cmp(wait, diff) < 0) {
-				printf("timeout exit, run_time_sec %d\n",
-				       run_time_sec);
+				printf("timeout exit 1, start_time_sec %d\n",
+				       start_time_sec);
 				return -1;
 			}
 		}
@@ -83,12 +82,12 @@ static int pktio_run_loop(odp_pool_t pool)
 
 	/* start ipc pktio, i.e. wait until other process connects */
 	for (;;) {
-		if (run_time_sec) {
+		if (start_time_sec) {
 			cycle = odp_time_local();
 			diff = odp_time_diff(cycle, start_cycle);
 			if (odp_time_cmp(wait, diff) < 0) {
-				printf("timeout exit, run_time_sec %d\n",
-				       run_time_sec);
+				printf("timeout exit 2, start_time_sec %d\n",
+				       start_time_sec);
 				goto exit;
 			}
 		}
@@ -102,6 +101,8 @@ static int pktio_run_loop(odp_pool_t pool)
 	}
 
 	/* packets loop */
+	wait = odp_time_local_from_ns(run_time_sec * ODP_TIME_SEC_IN_NS);
+	start_cycle = odp_time_local();
 	for (;;) {
 		int i;
 

--- a/platform/linux-generic/test/pktio_ipc/pktio_ipc2.c
+++ b/platform/linux-generic/test/pktio_ipc/pktio_ipc2.c
@@ -1,7 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/*  SPDX-License-Identifier: BSD-3-Clause
+ *  Copyright (c) 2015-2018 Linaro Limited
+ *  Copyright (c) 2023 Nokia
  */
 
 /**
@@ -46,17 +45,17 @@ static int ipc_second_process(int master_pid)
 		exit(EXIT_FAILURE);
 	}
 
-	wait = odp_time_local_from_ns(run_time_sec * ODP_TIME_SEC_IN_NS);
+	wait = odp_time_local_from_ns(start_time_sec * ODP_TIME_SEC_IN_NS);
 	start_cycle = odp_time_local();
 
 	for (;;) {
 		/*  exit loop if time specified */
-		if (run_time_sec) {
+		if (start_time_sec) {
 			cycle = odp_time_local();
 			diff = odp_time_diff(cycle, start_cycle);
 			if (odp_time_cmp(wait, diff) < 0) {
-				printf("timeout exit, run_time_sec %d\n",
-				       run_time_sec);
+				printf("timeout exit 1, start_time_sec %d\n",
+				       start_time_sec);
 				goto not_started;
 			}
 		}
@@ -85,12 +84,12 @@ static int ipc_second_process(int master_pid)
 	/* start ipc pktio, i.e. wait until other process connects */
 	for (;;) {
 		/* 1. exit loop if time specified */
-		if (run_time_sec) {
+		if (start_time_sec) {
 			cycle = odp_time_local();
 			diff = odp_time_diff(cycle, start_cycle);
 			if (odp_time_cmp(wait, diff) < 0) {
-				printf("timeout exit, run_time_sec %d\n",
-				       run_time_sec);
+				printf("timeout exit 2, start_time_sec %d\n",
+				       start_time_sec);
 				goto not_started;
 			}
 		}
@@ -103,6 +102,8 @@ static int ipc_second_process(int master_pid)
 		odp_time_wait_ns(50 * ODP_TIME_MSEC_IN_NS);
 	}
 
+	wait = odp_time_local_from_ns(run_time_sec * ODP_TIME_SEC_IN_NS);
+	start_cycle = odp_time_local();
 	for (;;) {
 		/* exit loop if time specified */
 		if (run_time_sec) {

--- a/platform/linux-generic/test/pktio_ipc/pktio_ipc_run.sh
+++ b/platform/linux-generic/test/pktio_ipc/pktio_ipc_run.sh
@@ -17,31 +17,22 @@ PATH=$(dirname $0)/../../../../platform/linux-generic/test/pktio_ipc:$PATH
 PATH=.:$PATH
 
 STARTTIME=30
-RUNTIME1=3
-RUNTIME2=1
-TIMEOUT=3
-if [ "${TEST}" = "coverage" ]; then
-	RUNTIME1=30
-	RUNTIME2=15
-	TIMEOUT=20
-fi
+RUNTIME=1
 
 run()
 {
 	local ret=0
 
 	echo "==== run pktio_ipc1 then pktio_ipc2 ===="
-	pktio_ipc1${EXEEXT} -s ${STARTTIME} -t ${RUNTIME1} &
+	pktio_ipc1${EXEEXT} -s ${STARTTIME} -t ${RUNTIME} &
 	IPC_PID=$!
 
-	pktio_ipc2${EXEEXT} -p ${IPC_PID}  -s ${STARTTIME} -t ${RUNTIME2}
+	pktio_ipc2${EXEEXT} -p ${IPC_PID}  -s ${STARTTIME} -t ${RUNTIME}
 	ret=$?
-	# pktio_ipc1 should do clean up and exit just
-	# after pktio_ipc2 exited. If it does not happen
-	# kill him in test.
-	sleep ${TIMEOUT}
+
 	(kill ${IPC_PID} 2>&1 > /dev/null ) > /dev/null
 	if [ $? -eq 0 ]; then
+		wait $IPC_PID
 		echo "pktio_ipc1${EXEEXT} was killed"
 		ls -l /dev/shm/${UID}/odp* 2> /dev/null
 		rm -rf /dev/shm/${UID}/odp-${IPC_PID}* 2>&1 > /dev/null
@@ -58,16 +49,15 @@ run()
 	fi
 
 	echo "==== run pktio_ipc2 then pktio_ipc1 ===="
-	pktio_ipc2${EXEEXT}  -s ${STARTTIME} -t ${RUNTIME1} &
+	pktio_ipc2${EXEEXT}  -s ${STARTTIME} -t ${RUNTIME} &
 	IPC_PID=$!
 
-	pktio_ipc1${EXEEXT} -p ${IPC_PID}  -s ${STARTTIME} -t ${RUNTIME2}
+	pktio_ipc1${EXEEXT} -p ${IPC_PID}  -s ${STARTTIME} -t ${RUNTIME}
 	ret=$?
-	# pktio_ipc2 do not exit on pktio_ipc1 disconnect
-	# wait until it exits cleanly
-	sleep ${TIMEOUT}
+
 	(kill ${IPC_PID} 2>&1 > /dev/null ) > /dev/null
 	if [ $? -eq 0 ]; then
+		wait $IPC_PID
 		echo "pktio_ipc2${EXEEXT} was killed"
 		ls -l /dev/shm/${UID}/odp* 2> /dev/null
 		rm -rf /dev/shm/${UID}/odp-${IPC_PID}* 2>&1 > /dev/null

--- a/platform/linux-generic/test/pktio_ipc/pktio_ipc_run.sh
+++ b/platform/linux-generic/test/pktio_ipc/pktio_ipc_run.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 #
-# Copyright (c) 2015-2018, Linaro Limited
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2015-2018 Linaro Limited
+# Copyright (c) 2023 Nokia
 #
 
 # directories where test binary can be found:
@@ -17,6 +16,7 @@ PATH=$(dirname $0):$PATH
 PATH=$(dirname $0)/../../../../platform/linux-generic/test/pktio_ipc:$PATH
 PATH=.:$PATH
 
+STARTTIME=30
 RUNTIME1=3
 RUNTIME2=1
 TIMEOUT=3
@@ -31,10 +31,10 @@ run()
 	local ret=0
 
 	echo "==== run pktio_ipc1 then pktio_ipc2 ===="
-	pktio_ipc1${EXEEXT} -t ${RUNTIME1} &
+	pktio_ipc1${EXEEXT} -s ${STARTTIME} -t ${RUNTIME1} &
 	IPC_PID=$!
 
-	pktio_ipc2${EXEEXT} -p ${IPC_PID} -t ${RUNTIME2}
+	pktio_ipc2${EXEEXT} -p ${IPC_PID}  -s ${STARTTIME} -t ${RUNTIME2}
 	ret=$?
 	# pktio_ipc1 should do clean up and exit just
 	# after pktio_ipc2 exited. If it does not happen
@@ -58,10 +58,10 @@ run()
 	fi
 
 	echo "==== run pktio_ipc2 then pktio_ipc1 ===="
-	pktio_ipc2${EXEEXT} -t ${RUNTIME1} &
+	pktio_ipc2${EXEEXT}  -s ${STARTTIME} -t ${RUNTIME1} &
 	IPC_PID=$!
 
-	pktio_ipc1${EXEEXT} -p ${IPC_PID} -t ${RUNTIME2}
+	pktio_ipc1${EXEEXT} -p ${IPC_PID}  -s ${STARTTIME} -t ${RUNTIME2}
 	ret=$?
 	# pktio_ipc2 do not exit on pktio_ipc1 disconnect
 	# wait until it exits cleanly

--- a/test/performance/odp_atomic_perf.c
+++ b/test/performance/odp_atomic_perf.c
@@ -24,7 +24,7 @@
 #include <odp/helper/odph_api.h>
 
 /* Default number of test rounds */
-#define NUM_ROUNDS 1000000u
+#define NUM_ROUNDS 100000u
 
 /* Initial value for atomic variables. Supports up to 2 billion
  * rounds of 32-bit min and max tests. */

--- a/test/performance/odp_bench_buffer.c
+++ b/test/performance/odp_bench_buffer.c
@@ -34,7 +34,7 @@
 #define TEST_REPEAT_COUNT 1000
 
 /** Default number of rounds per test case */
-#define TEST_ROUNDS 1000u
+#define TEST_ROUNDS 100u
 
 /** Maximum burst size for *_multi operations */
 #define TEST_MAX_BURST 64

--- a/test/performance/odp_bench_packet.c
+++ b/test/performance/odp_bench_packet.c
@@ -41,7 +41,7 @@
 #define TEST_REPEAT_COUNT 1000
 
 /** Number of rounds per test case */
-#define TEST_ROUNDS 10u
+#define TEST_ROUNDS 2u
 
 /** Maximum burst size for *_multi operations */
 #define TEST_MAX_BURST 64

--- a/test/performance/odp_scheduling_run.sh
+++ b/test/performance/odp_scheduling_run.sh
@@ -19,7 +19,7 @@ run()
 	if [ $(nproc) -lt $1 ]; then
 		echo "Not enough CPU cores. Skipping test."
 	else
-		$TEST_DIR/odp_scheduling${EXEEXT} -c $1
+		$TEST_DIR/odp_scheduling${EXEEXT} -c $1 -t 0.1
 		RET_VAL=$?
 		if [ $RET_VAL -ne 0 ]; then
 			echo odp_scheduling FAILED

--- a/test/performance/odp_stress.c
+++ b/test/performance/odp_stress.c
@@ -81,8 +81,8 @@ static void print_usage(void)
 	       "Stress test options:\n"
 	       "\n"
 	       "  -c, --num_cpu          Number of CPUs (worker threads). 0: all available CPUs. Default: 1\n"
-	       "  -p, --period_ns        Timeout period in nsec. Default: 1 sec\n"
-	       "  -r, --rounds           Number of timeout rounds. Default: 10\n"
+	       "  -p, --period_ns        Timeout period in nsec. Default: 100 ms\n"
+	       "  -r, --rounds           Number of timeout rounds. Default: 2\n"
 	       "  -m, --mode             Select test mode. Default: 1\n"
 	       "                           0: No stress, just wait for timeouts\n"
 	       "                           1: Memcpy\n"
@@ -114,8 +114,8 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	static const char *shortopts = "+c:p:r:m:s:g:h";
 
 	test_options->num_cpu     = 1;
-	test_options->period_ns   = 1000 * ODP_TIME_MSEC_IN_NS;
-	test_options->rounds      = 10;
+	test_options->period_ns   = 100 * ODP_TIME_MSEC_IN_NS;
+	test_options->rounds      = 2;
 	test_options->mode        = 1;
 	test_options->mem_size    = 2048;
 	test_options->group_mode  = 1;

--- a/test/validation/api/pktio/lso.c
+++ b/test/validation/api/pktio/lso.c
@@ -689,9 +689,9 @@ static void lso_send_custom_eth(const uint8_t *test_packet, uint32_t pkt_len, ui
 
 	ODPH_DBG("\n    Sent payload length:     %u bytes\n", sent_payload);
 
-	/* Wait 1 sec to receive all created segments. Timeout and MAX_NUM_SEG values should be
+	/* Wait a bit to receive all created segments. Timeout and MAX_NUM_SEG values should be
 	 * large enough to ensure that we receive all created segments. */
-	num = recv_packets(pktio_b, ODP_TIME_SEC_IN_NS, pkt_out, MAX_NUM_SEG);
+	num = recv_packets(pktio_b, 100 * ODP_TIME_MSEC_IN_NS, pkt_out, MAX_NUM_SEG);
 	CU_ASSERT(num > 0);
 	CU_ASSERT(num < MAX_NUM_SEG);
 
@@ -814,9 +814,9 @@ static void lso_send_ipv4(const uint8_t *test_packet, uint32_t pkt_len, uint32_t
 
 	ODPH_DBG("\n    Sent payload length:     %u bytes\n", sent_payload);
 
-	/* Wait 1 sec to receive all created segments. Timeout and MAX_NUM_SEG values should be
+	/* Wait a bit to receive all created segments. Timeout and MAX_NUM_SEG values should be
 	 * large enough to ensure that we receive all created segments. */
-	num = recv_packets(pktio_b, ODP_TIME_SEC_IN_NS, packet, MAX_NUM_SEG);
+	num = recv_packets(pktio_b, 100 * ODP_TIME_MSEC_IN_NS, packet, MAX_NUM_SEG);
 	CU_ASSERT(num > 0);
 	CU_ASSERT(num < MAX_NUM_SEG);
 

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -5097,7 +5097,7 @@ static void pktio_test_pktin_event_queue(odp_pktin_mode_t pktin_mode)
 	int num_buf = 0;
 	int num_bad = 0;
 	odp_pktio_t pktio[MAX_NUM_IFACES] = {0};
-	uint64_t wait_sec = odp_schedule_wait_time(ODP_TIME_SEC_IN_NS);
+	uint64_t wait_time = odp_schedule_wait_time(100 * ODP_TIME_MSEC_IN_NS);
 
 	CU_ASSERT_FATAL(num_ifaces >= 1);
 
@@ -5170,9 +5170,9 @@ static void pktio_test_pktin_event_queue(odp_pktin_mode_t pktin_mode)
 
 	/* Receive events */
 	while (1) {
-		/* Break after 1 sec of inactivity */
+		/* Break after a period of inactivity */
 		if (pktin_mode == ODP_PKTIN_MODE_SCHED) {
-			ev = odp_schedule(&from, wait_sec);
+			ev = odp_schedule(&from, wait_time);
 
 			if (ev == ODP_EVENT_INVALID)
 				break;

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -54,9 +54,9 @@
 #define CHAOS_PTR_TO_NDX(p) ((uint64_t)(uint32_t)(uintptr_t)p)
 #define CHAOS_NDX_TO_PTR(n) ((void *)(uintptr_t)n)
 
-#define WAIT_TIMEOUT     (1000 * ODP_TIME_MSEC_IN_NS)
+#define WAIT_TIMEOUT     (100 * ODP_TIME_MSEC_IN_NS)
 #define WAIT_ROUNDS      5
-#define WAIT_TOLERANCE   (150 * ODP_TIME_MSEC_IN_NS)
+#define WAIT_TOLERANCE   (15 * ODP_TIME_MSEC_IN_NS)
 #define WAIT_1MS_RETRIES 1000
 
 #define SCHED_AND_PLAIN_ROUNDS 10000

--- a/test/validation/api/system/system.c
+++ b/test/validation/api/system/system.c
@@ -241,7 +241,7 @@ static void system_test_cpu_cycles_long_period(void)
 	}
 
 	/* wrap was detected, no need to continue */
-	if (i < PERIODS_100_MSEC) {
+	if (i < periods) {
 		printf("wrap was detected.\n");
 		return;
 	}


### PR DESCRIPTION
Make 'make check' run slightly faster by speeding up various tests and other programs run during 'make check'.

Performance tests and examples are run in 'make check' just to see that they do not crash otherwise directly fail, so there is no use in running them for more than just a brief time.