### PR TITLE
[PATCH v3] linux-gen: packet: move packet header cos field

### DIFF
--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -107,6 +107,9 @@ typedef struct ODP_ALIGNED_CACHE odp_packet_hdr_t {
 
 	uint16_t tailroom;
 
+	/* Classifier handle index */
+	uint16_t cos;
+
 	/* Used as classifier destination queue, in IPsec inline input processing and as Tx
 	 * completion event queue. */
 	odp_queue_t dst_queue;
@@ -130,9 +133,6 @@ typedef struct ODP_ALIGNED_CACHE odp_packet_hdr_t {
 
 	/* Classifier mark */
 	uint16_t cls_mark;
-
-	/* Classifier handle index */
-	uint16_t cos;
 
 	/* Offset to payload start */
 	uint16_t payload_offset;


### PR DESCRIPTION
Move odp_packet_hdr_t.cos field to a gap on the previous 64-byte cache line. This cache line is always written during packet reception, so writing CoS here (when classifier is enabled) can reduce classification overhead.