### PR TITLE
[PATCH v2] build: add -wshadow compiler check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,7 @@ ODP_CHECK_CFLAG([-Wundef])
 ODP_CHECK_CFLAG([-Wwrite-strings])
 ODP_CHECK_CFLAG([-Wformat-truncation=0])
 ODP_CHECK_CFLAG([-Wformat-overflow=0])
+ODP_CHECK_CFLAG([-Wshadow=local])
 
 # GCC 10 sometimes gets confused about object sizes and gives bogus warnings.
 # Make the affected warnings generate only warnings, not errors.

--- a/example/ipsec_crypto/odp_ipsec.c
+++ b/example/ipsec_crypto/odp_ipsec.c
@@ -975,10 +975,10 @@ pkt_disposition_e do_ipsec_out_seq(odp_packet_t *pkt,
 		esp->seq_no = odp_cpu_to_be_32((*ctx->ipsec.esp_seq)++);
 	}
 	if (ctx->ipsec.tun_hdr_offset) {
-		odph_ipv4hdr_t *ip;
+		odph_ipv4hdr_t *ip_tun;
 
-		ip = (odph_ipv4hdr_t *)(ctx->ipsec.tun_hdr_offset + buf);
-		ip->id = odp_cpu_to_be_16((*ctx->ipsec.tun_hdr_id)++);
+		ip_tun = (odph_ipv4hdr_t *)(ctx->ipsec.tun_hdr_offset + buf);
+		ip_tun->id = odp_cpu_to_be_16((*ctx->ipsec.tun_hdr_id)++);
 	}
 
 	/* Issue crypto request */

--- a/example/timer/odp_timer_accuracy.c
+++ b/example/timer/odp_timer_accuracy.c
@@ -767,7 +767,7 @@ static int start_timers(test_global_t *test_global)
 			odp_timer_start_t start_param;
 
 			if (mode == MODE_PERIODIC) {
-				odp_timer_periodic_start_t start_param;
+				odp_timer_periodic_start_t periodic_start;
 
 				nsec = offset_ns + (j * burst_gap);
 
@@ -781,13 +781,13 @@ static int start_timers(test_global_t *test_global)
 				ctx->first_period = start_tick +
 					odp_timer_ns_to_tick(timer_pool,
 							     test_global->period_dbl + 0.5);
-				start_param.freq_multiplier = test_global->opt.multiplier;
-				start_param.first_tick = 0;
+				periodic_start.freq_multiplier = test_global->opt.multiplier;
+				periodic_start.first_tick = 0;
 				if (nsec)
-					start_param.first_tick =
+					periodic_start.first_tick =
 						start_tick + odp_timer_ns_to_tick(timer_pool, nsec);
-				start_param.tmo_ev = ctx->event;
-				retval = odp_timer_periodic_start(ctx->timer, &start_param);
+				periodic_start.tmo_ev = ctx->event;
+				retval = odp_timer_periodic_start(ctx->timer, &periodic_start);
 			} else {
 				nsec = offset_ns + (i * period_ns) + (j * burst_gap);
 				ctx->nsec = start_ns + nsec;
@@ -875,7 +875,6 @@ static void print_nsec_error(const char *str, int64_t nsec, double res_ns,
 
 static void print_stat(test_global_t *test_global)
 {
-	uint64_t i;
 	test_stat_t test_stat;
 	test_stat_t *stat = &test_stat;
 	uint64_t tot_timers;
@@ -943,7 +942,7 @@ static void print_stat(test_global_t *test_global)
 
 		fprintf(file, "   Timer  thread      tmo(ns)   diff(ns)\n");
 
-		for (i = 0; i < tot_timers; i++) {
+		for (uint64_t i = 0; i < tot_timers; i++) {
 			fprintf(file, "%8" PRIu64 " %7u %12" PRIu64 " %10"
 				PRIi64 "\n", i, log[i].tid, log[i].tmo_ns, log[i].diff_ns);
 		}

--- a/example/timer/odp_timer_test.c
+++ b/example/timer/odp_timer_test.c
@@ -167,7 +167,7 @@ static void test_abs_timeouts(int thr, test_globals_t *gbls)
 			ODPH_ABORT("Unexpected event type (%u) received\n",
 				   odp_event_type(ev));
 		}
-		odp_timeout_t tmo = odp_timeout_from_event(ev);
+		tmo = odp_timeout_from_event(ev);
 		tick = odp_timeout_tick(tmo);
 		ttp = odp_timeout_user_ptr(tmo);
 		ttp->ev = ev;

--- a/example/traffic_mgmt/odp_traffic_mgmt.c
+++ b/example/traffic_mgmt/odp_traffic_mgmt.c
@@ -637,20 +637,19 @@ static int create_and_config_tm(void)
 	tm_shaper_max_burst = tm_capa.per_level[0].max_burst;
 
 	for (level = 1; level < tm_capa.max_levels; level++) {
-		odp_tm_level_capabilities_t *per_level =
-			&tm_capa.per_level[level];
+		odp_tm_level_capabilities_t *level_capa = &tm_capa.per_level[level];
 
-		if (per_level->min_rate > tm_shaper_min_rate)
-			tm_shaper_min_rate = per_level->min_rate;
+		if (level_capa->min_rate > tm_shaper_min_rate)
+			tm_shaper_min_rate = level_capa->min_rate;
 
-		if (per_level->min_burst > tm_shaper_min_burst)
-			tm_shaper_min_burst = per_level->min_burst;
+		if (level_capa->min_burst > tm_shaper_min_burst)
+			tm_shaper_min_burst = level_capa->min_burst;
 
-		if (per_level->max_rate < tm_shaper_max_rate)
-			tm_shaper_max_rate = per_level->max_rate;
+		if (level_capa->max_rate < tm_shaper_max_rate)
+			tm_shaper_max_rate = level_capa->max_rate;
 
-		if (per_level->max_burst < tm_shaper_max_burst)
-			tm_shaper_max_burst = per_level->max_burst;
+		if (level_capa->max_burst < tm_shaper_max_burst)
+			tm_shaper_max_burst = level_capa->max_burst;
 	}
 
 	if (tm_shaper_min_rate > tm_shaper_max_rate ||

--- a/helper/include/odp/helper/macros.h
+++ b/helper/include/odp/helper/macros.h
@@ -32,9 +32,9 @@ extern "C" {
  */
 #define ODPH_MIN(a, b)				\
 	__extension__ ({			\
-		__typeof__(a) tmp_a = (a);	\
-		__typeof__(b) tmp_b = (b);	\
-		tmp_a < tmp_b ? tmp_a : tmp_b;	\
+		__typeof__(a) min_a = (a);	\
+		__typeof__(b) min_b = (b);	\
+		min_a < min_b ? min_a : min_b;	\
 	})
 
 /**
@@ -42,9 +42,9 @@ extern "C" {
  */
 #define ODPH_MAX(a, b)				\
 	__extension__ ({			\
-		__typeof__(a) tmp_a = (a);	\
-		__typeof__(b) tmp_b = (b);	\
-		tmp_a > tmp_b ? tmp_a : tmp_b;	\
+		__typeof__(a) max_a = (a);	\
+		__typeof__(b) max_b = (b);	\
+		max_a > max_b ? max_a : max_b;	\
 	})
 
 /**
@@ -52,8 +52,8 @@ extern "C" {
  */
 #define ODPH_ABS(v)				\
 	__extension__ ({			\
-		__typeof__(v) tmp_v = (v);	\
-		tmp_v < 0 ? -tmp_v : tmp_v;	\
+		__typeof__(v) abs_v = (v);	\
+		abs_v < 0 ? -abs_v : abs_v;	\
 	})
 
 /**

--- a/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
@@ -197,11 +197,11 @@ static inline int _odp_atomic_cas_acq_rel_u128(odp_atomic_u128_t *atom, odp_u128
 #define ATOMIC_CAS_OP_128(ret_ptr, old_val, new_val) \
 __extension__ ({ \
 	int *_ret_ptr = ret_ptr; \
-	odp_u128_t *_old_val = old_val; \
-	odp_u128_t _new_val = new_val; \
-	if (((_atom)->v.u64[0] == (_old_val)->u64[0]) && \
-	    ((_atom)->v.u64[1] == (_old_val)->u64[1])) { \
-		(_atom)->v = (_new_val); \
+	odp_u128_t *_cas_old = old_val; \
+	odp_u128_t _cas_new = new_val; \
+	if (((_atom)->v.u64[0] == (_cas_old)->u64[0]) && \
+	    ((_atom)->v.u64[1] == (_cas_old)->u64[1])) { \
+		(_atom)->v = (_cas_new); \
 		*(_ret_ptr) = 1; \
 	} else { \
 		*(_ret_ptr) = 0; \

--- a/platform/linux-generic/include/odp_macros_internal.h
+++ b/platform/linux-generic/include/odp_macros_internal.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
+ * Copyright (c) 2022-2024, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -26,19 +26,35 @@ extern "C" {
 
 #define _ODP_MIN(a, b)				\
 	__extension__ ({			\
-		__typeof__(a) tmp_a = (a);	\
-		__typeof__(b) tmp_b = (b);	\
-		tmp_a < tmp_b ? tmp_a : tmp_b;	\
+		__typeof__(a) min_a = (a);	\
+		__typeof__(b) min_b = (b);	\
+		min_a < min_b ? min_a : min_b;	\
 	})
 
 #define _ODP_MAX(a, b)				\
 	__extension__ ({			\
-		__typeof__(a) tmp_a = (a);	\
-		__typeof__(b) tmp_b = (b);	\
-		tmp_a > tmp_b ? tmp_a : tmp_b;	\
+		__typeof__(a) max_a = (a);	\
+		__typeof__(b) max_b = (b);	\
+		max_a > max_b ? max_a : max_b;	\
 	})
 
-#define _ODP_MAX3(a, b, c) (_ODP_MAX(_ODP_MAX((a), (b)), (c)))
+#define _ODP_MIN3(a, b, c)		\
+__extension__ ({			\
+	__typeof__(a) min3_a = (a);	\
+	__typeof__(b) min3_b = (b);	\
+	__typeof__(c) min3_c = (c);	\
+	(min3_a < min3_b ? (min3_a < min3_c ? min3_a : min3_c) : \
+	(min3_b < min3_c ? min3_b : min3_c)); \
+})
+
+#define _ODP_MAX3(a, b, c)		\
+__extension__ ({			\
+	__typeof__(a) max3_a = (a);	\
+	__typeof__(b) max3_b = (b);	\
+	__typeof__(c) max3_c = (c);	\
+	(max3_a > max3_b ? (max3_a > max3_c ? max3_a : max3_c) : \
+	(max3_b > max3_c ? max3_b : max3_c)); \
+})
 
 /* Macros to calculate ODP_ROUNDUP_POWER2_U32() in five rounds of shift
  * and OR operations. */

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -299,10 +299,11 @@ odp_cos_t odp_cls_cos_create(const char *name, const odp_cls_cos_param_t *param_
 							   param.hash_proto);
 				tbl_index = i * CLS_COS_QUEUE_MAX;
 				for (j = 0; j < param.num_queue; j++) {
-					char name[ODP_QUEUE_NAME_LEN];
+					char hq_name[ODP_QUEUE_NAME_LEN];
 
-					snprintf(name, sizeof(name), "_odp_cos_hq_%u_%u", i, j);
-					queue = odp_queue_create(name, &cos->queue_param);
+					snprintf(hq_name, sizeof(hq_name), "_odp_cos_hq_%u_%u",
+						 i, j);
+					queue = odp_queue_create(hq_name, &cos->queue_param);
 					if (queue == ODP_QUEUE_INVALID) {
 						/* unwind the queues */
 						_cls_queue_unwind(tbl_index, j);

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -2180,7 +2180,7 @@ finish:
 int odp_ipsec_in(const odp_packet_t pkt_in[], int num_in, odp_packet_t pkt_out[], int *num_out,
 		 const odp_ipsec_in_param_t *param)
 {
-	int max_out = _ODP_MIN(_ODP_MIN(num_in, *num_out), MAX_BURST), num_crypto;
+	int max_out = _ODP_MIN3(num_in, *num_out, MAX_BURST), num_crypto;
 	odp_packet_t crypto_pkts[MAX_BURST];
 	odp_crypto_packet_op_param_t crypto_param[MAX_BURST];
 	ipsec_op_t ops[MAX_BURST], *crypto_ops[MAX_BURST];
@@ -2288,7 +2288,7 @@ finish:
 int odp_ipsec_out(const odp_packet_t pkt_in[], int num_in, odp_packet_t pkt_out[], int *num_out,
 		  const odp_ipsec_out_param_t *param)
 {
-	int max_out = _ODP_MIN(_ODP_MIN(num_in, *num_out), MAX_BURST), num_crypto;
+	int max_out = _ODP_MIN3(num_in, *num_out, MAX_BURST), num_crypto;
 	odp_packet_t crypto_pkts[MAX_BURST];
 	odp_crypto_packet_op_param_t crypto_param[MAX_BURST];
 	ipsec_op_t ops[MAX_BURST], *crypto_ops[MAX_BURST];

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -543,7 +543,6 @@ static void init_event_hdr(pool_t *pool, _odp_event_hdr_t *event_hdr, uint32_t e
 
 static void init_buffers(pool_t *pool)
 {
-	uint64_t i;
 	_odp_event_hdr_t *event_hdr;
 	odp_buffer_hdr_t *buf_hdr;
 	odp_packet_hdr_t *pkt_hdr;
@@ -567,7 +566,7 @@ static void init_buffers(pool_t *pool)
 	mask = pool->ring_mask;
 	type = pool->type;
 
-	for (i = 0; i < pool->num + skipped_blocks ; i++) {
+	for (uint64_t i = 0; i < pool->num + skipped_blocks ; i++) {
 		int skip = 0;
 		addr = &pool->base_addr[i * pool->block_size];
 
@@ -1372,11 +1371,11 @@ static inline void event_free_to_pool(pool_t *pool,
 		if (odp_unlikely((uint32_t)num > cache_num))
 			burst = cache_num;
 
-		_odp_event_hdr_t *event_hdr[burst];
+		_odp_event_hdr_t *ev_hdr[burst];
 
-		cache_pop(cache, event_hdr, burst);
+		cache_pop(cache, ev_hdr, burst);
 
-		ring_ptr_enq_multi(ring, mask, (void **)event_hdr, burst);
+		ring_ptr_enq_multi(ring, mask, (void **)ev_hdr, burst);
 		if (CONFIG_POOL_STATISTICS && pool->params.stats.bit.free_ops)
 			odp_atomic_inc_u64(&pool->stats.free_ops);
 	}

--- a/platform/linux-generic/odp_schedule_scalable_ordered.c
+++ b/platform/linux-generic/odp_schedule_scalable_ordered.c
@@ -123,8 +123,6 @@ static void rwin_insert(reorder_window_t *rwin,
 				     /*readonly=*/false);
 		rctx = NULL;
 		do {
-			hc_t new;
-
 			new.head = old.head;
 			new.chgi = old.chgi + 1; /* Changed value */
 			/* Update head & chgi, fail if any has changed */

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -1241,7 +1241,7 @@ int main(int argc, char *argv[])
 	odp_pool_capability_t pool_capa;
 	odp_crypto_capability_t crypto_capa;
 	uint32_t max_seg_len;
-	unsigned i;
+	uint32_t i;
 
 	/* Let helper collect its own arguments (e.g. --odph_proc) */
 	argc = odph_parse_options(argc, argv);
@@ -1374,8 +1374,6 @@ int main(int argc, char *argv[])
 			run_measure_one_config(&test_run_arg);
 		}
 	} else {
-		unsigned int i;
-
 		for (i = 0; i < ODPH_ARRAY_SIZE(algs_config); i++) {
 			test_run_arg.crypto_alg_config = algs_config + i;
 			run_measure_one_config(&test_run_arg);

--- a/test/performance/odp_dma_perf.c
+++ b/test/performance/odp_dma_perf.c
@@ -251,14 +251,14 @@ static void init_config(prog_config_t *config)
 		stats = &config->thread_config[i].stats;
 		memset(sd, 0, sizeof(*sd));
 
-		for (uint32_t i = 0U; i < MAX_SEGS; ++i) {
-			info = &sd->dma.infos[i];
+		for (uint32_t j = 0U; j < MAX_SEGS; ++j) {
+			info = &sd->dma.infos[j];
 			info->compl_param.transfer_id = ODP_DMA_TRANSFER_ID_INVALID;
 			info->compl_param.event = ODP_EVENT_INVALID;
 			info->compl_param.queue = ODP_QUEUE_INVALID;
 			odp_ticketlock_init(&info->lock);
-			sd->seg.src_pkt[i] = ODP_PACKET_INVALID;
-			sd->seg.dst_pkt[i] = ODP_PACKET_INVALID;
+			sd->seg.src_pkt[j] = ODP_PACKET_INVALID;
+			sd->seg.dst_pkt[j] = ODP_PACKET_INVALID;
 		}
 
 		sd->dma.handle = ODP_DMA_INVALID;

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -1383,8 +1383,6 @@ int main(int argc, char *argv[])
 			run_measure_one_config(&cargs, cargs.alg_config);
 		}
 	} else {
-		unsigned int i;
-
 		for (i = 0; i < ODPH_ARRAY_SIZE(algs_config); i++) {
 			if (cargs.ah &&
 			    algs_config[i].crypto.cipher_alg !=

--- a/test/validation/api/random/random.c
+++ b/test/validation/api/random/random.c
@@ -313,11 +313,10 @@ static void random_test_independence(odp_random_kind_t kind)
 
 		for (int i = 0; i < 256; i++) {
 			for (int j = 0; j < 256; j++) {
-				double expected =
-					(double)row[i] * (double)col[j] / (double)num;
-				double diff =
-					(double)freq[i][j] - expected;
-				chisq += diff * diff / expected;
+				double expect = (double)row[i] * (double)col[j] / (double)num;
+				double diff   = (double)freq[i][j] - expect;
+
+				chisq += diff * diff / expect;
 			}
 		}
 

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -1469,8 +1469,7 @@ static int schedule_common_(void *arg)
 	odp_pool_t pool;
 	int locked;
 	int num;
-	odp_event_t ev;
-	odp_buffer_t buf, buf_cpy;
+	odp_buffer_t buf;
 	odp_queue_t from;
 
 	globals = args->globals;
@@ -1553,7 +1552,8 @@ static int schedule_common_(void *arg)
 				odp_event_free(events[j]);
 			}
 		} else {
-			ev  = odp_schedule(&from, ODP_SCHED_NO_WAIT);
+			odp_event_t ev = odp_schedule(&from, ODP_SCHED_NO_WAIT);
+
 			if (ev == ODP_EVENT_INVALID)
 				continue;
 
@@ -1564,6 +1564,7 @@ static int schedule_common_(void *arg)
 				uint32_t ndx;
 				uint32_t ndx_max;
 				int rc;
+				odp_buffer_t buf_cpy;
 
 				ndx_max = odp_queue_lock_count(from);
 				CU_ASSERT_FATAL(ndx_max > 0);

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -2403,7 +2403,6 @@ static int worker_entrypoint(void *arg ODP_UNUSED)
 			}
 		} else {
 			uint64_t cur_tick;
-			uint64_t tck;
 			int reset_timer = 0;
 
 			if (tt[i].ev != ODP_EVENT_INVALID) {


### PR DESCRIPTION
Enables compiler warnings (-Wshadow=local) when a local variable
shadows another local variable or parameter.

For example:

  for (int i = 0; i < N; ++i) {
      ...
    for (int i = 0; i < M; ++i) {
      ...
    }
  }