### PR TITLE
[PATCH v2] test: performance: fix initialization parameter usage

### DIFF
--- a/test/performance/odp_dmafwd.c
+++ b/test/performance/odp_dmafwd.c
@@ -1381,7 +1381,7 @@ int main(int argc, char **argv)
 	odp_init_param_init(&init_param);
 	init_param.mem_model = odph_opts.mem_model;
 
-	if (odp_init_global(&odp_instance, NULL, NULL)) {
+	if (odp_init_global(&odp_instance, &init_param, NULL)) {
 		ODPH_ERR("ODP global init failed, exiting\n");
 		exit(EXIT_FAILURE);
 	}

--- a/test/performance/odp_pool_latency.c
+++ b/test/performance/odp_pool_latency.c
@@ -1312,7 +1312,7 @@ int main(int argc, char **argv)
 	odp_init_param_init(&init_param);
 	init_param.mem_model = odph_opts.mem_model;
 
-	if (odp_init_global(&odp_instance, NULL, NULL)) {
+	if (odp_init_global(&odp_instance, &init_param, NULL)) {
 		ODPH_ERR("ODP global init failed, exiting\n");
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
In `odp_pool_latency` and `odp_dmafwd`, actually pass instance initialization parameters to `odp_init_global()`. Previously, they were defined but erroneously not utilized.

v2:
- Added reviewed-by tags