### PR TITLE
[PATCH v4] validation: pktio: ignore extra packets in pktio_test_pktin_event_queue

### DIFF
--- a/test/validation/api/pktio/lso.c
+++ b/test/validation/api/pktio/lso.c
@@ -655,7 +655,7 @@ static void test_lso_request_clear(odp_lso_profile_t lso_profile, const uint8_t 
 static void lso_send_custom_eth(const uint8_t *test_packet, uint32_t pkt_len, uint32_t max_payload,
 				int use_opt)
 {
-	int i, ret, num;
+	int i, ret, num, num_rcv;
 	odp_lso_profile_param_t param;
 	odp_lso_profile_t profile;
 	uint32_t offset, len, payload_len, payload_sum;
@@ -696,6 +696,7 @@ static void lso_send_custom_eth(const uint8_t *test_packet, uint32_t pkt_len, ui
 	offset = hdr_len;
 	payload_sum = 0;
 	segnum = 0xffff;
+	num_rcv = 0;
 	for (i = 0; i < num; i++) {
 		odph_ethhdr_t *eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt_out[i], NULL);
 
@@ -710,7 +711,7 @@ static void lso_send_custom_eth(const uint8_t *test_packet, uint32_t pkt_len, ui
 
 		if (ret == 0) {
 			segnum = odp_be_to_cpu_16(segnum);
-			CU_ASSERT(segnum == i);
+			CU_ASSERT(segnum == num_rcv);
 		} else {
 			CU_FAIL("Seg num field read failed\n");
 		}
@@ -727,6 +728,7 @@ static void lso_send_custom_eth(const uint8_t *test_packet, uint32_t pkt_len, ui
 
 		offset      += payload_len;
 		payload_sum += payload_len;
+		num_rcv++;
 	}
 
 	ODPH_DBG("    Received payload length: %u bytes\n", payload_sum);

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -5093,7 +5093,7 @@ static void pktio_test_pktin_event_queue(odp_pktin_mode_t pktin_mode)
 	odp_pktin_queue_param_t in_queue_param;
 	odp_pktout_queue_param_t out_queue_param;
 	odp_pktout_queue_t pktout_queue;
-	odp_queue_t queue, from;
+	odp_queue_t queue, from = ODP_QUEUE_INVALID;
 	odp_pool_t buf_pool;
 	odp_pool_param_t pool_param;
 	odp_packet_t pkt_tbl[TX_BATCH_LEN];
@@ -5187,8 +5187,6 @@ static void pktio_test_pktin_event_queue(odp_pktin_mode_t pktin_mode)
 
 			if (ev == ODP_EVENT_INVALID)
 				break;
-
-			CU_ASSERT(from == queue);
 		} else {
 			ev = odp_queue_deq(queue);
 
@@ -5212,9 +5210,12 @@ static void pktio_test_pktin_event_queue(odp_pktin_mode_t pktin_mode)
 		if (odp_event_type(ev) == ODP_EVENT_PACKET) {
 			pkt = odp_packet_from_event(ev);
 
-			if (pktio_pkt_seq(pkt) != TEST_SEQ_INVALID)
+			if (pktio_pkt_seq(pkt) != TEST_SEQ_INVALID) {
 				num_pkt++;
 
+				if (pktin_mode == ODP_PKTIN_MODE_SCHED)
+					CU_ASSERT(from == queue);
+			}
 		} else if (odp_event_type(ev) == ODP_EVENT_BUFFER) {
 			num_buf++;
 		} else {


### PR DESCRIPTION
Depending on OS and pktio device type extra packets may be received from interfaces (e.g. IPv6 ICMP). Ignore these packets also in pktio_test_pktin_event_queue() to avoid failures.