### PR TITLE
[PATCH v4] api: ml: add extra info field in model and IO info

### DIFF
--- a/include/odp/api/abi-default/ml_types.h
+++ b/include/odp/api/abi-default/ml_types.h
@@ -15,6 +15,24 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_ml_model_t;
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_ml_compl_t;
 
+/** @internal Implementation specific ML input info */
+struct _odp_ml_input_extra_info_t {
+	/** @internal Dummy field to avoid empty struct */
+	char dummy;
+};
+
+/** @internal Implementation specific ML output info */
+struct _odp_ml_output_extra_info_t {
+	/** @internal Dummy field to avoid empty struct */
+	char dummy;
+};
+
+/** @internal Implementation specific ML model info */
+struct _odp_ml_model_extra_info_t {
+	/** @internal Dummy field to avoid empty struct */
+	char dummy;
+};
+
 /** @internal Implementation specific ML parameters */
 struct _odp_ml_model_extra_param_t {
 	/** @internal Dummy field to avoid empty struct */
@@ -27,6 +45,9 @@ struct _odp_ml_model_extra_param_t {
 
 typedef _odp_abi_ml_model_t *odp_ml_model_t;
 typedef _odp_abi_ml_compl_t *odp_ml_compl_t;
+typedef struct _odp_ml_input_extra_info_t odp_ml_input_extra_info_t;
+typedef struct _odp_ml_output_extra_info_t odp_ml_output_extra_info_t;
+typedef struct _odp_ml_model_extra_info_t odp_ml_model_extra_info_t;
 typedef struct _odp_ml_model_extra_param_t odp_ml_model_extra_param_t;
 
 #define ODP_ML_MODEL_INVALID ((odp_ml_model_t)0)

--- a/include/odp/api/spec/ml_types.h
+++ b/include/odp/api/spec/ml_types.h
@@ -66,6 +66,21 @@ extern "C" {
  */
 
 /**
+ * @typedef odp_ml_input_extra_info_t
+ * ODP implementation specific extra input information
+ */
+
+/**
+ * @typedef odp_ml_output_extra_info_t
+ * ODP implementation specific extra output information
+ */
+
+/**
+ * @typedef odp_ml_model_extra_info_t
+ * ODP implementation specific extra model information
+ */
+
+/**
  * @typedef odp_ml_model_extra_param_t
  * ODP implementation specific extra parameters for model creation
  */
@@ -526,6 +541,15 @@ typedef struct odp_ml_input_info_t {
 	/** Model input data shape */
 	odp_ml_shape_info_t shape;
 
+	/**
+	 * ODP implementation specific extra input info.
+	 *
+	 * See ODP implementation documentation for details about extra input info usage. For
+	 * example, extra info may give hints about pre-defined scale and zeropoint that can
+	 * be used for quantization / dequantization.
+	 */
+	odp_ml_input_extra_info_t *extra_info;
+
 } odp_ml_input_info_t;
 
 /** Model output information */
@@ -541,6 +565,15 @@ typedef struct odp_ml_output_info_t {
 
 	/** Model output data shape */
 	odp_ml_shape_info_t shape;
+
+	/**
+	 * ODP implementation specific extra output info.
+	 *
+	 * See ODP implementation documentation for details about extra output info usage. For
+	 * example, extra info may give hints about pre-defined scale and zeropoint that can
+	 * be used for quantization / dequantization.
+	 */
+	odp_ml_output_extra_info_t *extra_info;
 
 } odp_ml_output_info_t;
 
@@ -574,6 +607,15 @@ typedef struct odp_ml_model_info_t {
 
 	/** Number of model outputs */
 	uint32_t num_outputs;
+
+	/**
+	 * ODP implementation specific extra model info.
+	 *
+	 * See ODP implementation documentation for details about extra model info usage. For
+	 * example, extra info may give hints about pre-defined scale and zeropoint that can
+	 * be used for quantization / dequantization.
+	 */
+	odp_ml_model_extra_info_t *extra_info;
 
 } odp_ml_model_info_t;
 

--- a/platform/linux-generic/include-abi/odp/api/abi/ml_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/ml_types.h
@@ -12,6 +12,24 @@ extern "C" {
 #include <odp/api/std_types.h>
 #include <odp/api/plat/strong_types.h>
 
+/** @internal Implementation specific ML input info */
+struct _odp_ml_input_extra_info_t {
+	/** @internal Dummy field to avoid empty struct */
+	char dummy;
+};
+
+/** @internal Implementation specific ML output info */
+struct _odp_ml_output_extra_info_t {
+	/** @internal Dummy field to avoid empty struct */
+	char dummy;
+};
+
+/** @internal Implementation specific ML model info */
+struct _odp_ml_model_extra_info_t {
+	/** @internal Dummy field to avoid empty struct */
+	char dummy;
+};
+
 /** @internal Implementation specific ML parameters */
 struct _odp_ml_model_extra_param_t {
 	/** @internal Dummy field to avoid empty struct */
@@ -24,6 +42,9 @@ struct _odp_ml_model_extra_param_t {
 
 typedef ODP_HANDLE_T(odp_ml_model_t);
 typedef ODP_HANDLE_T(odp_ml_compl_t);
+typedef struct _odp_ml_input_extra_info_t odp_ml_input_extra_info_t;
+typedef struct _odp_ml_output_extra_info_t odp_ml_output_extra_info_t;
+typedef struct _odp_ml_model_extra_info_t odp_ml_model_extra_info_t;
 typedef struct _odp_ml_model_extra_param_t odp_ml_model_extra_param_t;
 
 #define ODP_ML_MODEL_INVALID  _odp_cast_scalar(odp_ml_model_t, 0)


### PR DESCRIPTION
Added extra info fields in model, input and output info structures. Support for extra info would enable the user to fetch implementation specific information like number of layers, HW resource allocation for the model and pre-defined quantization scale factors and zero-point values for input and output.