### PR TITLE
[PATCH v3] linux-gen: cpu: make possible to read cpu id during every odp_cpu_id() call

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.28"
+config_file_version = "0.1.29"
 
 # System options
 system: {
@@ -37,6 +37,14 @@ system: {
 	# NOTE: This option should only be used on systems where CPU frequency
 	# scaling is disabled.
 	cpu_hz_static = 0
+
+	# When enabled (1), implementation reads the CPU identifier values from
+	# OS only once during ODP initialization. Enabling this option removes
+	# a system call from odp_cpu_id() implementation.
+	#
+	# This option should only be used when ODP threads are not migrated
+	# during application lifetime.
+	cpu_id_static = 1
 
 	# Maximum number of ODP threads that can be created.
 	# odp_thread_count_max() returns this value or the build time

--- a/platform/linux-generic/include/odp/api/plat/thread_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/thread_inline_types.h
@@ -17,6 +17,7 @@ extern "C" {
 
 typedef struct {
 	odp_log_func_t log_fn;
+	int (*cpu_id_fn)(void);
 	odp_thread_type_t type;
 	int thr;
 	int cpu;

--- a/platform/linux-generic/include/odp/api/plat/thread_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/thread_inlines.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2024 Nokia
  */
 
 #ifndef ODP_PLAT_THREAD_INLINES_H_
@@ -37,7 +38,10 @@ _ODP_INLINE odp_thread_type_t odp_thread_type(void)
 
 _ODP_INLINE int odp_cpu_id(void)
 {
-	return _odp_this_thread->cpu;
+	if (_odp_this_thread->cpu >= 0)
+		return _odp_this_thread->cpu;
+
+	return _odp_this_thread->cpu_id_fn();
 }
 
 /** @endcond */

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -33,6 +33,7 @@ typedef struct {
 	uint64_t page_size;
 	int      cache_line_size;
 	uint8_t cpu_hz_static;
+	uint8_t cpu_id_static;
 	uint8_t cpu_constant_tsc;
 	odp_cpu_arch_t cpu_arch;
 	odp_cpu_arch_isa_t cpu_isa_sw;

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -7,7 +7,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [28])
+m4_define([_odp_config_version_minor], [29])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2020-2022 Nokia
+ * Copyright (c) 2020-2024 Nokia
  *
  * Copyright(c) 2010-2014 Intel Corporation
  *   - lib/eal/common/eal_common_string_fns.c
@@ -336,6 +336,23 @@ static int read_config_file(void)
 		return -1;
 	}
 	odp_global_ro.system_info.cpu_hz_static = !!val;
+
+	str = "system.cpu_id_static";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		_ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+	odp_global_ro.system_info.cpu_id_static = !!val;
+
+	_ODP_PRINT("System config:\n");
+	_ODP_PRINT("  system.cpu_mhz: %" PRIu64 "\n",
+		   odp_global_ro.system_info.default_cpu_hz);
+	_ODP_PRINT("  system.cpu_mhz_max: %" PRIu64 "\n",
+		   odp_global_ro.system_info.default_cpu_hz_max);
+	_ODP_PRINT("  system.cpu_hz_static: %" PRIu8 "\n",
+		   odp_global_ro.system_info.cpu_hz_static);
+	_ODP_PRINT("  system.cpu_id_static: %" PRIu8 "\n\n",
+		   odp_global_ro.system_info.cpu_id_static);
 
 	return 0;
 }

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.28"
+config_file_version = "0.1.29"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/packet_align.conf
+++ b/platform/linux-generic/test/packet_align.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.28"
+config_file_version = "0.1.29"
 
 pool: {
 	pkt: {

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.28"
+config_file_version = "0.1.29"
 
 # Shared memory options
 shm: {

--- a/platform/linux-generic/test/sched-basic.conf
+++ b/platform/linux-generic/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.28"
+config_file_version = "0.1.29"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {

--- a/platform/linux-generic/test/stash-custom.conf
+++ b/platform/linux-generic/test/stash-custom.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.28"
+config_file_version = "0.1.29"
 
 # Test overflow safe stash variant
 stash: {


### PR DESCRIPTION
Add new config file option 'system:cpu_id_static' for selecting whether the implementation reads CPU identifier value from OS during every odp_cpu_id() call or only once  during thread initialization (default). If thread(s) may be migrated between cores during the application lifetime this option should be set to 0.