### PR TITLE
 [PATCH v3] test: build failure due to uninitialized variable

### DIFF
--- a/test/validation/api/buffer/buffer.c
+++ b/test/validation/api/buffer/buffer.c
@@ -59,7 +59,7 @@ static void test_pool_alloc_free(const odp_pool_param_t *param)
 	uint32_t i;
 	uint32_t num_buf = 0;
 	void *addr;
-	odp_event_subtype_t subtype;
+	odp_event_subtype_t subtype = ODP_EVENT_PACKET_BASIC;
 	const uint32_t max_size = pool_capa.buf.max_size;
 	uint32_t num = param->buf.num;
 	uint32_t size = param->buf.size;
@@ -142,7 +142,7 @@ static void test_pool_alloc_free_multi(const odp_pool_param_t *param)
 	int ret;
 	odp_event_t ev;
 	void *addr;
-	odp_event_subtype_t subtype;
+	odp_event_subtype_t subtype = ODP_EVENT_PACKET_BASIC;
 	const uint32_t max_size = pool_capa.buf.max_size;
 	uint32_t num = param->buf.num;
 	uint32_t size = param->buf.size;

--- a/test/validation/api/crypto/crypto_op_test.c
+++ b/test/validation/api/crypto/crypto_op_test.c
@@ -50,7 +50,7 @@ int crypto_op(odp_packet_t pkt_in,
 	int rc;
 	odp_event_t event, event2;
 	odp_crypto_packet_result_t result;
-	odp_event_subtype_t subtype;
+	odp_event_subtype_t subtype = ODP_EVENT_NO_SUBTYPE;
 	odp_packet_t orig_pkt_out;
 
 	if (op_type == ODP_CRYPTO_OP_TYPE_LEGACY)

--- a/test/validation/api/event/event.c
+++ b/test/validation/api/event/event.c
@@ -18,7 +18,7 @@ static void event_test_free(void)
 	odp_buffer_t buf;
 	odp_packet_t pkt;
 	odp_timeout_t tmo;
-	odp_event_subtype_t subtype;
+	odp_event_subtype_t subtype = ODP_EVENT_PACKET_BASIC;
 	odp_event_t event[EVENT_BURST];
 
 	/* Buffer events */
@@ -309,7 +309,7 @@ static void type_test_init(odp_pool_t *buf_pool, odp_pool_t *pkt_pool,
 static void event_test_type_multi(void)
 {
 	odp_pool_t buf_pool, pkt_pool;
-	odp_event_type_t type;
+	odp_event_type_t type = ODP_EVENT_PACKET;
 	int num;
 	odp_event_t buf_event[NUM_TYPE_TEST];
 	odp_event_t pkt_event[NUM_TYPE_TEST];
@@ -354,7 +354,7 @@ static void event_test_types_multi(void)
 	odp_event_t buf_event[NUM_TYPE_TEST];
 	odp_event_t pkt_event[NUM_TYPE_TEST];
 	odp_event_t event[2 * NUM_TYPE_TEST];
-	odp_event_type_t event_types[2 * NUM_TYPE_TEST];
+	odp_event_type_t event_types[2 * NUM_TYPE_TEST] = {ODP_EVENT_PACKET};
 	odp_event_subtype_t event_subtypes[2 * NUM_TYPE_TEST];
 	int i;
 

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -683,7 +683,7 @@ static int recv_pkts_inline(const ipsec_test_part *part,
 
 	for (i = 0; i < part->num_pkt;) {
 		odp_event_t ev;
-		odp_event_subtype_t subtype;
+		odp_event_subtype_t subtype = ODP_EVENT_NO_SUBTYPE;
 
 		ev = recv_event(queue, 0);
 		if (ODP_EVENT_INVALID != ev) {
@@ -787,7 +787,7 @@ static int ipsec_process_in(const ipsec_test_part *part,
 
 		for (i = 0; i < num_out; i++) {
 			odp_event_t event;
-			odp_event_subtype_t subtype;
+			odp_event_subtype_t subtype = ODP_EVENT_NO_SUBTYPE;
 
 			event = recv_pkt_async_inbound(part->out[i].status);
 
@@ -877,7 +877,7 @@ static int ipsec_send_out_one(const ipsec_test_part *part,
 
 		for (i = 0; i < num_out; i++) {
 			odp_event_t event;
-			odp_event_subtype_t subtype;
+			odp_event_subtype_t subtype = ODP_EVENT_NO_SUBTYPE;
 
 			event = recv_event(suite_context.queue, EVENT_WAIT_TIME);
 
@@ -954,7 +954,7 @@ static int ipsec_send_out_one(const ipsec_test_part *part,
 
 		for (i = 0; i < num_out;) {
 			odp_event_t ev;
-			odp_event_subtype_t subtype;
+			odp_event_subtype_t subtype = ODP_EVENT_NO_SUBTYPE;
 
 			ev = recv_event(queue, 0);
 			if (ODP_EVENT_INVALID != ev) {

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -400,7 +400,7 @@ static void packet_test_alloc_free(void)
 	odp_pool_t pool;
 	odp_packet_t packet;
 	odp_pool_param_t params;
-	odp_event_subtype_t subtype;
+	odp_event_subtype_t subtype = ODP_EVENT_NO_SUBTYPE;
 	odp_event_t ev;
 
 	odp_pool_param_init(&params);
@@ -501,7 +501,7 @@ static void packet_test_alloc_free_multi(void)
 	CU_ASSERT_FATAL(ret == num_pkt);
 
 	for (i = 0; i < 2 * num_pkt; ++i) {
-		odp_event_subtype_t subtype;
+		odp_event_subtype_t subtype = ODP_EVENT_NO_SUBTYPE;
 
 		CU_ASSERT(odp_packet_len(packet[i]) == packet_len);
 		CU_ASSERT(odp_event_type(odp_packet_to_event(packet[i])) ==
@@ -809,7 +809,7 @@ static void packet_test_event_conversion(void)
 	odp_packet_t pkt1 = segmented_test_packet;
 	odp_packet_t tmp_pkt;
 	odp_event_t event;
-	odp_event_subtype_t subtype;
+	odp_event_subtype_t subtype = ODP_EVENT_NO_SUBTYPE;
 	odp_packet_t pkt[2] = {pkt0, pkt1};
 	odp_event_t ev[2];
 	int i;
@@ -3395,7 +3395,7 @@ static void packet_vector_test_user_area(void)
 
 	for (i = 0; i < num; i++) {
 		odp_event_t ev;
-		int flag;
+		int flag = -1;
 
 		pktv[i] = odp_packet_vector_alloc(pool);
 
@@ -3588,7 +3588,7 @@ static void packet_test_user_area(void)
 	odp_packet_t pkt;
 	odp_pool_t pool;
 	odp_event_t ev;
-	int flag;
+	int flag = -1;
 
 	memcpy(&param, &default_param, sizeof(odp_pool_param_t));
 

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -429,7 +429,7 @@ static void timer_test_timeout_pool_alloc(void)
 
 	/* Try to allocate num items from the pool */
 	for (index = 0; index < num; index++) {
-		odp_event_subtype_t subtype;
+		odp_event_subtype_t subtype = ODP_EVENT_PACKET_BASIC;
 
 		tmo[index] = odp_timeout_alloc(pool);
 
@@ -2208,7 +2208,7 @@ static void timer_test_max_tmo_max_tmo_sched(void)
 /* Handle a received (timeout) event */
 static void handle_tmo(odp_event_t ev, bool stale, uint64_t prev_tick)
 {
-	odp_event_subtype_t subtype;
+	odp_event_subtype_t subtype = ODP_EVENT_PACKET_BASIC;
 	odp_timeout_t tmo;
 	odp_timer_t tim;
 	uint64_t tick;


### PR DESCRIPTION
Build failure has been observed, as some flags, sub event
types were uninitialized.

error: ‘subtype’ may be used uninitialized \
		[-Werror=maybe-uninitialized]

Signed-off-by: Harman Kalra <hkalra@marvell.com>
Reviewed-by: Matias Elo <matias.elo@nokia.com>
