### PR TITLE
[PATCH v3] linux-gen: update copyright format

### DIFF
--- a/platform/linux-generic/README
+++ b/platform/linux-generic/README
@@ -1,8 +1,6 @@
-Copyright (c) 2014-2018, Linaro Limited
-Copyright (c) 2019-2023, Nokia
-All rights reserved.
-
-SPDX-License-Identifier:        BSD-3-Clause
+SPDX-License-Identifier: BSD-3-Clause
+Copyright (c) 2014-2018 Linaro Limited
+Copyright (c) 2019-2023 Nokia
 
 1. Intro
     OpenDataPlane API generic Linux implementation. Directory linux-generic

--- a/platform/linux-generic/arch/aarch64/cpu_flags.c
+++ b/platform/linux-generic/arch/aarch64/cpu_flags.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2020-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2020-2023 Nokia
  */
 
 #include <odp/api/hints.h>

--- a/platform/linux-generic/arch/aarch64/cpu_flags.h
+++ b/platform/linux-generic/arch/aarch64/cpu_flags.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, ARM Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 ARM Limited
  */
 
 #ifndef ODP_PLAT_CPU_FLAGS_H_

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/atomic.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/atomic.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, ARM Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 ARM Limited
  */
 
 #ifdef __ARM_FEATURE_ATOMICS

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2021, ARM Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_API_ABI_ATOMIC_INLINES_H_

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/cpu.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/cpu.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #ifndef ODP_API_ABI_CPU_H_

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/cpu_inlines.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/cpu_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2021-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2021-2023 Nokia
  */
 
 #ifndef ODP_ARCH_CPU_INLINES_H_

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/hash_crc32.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/hash_crc32.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021 ARM Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 ARM Limited
  */
 
 #ifndef ODP_API_ABI_HASH_CRC32_H_

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/time_cpu.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/time_cpu.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_API_ABI_TIME_CPU_H_

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/time_inlines.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/time_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
  */
 
 #include <odp/api/abi/time_cpu_inlines.h>

--- a/platform/linux-generic/arch/aarch64/odp_atomic.c
+++ b/platform/linux-generic/arch/aarch64/odp_atomic.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021, ARM Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2021 ARM Limited
  */
 
 #include <odp/api/atomic.h>

--- a/platform/linux-generic/arch/aarch64/odp_atomic.h
+++ b/platform/linux-generic/arch/aarch64/odp_atomic.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2017-2021, ARM Limited
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2021 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #ifndef PLATFORM_LINUXGENERIC_ARCH_ARM_ODP_ATOMIC_H

--- a/platform/linux-generic/arch/aarch64/odp_cpu.h
+++ b/platform/linux-generic/arch/aarch64/odp_cpu.h
@@ -1,9 +1,6 @@
-/* Copyright (c) 2017, ARM Limited. All rights reserved.
- *
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #ifndef PLATFORM_LINUXGENERIC_ARCH_ARM_ODP_CPU_H

--- a/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
+++ b/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
@@ -1,9 +1,7 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021, ARM Limited
- * Copyright (c) 2022-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2022-2023 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/arch/aarch64/odp_random.h
+++ b/platform/linux-generic/arch/aarch64/odp_random.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, ARM Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 ARM Limited
  */
 
 #ifndef ODP_AARCH64_RANDOM_H_

--- a/platform/linux-generic/arch/aarch64/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/aarch64/odp_sysinfo_parse.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2020-2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2020-2021 Nokia
  */
 
 #include <stdio.h>

--- a/platform/linux-generic/arch/arm/odp/api/abi/cpu.h
+++ b/platform/linux-generic/arch/arm/odp/api/abi/cpu.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #ifndef ODP_API_ABI_CPU_H_

--- a/platform/linux-generic/arch/arm/odp/api/abi/cpu_inlines.h
+++ b/platform/linux-generic/arch/arm/odp/api/abi/cpu_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_ARCH_CPU_INLINES_H_

--- a/platform/linux-generic/arch/arm/odp_cpu.h
+++ b/platform/linux-generic/arch/arm/odp_cpu.h
@@ -1,9 +1,6 @@
-/* Copyright (c) 2017, ARM Limited. All rights reserved.
- *
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #ifndef PLATFORM_LINUXGENERIC_ARCH_ARM_ODP_CPU_H

--- a/platform/linux-generic/arch/arm/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/arm/odp_sysinfo_parse.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2020, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020 Nokia
  */
 
 #include <odp_global_data.h>

--- a/platform/linux-generic/arch/common/odp/api/abi/time_cpu_inlines.h
+++ b/platform/linux-generic/arch/common/odp/api/abi/time_cpu_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2020-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2020-2023 Nokia
  */
 
 #ifndef ODP_ARCH_TIME_CPU_INLINES_H_

--- a/platform/linux-generic/arch/common/odp_time_cpu.c
+++ b/platform/linux-generic/arch/common/odp_time_cpu.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2020-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2020-2023 Nokia
  */
 
 #include <odp/api/time_types.h>

--- a/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2021, ARM Limited
- * Copyright (c) 2021-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2021-2022 Nokia
  */
 
 #ifndef ODP_API_ABI_ATOMIC_GENERIC_H_

--- a/platform/linux-generic/arch/default/odp/api/abi/atomic_inlines.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/atomic_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 #include <odp/api/abi/atomic_generic.h>

--- a/platform/linux-generic/arch/default/odp/api/abi/cpu.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/cpu.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #ifndef ODP_API_ABI_CPU_H_

--- a/platform/linux-generic/arch/default/odp/api/abi/cpu_generic.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/cpu_generic.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_API_ABI_CPU_GENERIC_H_

--- a/platform/linux-generic/arch/default/odp/api/abi/cpu_inlines.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/cpu_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #ifndef ODP_ARCH_CPU_INLINES_H_

--- a/platform/linux-generic/arch/default/odp/api/abi/hash_crc32.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/hash_crc32.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_API_ABI_HASH_CRC32_H_

--- a/platform/linux-generic/arch/default/odp/api/abi/time_inlines.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/time_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2020-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2020-2023 Nokia
  */
 
 #ifndef ODP_ARCH_TIME_INLINES_H_

--- a/platform/linux-generic/arch/default/odp_atomic.c
+++ b/platform/linux-generic/arch/default/odp_atomic.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021, ARM Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2021 ARM Limited
  */
 
 #include <odp/api/atomic.h>

--- a/platform/linux-generic/arch/default/odp_atomic.h
+++ b/platform/linux-generic/arch/default/odp_atomic.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, ARM Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 ARM Limited
  */
 
 #ifndef ODP_DEFAULT_ATOMIC_H_

--- a/platform/linux-generic/arch/default/odp_cpu.h
+++ b/platform/linux-generic/arch/default/odp_cpu.h
@@ -1,9 +1,6 @@
-/* Copyright (c) 2017, ARM Limited. All rights reserved.
- *
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #ifndef ODP_DEFAULT_CPU_H_

--- a/platform/linux-generic/arch/default/odp_cpu_cycles.c
+++ b/platform/linux-generic/arch/default/odp_cpu_cycles.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/arch/default/odp_hash_crc32.c
+++ b/platform/linux-generic/arch/default/odp_hash_crc32.c
@@ -1,40 +1,8 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  *
- * SPDX-License-Identifier:     BSD-3-Clause
- */
-
-/*-
- *   BSD LICENSE
- *
- *   Copyright(c) 2010-2013 Intel Corporation. All rights reserved.
- *   All rights reserved.
- *
- *   Redistribution and use in source and binary forms, with or without
- *   modification, are permitted provided that the following conditions
- *   are met:
- *
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in
- *       the documentation and/or other materials provided with the
- *       distribution.
- *     * Neither the name of Intel Corporation nor the names of its
- *       contributors may be used to endorse or promote products derived
- *       from this software without specific prior written permission.
- *
- *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright(c) 2010-2014 Intel Corporation
+ *   - lib/hash/rte_crc_sw.h
  */
 
 #include <odp/api/align.h>

--- a/platform/linux-generic/arch/default/odp_random.c
+++ b/platform/linux-generic/arch/default/odp_random.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 #include <odp_random.h>

--- a/platform/linux-generic/arch/default/odp_random.h
+++ b/platform/linux-generic/arch/default/odp_random.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_DEFAULT_RANDOM_H_

--- a/platform/linux-generic/arch/default/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/default/odp_sysinfo_parse.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #include <odp_global_data.h>

--- a/platform/linux-generic/arch/default/odp_time.c
+++ b/platform/linux-generic/arch/default/odp_time.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2020-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2020-2023 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/arch/powerpc/odp/api/abi/cpu.h
+++ b/platform/linux-generic/arch/powerpc/odp/api/abi/cpu.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_API_ABI_CPU_H_

--- a/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #include <odp_global_data.h>

--- a/platform/linux-generic/arch/x86/cpu_flags.c
+++ b/platform/linux-generic/arch/x86/cpu_flags.c
@@ -1,12 +1,11 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
- */
-
 /* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
+ * Copyright (c) 2023 Nokia
+ *
  * Copyright(c) 2010-2015 Intel Corporation
+ *   - lib/eal/x86/include/rte_cpuflags.h
+ *   - lib/eal/x86/rte_cpuflags.c
+ *   - lib/eal/x86/rte_cpuid.h
  */
 
 #include "cpu_flags.h"

--- a/platform/linux-generic/arch/x86/cpu_flags.h
+++ b/platform/linux-generic/arch/x86/cpu_flags.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #ifndef ODP_PLAT_CPU_FLAGS_H_

--- a/platform/linux-generic/arch/x86/odp/api/abi/cpu.h
+++ b/platform/linux-generic/arch/x86/odp/api/abi/cpu.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #ifndef ODP_API_ABI_CPU_H_

--- a/platform/linux-generic/arch/x86/odp/api/abi/cpu_inlines.h
+++ b/platform/linux-generic/arch/x86/odp/api/abi/cpu_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_ARCH_CPU_INLINES_H_

--- a/platform/linux-generic/arch/x86/odp/api/abi/cpu_rdtsc.h
+++ b/platform/linux-generic/arch/x86/odp/api/abi/cpu_rdtsc.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #ifndef ODP_ARCH_CPU_RDTSC_H_

--- a/platform/linux-generic/arch/x86/odp/api/abi/hash_crc32.h
+++ b/platform/linux-generic/arch/x86/odp/api/abi/hash_crc32.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_API_ABI_HASH_CRC32_H_

--- a/platform/linux-generic/arch/x86/odp/api/abi/time_cpu.h
+++ b/platform/linux-generic/arch/x86/odp/api/abi/time_cpu.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #ifndef ODP_ARCH_TIME_CPU_H_

--- a/platform/linux-generic/arch/x86/odp/api/abi/time_inlines.h
+++ b/platform/linux-generic/arch/x86/odp/api/abi/time_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
  */
 
 #include <odp/api/abi/time_cpu_inlines.h>

--- a/platform/linux-generic/arch/x86/odp_cpu.h
+++ b/platform/linux-generic/arch/x86/odp_cpu.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_X86_CPU_H_

--- a/platform/linux-generic/arch/x86/odp_cpu_cycles.c
+++ b/platform/linux-generic/arch/x86/odp_cpu_cycles.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #include <odp/api/cpu.h>

--- a/platform/linux-generic/arch/x86/odp_random.h
+++ b/platform/linux-generic/arch/x86/odp_random.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 /*

--- a/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2023 Nokia
  */
 
 #include <odp_sysinfo_internal.h>

--- a/platform/linux-generic/doc/platform_specific.dox
+++ b/platform/linux-generic/doc/platform_specific.dox
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/dumpconfig/dumpconfig.c
+++ b/platform/linux-generic/dumpconfig/dumpconfig.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #include <stdio.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/align.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/align.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/abi-default/align.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/atomic.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/atomic.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/barrier.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/barrier.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/buffer.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/buffer.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/buffer_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/buffer_types.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/byteorder.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/byteorder.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/classification.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/classification.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/comp.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/comp.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #ifndef ODP_ABI_COMP_H_

--- a/platform/linux-generic/include-abi/odp/api/abi/cpumask.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/cpumask.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/abi-default/cpumask.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/crypto.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/crypto.h
@@ -1,10 +1,7 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
-
 
 /**
  * @file

--- a/platform/linux-generic/include-abi/odp/api/abi/crypto_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/crypto_types.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/debug.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/debug.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/dma.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/dma.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/dma_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/dma_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_API_ABI_DMA_TYPES_H_

--- a/platform/linux-generic/include-abi/odp/api/abi/errno.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/errno.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2020, Marvell
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020 Marvell
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/event.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/event.h
@@ -1,10 +1,7 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
-
 
 /**
  * @file

--- a/platform/linux-generic/include-abi/odp/api/abi/event_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/event_types.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2022-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2022-2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/hash.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/hash.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2020, Marvell
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020 Marvell
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/init.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/init.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/abi-default/init.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/ipsec.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/ipsec.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/ipsec_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/ipsec_types.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/packet.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2019, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2019 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_flags.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_flags.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_io.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_io.h
@@ -1,10 +1,7 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2020-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2020-2022 Nokia
  */
-
 
 /**
  * @file

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_io_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_io_types.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2020-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2020-2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_types.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2019-2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2019-2021 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/pool.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/pool.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/pool_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/pool_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/proto_stats.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/proto_stats.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2021, Marvell
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Marvell
+ * Copyright (c) 2021 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/proto_stats_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/proto_stats_types.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2021, Marvell
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Marvell
+ * Copyright (c) 2021 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/queue.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/queue.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/queue_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/queue_types.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/random.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/random.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/rwlock.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/rwlock.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/abi-default/rwlock.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/rwlock_recursive.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/rwlock_recursive.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/abi-default/rwlock_recursive.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/schedule.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/schedule.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/schedule_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/schedule_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/abi-default/schedule_types.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/shared_memory.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/shared_memory.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 

--- a/platform/linux-generic/include-abi/odp/api/abi/spinlock.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/spinlock.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/abi-default/spinlock.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/spinlock_recursive.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/spinlock_recursive.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/abi-default/spinlock_recursive.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/stash.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/stash.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2020, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/stash_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/stash_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/std.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/std.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/std_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/std_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/abi-default/std_types.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/sync.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/sync.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/thread.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/thread.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 /* Inlined API functions */

--- a/platform/linux-generic/include-abi/odp/api/abi/thrmask.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/thrmask.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/abi-default/thrmask.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/ticketlock.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/ticketlock.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include-abi/odp/api/abi/time.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/time.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 /* Inlined API functions */

--- a/platform/linux-generic/include-abi/odp/api/abi/time_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/time_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
  */
 
 #include <odp/api/abi-default/time_types.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/timer.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/timer.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 /* Inlined functions for non-ABI compat mode */

--- a/platform/linux-generic/include-abi/odp/api/abi/timer_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/timer_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
  */
 
 

--- a/platform/linux-generic/include-abi/odp/api/abi/traffic_mngr.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/traffic_mngr.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/abi-default/traffic_mngr.h>

--- a/platform/linux-generic/include-abi/odp/api/abi/version.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/version.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/abi-default/version.h>

--- a/platform/linux-generic/include/ishmphy_internal.h
+++ b/platform/linux-generic/include/ishmphy_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #ifndef _ISHMPHY_INTERNAL_H_

--- a/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp/api/plat/buffer_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/buffer_inline_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_BUFFER_INLINE_TYPES_H_

--- a/platform/linux-generic/include/odp/api/plat/buffer_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/buffer_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2019-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2019-2023 Nokia
  */
 
 #ifndef ODP_PLAT_BUFFER_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/byteorder_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/byteorder_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include/odp/api/plat/cpu_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/cpu_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2021-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2021-2023 Nokia
  */
 
 #ifndef ODP_PLAT_CPU_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/crypto_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/crypto_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_CRYPTO_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/debug_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/debug_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2020-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2020-2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp/api/plat/dma_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/dma_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
  */
 
 #ifndef ODP_PLAT_DMA_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/event_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/event_inline_types.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_EVENT_INLINE_TYPES_H_

--- a/platform/linux-generic/include/odp/api/plat/event_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/event_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2022-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2022-2023 Nokia
  */
 
 #ifndef ODP_PLAT_EVENT_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/event_validation_external.h
+++ b/platform/linux-generic/include/odp/api/plat/event_validation_external.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp/api/plat/event_vector_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/event_vector_inline_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2020, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020 Nokia
  */
 
 #ifndef ODP_PLAT_EVENT_VECTOR_INLINE_TYPES_H_

--- a/platform/linux-generic/include/odp/api/plat/hash_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/hash_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_PLAT_HASH_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/ipsec_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/ipsec_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_IPSEC_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/packet_flag_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_flag_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2019-2022 Nokia
  */
 
 

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
+ * Copyright (c) 2019-2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp/api/plat/packet_io_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_io_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_PACKET_IO_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
@@ -1,8 +1,5 @@
-/* Copyright (c) 2020-2022, Nokia
- *
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020-2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp/api/plat/pool_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/pool_inline_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include/odp/api/plat/pool_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/pool_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_POOL_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2023 Nokia
  */
 
 #ifndef ODP_PLAT_QUEUE_INLINE_TYPES_H_

--- a/platform/linux-generic/include/odp/api/plat/queue_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/queue_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2023 Nokia
  */
 
 #ifndef ODP_PLAT_QUEUE_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/rwlock_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/rwlock_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_RWLOCK_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/rwlock_recursive_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/rwlock_recursive_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_RWLOCK_RECURSIVE_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/schedule_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/schedule_inline_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_SCHEDULE_INLINE_TYPES_H_

--- a/platform/linux-generic/include/odp/api/plat/schedule_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/schedule_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_SCHEDULE_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/spinlock_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/spinlock_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_SPINLOCK_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/spinlock_recursive_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/spinlock_recursive_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_SPINLOCK_RECURSIVE_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/std_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/std_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #ifndef ODP_PLAT_STD_INLINE_H_

--- a/platform/linux-generic/include/odp/api/plat/strong_types.h
+++ b/platform/linux-generic/include/odp/api/plat/strong_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 

--- a/platform/linux-generic/include/odp/api/plat/thread_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/thread_inline_types.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_THREAD_INLINE_TYPES_H_

--- a/platform/linux-generic/include/odp/api/plat/thread_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/thread_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #ifndef ODP_PLAT_THREAD_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/ticketlock_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/ticketlock_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #ifndef _ODP_PLAT_TICKETLOCK_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/time_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/time_inlines.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2020-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2020-2023 Nokia
  */
 
 #ifndef ODP_PLAT_TIME_INLINES_H_

--- a/platform/linux-generic/include/odp/api/plat/timer_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/timer_inline_types.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_PLAT_TIMER_INLINE_TYPES_H_

--- a/platform/linux-generic/include/odp/api/plat/timer_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/timer_inlines.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022-2023 Nokia
  */
 
 #ifndef ODP_PLAT_TIMER_INLINES_H_

--- a/platform/linux-generic/include/odp_atomic_internal.h
+++ b/platform/linux-generic/include/odp_atomic_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include/odp_bitset.h
+++ b/platform/linux-generic/include/odp_bitset.h
@@ -1,9 +1,6 @@
-/* Copyright (c) 2017, ARM Limited. All rights reserved.
- *
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #ifndef _ODP_BITSET_H_

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2021 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp_chksum_internal.h
+++ b/platform/linux-generic/include/odp_chksum_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2020, 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:	BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020-2023 Nokia
  */
 
 #ifndef ODP_CHKSUM_INTERNAL_H_

--- a/platform/linux-generic/include/odp_classification_datamodel.h
+++ b/platform/linux-generic/include/odp_classification_datamodel.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include/odp_classification_internal.h
+++ b/platform/linux-generic/include/odp_classification_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2021-2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2019-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2019-2023 Nokia
  */
 
 #ifndef ODP_CONFIG_INTERNAL_H_

--- a/platform/linux-generic/include/odp_debug_internal.h
+++ b/platform/linux-generic/include/odp_debug_internal.h
@@ -1,9 +1,8 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2020-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2020-2022 Nokia
  */
+
 /**
  * @file
  *

--- a/platform/linux-generic/include/odp_errno_define.h
+++ b/platform/linux-generic/include/odp_errno_define.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include/odp_ethtool_rss.h
+++ b/platform/linux-generic/include/odp_ethtool_rss.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #ifndef ODP_ETHTOOL_RSS_H_

--- a/platform/linux-generic/include/odp_ethtool_stats.h
+++ b/platform/linux-generic/include/odp_ethtool_stats.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_ETHTOOL_H_

--- a/platform/linux-generic/include/odp_event_internal.h
+++ b/platform/linux-generic/include/odp_event_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021-2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp_event_validation_internal.h
+++ b/platform/linux-generic/include/odp_event_validation_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
  */
 
 #ifndef ODP_EVENT_VALIDATION_INTERNAL_H_

--- a/platform/linux-generic/include/odp_event_vector_internal.h
+++ b/platform/linux-generic/include/odp_event_vector_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2020-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020-2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp_fdserver_internal.h
+++ b/platform/linux-generic/include/odp_fdserver_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #ifndef _FD_SERVER_INTERNAL_H

--- a/platform/linux-generic/include/odp_forward_typedefs_internal.h
+++ b/platform/linux-generic/include/odp_forward_typedefs_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2023 Nokia
  */
 
 #ifndef ODP_GLOBAL_DATA_H_

--- a/platform/linux-generic/include/odp_init_internal.h
+++ b/platform/linux-generic/include/odp_init_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
  */
 
 #ifndef ODP_INIT_INTERNAL_H_

--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * Copyright (c) 2018, 2020-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:	BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
+ * Copyright (c) 2018-2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp_ishmphy_internal.h
+++ b/platform/linux-generic/include/odp_ishmphy_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #ifndef _ISHMPHY_INTERNAL_H

--- a/platform/linux-generic/include/odp_ishmpool_internal.h
+++ b/platform/linux-generic/include/odp_ishmpool_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #ifndef ODP_ISHMBUDDY_INTERNAL_H_

--- a/platform/linux-generic/include/odp_libconfig_internal.h
+++ b/platform/linux-generic/include/odp_libconfig_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include/odp_llqueue.h
+++ b/platform/linux-generic/include/odp_llqueue.h
@@ -1,9 +1,6 @@
-/* Copyright (c) 2017, ARM Limited. All rights reserved.
- *
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #ifndef ODP_LLQUEUE_H_

--- a/platform/linux-generic/include/odp_macros_internal.h
+++ b/platform/linux-generic/include/odp_macros_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2022-2024, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2022-2024 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp_name_table_internal.h
+++ b/platform/linux-generic/include/odp_name_table_internal.h
@@ -1,9 +1,6 @@
-/* Copyright 2015 EZchip Semiconductor Ltd. All Rights Reserved.
- *
- * Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015 EZchip Semiconductor Ltd.
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #ifndef ODP_INT_NAME_TABLE_H_

--- a/platform/linux-generic/include/odp_packet_dpdk.h
+++ b/platform/linux-generic/include/odp_packet_dpdk.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2019-2022 Nokia
  */
 
 #ifndef ODP_PACKET_DPDK_H

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp_packet_io_stats.h
+++ b/platform/linux-generic/include/odp_packet_io_stats.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_PACKET_IO_STATS_H_

--- a/platform/linux-generic/include/odp_packet_io_stats_common.h
+++ b/platform/linux-generic/include/odp_packet_io_stats_common.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #ifndef ODP_PACKET_IO_STATS_COMMON_H_

--- a/platform/linux-generic/include/odp_parse_internal.h
+++ b/platform/linux-generic/include/odp_parse_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2022 Nokia
  */
 
 #ifndef ODP_PARSE_INTERNAL_H_

--- a/platform/linux-generic/include/odp_pcapng.h
+++ b/platform/linux-generic/include/odp_pcapng.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2019, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2019 Nokia
  */
 
 #ifndef ODP_PCAPNG_H_

--- a/platform/linux-generic/include/odp_pkt_queue_internal.h
+++ b/platform/linux-generic/include/odp_pkt_queue_internal.h
@@ -1,9 +1,6 @@
-/* Copyright 2015 EZchip Semiconductor Ltd. All Rights Reserved.
- *
- * Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015 EZchip Semiconductor Ltd.
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #ifndef _ODP_INT_PKT_QUEUE_H_

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp_posix_extensions.h
+++ b/platform/linux-generic/include/odp_posix_extensions.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #ifndef ODP_POSIX_EXTENSIONS_H

--- a/platform/linux-generic/include/odp_queue_basic_internal.h
+++ b/platform/linux-generic/include/odp_queue_basic_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2023 Nokia
  */
 
 #ifndef ODP_QUEUE_BASIC_INTERNAL_H_

--- a/platform/linux-generic/include/odp_queue_if.h
+++ b/platform/linux-generic/include/odp_queue_if.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2017, ARM Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_QUEUE_IF_H_

--- a/platform/linux-generic/include/odp_queue_lf.h
+++ b/platform/linux-generic/include/odp_queue_lf.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #ifndef ODP_QUEUE_LF_H_

--- a/platform/linux-generic/include/odp_queue_scalable_internal.h
+++ b/platform/linux-generic/include/odp_queue_scalable_internal.h
@@ -1,9 +1,6 @@
-/* Copyright (c) 2017, ARM Limited. All rights reserved.
- *
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #ifndef ODP_QUEUE_SCALABLE_INTERNAL_H_

--- a/platform/linux-generic/include/odp_random_openssl_internal.h
+++ b/platform/linux-generic/include/odp_random_openssl_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2020, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020 Nokia
  */
 
 #ifndef ODP_RANDOM_OPENSSL_INTERNAL_H_

--- a/platform/linux-generic/include/odp_random_std_internal.h
+++ b/platform/linux-generic/include/odp_random_std_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2020, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020 Nokia
  */
 
 #ifndef ODP_RANDOM_STD_INTERNAL_H_

--- a/platform/linux-generic/include/odp_ring_common.h
+++ b/platform/linux-generic/include/odp_ring_common.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2019-2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2019-2021 Nokia
  */
 
 #ifndef ODP_RING_COMMON_H_

--- a/platform/linux-generic/include/odp_ring_internal.h
+++ b/platform/linux-generic/include/odp_ring_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2019-2022 Nokia
  */
 
 /* This header should NOT be included directly. There are no include guards for

--- a/platform/linux-generic/include/odp_ring_mpmc_internal.h
+++ b/platform/linux-generic/include/odp_ring_mpmc_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2023 Nokia
  */
 
 #ifndef ODP_RING_MPMC_INTERNAL_H_

--- a/platform/linux-generic/include/odp_ring_mpmc_u32_internal.h
+++ b/platform/linux-generic/include/odp_ring_mpmc_u32_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
  */
 
 #ifndef ODP_RING_MPMC_U32_INTERNAL_H_

--- a/platform/linux-generic/include/odp_ring_mpmc_u64_internal.h
+++ b/platform/linux-generic/include/odp_ring_mpmc_u64_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
  */
 
 #ifndef ODP_RING_MPMC_U64_INTERNAL_H_

--- a/platform/linux-generic/include/odp_ring_ptr_internal.h
+++ b/platform/linux-generic/include/odp_ring_ptr_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2019, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2019 Nokia
  */
 
 #ifndef ODP_RING_PTR_INTERNAL_H_

--- a/platform/linux-generic/include/odp_ring_spsc_internal.h
+++ b/platform/linux-generic/include/odp_ring_spsc_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #ifndef ODP_RING_SPSC_INTERNAL_H_

--- a/platform/linux-generic/include/odp_ring_st_internal.h
+++ b/platform/linux-generic/include/odp_ring_st_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #ifndef ODP_RING_ST_INTERNAL_H_

--- a/platform/linux-generic/include/odp_ring_u32_internal.h
+++ b/platform/linux-generic/include/odp_ring_u32_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2019, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2019 Nokia
  */
 
 #ifndef ODP_RING_U32_INTERNAL_H_

--- a/platform/linux-generic/include/odp_ring_u64_internal.h
+++ b/platform/linux-generic/include/odp_ring_u64_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_RING_U64_INTERNAL_H_

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_SCHEDULE_IF_H_

--- a/platform/linux-generic/include/odp_schedule_scalable.h
+++ b/platform/linux-generic/include/odp_schedule_scalable.h
@@ -1,9 +1,6 @@
-/* Copyright (c) 2017, ARM Limited. All rights reserved.
- *
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #ifndef ODP_SCHEDULE_SCALABLE_H

--- a/platform/linux-generic/include/odp_schedule_scalable_config.h
+++ b/platform/linux-generic/include/odp_schedule_scalable_config.h
@@ -1,9 +1,6 @@
-/* Copyright (c) 2017, ARM Limited. All rights reserved.
- *
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #ifndef ODP_SCHEDULE_SCALABLE_CONFIG_H_

--- a/platform/linux-generic/include/odp_schedule_scalable_ordered.h
+++ b/platform/linux-generic/include/odp_schedule_scalable_ordered.h
@@ -1,9 +1,6 @@
-/* Copyright (c) 2017, ARM Limited. All rights reserved.
- *
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #ifndef ODP_SCHEDULE_SCALABLE_ORDERED_H

--- a/platform/linux-generic/include/odp_shm_internal.h
+++ b/platform/linux-generic/include/odp_shm_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2019, Nokia
- * Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2019 Nokia
  */
 
 #ifndef ODP_SHM_INTERNAL_H_

--- a/platform/linux-generic/include/odp_socket_common.h
+++ b/platform/linux-generic/include/odp_socket_common.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2019, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2019 Nokia
  */
 
 #ifndef ODP_SOCKET_COMMON_H_

--- a/platform/linux-generic/include/odp_sorted_list_internal.h
+++ b/platform/linux-generic/include/odp_sorted_list_internal.h
@@ -1,9 +1,6 @@
-/* Copyright 2015 EZchip Semiconductor Ltd. All Rights Reserved.
- *
- * Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015 EZchip Semiconductor Ltd.
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #ifndef _ODP_INT_SORTED_LIST_H_

--- a/platform/linux-generic/include/odp_string_internal.h
+++ b/platform/linux-generic/include/odp_string_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_STRING_INTERNAL_H_

--- a/platform/linux-generic/include/odp_sysfs_stats.h
+++ b/platform/linux-generic/include/odp_sysfs_stats.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #ifndef ODP_SYSFS_STATS_H_

--- a/platform/linux-generic/include/odp_sysinfo_internal.h
+++ b/platform/linux-generic/include/odp_sysinfo_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
  */
 
 #ifndef ODP_SYSINFO_INTERNAL_H_

--- a/platform/linux-generic/include/odp_timer_internal.h
+++ b/platform/linux-generic/include/odp_timer_internal.h
@@ -1,8 +1,6 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2021-2022 Nokia
  */
 
 /**

--- a/platform/linux-generic/include/odp_timer_wheel_internal.h
+++ b/platform/linux-generic/include/odp_timer_wheel_internal.h
@@ -1,9 +1,6 @@
-/* Copyright 2015 EZchip Semiconductor Ltd. All Rights Reserved.
- *
- * Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015 EZchip Semiconductor Ltd.
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #ifndef _ODP_INT_TIMER_WHEEL_H_

--- a/platform/linux-generic/include/odp_traffic_mngr_internal.h
+++ b/platform/linux-generic/include/odp_traffic_mngr_internal.h
@@ -1,9 +1,6 @@
-/* Copyright 2015 EZchip Semiconductor Ltd. All Rights Reserved.
- *
- * Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015 EZchip Semiconductor Ltd.
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include/odp_types_internal.h
+++ b/platform/linux-generic/include/odp_types_internal.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:	BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #ifndef ODP_TYPES_INTERNAL_H_

--- a/platform/linux-generic/include/protocols/eth.h
+++ b/platform/linux-generic/include/protocols/eth.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include/protocols/ip.h
+++ b/platform/linux-generic/include/protocols/ip.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include/protocols/ipsec.h
+++ b/platform/linux-generic/include/protocols/ipsec.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 

--- a/platform/linux-generic/include/protocols/sctp.h
+++ b/platform/linux-generic/include/protocols/sctp.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include/protocols/tcp.h
+++ b/platform/linux-generic/include/protocols/tcp.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 

--- a/platform/linux-generic/include/protocols/thash.h
+++ b/platform/linux-generic/include/protocols/thash.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/include/protocols/udp.h
+++ b/platform/linux-generic/include/protocols/udp.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 /**

--- a/platform/linux-generic/odp_atomic_api.c
+++ b/platform/linux-generic/odp_atomic_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #include <odp/api/atomic.h>

--- a/platform/linux-generic/odp_barrier.c
+++ b/platform/linux-generic/odp_barrier.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
  */
 
 #include <odp/api/barrier.h>

--- a/platform/linux-generic/odp_buffer.c
+++ b/platform/linux-generic/odp_buffer.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2022 Nokia
  */
 
 #include <odp/api/align.h>

--- a/platform/linux-generic/odp_buffer_api.c
+++ b/platform/linux-generic/odp_buffer_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2019, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2019 Nokia
  */
 
 #include <odp/api/buffer.h>

--- a/platform/linux-generic/odp_byteorder_api.c
+++ b/platform/linux-generic/odp_byteorder_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #include <odp/api/byteorder.h>

--- a/platform/linux-generic/odp_chksum.c
+++ b/platform/linux-generic/odp_chksum.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/chksum.h>

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2019-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2019-2023 Nokia
  */
 
 #include <odp/api/classification.h>

--- a/platform/linux-generic/odp_comp.c
+++ b/platform/linux-generic/odp_comp.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #include <string.h>

--- a/platform/linux-generic/odp_cpu_api.c
+++ b/platform/linux-generic/odp_cpu_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #include <odp/api/cpu.h>

--- a/platform/linux-generic/odp_cpumask.c
+++ b/platform/linux-generic/odp_cpumask.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/odp_cpumask_task.c
+++ b/platform/linux-generic/odp_cpumask_task.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2021-2022 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/odp_crypto_api.c
+++ b/platform/linux-generic/odp_crypto_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp/api/crypto.h>

--- a/platform/linux-generic/odp_crypto_ipsecmb.c
+++ b/platform/linux-generic/odp_crypto_ipsecmb.c
@@ -1,9 +1,7 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021, ARM Limited
- * Copyright (c) 2022-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2022-2023 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/odp_crypto_null.c
+++ b/platform/linux-generic/odp_crypto_null.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2021-2023 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2021-2023 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/odp_dma.c
+++ b/platform/linux-generic/odp_dma.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021-2023 Nokia
  */
 
 #include <odp/api/dma.h>

--- a/platform/linux-generic/odp_dma_api.c
+++ b/platform/linux-generic/odp_dma_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
  */
 
 #include <odp/api/dma.h>

--- a/platform/linux-generic/odp_errno.c
+++ b/platform/linux-generic/odp_errno.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:	BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #include <odp/api/errno.h>

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2020-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2020-2023 Nokia
  */
 
 #include <odp/api/event.h>

--- a/platform/linux-generic/odp_event_api.c
+++ b/platform/linux-generic/odp_event_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #include <odp/api/event.h>

--- a/platform/linux-generic/odp_event_validation.c
+++ b/platform/linux-generic/odp_event_validation.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Nokia
  */
 
 #include <odp/api/atomic.h>

--- a/platform/linux-generic/odp_fdserver.c
+++ b/platform/linux-generic/odp_fdserver.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 /*

--- a/platform/linux-generic/odp_hash_api.c
+++ b/platform/linux-generic/odp_hash_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 #include <odp/api/hash.h>

--- a/platform/linux-generic/odp_hash_crc_gen.c
+++ b/platform/linux-generic/odp_hash_crc_gen.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #include <stdio.h>

--- a/platform/linux-generic/odp_impl.c
+++ b/platform/linux-generic/odp_impl.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
  */
 
 #include <odp/autoheader_internal.h>

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2021-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2021-2023 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * Copyright (c) 2018-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
+ * Copyright (c) 2018-2022 Nokia
  */
 
 #include <odp/api/byteorder.h>

--- a/platform/linux-generic/odp_ipsec_api.c
+++ b/platform/linux-generic/odp_ipsec_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp/api/ipsec.h>

--- a/platform/linux-generic/odp_ipsec_events.c
+++ b/platform/linux-generic/odp_ipsec_events.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/ipsec.h>

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * Copyright (c) 2018-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
+ * Copyright (c) 2018-2023 Nokia
  */
 
 #include <odp/api/atomic.h>

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2019, Nokia
- * Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2019 Nokia
  */
 
 /* This file handles the internal shared memory: internal shared memory

--- a/platform/linux-generic/odp_ishmphy.c
+++ b/platform/linux-generic/odp_ishmphy.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 /*

--- a/platform/linux-generic/odp_ishmpool.c
+++ b/platform/linux-generic/odp_ishmpool.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 /* This file gathers the buddy and slab allocation functionality provided

--- a/platform/linux-generic/odp_libconfig.c
+++ b/platform/linux-generic/odp_libconfig.c
@@ -1,9 +1,7 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2020, Nokia
- * Copyright (c) 2021, Marvell
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2020 Nokia
+ * Copyright (c) 2021 Marvell
  */
 
 #include <stdlib.h>

--- a/platform/linux-generic/odp_name_table.c
+++ b/platform/linux-generic/odp_name_table.c
@@ -1,9 +1,6 @@
- /* Copyright 2015 EZchip Semiconductor Ltd. All Rights Reserved.
-
- * Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+ /* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015 EZchip Semiconductor Ltd.
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #include <odp/api/hash.h>

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2023 Nokia
  */
 
 #include <odp/autoheader_external.h>

--- a/platform/linux-generic/odp_packet_api.c
+++ b/platform/linux-generic/odp_packet_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
  */
 
 #include <odp/api/packet.h>

--- a/platform/linux-generic/odp_packet_flags.c
+++ b/platform/linux-generic/odp_packet_flags.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
  */
 
 #include <odp/api/plat/packet_flag_inlines.h>

--- a/platform/linux-generic/odp_packet_flags_api.c
+++ b/platform/linux-generic/odp_packet_flags_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
  */
 
 #include <odp/api/packet_flags.h>

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2023 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/odp_packet_io_api.c
+++ b/platform/linux-generic/odp_packet_io_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #include <odp/api/packet_io.h>

--- a/platform/linux-generic/odp_packet_vector.c
+++ b/platform/linux-generic/odp_packet_vector.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2020-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020-2022 Nokia
  */
 
 #include <odp/api/align.h>

--- a/platform/linux-generic/odp_parse.c
+++ b/platform/linux-generic/odp_parse.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2022 Nokia
  */
 
 #include <odp_parse_internal.h>

--- a/platform/linux-generic/odp_pcapng.c
+++ b/platform/linux-generic/odp_pcapng.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2019-2022 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/odp_pkt_queue.c
+++ b/platform/linux-generic/odp_pkt_queue.c
@@ -1,9 +1,6 @@
-/* Copyright 2015 EZchip Semiconductor Ltd. All Rights Reserved.
-
- * Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015 EZchip Semiconductor Ltd.
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #include <odp/api/packet.h>

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2023 Nokia
  */
 
 #include <odp/api/align.h>

--- a/platform/linux-generic/odp_pool_api.c
+++ b/platform/linux-generic/odp_pool_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp/api/pool.h>

--- a/platform/linux-generic/odp_pool_mem_src_ops.c
+++ b/platform/linux-generic/odp_pool_mem_src_ops.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp/autoheader_internal.h>

--- a/platform/linux-generic/odp_queue_api.c
+++ b/platform/linux-generic/odp_queue_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #include <odp/api/queue.h>

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2021-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2021-2023 Nokia
  */
 
 #include <odp/api/align.h>

--- a/platform/linux-generic/odp_queue_if.c
+++ b/platform/linux-generic/odp_queue_if.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2017, ARM Limited
- * Copyright (c) 2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2023 Nokia
  */
 
 #include <odp/autoheader_internal.h>

--- a/platform/linux-generic/odp_queue_lf.c
+++ b/platform/linux-generic/odp_queue_lf.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #include <odp/api/queue.h>

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2017, ARM Limited
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/hints.h>

--- a/platform/linux-generic/odp_queue_spsc.c
+++ b/platform/linux-generic/odp_queue_spsc.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #include <odp_debug_internal.h>

--- a/platform/linux-generic/odp_random.c
+++ b/platform/linux-generic/odp_random.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2020, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020 Nokia
  */
 
 #include <stdint.h>

--- a/platform/linux-generic/odp_random_openssl.c
+++ b/platform/linux-generic/odp_random_openssl.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2020, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2020 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/odp_random_std.c
+++ b/platform/linux-generic/odp_random_std.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
  */
 
 #include <odp/api/byteorder.h>

--- a/platform/linux-generic/odp_rwlock_api.c
+++ b/platform/linux-generic/odp_rwlock_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp/api/rwlock.h>

--- a/platform/linux-generic/odp_rwlock_recursive_api.c
+++ b/platform/linux-generic/odp_rwlock_recursive_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp/api/rwlock_recursive.h>

--- a/platform/linux-generic/odp_schedule_api.c
+++ b/platform/linux-generic/odp_schedule_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp/api/schedule.h>

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2022 Nokia
  */
 
 /*

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2021-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2021-2022 Nokia
  */
 
 #include <odp/autoheader_internal.h>

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -1,9 +1,6 @@
-/* Copyright (c) 2017, ARM Limited. All rights reserved.
- *
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/align.h>

--- a/platform/linux-generic/odp_schedule_scalable_ordered.c
+++ b/platform/linux-generic/odp_schedule_scalable_ordered.c
@@ -1,9 +1,6 @@
-/* Copyright (c) 2017, ARM Limited. All rights reserved.
- *
- * Copyright (c) 2017-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 ARM Limited
+ * Copyright (c) 2017-2018 Linaro Limited
  */
 
 #include <odp/api/shared_memory.h>

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2019-2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2019-2021 Nokia
  */
 
 /*

--- a/platform/linux-generic/odp_shared_memory.c
+++ b/platform/linux-generic/odp_shared_memory.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2021 Nokia
  */
 
 #include <odp_config_internal.h>

--- a/platform/linux-generic/odp_sorted_list.c
+++ b/platform/linux-generic/odp_sorted_list.c
@@ -1,9 +1,6 @@
-/* Copyright 2015 EZchip Semiconductor Ltd. All Rights Reserved.
- *
- * Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015 EZchip Semiconductor Ltd.
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #include <stdint.h>

--- a/platform/linux-generic/odp_spinlock_api.c
+++ b/platform/linux-generic/odp_spinlock_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp/api/spinlock.h>

--- a/platform/linux-generic/odp_spinlock_recursive_api.c
+++ b/platform/linux-generic/odp_spinlock_recursive_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp/api/spinlock_recursive.h>

--- a/platform/linux-generic/odp_stash.c
+++ b/platform/linux-generic/odp_stash.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2020-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020-2023 Nokia
  */
 
 #include <odp/api/align.h>

--- a/platform/linux-generic/odp_std.c
+++ b/platform/linux-generic/odp_std.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2021 Nokia
  */
 
 #include <odp/api/std.h>

--- a/platform/linux-generic/odp_std_api.c
+++ b/platform/linux-generic/odp_std_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #include <odp/api/std.h>

--- a/platform/linux-generic/odp_string.c
+++ b/platform/linux-generic/odp_string.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp/api/hints.h>

--- a/platform/linux-generic/odp_sync_api.c
+++ b/platform/linux-generic/odp_sync_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #include <odp/api/sync.h>

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -1,15 +1,10 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2020-2022, Nokia
- * All rights reserved.
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2020-2022 Nokia
  *
- * SPDX-License-Identifier:     BSD-3-Clause
- */
-
-/*
- *   BSD LICENSE
- *
- *   Copyright(c) 2010-2014 Intel Corporation. All rights reserved.
- *   All rights reserved.
+ * Copyright(c) 2010-2014 Intel Corporation
+ *   - lib/eal/common/eal_common_string_fns.c
+ *   - lib/eal/linux/eal_hugepage_info.c
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/odp_thread.c
+++ b/platform/linux-generic/odp_thread.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/odp_thread_api.c
+++ b/platform/linux-generic/odp_thread_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #include <odp/api/thread.h>

--- a/platform/linux-generic/odp_thrmask.c
+++ b/platform/linux-generic/odp_thrmask.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #include <odp/api/thrmask.h>

--- a/platform/linux-generic/odp_ticketlock_api.c
+++ b/platform/linux-generic/odp_ticketlock_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
  */
 
 #include <odp/api/ticketlock.h>

--- a/platform/linux-generic/odp_time_api.c
+++ b/platform/linux-generic/odp_time_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
  */
 
 #include <odp/api/time.h>

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2019-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2019-2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/odp_timer_api.c
+++ b/platform/linux-generic/odp_timer_api.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp/api/timer.h>

--- a/platform/linux-generic/odp_timer_wheel.c
+++ b/platform/linux-generic/odp_timer_wheel.c
@@ -1,9 +1,6 @@
-/* Copyright 2015 EZchip Semiconductor Ltd. All Rights Reserved.
- *
- * Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015 EZchip Semiconductor Ltd.
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #include <stdint.h>

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -1,11 +1,8 @@
-/* Copyright 2015 EZchip Semiconductor Ltd. All Rights Reserved.
- *
- * Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2022, Marvell
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015 EZchip Semiconductor Ltd.
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2022 Marvell
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/odp_version.c
+++ b/platform/linux-generic/odp_version.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #include <odp/api/version.h>

--- a/platform/linux-generic/odp_weak.c
+++ b/platform/linux-generic/odp_weak.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
  */
 
 #include <odp/api/debug.h>

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * Copyright (c) 2019-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
+ * Copyright (c) 2019-2023 Nokia
  */
 
 #include <odp/autoheader_internal.h>

--- a/platform/linux-generic/pktio/ethtool_rss.c
+++ b/platform/linux-generic/pktio/ethtool_rss.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/pktio/io_ops.c
+++ b/platform/linux-generic/pktio/io_ops.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
  */
 
 #include <odp/autoheader_internal.h>

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2019-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2019-2022 Nokia
  */
 
 #include <odp/api/hints.h>

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2013-2023, Nokia Solutions and Networks
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2013-2023 Nokia Solutions and Networks
  */
 
 #include <odp/api/debug.h>

--- a/platform/linux-generic/pktio/null.c
+++ b/platform/linux-generic/pktio/null.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018-2018, Linaro Limited
- * Copyright (c) 2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2022 Nokia
  */
 
 #include <odp/api/debug.h>

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2021-2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/pktio/pktio_common.c
+++ b/platform/linux-generic/pktio/pktio_common.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2013, Nokia Solutions and Networks
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2013 Nokia Solutions and Networks
  */
 
 #include <odp_packet_io_internal.h>

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2013-2023, Nokia Solutions and Networks
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2013-2023 Nokia Solutions and Networks
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/pktio/socket_common.c
+++ b/platform/linux-generic/pktio/socket_common.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2018, Linaro Limited
- * Copyright (c) 2019-2020, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2019-2020 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2013-2023, Nokia Solutions and Networks
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2013-2018 Linaro Limited
+ * Copyright (c) 2013-2023 Nokia Solutions and Networks
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/pktio/socket_xdp.c
+++ b/platform/linux-generic/pktio/socket_xdp.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2022-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022-2023 Nokia
  */
 
 #include <odp/autoheader_internal.h>

--- a/platform/linux-generic/pktio/stats/ethtool_stats.c
+++ b/platform/linux-generic/pktio/stats/ethtool_stats.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2021-2022 Nokia
  */
 
 #include <odp_posix_extensions.h>

--- a/platform/linux-generic/pktio/stats/packet_io_stats.c
+++ b/platform/linux-generic/pktio/stats/packet_io_stats.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2018 Linaro Limited
+ * Copyright (c) 2021 Nokia
  */
 
 #include <odp_packet_io_stats.h>

--- a/platform/linux-generic/pktio/stats/sysfs_stats.c
+++ b/platform/linux-generic/pktio/stats/sysfs_stats.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015-2018, Linaro Limited
- * Copyright (c) 2021-2022, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015-2018 Linaro Limited
+ * Copyright (c) 2021-2022 Nokia
  */
 
 #include <odp/api/packet_io_stats.h>

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -1,8 +1,6 @@
-/* Copyright (c) 2015, Ilya Maximets <i.maximets@samsung.com>
- * Copyright (c) 2021-2023, Nokia
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2015 Ilya Maximets <i.maximets@samsung.com>
+ * Copyright (c) 2021-2023 Nokia
  */
 
 /**

--- a/platform/linux-generic/test/example/classifier/pktio_env
+++ b/platform/linux-generic/test/example/classifier/pktio_env
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (c) 2020, Marvell
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020 Marvell
 #
 # Script to setup interfaces used for running application on linux-generic.
 #

--- a/platform/linux-generic/test/example/ipsec_api/pktio_env
+++ b/platform/linux-generic/test/example/ipsec_api/pktio_env
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (C) 2021, Marvell
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Marvell
 #
 # Script to setup interfaces used for running application on linux-generic.
 #

--- a/platform/linux-generic/test/example/ipsec_crypto/pktio_env
+++ b/platform/linux-generic/test/example/ipsec_crypto/pktio_env
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (C) 2021, Marvell
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Marvell
 #
 # Script to setup interfaces used for running application on linux-generic.
 #

--- a/platform/linux-generic/test/example/l2fwd_simple/pktio_env
+++ b/platform/linux-generic/test/example/l2fwd_simple/pktio_env
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (C) 2020, Marvell
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020 Marvell
 #
 # Script to setup interfaces used for running application on linux-generic.
 #

--- a/platform/linux-generic/test/example/l3fwd/pktio_env
+++ b/platform/linux-generic/test/example/l3fwd/pktio_env
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (C) 2020, Marvell
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020 Marvell
 #
 # Script to setup interfaces used for running application on linux-generic.
 #

--- a/platform/linux-generic/test/example/packet/pktio_env
+++ b/platform/linux-generic/test/example/packet/pktio_env
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (C) 2020, Marvell
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020 Marvell
 #
 # Script to setup interfaces used for running application on linux-generic.
 #

--- a/platform/linux-generic/test/example/ping/pktio_env
+++ b/platform/linux-generic/test/example/ping/pktio_env
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (C) 2020, Marvell
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020 Marvell
 #
 # Script to setup interfaces used for running application on linux-generic.
 #

--- a/platform/linux-generic/test/example/simple_pipeline/pktio_env
+++ b/platform/linux-generic/test/example/simple_pipeline/pktio_env
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (C) 2020, Marvell
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020 Marvell
 #
 # Script to setup interfaces used for running application on linux-generic.
 #

--- a/platform/linux-generic/test/example/switch/pktio_env
+++ b/platform/linux-generic/test/example/switch/pktio_env
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (C) 2020, Marvell
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020 Marvell
 #
 # Script to setup interfaces used for running application on linux-generic.
 #

--- a/platform/linux-generic/test/validation/api/pktio/pktio_env
+++ b/platform/linux-generic/test/validation/api/pktio/pktio_env
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (c) 2015-2018, Linaro Limited
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2015-2018 Linaro Limited
 #
 # Test script wrapper for running ODP pktio apps on linux-generic.
 #

--- a/platform/linux-generic/test/validation/api/pktio/pktio_run.sh
+++ b/platform/linux-generic/test/validation/api/pktio/pktio_run.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (c) 2015-2018, Linaro Limited
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2015-2018 Linaro Limited
 #
 
 # Proceed the pktio tests. This script expects at least one argument:

--- a/platform/linux-generic/test/validation/api/pktio/pktio_run_dpdk.sh
+++ b/platform/linux-generic/test/validation/api/pktio/pktio_run_dpdk.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (c) 2016-2018, Linaro Limited
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2016-2018 Linaro Limited
 #
 
 # Proceed the pktio tests. This script expects at least one argument:

--- a/platform/linux-generic/test/validation/api/pktio/pktio_run_pcap.sh
+++ b/platform/linux-generic/test/validation/api/pktio/pktio_run_pcap.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (c) 2015-2018, Linaro Limited
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2015-2018 Linaro Limited
 #
 
 # any parameter passed as arguments to this script is passed unchanged to

--- a/platform/linux-generic/test/validation/api/pktio/pktio_run_tap.sh
+++ b/platform/linux-generic/test/validation/api/pktio/pktio_run_tap.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 #
-# Copyright (c) 2015, Ilya Maximets <i.maximets@samsung.com>
-# All rights reserved.
-#
-# SPDX-License-Identifier:	BSD-3-Clause
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2015 Ilya Maximets <i.maximets@samsung.com>
 #
 
 

--- a/platform/linux-generic/test/validation/api/shmem/shmem_common.h
+++ b/platform/linux-generic/test/validation/api/shmem/shmem_common.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #ifndef _COMMON_TEST_SHMEM_H_

--- a/platform/linux-generic/test/validation/api/shmem/shmem_linux.c
+++ b/platform/linux-generic/test/validation/api/shmem/shmem_linux.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 /* this test makes sure that odp shared memory created with the ODP_SHM_PROC

--- a/platform/linux-generic/test/validation/api/shmem/shmem_linux.h
+++ b/platform/linux-generic/test/validation/api/shmem/shmem_linux.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:	BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 void test_success(char *fifo_name, int fd, pid_t odp_app);

--- a/platform/linux-generic/test/validation/api/shmem/shmem_odp1.c
+++ b/platform/linux-generic/test/validation/api/shmem/shmem_odp1.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #include <odp_api.h>

--- a/platform/linux-generic/test/validation/api/shmem/shmem_odp1.h
+++ b/platform/linux-generic/test/validation/api/shmem/shmem_odp1.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 void shmem_test_odp_shm_proc(void);

--- a/platform/linux-generic/test/validation/api/shmem/shmem_odp2.c
+++ b/platform/linux-generic/test/validation/api/shmem/shmem_odp2.c
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 #include <odp_api.h>

--- a/platform/linux-generic/test/validation/api/shmem/shmem_odp2.h
+++ b/platform/linux-generic/test/validation/api/shmem/shmem_odp2.h
@@ -1,7 +1,5 @@
-/* Copyright (c) 2016-2018, Linaro Limited
- * All rights reserved.
- *
- * SPDX-License-Identifier:     BSD-3-Clause
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2016-2018 Linaro Limited
  */
 
 int main(int argc, char *argv[]);


### PR DESCRIPTION
Update all implementation files to use the new shorter copyright format:

/* SPDX-License-Identifier: BSD-3-Clause
 * Copyright (c) <YEAR> <COPYRIGHT HOLDER> */