### PR TITLE
[PATCH v4] test: dyn_workers: add CI integration

### DIFF
--- a/test/miscellaneous/Makefile.am
+++ b/test/miscellaneous/Makefile.am
@@ -4,11 +4,18 @@ bin_PROGRAMS = odp_dyn_workers
 
 if test_cpp
 bin_PROGRAMS +=  odp_api_from_cpp
-TESTS = odp_api_from_cpp
 endif
 
 odp_dyn_workers_SOURCES = odp_dyn_workers.c
 odp_api_from_cpp_SOURCES = odp_api_from_cpp.cpp
+
+TESTSCRIPTS = odp_dyn_workers_run.sh
+
+TESTS = $(TESTSCRIPTS)
+
+if test_cpp
+TESTS += odp_api_from_cpp
+endif
 
 noinst_PROGRAMS = odp_api_headers
 odp_api_headers_CFLAGS = $(AM_CFLAGS) -Wconversion
@@ -46,3 +53,25 @@ endif
 endif
 
 DISTCLEANFILES = $(PROGRAM_shared) $(PROGRAM_static)
+
+dist_check_SCRIPTS = $(TESTSCRIPTS)
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS) $(dist_check_DATA); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS) $(dist_check_DATA); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/test/miscellaneous/odp_dyn_workers_run.sh
+++ b/test/miscellaneous/odp_dyn_workers_run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Nokia
+#
+
+MAX_CPUS=$(nproc)
+# Frontend and control threads on one core and to-be-swapped worker thread on another core,
+# otherwise weird issues might occur
+REQ_CPUS=2
+TEST_DIR="${TEST_DIR:-$(dirname $0)}"
+BIN=odp_dyn_workers
+DELAY=100000000
+
+if [ ${MAX_CPUS} -lt ${REQ_CPUS} ]; then
+	echo "Not enough CPUs (requested ${REQ_CPUS}, available ${MAX_CPUS}). Skipping test."
+	exit 77
+fi
+
+taskset -c 0 ${TEST_DIR}/${BIN}${EXEEXT} -c 0x2,0x2 -p a0,d${DELAY},r0,d${DELAY},a1,d${DELAY},r1


### PR DESCRIPTION
Add new option to execute tester in non-interactive mode. A pattern of additions, removals and delays can be passed to the tester which then executes the commands sequentially. New test script utilizing the new mode is added to be run as part of `make check`.

Additionally, existing logic is refactored slightly to dump summaries of workers that are still active when interactive session is terminated from command line.

v2:
- Rebased

v3:
- Run script copyright format updated
- Fixed typo in help
- Added additional logging to summary check