### PR TITLE
[PATCH v2] github_ci: remove CentOS 7 build test

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -221,7 +221,7 @@ jobs:
       fail-fast: false
       matrix:
         cc: [gcc, clang]
-        os: ['centos_7', 'rocky_linux_8']
+        os: ['rocky_linux_8']
         conf: ['--enable-abi-compat']
     steps:
       - uses: actions/checkout@v4

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,8 +1,8 @@
 Prerequisites for building the OpenDataPlane (ODP) API
 
 1. Linux
-   CentOS 7 (kernel v3.10) is the oldest Linux distributions tested by the ODP
-   CI. Earlier versions may or may not work.
+   Rocky Linux 8 (kernel v4.18) is the oldest Linux distribution tested by the
+   ODP CI. Earlier versions may or may not work.
 
    For CentOS/RedHat distros, configure the system to use Fedora EPEL repos and
    third-party packages:


### PR DESCRIPTION
CentOS 7 has reached EOL, so remove it from the CI tests.