### PR TITLE
[PATCH v2] linux-gen: pktio: avoid possibility of out of bounds warnings in lso_update_custom()

### DIFF
--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -3015,8 +3015,15 @@ static int lso_update_custom(lso_profile_t *lso_prof, odp_packet_t pkt, int segn
 			ptr = &u32;
 		else if (size == 2)
 			ptr = &u16;
-		else
+		else {
+			/*
+			 * odp_lso_profile_create() ensures that size is one of the allowed values.
+			 * But compiler doesn't know that, so set it here to avoid possibility of
+			 * out of bounds warnings.
+			 */
+			size = 1;
 			ptr = &u8;
+		}
 
 		if (odp_packet_copy_to_mem(pkt, offset, size, ptr)) {
 			_ODP_ERR("Read from packet failed at offset %u\n", offset);


### PR DESCRIPTION
odp_lso_profile_create() ensures that size is one of the allowed values. But the compiler doesn't know that, and it may generate out of bounds warnings in some cases. For example, in odp-dpdk, where odp_packet_copy_to_mem() calls rte_memcpy(), this results in:

/usr/lib/gcc/x86_64-redhat-linux/13/include/emmintrin.h:742:8: warning: array subscript ‘__m128i_u[0]’ is partly outside array bounds of ‘void[8]’ [-Warray-bounds=]

Set the value of size to 1 if it's not one of the allowed values.