### PR TITLE
[PATCH v6] Fixes to packet gen and validation suite make file

### DIFF
--- a/test/performance/odp_packet_gen.c
+++ b/test/performance/odp_packet_gen.c
@@ -1563,7 +1563,12 @@ static int rx_thread(void *arg)
 static void drain_scheduler(test_global_t *global)
 {
 	odp_event_t ev;
-	uint64_t wait_time = odp_schedule_wait_time(100 * ODP_TIME_MSEC_IN_NS);
+	uint64_t wait_time;
+
+	if (!global->test_options.num_rx)
+		return;
+
+	wait_time = odp_schedule_wait_time(100 * ODP_TIME_MSEC_IN_NS);
 
 	while ((ev = odp_schedule(NULL, wait_time)) != ODP_EVENT_INVALID) {
 		global->drained++;

--- a/test/validation/api/init/Makefile.am
+++ b/test/validation/api/init/Makefile.am
@@ -13,3 +13,25 @@ EXTRA_DIST = \
 	init_log_thread.sh \
 	init_test_param_init.sh \
 	init_test_term_abnormal.sh
+
+dist_check_SCRIPTS = $(EXTRA_DIST)
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi

--- a/test/validation/api/ipsec/Makefile.am
+++ b/test/validation/api/ipsec/Makefile.am
@@ -23,3 +23,25 @@ EXTRA_DIST = \
 	ipsec_async.sh \
 	ipsec_inline_in.sh \
 	ipsec_inline_out.sh
+
+dist_check_SCRIPTS = $(EXTRA_DIST)
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi


### PR DESCRIPTION
commit 71a76ef6c0e26903d41680188ada869a2d931066 (HEAD -> dev-fixes-145, origin/dev-fixes-145)
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Tue May 21 17:47:43 2024 +0530

    test: packet_gen: fix pktio draining path

    Avoid calling odp_schedule() when there are no Rx queues.
    Also don't break Tx thread on enqueue failure as it
    can happen due to backpressure.

    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit cb497d0e323a42b28e04755d04a1d1cf6aab1f13
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed May 15 16:18:25 2024 +0530

    test: validation: install new test scripts

    Make changes to install new test scripts that were added
    as part of IPsec and init validation suite.

    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>
