### PR TITLE
[PATCH v4] test: dyn_workers: improve command granularity

### DIFF
--- a/test/miscellaneous/Makefile.am
+++ b/test/miscellaneous/Makefile.am
@@ -6,6 +6,7 @@ if test_cpp
 bin_PROGRAMS +=  odp_api_from_cpp
 endif
 
+odp_dyn_workers_CFLAGS = $(AM_CFLAGS) -Wno-format-nonliteral
 odp_dyn_workers_SOURCES = odp_dyn_workers.c
 odp_api_from_cpp_SOURCES = odp_api_from_cpp.cpp
 

--- a/test/miscellaneous/odp_dyn_workers.c
+++ b/test/miscellaneous/odp_dyn_workers.c
@@ -73,7 +73,7 @@ enum {
 	CONN_ERR = -1,
 	PEER_ERR,
 	CMD_NOK,
-	CMD_STATS,
+	CMD_SUMMARY,
 	CMD_OK
 };
 
@@ -451,11 +451,11 @@ static void run_command(cmd_fn_t cmd_fn, prog_config_t *config, int socket)
 {
 	const odp_bool_t is_ok = cmd_fn(config);
 	const summary_t *summary = config->pending_summary;
-	uint8_t rep = !is_ok ? CMD_NOK : summary != NULL ? CMD_STATS : CMD_OK;
+	uint8_t rep = !is_ok ? CMD_NOK : summary != NULL ? CMD_SUMMARY : CMD_OK;
 
 	(void)TEMP_FAILURE_RETRY(send(socket, &rep, sizeof(rep), MSG_NOSIGNAL));
 
-	if (rep == CMD_STATS) {
+	if (rep == CMD_SUMMARY) {
 		/* Same machine, no internet in-between, just send the struct as is. */
 		(void)TEMP_FAILURE_RETRY(send(socket, (const void *)summary, sizeof(*summary),
 					      MSG_NOSIGNAL));
@@ -1023,7 +1023,7 @@ static odp_bool_t run_global(global_config_t *config)
 			continue;
 		}
 
-		if (ret == CMD_STATS) {
+		if (ret == CMD_SUMMARY) {
 			is_recv = recv_summary(prog->socket, &prog->summary);
 
 			if (is_recv)

--- a/test/miscellaneous/odp_dyn_workers.c
+++ b/test/miscellaneous/odp_dyn_workers.c
@@ -394,8 +394,15 @@ int log_fn(odp_log_level_t level, const char *fmt, ...)
 static odp_bool_t disable_stream(int fd, odp_bool_t read)
 {
 	const int null = open("/dev/null", read ? O_RDONLY : O_WRONLY);
+	odp_bool_t ret = false;
 
-	return null != -1 && dup2(null, fd) != -1;
+	if (null == -1)
+		return ret;
+
+	ret = dup2(null, fd) != -1;
+	close(null);
+
+	return ret;
 }
 
 static odp_bool_t set_odp_env(char *env)

--- a/test/miscellaneous/odp_dyn_workers_run.sh
+++ b/test/miscellaneous/odp_dyn_workers_run.sh
@@ -10,11 +10,11 @@ MAX_CPUS=$(nproc)
 REQ_CPUS=2
 TEST_DIR="${TEST_DIR:-$(dirname $0)}"
 BIN=odp_dyn_workers
-DELAY=100000000
+DEL=100000000
 
 if [ ${MAX_CPUS} -lt ${REQ_CPUS} ]; then
 	echo "Not enough CPUs (requested ${REQ_CPUS}, available ${MAX_CPUS}). Skipping test."
 	exit 77
 fi
 
-taskset -c 0 ${TEST_DIR}/${BIN}${EXEEXT} -c 0x2,0x2 -p a0,d${DELAY},r0,d${DELAY},a1,d${DELAY},r1
+taskset -c 0 ${TEST_DIR}/${BIN}${EXEEXT} -c 0x2,0x2 -p a0:0,d${DEL},r0:0,d${DEL},a1:0,d${DEL},r1:0


### PR DESCRIPTION
User commands in both interactive and non-interactive modes now take an additional index parameter which is used to launch or remove workers to/from a specific index. The index is relative to the given CPU masks, e.g. index 0 would launch a worker on CPU 0x1 with CPU mask 0x111 and index 2 would launch a worker to CPU 0x100 with the same mask.

Additionally, add a new print after worker additions which lists all active workers on the particular ODP process.

On top of #2038 

v3:
- Rebased
- Added reviewed-by tags
