### PR TITLE
[PATCH v2] test: dyn_workers: allow overwriting environment variables

### DIFF
--- a/test/miscellaneous/odp_dyn_workers.c
+++ b/test/miscellaneous/odp_dyn_workers.c
@@ -451,7 +451,7 @@ static odp_bool_t set_odp_env(char *env)
 	tmp = strtok(tmp_str, ENV_DELIMITER);
 
 	if (tmp != NULL) {
-		ret = setenv(tmp, strstr(env, ENV_DELIMITER) + 1U, 0);
+		ret = setenv(tmp, strstr(env, ENV_DELIMITER) + 1U, 1);
 
 		if (ret == -1)
 			perror("setenv");


### PR DESCRIPTION
Allow setenv() to overwrite existing environment variable values. For example, some implementations may use environment variables (e.g. ODP_PLATFORM_PARAMS for odp-dpdk) during 'make check' to configure resources per application, so a variable may already be set when odp_dyn_workers is run.