### PR TITLE
[PATCH v2] api: increment ODP API version to 1.44.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,40 @@
+== OpenDataPlane (1.44.0.0)
+
+=== Backward compatible API changes
+==== ML
+* Add new API module for Machine Learning offload.
+
+=== Implementation
+==== ML
+* Implement the API using ONNX Runtime. A non-standard ONNX install path can be
+passed with `--with-ort-path` configure option. See `DEPENDENCIES` for
+additional information.
+
+=== Example Applications
+==== debug
+* Print packet IO link information.
+* Add packet IO interface name option (`-i`).
+
+==== packet_dump
+* Add support for measuring packet input delay.
+
+=== Performance Tests
+==== l2fwd
+* Add packet input timestamping option (`-T`).
+* Add packet data prefetch option (`-F`).
+* Add packet data read option (`-R`).
+* Add packet print option (`-V`).
+
+==== pool_latency
+* New pool latency tester application for profiling pool allocation and free
+latencies under different load patterns.
+
+==== sched_perf
+* Add options to read (`-u`) and modify (`-U`) event user area contents per
+event reception.
+* Run application indefinitely when the number of events to schedule option
+(`-s`) is set to zero.
+
 == OpenDataPlane (1.43.0.0)
 
 === Backward incompatible API changes

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ([2.5])
 # ODP API version
 ##########################################################################
 m4_define([odp_version_generation], [1])
-m4_define([odp_version_major],     [43])
+m4_define([odp_version_major],     [44])
 m4_define([odp_version_minor],      [0])
 m4_define([odp_version_patch],      [0])
 


### PR DESCRIPTION
Increment API version number to reflect the following changes:

Backward compatible:
- ml: add new API module for machine learning offload