### PR TITLE
[PATCH v2] api: fix doxygen documentation grouping

### DIFF
--- a/doc/implementers-guide/implementers-guide.adoc
+++ b/doc/implementers-guide/implementers-guide.adoc
@@ -208,7 +208,7 @@ Within the platform agnostic area, the validation tests for a given interface
 are also grouped by modules, matching the ODP interface modules: for instance,
 `test/common_plat/validation/api` mainly contains a list of
 directories matching each module name (as defined by the doxygen `@defgroup`
-or `@ingroup` statement present in each API `.h` file).
+or `@addtogroup` statement present in each API `.h` file).
 
 Within each of these directories, a library (called `libtest<module>.la`) and
 its associated `.h` file (called `<module>.h`) defines all the test functions

--- a/include/odp/api/abi-default/align.h
+++ b/include/odp/api/abi-default/align.h
@@ -17,7 +17,7 @@ extern "C" {
 
 #include <odp/api/abi/cpu.h>
 
-/** @ingroup odp_compiler_optim
+/** @addtogroup odp_compiler_optim
  *  @{
  */
 

--- a/include/odp/api/abi-default/buffer_types.h
+++ b/include/odp/api/abi-default/buffer_types.h
@@ -13,7 +13,7 @@ extern "C" {
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_buffer_t;
 
-/** @ingroup odp_buffer
+/** @addtogroup odp_buffer
  *  @{
  */
 

--- a/include/odp/api/abi-default/classification.h
+++ b/include/odp/api/abi-default/classification.h
@@ -15,7 +15,7 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_cos_t;
 /** Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_pmr_t;
 
-/** @ingroup odp_classification
+/** @addtogroup odp_classification
  *  @{
  */
 

--- a/include/odp/api/abi-default/comp.h
+++ b/include/odp/api/abi-default/comp.h
@@ -14,7 +14,7 @@ extern "C" {
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_comp_session_t;
 
-/** @ingroup odp_compression
+/** @addtogroup odp_compression
  *  @{
  */
 

--- a/include/odp/api/abi-default/crypto_types.h
+++ b/include/odp/api/abi-default/crypto_types.h
@@ -12,7 +12,7 @@ extern "C" {
 
 #include <stdint.h>
 
-/** @ingroup odp_crypto
+/** @addtogroup odp_crypto
  *  @{
  */
 

--- a/include/odp/api/abi-default/dma_types.h
+++ b/include/odp/api/abi-default/dma_types.h
@@ -17,7 +17,7 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_dma_t;
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_dma_compl_t;
 
-/** @ingroup odp_dma
+/** @addtogroup odp_dma
  *  @{
  */
 

--- a/include/odp/api/abi-default/event_types.h
+++ b/include/odp/api/abi-default/event_types.h
@@ -15,7 +15,7 @@ extern "C" {
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_event_t;
 
-/** @ingroup odp_event
+/** @addtogroup odp_event
  *  @{
  */
 

--- a/include/odp/api/abi-default/ipsec_types.h
+++ b/include/odp/api/abi-default/ipsec_types.h
@@ -15,7 +15,7 @@ extern "C" {
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_ipsec_sa_t;
 
-/** @ingroup odp_ipsec
+/** @addtogroup odp_ipsec
  *  @{
  */
 

--- a/include/odp/api/abi-default/packet_io_types.h
+++ b/include/odp/api/abi-default/packet_io_types.h
@@ -25,7 +25,6 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_pktio_t;
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_lso_profile_t;
 
 /** @addtogroup odp_packet_io
- *  Operations on a packet.
  *  @{
  */
 

--- a/include/odp/api/abi-default/packet_types.h
+++ b/include/odp/api/abi-default/packet_types.h
@@ -27,7 +27,7 @@ typedef struct { char dummy; /**< *internal Dummy */ } _odp_abi_packet_vector_t;
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< *internal Dummy */ } _odp_abi_packet_tx_compl_t;
 
-/** @ingroup odp_packet
+/** @addtogroup odp_packet
  *  @{
  */
 

--- a/include/odp/api/abi-default/pool_types.h
+++ b/include/odp/api/abi-default/pool_types.h
@@ -13,7 +13,7 @@ extern "C" {
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_pool_t;
 
-/** @ingroup odp_pool
+/** @addtogroup odp_pool
  *  @{
  */
 

--- a/include/odp/api/abi-default/proto_stats_types.h
+++ b/include/odp/api/abi-default/proto_stats_types.h
@@ -15,8 +15,7 @@ extern "C" {
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_proto_stats_t;
 
-/** @ingroup odp_proto_stats
- *  Operations on a proto stats object.
+/** @addtogroup odp_proto_stats
  *  @{
  */
 

--- a/include/odp/api/abi-default/queue_types.h
+++ b/include/odp/api/abi-default/queue_types.h
@@ -13,7 +13,7 @@ extern "C" {
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_queue_t;
 
-/** @ingroup odp_queue
+/** @addtogroup odp_queue
  *  @{
  */
 

--- a/include/odp/api/abi-default/shared_memory.h
+++ b/include/odp/api/abi-default/shared_memory.h
@@ -12,7 +12,7 @@ extern "C" {
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_shm_t;
 
-/** @ingroup odp_shared_memory
+/** @addtogroup odp_shared_memory
  *  @{
  */
 

--- a/include/odp/api/abi-default/stash_types.h
+++ b/include/odp/api/abi-default/stash_types.h
@@ -12,7 +12,7 @@ extern "C" {
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_stash_t;
 
-/** @ingroup odp_stash
+/** @addtogroup odp_stash
  *  @{
  */
 

--- a/include/odp/api/abi-default/thread_types.h
+++ b/include/odp/api/abi-default/thread_types.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-/** @ingroup odp_thread
+/** @addtogroup odp_thread
  *  @{
  */
 

--- a/include/odp/api/abi-default/time_types.h
+++ b/include/odp/api/abi-default/time_types.h
@@ -11,7 +11,7 @@ extern "C" {
 
 #include <stdint.h>
 
-/** @ingroup odp_time
+/** @addtogroup odp_time
  *  @{
  **/
 

--- a/include/odp/api/spec/buffer.h
+++ b/include/odp/api/spec/buffer.h
@@ -22,7 +22,7 @@ extern "C" {
 #include <odp/api/pool_types.h>
 #include <odp/api/std_types.h>
 
-/** @defgroup odp_buffer ODP BUFFER
+/** @addtogroup odp_buffer
  *  Buffer event metadata and operations.
  *  @{
  */

--- a/include/odp/api/spec/buffer_types.h
+++ b/include/odp/api/spec/buffer_types.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif
 
-/** @addtogroup odp_buffer
+/** @defgroup odp_buffer ODP BUFFER
  *  @{
  */
 

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-/** @defgroup odp_crypto ODP CRYPTO
+/** @addtogroup odp_crypto
  *  Data ciphering and authentication.
  *  @{
  */

--- a/include/odp/api/spec/crypto_types.h
+++ b/include/odp/api/spec/crypto_types.h
@@ -20,7 +20,7 @@
 extern "C" {
 #endif
 
-/** @addtogroup odp_crypto
+/** @defgroup odp_crypto ODP CRYPTO
  *  @{
  */
 

--- a/include/odp/api/spec/debug.h
+++ b/include/odp/api/spec/debug.h
@@ -15,6 +15,10 @@
 extern "C" {
 #endif
 
+/** @addtogroup odp_initialization
+ *  @{
+ */
+
 /**
  * @def ODP_STATIC_ASSERT
  * Compile time assertion macro. Fails compilation and outputs message 'msg'
@@ -24,6 +28,10 @@ extern "C" {
  * @param cond Conditional expression to be evaluated at compile time
  *
  * @param msg  Compile time error message to be displayed if cond is false
+ */
+
+/**
+ * @}
  */
 
 #ifdef __cplusplus

--- a/include/odp/api/spec/event.h
+++ b/include/odp/api/spec/event.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <odp/api/packet_types.h>
 #include <odp/api/pool_types.h>
 
-/** @defgroup odp_event ODP EVENT
+/** @addtogroup odp_event
  *  Generic event metadata and operations.
  *  @{
  */

--- a/include/odp/api/spec/event_types.h
+++ b/include/odp/api/spec/event_types.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif
 
-/** @addtogroup odp_event
+/** @defgroup odp_event ODP EVENT
  *  @{
  */
 

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -23,7 +23,7 @@ extern "C" {
 #include <odp/api/packet_types.h>
 #include <odp/api/std_types.h>
 
-/** @defgroup odp_ipsec ODP IPSEC
+/** @addtogroup odp_ipsec
  *  IPSEC protocol offload.
  *  @{
  */

--- a/include/odp/api/spec/ipsec_types.h
+++ b/include/odp/api/spec/ipsec_types.h
@@ -24,7 +24,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/traffic_mngr.h>
 
-/** @addtogroup odp_ipsec
+/** @defgroup odp_ipsec ODP IPSEC
  *  @{
  */
 

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -25,7 +25,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/time_types.h>
 
-/** @defgroup odp_packet ODP PACKET
+/** @addtogroup odp_packet
  *  Packet event metadata and operations.
  *  @{
  */

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -25,7 +25,7 @@ extern "C" {
 #include <odp/api/reassembly.h>
 #include <odp/api/time_types.h>
 
-/** @defgroup odp_packet_io ODP PACKET IO
+/** @addtogroup odp_packet_io
  *  Packet IO interfaces.
  *
  * Packet IO is the Ingress and Egress interface to ODP processing. It

--- a/include/odp/api/spec/packet_io_types.h
+++ b/include/odp/api/spec/packet_io_types.h
@@ -24,7 +24,7 @@ extern "C" {
 #include <odp/api/reassembly.h>
 #include <odp/api/std_types.h>
 
-/** @addtogroup odp_packet_io
+/** @defgroup odp_packet_io ODP PACKET IO
  *  @{
  */
 

--- a/include/odp/api/spec/packet_types.h
+++ b/include/odp/api/spec/packet_types.h
@@ -20,7 +20,7 @@ extern "C" {
 #include <odp/api/proto_stats_types.h>
 #include <odp/api/queue_types.h>
 
-/** @addtogroup odp_packet
+/** @defgroup odp_packet ODP PACKET
  *  @{
  */
 

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -20,7 +20,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/pool_types.h>
 
-/** @defgroup odp_pool ODP POOL
+/** @addtogroup odp_pool
  *  Packet and buffer (event) pools.
  *  @{
  */

--- a/include/odp/api/spec/pool_types.h
+++ b/include/odp/api/spec/pool_types.h
@@ -19,7 +19,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/dma_types.h>
 
-/** @addtogroup odp_pool
+/** @defgroup odp_pool ODP POOL
  *  @{
  */
 

--- a/include/odp/api/spec/proto_stats.h
+++ b/include/odp/api/spec/proto_stats.h
@@ -18,7 +18,7 @@ extern "C" {
 
 #include <odp/api/proto_stats_types.h>
 
-/** @defgroup odp_proto_stats ODP PROTO STATS
+/** @addtogroup odp_proto_stats
  *  Flow specific packet statistics.
  *  @{
  */

--- a/include/odp/api/spec/proto_stats_types.h
+++ b/include/odp/api/spec/proto_stats_types.h
@@ -19,8 +19,13 @@ extern "C" {
 
 #include <odp/api/std_types.h>
 
-/** @addtogroup odp_proto_stats
+/** @defgroup odp_proto_stats ODP PROTO STATS
  *  @{
+ */
+
+/**
+ * @typedef odp_proto_stats_t
+ * ODP proto stats handle
  */
 
 /**

--- a/include/odp/api/spec/queue.h
+++ b/include/odp/api/spec/queue.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <odp/api/queue_types.h>
 #include <odp/api/std_types.h>
 
-/** @defgroup odp_queue ODP QUEUE
+/** @addtogroup odp_queue
  *  Queues for event passing and scheduling.
  *  @{
  */

--- a/include/odp/api/spec/queue_types.h
+++ b/include/odp/api/spec/queue_types.h
@@ -18,7 +18,7 @@ extern "C" {
 
 #include <odp/api/schedule_types.h>
 
-/** @addtogroup odp_queue
+/** @defgroup odp_queue ODP QUEUE
  *  @{
  */
 

--- a/include/odp/api/spec/random.h
+++ b/include/odp/api/spec/random.h
@@ -19,7 +19,7 @@ extern "C" {
 #include <odp/api/random_types.h>
 #include <odp/api/std_types.h>
 
-/** @defgroup odp_random ODP RANDOM
+/** @addtogroup odp_random
  *  Random number generation.
  *  @{
  */

--- a/include/odp/api/spec/random_types.h
+++ b/include/odp/api/spec/random_types.h
@@ -19,7 +19,7 @@ extern "C" {
 
 #include <odp/api/std_types.h>
 
-/** @addtogroup odp_random
+/** @defgroup odp_random ODP RANDOM
  *  @{
  */
 

--- a/include/odp/api/spec/schedule.h
+++ b/include/odp/api/spec/schedule.h
@@ -22,7 +22,7 @@ extern "C" {
 #include <odp/api/schedule_types.h>
 #include <odp/api/thrmask.h>
 
-/** @defgroup odp_scheduler ODP SCHEDULER
+/** @addtogroup odp_scheduler
  *  Event scheduler for work load balancing and prioritization.
  *  @{
  */

--- a/include/odp/api/spec/schedule_types.h
+++ b/include/odp/api/spec/schedule_types.h
@@ -20,7 +20,7 @@
 extern "C" {
 #endif
 
-/** @addtogroup odp_scheduler
+/** @defgroup odp_scheduler ODP SCHEDULER
  *  @{
  */
 

--- a/include/odp/api/spec/stash.h
+++ b/include/odp/api/spec/stash.h
@@ -18,7 +18,7 @@ extern "C" {
 
 #include <odp/api/stash_types.h>
 
-/** @defgroup odp_stash ODP STASH
+/** @addtogroup odp_stash
  *  Stash for storing object handles
  *  @{
  */

--- a/include/odp/api/spec/stash_types.h
+++ b/include/odp/api/spec/stash_types.h
@@ -18,7 +18,7 @@ extern "C" {
 
 #include <odp/api/std_types.h>
 
-/** @addtogroup odp_stash
+/** @defgroup odp_stash ODP STASH
  *  @{
  */
 

--- a/include/odp/api/spec/std.h
+++ b/include/odp/api/spec/std.h
@@ -19,12 +19,10 @@ extern "C" {
 
 #include <odp/api/std_types.h>
 
-/**
- * @defgroup odp_std ODP STD
- * Standard types and performance optimized versions of selected C library
- * functions.
- *
- * @{
+/** @addtogroup odp_std
+ *  Standard types and performance optimized versions of selected C library
+ *  functions.
+ *  @{
  */
 
 /**

--- a/include/odp/api/spec/std_types.h
+++ b/include/odp/api/spec/std_types.h
@@ -22,7 +22,7 @@
 extern "C" {
 #endif
 
-/** @addtogroup odp_std ODP STD
+/** @defgroup odp_std ODP STD
  *  @{
  */
 

--- a/include/odp/api/spec/thread.h
+++ b/include/odp/api/spec/thread.h
@@ -19,7 +19,7 @@ extern "C" {
 
 #include <odp/api/thread_types.h>
 
-/** @defgroup odp_thread ODP THREAD
+/** @addtogroup odp_thread
  *  Thread types, masks and IDs.
  *  @{
  */

--- a/include/odp/api/spec/thread_types.h
+++ b/include/odp/api/spec/thread_types.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-/** @ingroup odp_thread ODP THREAD
+/** @defgroup odp_thread ODP THREAD
  *  @{
  */
 

--- a/include/odp/api/spec/time.h
+++ b/include/odp/api/spec/time.h
@@ -20,7 +20,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/time_types.h>
 
-/** @defgroup odp_time ODP TIME
+/** @addtogroup odp_time
  *  SoC global and CPU local wall clock time
  *
  *  @{

--- a/include/odp/api/spec/time_types.h
+++ b/include/odp/api/spec/time_types.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif
 
-/** @addtogroup odp_time
+/** @defgroup odp_time ODP TIME
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/atomic.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/atomic.h
@@ -80,7 +80,7 @@ typedef struct ODP_ALIGNED(sizeof(odp_u128_t)) odp_atomic_u128_s {
 
 #endif
 
-/** @ingroup odp_atomic
+/** @addtogroup odp_atomic
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/buffer_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/buffer_types.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_buffer
+/** @addtogroup odp_buffer
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/classification.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/classification.h
@@ -19,7 +19,7 @@ extern "C" {
 
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_classification
+/** @addtogroup odp_classification
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/comp.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/comp.h
@@ -15,7 +15,7 @@ extern "C" {
 
 #include <stdint.h>
 
-/** @ingroup odp_compression
+/** @addtogroup odp_compression
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/crypto_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/crypto_types.h
@@ -22,7 +22,7 @@ extern "C" {
 
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_crypto
+/** @addtogroup odp_crypto
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/dma_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/dma_types.h
@@ -13,7 +13,7 @@ extern "C" {
 
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_dma
+/** @addtogroup odp_dma
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/event_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/event_types.h
@@ -20,7 +20,7 @@ extern "C" {
 
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_event
+/** @addtogroup odp_event
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/ipsec_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/ipsec_types.h
@@ -22,7 +22,7 @@ extern "C" {
 
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_ipsec
+/** @addtogroup odp_ipsec
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_io_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_io_types.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_packet_io
+/** @addtogroup odp_packet_io
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_types.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_packet
+/** @addtogroup odp_packet
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/pool_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/pool_types.h
@@ -19,7 +19,7 @@ extern "C" {
 
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_pool
+/** @addtogroup odp_pool
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/proto_stats_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/proto_stats_types.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_proto_stats
+/** @addtogroup odp_proto_stats
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/queue_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/queue_types.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_queue
+/** @addtogroup odp_queue
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/shared_memory.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/shared_memory.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_shared_memory
+/** @addtogroup odp_shared_memory
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/stash_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/stash_types.h
@@ -17,7 +17,7 @@ extern "C" {
 
 #include <odp/api/plat/strong_types.h>
 
-/** @ingroup odp_stash
+/** @addtogroup odp_stash
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/sync.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/sync.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif
 
-/** @ingroup odp_barrier
+/** @addtogroup odp_barrier
  *  @{
  */
 

--- a/platform/linux-generic/include-abi/odp/api/abi/ticketlock.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/ticketlock.h
@@ -19,7 +19,7 @@ extern "C" {
 
 #include <odp/api/atomic.h>
 
-/** @ingroup odp_locks
+/** @addtogroup odp_locks
  *  @{
  */
 

--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -30,7 +30,7 @@ extern "C" {
 #include <protocols/ip.h>
 #include <stdint.h>
 
-/** @ingroup odp_ipsec
+/** @addtogroup odp_ipsec
  *  @{
  */
 


### PR DESCRIPTION
Previously, all types and defines from ABI headers were listed as functions
in Doxygen HTML output. No actual API changes.
