### PR TITLE
[PATCH v6] helper: threads: add new join function

### DIFF
--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2019-2021 Nokia
+ * Copyright (c) 2019-2024 Nokia
  */
 
 
@@ -191,6 +191,20 @@ typedef struct {
 
 } odph_thread_common_param_t;
 
+/** Thread join result */
+typedef struct {
+	/** Exit caused by signal */
+	odp_bool_t is_sig;
+
+	/**
+	 * Exit status of the joined thread/process
+	 *
+	 * If 'is_sig' is true, then this is the signal number that caused
+	 * process exit. Otherwise status of the exited thread/process.
+	 */
+	int ret;
+} odph_thread_join_result_t;
+
 /**
  * Initialize thread params
  *
@@ -261,15 +275,39 @@ int odph_thread_create(odph_thread_t thread[],
  * A function call may be used to wait any number of launched threads to exit.
  * A particular thread may be waited only once.
  *
+ * Threads are joined in the order they are in 'thread' table. Returns on the
+ * first non-zero exit status or other failure.
+ *
  * @param thread        Table of threads to exit
  * @param num           Number of threads to exit
  *
- * @return Number of threads exited
+ * @return Number of threads successfully joined with zero exit status
+ *         (0 ... num)
  * @retval -1  On failure
  *
  * @see odph_thread_create()
  */
 int odph_thread_join(odph_thread_t thread[], int num);
+
+/**
+ * Wait previously launched threads to exit
+ *
+ * Similar to odph_thread_join() but outputs results of joined threads and
+ * stops only if the actual join operation fails for some thread. Threads are
+ * joined in the order they are in 'thread' table. Returns number of threads
+ * successfully joined and writes respective exit statuses into the 'res'
+ * table.
+ *
+ * @param thread        Table of threads to exit
+ * @param[out] res      Table for result output
+ * @param num           Number of threads to exit and results to output
+ *
+ * @return Number of threads successfully joined (0 ... num)
+ * @retval -1  On failure
+ *
+ * @see odph_thread_create()
+ */
+int odph_thread_join_result(odph_thread_t thread[], odph_thread_join_result_t res[], int num);
 
 /**
  * Set CPU affinity of the current odp thread

--- a/helper/test/cli.c
+++ b/helper/test/cli.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2021 Nokia
+ * Copyright (c) 2021-2024 Nokia
  */
 
 #include <odp_api.h>
@@ -9,7 +9,7 @@ static int cli_server(void *arg ODP_UNUSED)
 {
 	if (odph_cli_run()) {
 		ODPH_ERR("odph_cli_run() failed.\n");
-		exit(EXIT_FAILURE);
+		return -1;
 	}
 
 	return 0;
@@ -55,6 +55,7 @@ int main(int argc, char *argv[])
 	odph_thread_common_param_t thr_common;
 	odph_thread_param_t thr_param;
 	odph_thread_t thr_server;
+	odph_thread_join_result_t res;
 
 	if (odp_cpumask_default_control(&cpumask, 1) != 1) {
 		ODPH_ERR("Failed to get default CPU mask.\n");
@@ -86,8 +87,14 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	}
 
-	if (odph_thread_join(&thr_server, 1) != 1) {
-		ODPH_ERR("Failed to join server thread.\n");
+	if (odph_thread_join_result(&thr_server, &res, 1) != 1) {
+		ODPH_ERR("Error: failed to join server thread.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (res.is_sig || res.ret != 0) {
+		ODPH_ERR("Error: worker thread failure%s: %d.\n", res.is_sig ? " (signaled)" : "",
+			 res.ret);
 		exit(EXIT_FAILURE);
 	}
 

--- a/test/common/odp_cunit_common.c
+++ b/test/common/odp_cunit_common.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
- * Copyright (c) 2019-2022 Nokia
+ * Copyright (c) 2019-2024 Nokia
  * Copyright (c) 2021 Marvell
  */
 
@@ -242,13 +242,24 @@ int odp_cunit_thread_create(int num, int func_ptr(void *), void *const arg[], in
 
 int odp_cunit_thread_join(int num)
 {
+	odph_thread_join_result_t res[num];
+
 	/* Wait for threads to exit */
-	if (odph_thread_join(thread_tbl, num) != num) {
-		fprintf(stderr, "error: odph_thread_join() failed.\n");
+	if (odph_thread_join_result(thread_tbl, res, num) != num) {
+		fprintf(stderr, "error: odph_thread_join_result() failed.\n");
 		return -1;
 	}
+
 	threads_running = 0;
 	thread_func = 0;
+
+	for (int i = 0; i < num; i++) {
+		if (res[i].is_sig || res[i].ret != 0) {
+			fprintf(stderr, "error: worker thread failure%s: %d.\n", res[i].is_sig ?
+					" (signaled)" : "", res[i].ret);
+			return -1;
+		}
+	}
 
 	handle_postponed_asserts();
 

--- a/test/performance/odp_random.c
+++ b/test/performance/odp_random.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2021-2022 Nokia
+ * Copyright (c) 2021-2024 Nokia
  */
 
 /**
@@ -376,9 +376,18 @@ static void test_type(odp_instance_t instance, test_global_t *global, odp_random
 		exit(EXIT_FAILURE);
 	}
 
-	if (odph_thread_join(thr_worker, num_threads) != num_threads) {
+	odph_thread_join_result_t res[num_threads];
+
+	if (odph_thread_join_result(thr_worker, res, num_threads) != num_threads) {
 		ODPH_ERR("Failed to join worker threads.\n");
 		exit(EXIT_FAILURE);
+	}
+
+	for (i = 0; i < num_threads; i++) {
+		if (res[i].ret != 0) {
+			ODPH_ERR("Worker thread failure: %d.\n", res[i].ret);
+			exit(EXIT_FAILURE);
+		}
 	}
 
 	double mb, seconds, nsec = 0;

--- a/test/validation/api/time/time.c
+++ b/test/validation/api/time/time.c
@@ -926,7 +926,14 @@ static void time_test_global_sync(const int ctrl)
 		cpu = odp_cpumask_next(&cpumask, cpu);
 	}
 
-	CU_ASSERT(odph_thread_join(thread_tbl, num) == num);
+	odph_thread_join_result_t res[num];
+
+	int ret = odph_thread_join_result(thread_tbl, res, num);
+
+	CU_ASSERT(ret == num);
+
+	for (int i = 0; i < num; i++)
+		CU_ASSERT(!res[i].is_sig && res[i].ret == 0);
 
 	for (int s = 0; s < TIME_SAMPLES; s++) {
 		int min_idx = 0, max_idx = 0;
@@ -1115,7 +1122,14 @@ static void time_test_global_mt(void)
 	CU_ASSERT_FATAL(odph_thread_create(thread_tbl, &thr_common, &thr_param, num_workers) ==
 			num_workers);
 
-	CU_ASSERT(odph_thread_join(thread_tbl, num_workers) == num_workers);
+	odph_thread_join_result_t res[num_workers];
+
+	int ret = odph_thread_join_result(thread_tbl, res, num_workers);
+
+	CU_ASSERT(ret == num_workers);
+
+	for (i = 0; i < (uint32_t)num_workers; i++)
+		CU_ASSERT(!res[i].is_sig && res[i].ret == 0);
 
 	cur_time = odp_time_global_strict();
 


### PR DESCRIPTION
Add new join function which is similar to the existing `odph_thread_join()` but optionally outputs results of joined threads and interrupts only if the actual join operation fails for some thread.

v3:
- Rebased
- Switched to utilize new `odph_thread_join_res()` in cases where result of the join operation was checked

v4:
- Initialized result structure in cases where LTO wrongly thinks it might be uninitialized

v5:
- Matias' comments

v6:
- Matias' comments
- Bumped copyright years
- Added reviewed-by tags