### PR TITLE
[PATCH v10] api: atomic: add functions for fetching and updating maximum/minimum values

### DIFF
--- a/include/odp/api/spec/atomic.h
+++ b/include/odp/api/spec/atomic.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
  * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2024 Nokia
  */
 
 /**
@@ -26,11 +27,12 @@ extern "C" {
  *
  * Atomic integer types (odp_atomic_u32_t, odp_atomic_u64_t and
  * odp_atomic_u128_t) can be used to implement e.g. shared counters. If not
- * otherwise documented, operations in this API are implemented using
- * <b> RELAXED memory ordering </b> (see memory order descriptions in
- * the C11 specification). Relaxed operations do not provide synchronization or
- * ordering for other memory accesses (initiated before or after the operation),
- * only atomicity of the operation itself is guaranteed.
+ * otherwise documented, all functions in this API perform their operations
+ * atomically and are implemented using <b> RELAXED memory ordering </b> (see
+ * memory order descriptions in the C11 specification). Relaxed operations do
+ * not provide synchronization or ordering for other memory accesses (initiated
+ * before or after the operation), only atomicity of the operation itself is
+ * guaranteed.
  *
  * <b> Operations with non-relaxed memory ordering </b>
  *
@@ -175,6 +177,20 @@ void odp_atomic_dec_u32(odp_atomic_u32_t *atom);
  * @param new_max New maximum value to be written into the atomic variable
  */
 void odp_atomic_max_u32(odp_atomic_u32_t *atom, uint32_t new_max);
+
+/**
+ * Fetch and update maximum value of atomic uint32 variable
+ *
+ * Compares value of atomic variable to the new maximum value. If the new value
+ * is greater than the current value, writes the new value into the variable.
+ * Always returns the original value of the atomic variable.
+ *
+ * @param atom    Pointer to atomic variable
+ * @param new_max New maximum value to be written into the atomic variable
+ *
+ * @return Original value of the atomic variable
+ */
+uint32_t odp_atomic_fetch_max_u32(odp_atomic_u32_t *atom, uint32_t new_max);
 
 /**
  * Update minimum value of atomic uint32 variable
@@ -330,6 +346,20 @@ void odp_atomic_dec_u64(odp_atomic_u64_t *atom);
  * @param new_max New maximum value to be written into the atomic variable
  */
 void odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t new_max);
+
+/**
+ * Fetch and update maximum value of atomic uint64 variable
+ *
+ * Compares value of atomic variable to the new maximum value. If the new value
+ * is greater than the current value, writes the new value into the variable.
+ * Always returns the original value of the atomic variable.
+ *
+ * @param atom    Pointer to atomic variable
+ * @param new_max New maximum value to be written into the atomic variable
+ *
+ * @return Original value of the atomic variable
+ */
+uint64_t odp_atomic_fetch_max_u64(odp_atomic_u64_t *atom, uint64_t new_max);
 
 /**
  * Update minimum value of atomic uint64 variable
@@ -644,6 +674,7 @@ typedef union odp_atomic_op_t {
 		uint32_t dec       : 1;  /**< Atomic decrement */
 		uint32_t min       : 1;  /**< Atomic minimum */
 		uint32_t max       : 1;  /**< Atomic maximum */
+		uint32_t fetch_max : 1;  /**< Atomic fetch and maximum */
 		uint32_t cas       : 1;  /**< Atomic compare and swap */
 		uint32_t xchg      : 1;  /**< Atomic exchange */
 	} op;

--- a/include/odp/api/spec/atomic.h
+++ b/include/odp/api/spec/atomic.h
@@ -204,6 +204,20 @@ uint32_t odp_atomic_fetch_max_u32(odp_atomic_u32_t *atom, uint32_t new_max);
 void odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t new_min);
 
 /**
+ * Fetch and update minimum value of atomic uint32 variable
+ *
+ * Compares value of atomic variable to the new minimum value. If the new value
+ * is less than the current value, writes the new value into the variable.
+ * Always returns the original value of the atomic variable.
+ *
+ * @param atom    Pointer to atomic variable
+ * @param new_min New minimum value to be written into the atomic variable
+ *
+ * @return Original value of the atomic variable
+ */
+uint32_t odp_atomic_fetch_min_u32(odp_atomic_u32_t *atom, uint32_t new_min);
+
+/**
  * Compare and swap atomic uint32 variable
  *
  * Compares value of atomic variable to the value pointed by 'old_val'.
@@ -371,6 +385,20 @@ uint64_t odp_atomic_fetch_max_u64(odp_atomic_u64_t *atom, uint64_t new_max);
  * @param new_min New minimum value to be written into the atomic variable
  */
 void odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t new_min);
+
+/**
+ * Fetch and update minimum value of atomic uint64_t variable
+ *
+ * Compares value of atomic variable to the new minimum value. If the new value
+ * is less than the current value, writes the new value into the variable.
+ * Always returns the original value of the atomic variable.
+ *
+ * @param atom    Pointer to atomic variable
+ * @param new_min New minimum value to be written into the atomic variable
+ *
+ * @return Original value of the atomic variable
+ */
+uint64_t odp_atomic_fetch_min_u64(odp_atomic_u64_t *atom, uint64_t new_min);
 
 /**
  * Compare and swap atomic uint64 variable
@@ -673,6 +701,7 @@ typedef union odp_atomic_op_t {
 		uint32_t fetch_dec : 1;  /**< Atomic fetch and decrement */
 		uint32_t dec       : 1;  /**< Atomic decrement */
 		uint32_t min       : 1;  /**< Atomic minimum */
+		uint32_t fetch_min : 1;  /**< Atomic fetch and minimum */
 		uint32_t max       : 1;  /**< Atomic maximum */
 		uint32_t fetch_max : 1;  /**< Atomic fetch and maximum */
 		uint32_t cas       : 1;  /**< Atomic compare and swap */

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h
@@ -227,6 +227,16 @@ static inline void _odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t val)
 			 : [val] "r" (val));
 }
 
+static inline uint32_t _odp_atomic_fetch_min_u32(odp_atomic_u32_t *atom, uint32_t val)
+{
+	uint32_t old;
+
+	__asm__ volatile("ldumin   %w[val], %w[old], %[atom]"
+			 : [old] "=&r"(old), [atom] "+Q" (atom->v)
+			 : [val] "r" (val));
+	return old;
+}
+
 static inline void _odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t val)
 {
 	__asm__ volatile("stumax   %[val], %[atom]"
@@ -249,6 +259,16 @@ static inline void _odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t val)
 	__asm__ volatile("stumin   %[val], %[atom]"
 			 : [atom] "+Q" (atom->v)
 			 : [val] "r" (val));
+}
+
+static inline uint64_t _odp_atomic_fetch_min_u64(odp_atomic_u64_t *atom, uint64_t val)
+{
+	uint64_t old;
+
+	__asm__ volatile("ldumin   %[val], %[old], %[atom]"
+			 : [old] "=&r"(old), [atom] "+Q" (atom->v)
+			 : [val] "r" (val));
+	return old;
 }
 
 static inline void _odp_atomic_add_rel_u32(odp_atomic_u32_t *atom, uint32_t val)

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h
@@ -210,6 +210,16 @@ static inline void _odp_atomic_max_u32(odp_atomic_u32_t *atom, uint32_t val)
 			 : [val] "r" (val));
 }
 
+static inline uint32_t _odp_atomic_fetch_max_u32(odp_atomic_u32_t *atom, uint32_t val)
+{
+	uint32_t old;
+
+	__asm__ volatile("ldumax   %w[val], %w[old], %[atom]"
+			 : [old] "=&r"(old), [atom] "+Q" (atom->v)
+			 : [val] "r" (val));
+	return old;
+}
+
 static inline void _odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t val)
 {
 	__asm__ volatile("stumin   %w[val], %[atom]"
@@ -222,6 +232,16 @@ static inline void _odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t val)
 	__asm__ volatile("stumax   %[val], %[atom]"
 			 : [atom] "+Q" (atom->v)
 			 : [val] "r" (val));
+}
+
+static inline uint64_t _odp_atomic_fetch_max_u64(odp_atomic_u64_t *atom, uint64_t val)
+{
+	uint64_t old;
+
+	__asm__ volatile("ldumax   %[val], %[old], %[atom]"
+			 : [old] "=&r"(old), [atom] "+Q" (atom->v)
+			 : [val] "r" (val));
+	return old;
 }
 
 static inline void _odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t val)

--- a/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
@@ -68,6 +68,20 @@ static inline void _odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t new_val)
 	}
 }
 
+static inline uint32_t _odp_atomic_fetch_min_u32(odp_atomic_u32_t *atom, uint32_t new_val)
+{
+	uint32_t old_val;
+
+	old_val = __atomic_load_n(&atom->v, __ATOMIC_RELAXED);
+
+	while (new_val < old_val) {
+		if (__atomic_compare_exchange_n(&atom->v, &old_val, new_val, 0 /* strong */,
+						__ATOMIC_RELAXED, __ATOMIC_RELAXED))
+			break;
+	}
+	return old_val;
+}
+
 static inline void _odp_atomic_add_rel_u32(odp_atomic_u32_t *atom, uint32_t val)
 {
 	(void)__atomic_fetch_add(&atom->v, val, __ATOMIC_RELEASE);
@@ -136,6 +150,20 @@ static inline void _odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t new_val)
 						__ATOMIC_RELAXED, __ATOMIC_RELAXED))
 			break;
 	}
+}
+
+static inline uint64_t _odp_atomic_fetch_min_u64(odp_atomic_u64_t *atom, uint64_t new_val)
+{
+	uint64_t old_val;
+
+	old_val = __atomic_load_n(&atom->v, __ATOMIC_RELAXED);
+
+	while (new_val < old_val) {
+		if (__atomic_compare_exchange_n(&atom->v, &old_val, new_val, 0 /* strong */,
+						__ATOMIC_RELAXED, __ATOMIC_RELAXED))
+			break;
+	}
+	return old_val;
 }
 
 #ifndef ODP_ATOMIC_U64_LOCK

--- a/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2021 ARM Limited
- * Copyright (c) 2021-2022 Nokia
+ * Copyright (c) 2021-2024 Nokia
  */
 
 #ifndef ODP_API_ABI_ATOMIC_GENERIC_H_
@@ -39,6 +39,20 @@ static inline void _odp_atomic_max_u32(odp_atomic_u32_t *atom, uint32_t new_val)
 						__ATOMIC_RELAXED, __ATOMIC_RELAXED))
 			break;
 	}
+}
+
+static inline uint32_t _odp_atomic_fetch_max_u32(odp_atomic_u32_t *atom, uint32_t new_val)
+{
+	uint32_t old_val;
+
+	old_val = __atomic_load_n(&atom->v, __ATOMIC_RELAXED);
+
+	while (new_val > old_val) {
+		if (__atomic_compare_exchange_n(&atom->v, &old_val, new_val, 0 /* strong */,
+						__ATOMIC_RELAXED, __ATOMIC_RELAXED))
+			break;
+	}
+	return old_val;
 }
 
 static inline void _odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t new_val)
@@ -95,6 +109,20 @@ static inline void _odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t new_val)
 						__ATOMIC_RELAXED, __ATOMIC_RELAXED))
 			break;
 	}
+}
+
+static inline uint64_t _odp_atomic_fetch_max_u64(odp_atomic_u64_t *atom, uint64_t new_val)
+{
+	uint64_t old_val;
+
+	old_val = __atomic_load_n(&atom->v, __ATOMIC_RELAXED);
+
+	while (new_val > old_val) {
+		if (__atomic_compare_exchange_n(&atom->v, &old_val, new_val, 0 /* strong */,
+						__ATOMIC_RELAXED, __ATOMIC_RELAXED))
+			break;
+	}
+	return old_val;
 }
 
 static inline void _odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t new_val)

--- a/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2016-2018 Linaro Limited
- * Copyright (c) 2021 Nokia
+ * Copyright (c) 2021-2024 Nokia
  */
 
 /**
@@ -40,6 +40,7 @@
 	#define odp_atomic_cas_rel_u32 __odp_atomic_cas_rel_u32
 	#define odp_atomic_cas_acq_rel_u32 __odp_atomic_cas_acq_rel_u32
 	#define odp_atomic_max_u32 __odp_atomic_max_u32
+	#define odp_atomic_fetch_max_u32 __odp_atomic_fetch_max_u32
 	#define odp_atomic_min_u32 __odp_atomic_min_u32
 	#define odp_atomic_init_u64 __odp_atomic_init_u64
 	#define odp_atomic_load_u64 __odp_atomic_load_u64
@@ -62,6 +63,7 @@
 	#define odp_atomic_cas_rel_u64 __odp_atomic_cas_rel_u64
 	#define odp_atomic_cas_acq_rel_u64 __odp_atomic_cas_acq_rel_u64
 	#define odp_atomic_max_u64 __odp_atomic_max_u64
+	#define odp_atomic_fetch_max_u64 __odp_atomic_fetch_max_u64
 	#define odp_atomic_min_u64 __odp_atomic_min_u64
 	#define odp_atomic_init_u128 __odp_atomic_init_u128
 	#define odp_atomic_load_u128 __odp_atomic_load_u128
@@ -150,6 +152,11 @@ _ODP_INLINE uint32_t odp_atomic_xchg_u32(odp_atomic_u32_t *atom,
 _ODP_INLINE void odp_atomic_max_u32(odp_atomic_u32_t *atom, uint32_t val)
 {
 	_odp_atomic_max_u32(atom, val);
+}
+
+_ODP_INLINE uint32_t odp_atomic_fetch_max_u32(odp_atomic_u32_t *atom, uint32_t val)
+{
+	return _odp_atomic_fetch_max_u32(atom, val);
 }
 
 _ODP_INLINE void odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t val)
@@ -314,6 +321,11 @@ _ODP_INLINE void odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t new_val)
 	(void)_ODP_ATOMIC_OP(atom, atom->v = atom->v < new_val ? new_val : atom->v);
 }
 
+_ODP_INLINE uint64_t odp_atomic_fetch_max_u64(odp_atomic_u64_t *atom, uint64_t new_val)
+{
+	return _ODP_ATOMIC_OP(atom, atom->v = atom->v < new_val ? new_val : atom->v);
+}
+
 _ODP_INLINE void odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t new_val)
 {
 	(void)_ODP_ATOMIC_OP(atom, atom->v = atom->v > new_val ? new_val : atom->v);
@@ -444,6 +456,11 @@ _ODP_INLINE int odp_atomic_cas_acq_rel_u64(odp_atomic_u64_t *atom,
 _ODP_INLINE void odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t val)
 {
 	_odp_atomic_max_u64(atom, val);
+}
+
+_ODP_INLINE uint64_t odp_atomic_fetch_max_u64(odp_atomic_u64_t *atom, uint64_t val)
+{
+	return _odp_atomic_fetch_max_u64(atom, val);
 }
 
 _ODP_INLINE void odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t val)

--- a/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
@@ -42,6 +42,7 @@
 	#define odp_atomic_max_u32 __odp_atomic_max_u32
 	#define odp_atomic_fetch_max_u32 __odp_atomic_fetch_max_u32
 	#define odp_atomic_min_u32 __odp_atomic_min_u32
+	#define odp_atomic_fetch_min_u32 __odp_atomic_fetch_min_u32
 	#define odp_atomic_init_u64 __odp_atomic_init_u64
 	#define odp_atomic_load_u64 __odp_atomic_load_u64
 	#define odp_atomic_store_u64 __odp_atomic_store_u64
@@ -65,6 +66,7 @@
 	#define odp_atomic_max_u64 __odp_atomic_max_u64
 	#define odp_atomic_fetch_max_u64 __odp_atomic_fetch_max_u64
 	#define odp_atomic_min_u64 __odp_atomic_min_u64
+	#define odp_atomic_fetch_min_u64 __odp_atomic_fetch_min_u64
 	#define odp_atomic_init_u128 __odp_atomic_init_u128
 	#define odp_atomic_load_u128 __odp_atomic_load_u128
 	#define odp_atomic_store_u128 __odp_atomic_store_u128
@@ -162,6 +164,11 @@ _ODP_INLINE uint32_t odp_atomic_fetch_max_u32(odp_atomic_u32_t *atom, uint32_t v
 _ODP_INLINE void odp_atomic_min_u32(odp_atomic_u32_t *atom, uint32_t val)
 {
 	_odp_atomic_min_u32(atom, val);
+}
+
+_ODP_INLINE uint32_t odp_atomic_fetch_min_u32(odp_atomic_u32_t *atom, uint32_t val)
+{
+	return _odp_atomic_fetch_min_u32(atom, val);
 }
 
 #ifdef ODP_ATOMIC_U64_LOCK
@@ -331,6 +338,11 @@ _ODP_INLINE void odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t new_val)
 	(void)_ODP_ATOMIC_OP(atom, atom->v = atom->v > new_val ? new_val : atom->v);
 }
 
+_ODP_INLINE uint64_t odp_atomic_fetch_min_u64(odp_atomic_u64_t *atom, uint64_t new_val)
+{
+	return _ODP_ATOMIC_OP(atom, atom->v = atom->v > new_val ? new_val : atom->v);
+}
+
 #else /* !ODP_ATOMIC_U64_LOCK */
 
 _ODP_INLINE void odp_atomic_init_u64(odp_atomic_u64_t *atom, uint64_t val)
@@ -466,6 +478,11 @@ _ODP_INLINE uint64_t odp_atomic_fetch_max_u64(odp_atomic_u64_t *atom, uint64_t v
 _ODP_INLINE void odp_atomic_min_u64(odp_atomic_u64_t *atom, uint64_t val)
 {
 	_odp_atomic_min_u64(atom, val);
+}
+
+_ODP_INLINE uint64_t odp_atomic_fetch_min_u64(odp_atomic_u64_t *atom, uint64_t val)
+{
+	return _odp_atomic_fetch_min_u64(atom, val);
 }
 
 #endif /* !ODP_ATOMIC_U64_LOCK */


### PR DESCRIPTION
V4:
- Moved `odp_atomic_add_u32/64()` calls out of validation tests loops