### PR TITLE
[PATCH v2] build: re-enable parallel build

### DIFF
--- a/example/packet/Makefile.am
+++ b/example/packet/Makefile.am
@@ -35,5 +35,3 @@ clean-local:
 			rm -f $(builddir)/$$f; \
 		done \
 	fi
-
-.NOTPARALLEL:

--- a/example/timer/Makefile.am
+++ b/example/timer/Makefile.am
@@ -16,5 +16,3 @@ TESTS  = odp_timer_accuracy_run.sh \
 endif
 
 EXTRA_DIST = odp_timer_accuracy_run.sh
-
-.NOTPARALLEL:

--- a/helper/test/Makefile.am
+++ b/helper/test/Makefile.am
@@ -67,5 +67,3 @@ clean-local:
 			rm -f $(builddir)/$$f; \
 		done \
 	fi
-
-.NOTPARALLEL:

--- a/platform/linux-generic/test/example/ipsec_api/Makefile.am
+++ b/platform/linux-generic/test/example/ipsec_api/Makefile.am
@@ -19,5 +19,3 @@ clean-local:
 			rm -f $(builddir)/$$f; \
 		done \
 	fi
-
-.NOTPARALLEL:

--- a/platform/linux-generic/test/example/ipsec_crypto/Makefile.am
+++ b/platform/linux-generic/test/example/ipsec_crypto/Makefile.am
@@ -19,5 +19,3 @@ clean-local:
 			rm -f $(builddir)/$$f; \
 		done \
 	fi
-
-.NOTPARALLEL:

--- a/scripts/ci/distcheck.sh
+++ b/scripts/ci/distcheck.sh
@@ -16,4 +16,4 @@ export CI="true"
 # Additional configure flags for distcheck
 export DISTCHECK_CONFIGURE_FLAGS="${CONF}"
 
-make -j $(nproc) distcheck
+make distcheck

--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -123,5 +123,3 @@ clean-local:
 			rm -f $(builddir)/$$f; \
 		done \
 	fi
-
-.NOTPARALLEL:


### PR DESCRIPTION
Enabling parallel build in all directories outweighs the benefits from being able to run distcheck in parallel. Running 'make check' with -j option is not expected to work anymore after this commit.