### PR TITLE
[PATCH v3] linux-gen: time: improve TSC frequency measurement

### DIFF
--- a/platform/linux-generic/arch/x86/odp_time_cpu.c
+++ b/platform/linux-generic/arch/x86/odp_time_cpu.c
@@ -1,7 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2024 Nokia
  */
 
 #include <odp_posix_extensions.h>
@@ -14,42 +13,77 @@
 #include <odp_debug_internal.h>
 
 #include <time.h>
+#include <errno.h>
+#include <string.h>
 
-/* Measure TSC frequency. Frequency information registers are defined for x86,
- * but those are often not enumerated. */
+static int nwait(uint64_t nsec)
+{
+	struct timespec ts1, ts2;
+	uint64_t diff;
+
+	if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts1))
+		return 1;
+
+	do {
+		if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts2))
+			return 1;
+
+		diff = (ts2.tv_sec - ts1.tv_sec) * ODP_TIME_SEC_IN_NS +
+			ts2.tv_nsec - ts1.tv_nsec;
+	} while (diff < nsec);
+
+	return 0;
+}
+
+static void sort(uint64_t values[], int num)
+{
+	for (int n = 0; n < num; n++) {
+		for (int i = n + 1; i < num; i++) {
+			if (values[i] < values[n]) {
+				uint64_t tmp = values[i];
+
+				values[i] = values[n];
+				values[n] = tmp;
+			}
+		}
+	}
+}
+
+static uint64_t median(uint64_t values[], int num)
+{
+	sort(values, num);
+	if (num % 2 == 0)
+		return (values[num / 2 - 1] + values[num / 2]) / 2;
+	else
+		return values[num / 2];
+}
+
+/* Measure TSC frequency. */
 uint64_t _odp_time_cpu_global_freq(void)
 {
-	struct timespec sleep, ts1, ts2;
-	uint64_t t1, t2, ts_nsec, cycles, hz;
+	struct timespec ts1, ts2;
+	uint64_t t1, t2, ts_nsec, cycles;
 	int i;
-	uint64_t avg = 0;
-	int rounds = 3;
+	const int rounds = 6; /* first round is warmup */
 	int warm_up = 1;
+	uint64_t hz[rounds];
 
 	for (i = 0; i < rounds; i++) {
-		sleep.tv_sec = 0;
+		uint64_t wait_nsec = ODP_TIME_SEC_IN_NS / 50;
 
 		if (warm_up)
-			sleep.tv_nsec = ODP_TIME_SEC_IN_NS / 1000;
-		else
-			sleep.tv_nsec = ODP_TIME_SEC_IN_NS / 4;
+			wait_nsec = ODP_TIME_SEC_IN_NS / 1000;
 
-		if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts1)) {
-			_ODP_ERR("clock_gettime() failed\n");
-			return 0;
-		}
+		if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts1))
+			goto err_out;
 
 		t1 = _odp_time_cpu_global();
 
-		if (nanosleep(&sleep, NULL) < 0) {
-			_ODP_ERR("nanosleep() failed\n");
-			return 0;
-		}
+		if (nwait(wait_nsec))
+			goto err_out;
 
-		if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts2)) {
-			_ODP_ERR("clock_gettime() failed\n");
-			return 0;
-		}
+		if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts2))
+			goto err_out;
 
 		t2 = _odp_time_cpu_global();
 
@@ -58,13 +92,15 @@ uint64_t _odp_time_cpu_global_freq(void)
 
 		cycles = t2 - t1;
 
-		hz = (cycles * ODP_TIME_SEC_IN_NS) / ts_nsec;
+		hz[i] = (cycles * ODP_TIME_SEC_IN_NS) / ts_nsec;
 
 		if (warm_up)
 			warm_up = 0;
-		else
-			avg += hz;
 	}
 
-	return avg / (rounds - 1);
+	return median(&hz[1], rounds - 1);
+
+err_out:
+	_ODP_ERR("clock_gettime() failed (%s)\n", strerror(errno));
+	return 0;
 }

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -386,8 +386,9 @@ int _odp_system_info_init(void)
 			num_cpus);
 
 	/* Read and save all CPU frequencies for static mode */
-	for (i = 0; i < CONFIG_NUM_CPU_IDS; i++)
-		odp_global_ro.system_info.cpu_hz[i] = cpu_hz_current(i);
+	if (odp_global_ro.system_info.cpu_hz_static)
+		for (i = 0; i < CONFIG_NUM_CPU_IDS; i++)
+			odp_global_ro.system_info.cpu_hz[i] = cpu_hz_current(i);
 
 	/* By default, read max frequency from a cpufreq file */
 	for (i = 0; i < CONFIG_NUM_CPU_IDS; i++) {


### PR DESCRIPTION
    Speed up TSC frequency measurement and thus ODP startup by reducing the
    measurement duration. Make the result more accurate despite the decreased
    duration by using a busyloop instead of nanosleep and by taking the median
    of several measurements.

    Using a busyloop instead of nanosleep also fixes the measurement in (old)
    systems that have constant but not invariant TSC which may stop or change
    frequency in C-states.
