### PR TITLE
[PATCH v2] helper: threads: clarify odph_thread_create() documentation

### DIFF
--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -250,7 +250,8 @@ void odph_thread_common_param_init(odph_thread_common_param_t *param);
  * thread goes to the smallest CPU number of the mask, etc.
  *
  * Launched threads may be waited for exit with odph_thread_join(), or with
- * direct Linux system calls.
+ * direct Linux system calls. If odph_thread_join() is used, the output thread
+ * table elements must not be modified during the life time of the threads.
  *
  * @param[out] thread        Thread table for output
  * @param      param         Common parameters for all threads to be created


### PR DESCRIPTION
Clarify in odph_thread_create() specification that the output thread table elements must not be modified during the life time of the threads if odph_thread_join() is used to wait for thread exit.