### PR TITLE
[PATCH v3] speed up testing

### DIFF
--- a/test/performance/odp_cpu_bench.c
+++ b/test/performance/odp_cpu_bench.c
@@ -335,7 +335,7 @@ static int run_thread(void *arg)
 		odp_event_t  ev;
 
 		ev = odp_schedule(NULL,
-				  odp_schedule_wait_time(ODP_TIME_SEC_IN_NS));
+				  odp_schedule_wait_time(100 * ODP_TIME_MSEC_IN_NS));
 
 		if (ev == ODP_EVENT_INVALID)
 			break;

--- a/test/performance/odp_dma_perf.c
+++ b/test/performance/odp_dma_perf.c
@@ -1692,7 +1692,7 @@ static void print_humanised(uint64_t value, const char *type)
 	else if (value > MEGAS)
 		printf("%.2f M%s\n", (double)value / MEGAS, type);
 	else if (value > KILOS)
-		printf("%.2f K%s\n", (double)value / KILOS, type);
+		printf("%.2f k%s\n", (double)value / KILOS, type);
 	else
 		printf("%" PRIu64 " %s\n", value, type);
 }
@@ -1702,8 +1702,8 @@ static void print_stats(const prog_config_t *config)
 	const stats_t *stats;
 	uint64_t data_cnt = config->num_in_segs * config->src_seg_len, tot_completed = 0U,
 	tot_tm = 0U, tot_trs_tm = 0U, tot_trs_cc = 0U, tot_trs_cnt = 0U, tot_min_tm = UINT64_MAX,
-	tot_max_tm = 0U, tot_min_cc = UINT64_MAX, tot_max_cc = 0U, avg_start_cc, avg_wait_cc,
-	avg_tot_tm;
+	tot_max_tm = 0U, tot_min_cc = UINT64_MAX, tot_max_cc = 0U, avg_start_cc, avg_wait_cc;
+	double avg_tot_tm;
 
 	printf("\n======================\n\n"
 	       "DMA performance test done\n\n"
@@ -1771,11 +1771,12 @@ static void print_stats(const prog_config_t *config)
 			       stats->trs_cnt > 0U ? stats->trs_cc / stats->trs_cnt : 0U,
 			       stats->trs_cnt > 0U ? stats->min_trs_cc : 0U,
 			       stats->trs_cnt > 0U ? stats->max_trs_cc : 0U);
-			print_humanised(stats->completed / (stats->tot_tm / ODP_TIME_SEC_IN_NS),
+			print_humanised(stats->completed /
+					((double)stats->tot_tm / ODP_TIME_SEC_IN_NS),
 					"OPS");
 			printf("            speed:                       ");
 			print_humanised(stats->completed * data_cnt /
-					(stats->tot_tm / ODP_TIME_SEC_IN_NS), "B/s");
+					((double)stats->tot_tm / ODP_TIME_SEC_IN_NS), "B/s");
 		}
 
 		avg_start_cc = stats->start_cnt > 0U ? stats->start_cc / stats->start_cnt : 0U;
@@ -1818,7 +1819,7 @@ static void print_stats(const prog_config_t *config)
 		printf("\n");
 	}
 
-	avg_tot_tm = tot_tm / config->num_workers / ODP_TIME_SEC_IN_NS;
+	avg_tot_tm = (double)tot_tm / config->num_workers / ODP_TIME_SEC_IN_NS;
 	printf("    total:\n"
 	       "        average time per transfer:   %" PRIu64 " (min: %" PRIu64
 	       ", max: %" PRIu64 ") ns\n"

--- a/test/performance/odp_dma_perf_run.sh
+++ b/test/performance/odp_dma_perf_run.sh
@@ -10,7 +10,7 @@ BIN_NAME=odp_dma_perf
 SEGC=0
 SEGS=1024
 INFL=1
-TIME=1
+TIME=0.1
 TESTS_RUN=0
 
 check_result()

--- a/test/performance/odp_dmafwd.c
+++ b/test/performance/odp_dmafwd.c
@@ -22,6 +22,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <time.h>
 
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
@@ -154,7 +155,7 @@ typedef struct prog_config_s {
 	uint32_t trs_cache_size;
 	uint32_t compl_cache_size;
 	uint32_t stash_cache_size;
-	uint32_t time_sec;
+	double time_sec;
 	odp_stash_type_t stash_type;
 	int num_thrs;
 	uint8_t num_ifs;
@@ -507,7 +508,7 @@ static parse_result_t parse_options(int argc, char **argv, prog_config_t *config
 			config->cache_size = atoi(optarg);
 			break;
 		case 'T':
-			config->time_sec = atoi(optarg);
+			config->time_sec = atof(optarg);
 			break;
 		case 'h':
 			print_usage(&config->dyn_defs);
@@ -760,7 +761,7 @@ static void drain_events(thread_config_t *config ODP_UNUSED)
 	transfer_t *trs;
 
 	while (true) {
-		ev = odp_schedule(NULL, odp_schedule_wait_time(ODP_TIME_SEC_IN_NS * 2U));
+		ev = odp_schedule(NULL, odp_schedule_wait_time(100 * ODP_TIME_MSEC_IN_NS));
 
 		if (ev == ODP_EVENT_INVALID)
 			break;
@@ -1438,8 +1439,12 @@ int main(int argc, char **argv)
 		goto out_test;
 	}
 
-	if (prog_conf->time_sec) {
-		sleep(prog_conf->time_sec);
+	if (prog_conf->time_sec > 0.001) {
+		struct timespec ts;
+
+		ts.tv_sec = prog_conf->time_sec;
+		ts.tv_nsec = (prog_conf->time_sec - ts.tv_sec) * ODP_TIME_SEC_IN_NS;
+		nanosleep(&ts, NULL);
 		odp_atomic_store_u32(&prog_conf->is_running, 0U);
 	} else {
 		while (odp_atomic_load_u32(&prog_conf->is_running))

--- a/test/performance/odp_dmafwd_run.sh
+++ b/test/performance/odp_dmafwd_run.sh
@@ -10,7 +10,7 @@ PERF_TEST_DIR=${TEST_SRC_DIR}/../../${PERF_TEST_DIR}
 
 BIN_NAME=odp_dmafwd
 BATCH=10
-TIME=2
+TIME=0.1
 TESTS_RUN=0
 
 check_env()

--- a/test/performance/odp_sched_latency_run.sh
+++ b/test/performance/odp_sched_latency_run.sh
@@ -19,7 +19,7 @@ run()
 	if [ $(nproc) -lt $1 ]; then
 		echo "Not enough CPU cores. Skipping test."
 	else
-		$TEST_DIR/odp_sched_latency${EXEEXT} -c $1 || exit $?
+		$TEST_DIR/odp_sched_latency${EXEEXT} -c $1 -d 1 || exit $?
 	fi
 }
 

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -192,8 +192,8 @@ static int timer_global_init(odp_instance_t *instance)
 
 	global_mem->periodic_support = capa.periodic.max_pools > 0;
 
-	/* By default 20 msec resolution */
-	res_ns = 20 * ODP_TIME_MSEC_IN_NS;
+	/* By default 2 msec resolution */
+	res_ns = 2 * ODP_TIME_MSEC_IN_NS;
 	if (res_ns < capa.max_res.res_ns)
 		res_ns = capa.max_res.res_ns;
 
@@ -1131,42 +1131,42 @@ static void timer_single_shot(odp_queue_type_t queue_type, odp_timer_tick_type_t
 
 static void timer_plain_rel_wait(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, RELATIVE, START, TIMEOUT, 2, 500 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, RELATIVE, START, TIMEOUT, 2, 50 * MSEC);
 }
 
 static void timer_plain_abs_wait(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, ABSOLUTE, START, TIMEOUT, 2, 500 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, ABSOLUTE, START, TIMEOUT, 2, 50 * MSEC);
 }
 
 static void timer_plain_rel_cancel(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, RELATIVE, START, CANCEL, 5, 1000 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, RELATIVE, START, CANCEL, 5, 100 * MSEC);
 }
 
 static void timer_plain_abs_cancel(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, ABSOLUTE, START, CANCEL, 5, 1000 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, ABSOLUTE, START, CANCEL, 5, 100 * MSEC);
 }
 
 static void timer_plain_rel_restart_wait(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, RELATIVE, RESTART, TIMEOUT, 2, 600 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, RELATIVE, RESTART, TIMEOUT, 2, 60 * MSEC);
 }
 
 static void timer_plain_abs_restart_wait(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, ABSOLUTE, RESTART, TIMEOUT, 2, 600 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, ABSOLUTE, RESTART, TIMEOUT, 2, 60 * MSEC);
 }
 
 static void timer_plain_rel_restart_cancel(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, RELATIVE, RESTART, CANCEL, 5, 1000 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, RELATIVE, RESTART, CANCEL, 5, 100 * MSEC);
 }
 
 static void timer_plain_abs_restart_cancel(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, ABSOLUTE, RESTART, CANCEL, 5, 1000 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_PLAIN, ABSOLUTE, RESTART, CANCEL, 5, 100 * MSEC);
 }
 
 static void timer_plain_abs_wait_3sec(void)
@@ -1176,42 +1176,42 @@ static void timer_plain_abs_wait_3sec(void)
 
 static void timer_sched_rel_wait(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_SCHED, RELATIVE, START, TIMEOUT, 2, 500 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_SCHED, RELATIVE, START, TIMEOUT, 2, 50 * MSEC);
 }
 
 static void timer_sched_abs_wait(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_SCHED, ABSOLUTE, START, TIMEOUT, 2, 500 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_SCHED, ABSOLUTE, START, TIMEOUT, 2, 50 * MSEC);
 }
 
 static void timer_sched_rel_cancel(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_SCHED, RELATIVE, START, CANCEL, 5, 1000 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_SCHED, RELATIVE, START, CANCEL, 5, 100 * MSEC);
 }
 
 static void timer_sched_abs_cancel(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_SCHED, ABSOLUTE, START, CANCEL, 5, 1000 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_SCHED, ABSOLUTE, START, CANCEL, 5, 100 * MSEC);
 }
 
 static void timer_sched_rel_restart_wait(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_SCHED, RELATIVE, RESTART, TIMEOUT, 2, 600 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_SCHED, RELATIVE, RESTART, TIMEOUT, 2, 60 * MSEC);
 }
 
 static void timer_sched_abs_restart_wait(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_SCHED, ABSOLUTE, RESTART, TIMEOUT, 2, 600 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_SCHED, ABSOLUTE, RESTART, TIMEOUT, 2, 60 * MSEC);
 }
 
 static void timer_sched_rel_restart_cancel(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_SCHED, RELATIVE, RESTART, CANCEL, 5, 1000 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_SCHED, RELATIVE, RESTART, CANCEL, 5, 100 * MSEC);
 }
 
 static void timer_sched_abs_restart_cancel(void)
 {
-	timer_single_shot(ODP_QUEUE_TYPE_SCHED, ABSOLUTE, RESTART, CANCEL, 5, 1000 * MSEC);
+	timer_single_shot(ODP_QUEUE_TYPE_SCHED, ABSOLUTE, RESTART, CANCEL, 5, 100 * MSEC);
 }
 
 static void timer_sched_abs_wait_3sec(void)
@@ -2862,9 +2862,9 @@ static void timer_test_periodic(odp_queue_type_t queue_type, int use_first, int 
 	int num_tmo;
 	int done;
 	const int num = 200;
-	/* Test frequency: 1x 100Hz, or 1x min/max_base_freq */
+	/* Test frequency: 1x 1000 Hz, or 1x min/max_base_freq */
 	const uint64_t multiplier = 1;
-	odp_fract_u64_t base_freq = {100, 0, 0};
+	odp_fract_u64_t base_freq = {1000, 0, 0};
 	odp_timer_clk_src_t clk_src = test_global->clk_src;
 
 	memset(&timer_capa, 0, sizeof(odp_timer_capability_t));


### PR DESCRIPTION
Speed up 'make check' by making certain tests (mainly timer validation and dma perf tests) complete faster.