### PR TITLE
[PATCH v3] linux-gen: cls: implement odp_cls_hash_result()

### DIFF
--- a/platform/linux-generic/include/protocols/thash.h
+++ b/platform/linux-generic/include/protocols/thash.h
@@ -86,7 +86,7 @@ uint32_t thash_softrss(uint32_t *tuple, uint8_t len,
 
 	for (j = 0; j < len; j++) {
 		for (i = 0; i < 32; i++) {
-			if (tuple[j] & (1 << (31 - i))) {
+			if (tuple[j] & (1U << (31 - i))) {
 				ret ^= odp_cpu_to_be_32(((const uint32_t *)
 				key.u32)[j]) << i | (uint32_t)((uint64_t)
 				(odp_cpu_to_be_32(((const uint32_t *)key.u32)


### PR DESCRIPTION
Implement `odp_cls_hash_result()` function utilizing the existing hashing machinery used in packet classification.

v2:
- Matias' comments

v3:
- Added reviewed-by tags