### PR TITLE
[PATCH v2] github_ci: improve checkpatch testing for push operations

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           AFTER=${{ github.event.after }}
           BEFORE=${{ github.event.before }}
-          if [ -z "${BEFORE//0}" ] || [ -z "${AFTER//0}" ]; then
+          if [ -z "${BEFORE//0}" ] || [ -z "${AFTER//0}" ] || ${{ github.event.forced }}; then
             COMMIT_RANGE=""
           else
             COMMIT_RANGE="${BEFORE}..${AFTER}"

--- a/scripts/ci-checkpatches.sh
+++ b/scripts/ci-checkpatches.sh
@@ -2,22 +2,14 @@
 
 PATCHES=$1
 echo "Run checkpatch for ${PATCHES}"
-# Generate patches provided with $1.
-# In case of force push and range is broken
-# validate only the latest commit if it's not merge commit.
+# Generate patches provided with $1. If commit range is not available validate
+# only the latest commit.
 
 if [ "$PATCHES" = "" ]; then
 	git format-patch -1 -M HEAD;
-	perl ./scripts/checkpatch.pl *.patch;
-	exit $?
+else
+	git format-patch ${PATCHES}
 fi
 
-git show --summary HEAD| grep -q '^Merge:';
-if [ $? -ne 0 ]; then
-	git format-patch -1 -M HEAD;
-	perl ./scripts/checkpatch.pl *.patch;
-	exit $?
-fi
-
-git format-patch ${PATCHES}
 perl ./scripts/checkpatch.pl *.patch;
+exit $?


### PR DESCRIPTION
Previously, in case of push operations only the latest commit was tested to avoid issues with invalid commit ranges in force pushes. Read force push status from GitHub events and test full commit range with normal push operations.