### PR TITLE
[PATCH v9] api: atomic: add atomic bit set and clear functions

### DIFF
--- a/include/odp/api/spec/atomic.h
+++ b/include/odp/api/spec/atomic.h
@@ -248,6 +248,42 @@ int odp_atomic_cas_u32(odp_atomic_u32_t *atom, uint32_t *old_val, uint32_t new_v
  */
 uint32_t odp_atomic_xchg_u32(odp_atomic_u32_t *atom, uint32_t new_val);
 
+/**
+ * Set bits in atomic uint32 variable
+ *
+ * @param atom    Pointer to atomic variable
+ * @param bits    Bits to set
+ */
+void odp_atomic_bit_set_u32(odp_atomic_u32_t *atom, uint32_t bits);
+
+/**
+ * Fetch value and set bits in atomic uint32 variable
+ *
+ * @param atom    Pointer to atomic variable
+ * @param bits    Bits to set
+ *
+ * @return Value of the variable before modification
+ */
+uint32_t odp_atomic_bit_fetch_set_u32(odp_atomic_u32_t *atom, uint32_t bits);
+
+/**
+ * Clear bits in atomic uint32 variable
+ *
+ * @param atom    Pointer to atomic variable
+ * @param bits    Bits to clear
+ */
+void odp_atomic_bit_clr_u32(odp_atomic_u32_t *atom, uint32_t bits);
+
+/**
+ * Fetch value and clear bits in atomic uint32 variable
+ *
+ * @param atom    Pointer to atomic variable
+ * @param bits    Bits to clear
+ *
+ * @return Value of the variable before modification
+ */
+uint32_t odp_atomic_bit_fetch_clr_u32(odp_atomic_u32_t *atom, uint32_t bits);
+
 /*
  * 64-bit operations in RELAXED memory ordering
  * --------------------------------------------
@@ -431,6 +467,42 @@ int odp_atomic_cas_u64(odp_atomic_u64_t *atom, uint64_t *old_val, uint64_t new_v
  */
 uint64_t odp_atomic_xchg_u64(odp_atomic_u64_t *atom, uint64_t new_val);
 
+/**
+ * Set bits in atomic uint64 variable
+ *
+ * @param atom    Pointer to atomic variable
+ * @param bits    Bits to set
+ */
+void odp_atomic_bit_set_u64(odp_atomic_u64_t *atom, uint64_t bits);
+
+/**
+ * Fetch value and set bits in atomic uint64 variable
+ *
+ * @param atom    Pointer to atomic variable
+ * @param bits    Bits to set
+ *
+ * @return Value of the variable before modification
+ */
+uint64_t odp_atomic_bit_fetch_set_u64(odp_atomic_u64_t *atom, uint64_t bits);
+
+/**
+ * Clear bits in atomic uint64 variable
+ *
+ * @param atom    Pointer to atomic variable
+ * @param bits    Bits to clear
+ */
+void odp_atomic_bit_clr_u64(odp_atomic_u64_t *atom, uint64_t bits);
+
+/**
+ * Fetch value and clear bits in atomic uint64 variable
+ *
+ * @param atom    Pointer to atomic variable
+ * @param bits    Bits to clear
+ *
+ * @return Value of the variable before modification
+ */
+uint64_t odp_atomic_bit_fetch_clr_u64(odp_atomic_u64_t *atom, uint64_t bits);
+
 /*
  * 128-bit operations in RELAXED memory ordering
  * --------------------------------------------
@@ -582,6 +654,28 @@ int odp_atomic_cas_rel_u32(odp_atomic_u32_t *atom, uint32_t *old_val,
 int odp_atomic_cas_acq_rel_u32(odp_atomic_u32_t *atom, uint32_t *old_val,
 			       uint32_t new_val);
 
+/**
+ * Set bits in atomic uint32 variable using RELEASE memory ordering
+ *
+ * Otherwise identical to odp_atomic_bit_set_u32() but ensures RELEASE memory
+ * ordering.
+ *
+ * @param atom    Pointer to atomic variable
+ * @param bits    Bits to set
+ */
+void odp_atomic_bit_set_rel_u32(odp_atomic_u32_t *atom, uint32_t bits);
+
+/**
+ * Clear bits in atomic uint32 variable using RELEASE memory ordering
+ *
+ * Otherwise identical to odp_atomic_bit_clr_u32() but ensures RELEASE memory
+ * ordering.
+ *
+ * @param atom    Pointer to atomic variable
+ * @param bits    Bits to clear
+ */
+void odp_atomic_bit_clr_rel_u32(odp_atomic_u32_t *atom, uint32_t bits);
+
 /*
  * 64-bit operations in non-RELAXED memory ordering
  * ------------------------------------------------
@@ -682,6 +776,28 @@ int odp_atomic_cas_acq_rel_u64(odp_atomic_u64_t *atom, uint64_t *old_val,
 			       uint64_t new_val);
 
 /**
+ * Set bits in atomic uint64 variable using RELEASE memory ordering
+ *
+ * Otherwise identical to odp_atomic_bit_set_u64() but ensures RELEASE memory
+ * ordering.
+ *
+ * @param atom    Pointer to atomic variable
+ * @param bits    Bits to set
+ */
+void odp_atomic_bit_set_rel_u64(odp_atomic_u64_t *atom, uint64_t bits);
+
+/**
+ * Clear bits in atomic uint64 variable using RELEASE memory ordering
+ *
+ * Otherwise identical to odp_atomic_bit_clr_u64() but ensures RELEASE memory
+ * ordering.
+ *
+ * @param atom    Pointer to atomic variable
+ * @param bits    Bits to clear
+ */
+void odp_atomic_bit_clr_rel_u64(odp_atomic_u64_t *atom, uint64_t bits);
+
+/**
  * Atomic operations
  *
  * Atomic operations listed in a bit field structure.
@@ -689,23 +805,27 @@ int odp_atomic_cas_acq_rel_u64(odp_atomic_u64_t *atom, uint64_t *old_val,
 typedef union odp_atomic_op_t {
 	/** Operation flags */
 	struct {
-		uint32_t init      : 1;  /**< Init atomic variable */
-		uint32_t load      : 1;  /**< Atomic load */
-		uint32_t store     : 1;  /**< Atomic store */
-		uint32_t fetch_add : 1;  /**< Atomic fetch and add */
-		uint32_t add       : 1;  /**< Atomic add */
-		uint32_t fetch_sub : 1;  /**< Atomic fetch and subtract */
-		uint32_t sub       : 1;  /**< Atomic subtract */
-		uint32_t fetch_inc : 1;  /**< Atomic fetch and increment */
-		uint32_t inc       : 1;  /**< Atomic increment */
-		uint32_t fetch_dec : 1;  /**< Atomic fetch and decrement */
-		uint32_t dec       : 1;  /**< Atomic decrement */
-		uint32_t min       : 1;  /**< Atomic minimum */
-		uint32_t fetch_min : 1;  /**< Atomic fetch and minimum */
-		uint32_t max       : 1;  /**< Atomic maximum */
-		uint32_t fetch_max : 1;  /**< Atomic fetch and maximum */
-		uint32_t cas       : 1;  /**< Atomic compare and swap */
-		uint32_t xchg      : 1;  /**< Atomic exchange */
+		uint32_t init          : 1;  /**< Init atomic variable */
+		uint32_t load          : 1;  /**< Atomic load */
+		uint32_t store         : 1;  /**< Atomic store */
+		uint32_t fetch_add     : 1;  /**< Atomic fetch and add */
+		uint32_t add           : 1;  /**< Atomic add */
+		uint32_t fetch_sub     : 1;  /**< Atomic fetch and subtract */
+		uint32_t sub           : 1;  /**< Atomic subtract */
+		uint32_t fetch_inc     : 1;  /**< Atomic fetch and increment */
+		uint32_t inc           : 1;  /**< Atomic increment */
+		uint32_t fetch_dec     : 1;  /**< Atomic fetch and decrement */
+		uint32_t dec           : 1;  /**< Atomic decrement */
+		uint32_t min           : 1;  /**< Atomic minimum */
+		uint32_t fetch_min     : 1;  /**< Atomic fetch and minimum */
+		uint32_t max           : 1;  /**< Atomic maximum */
+		uint32_t fetch_max     : 1;  /**< Atomic fetch and maximum */
+		uint32_t cas           : 1;  /**< Atomic compare and swap */
+		uint32_t xchg          : 1;  /**< Atomic exchange */
+		uint32_t bit_fetch_set : 1;  /**< Atomic bit fetch and set */
+		uint32_t bit_set       : 1;  /**< Atomic bit set */
+		uint32_t bit_fetch_clr : 1;  /**< Atomic bit fetch and clear */
+		uint32_t bit_clr       : 1;  /**< Atomic bit clear */
 	} op;
 
 	/** All bits of the bit field structure.

--- a/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
@@ -32,6 +32,10 @@
 	#define odp_atomic_dec_u32 __odp_atomic_dec_u32
 	#define odp_atomic_cas_u32 __odp_atomic_cas_u32
 	#define odp_atomic_xchg_u32 __odp_atomic_xchg_u32
+	#define odp_atomic_bit_set_u32 __odp_atomic_bit_set_u32
+	#define odp_atomic_bit_fetch_set_u32 __odp_atomic_bit_fetch_set_u32
+	#define odp_atomic_bit_clr_u32 __odp_atomic_bit_clr_u32
+	#define odp_atomic_bit_fetch_clr_u32 __odp_atomic_bit_fetch_clr_u32
 	#define odp_atomic_load_acq_u32 __odp_atomic_load_acq_u32
 	#define odp_atomic_store_rel_u32 __odp_atomic_store_rel_u32
 	#define odp_atomic_add_rel_u32 __odp_atomic_add_rel_u32
@@ -39,6 +43,8 @@
 	#define odp_atomic_cas_acq_u32 __odp_atomic_cas_acq_u32
 	#define odp_atomic_cas_rel_u32 __odp_atomic_cas_rel_u32
 	#define odp_atomic_cas_acq_rel_u32 __odp_atomic_cas_acq_rel_u32
+	#define odp_atomic_bit_set_rel_u32 __odp_atomic_bit_set_rel_u32
+	#define odp_atomic_bit_clr_rel_u32 __odp_atomic_bit_clr_rel_u32
 	#define odp_atomic_max_u32 __odp_atomic_max_u32
 	#define odp_atomic_fetch_max_u32 __odp_atomic_fetch_max_u32
 	#define odp_atomic_min_u32 __odp_atomic_min_u32
@@ -56,6 +62,10 @@
 	#define odp_atomic_dec_u64 __odp_atomic_dec_u64
 	#define odp_atomic_cas_u64 __odp_atomic_cas_u64
 	#define odp_atomic_xchg_u64 __odp_atomic_xchg_u64
+	#define odp_atomic_bit_set_u64 __odp_atomic_bit_set_u64
+	#define odp_atomic_bit_fetch_set_u64 __odp_atomic_bit_fetch_set_u64
+	#define odp_atomic_bit_clr_u64 __odp_atomic_bit_clr_u64
+	#define odp_atomic_bit_fetch_clr_u64 __odp_atomic_bit_fetch_clr_u64
 	#define odp_atomic_load_acq_u64 __odp_atomic_load_acq_u64
 	#define odp_atomic_store_rel_u64 __odp_atomic_store_rel_u64
 	#define odp_atomic_add_rel_u64 __odp_atomic_add_rel_u64
@@ -63,6 +73,8 @@
 	#define odp_atomic_cas_acq_u64 __odp_atomic_cas_acq_u64
 	#define odp_atomic_cas_rel_u64 __odp_atomic_cas_rel_u64
 	#define odp_atomic_cas_acq_rel_u64 __odp_atomic_cas_acq_rel_u64
+	#define odp_atomic_bit_set_rel_u64 __odp_atomic_bit_set_rel_u64
+	#define odp_atomic_bit_clr_rel_u64 __odp_atomic_bit_clr_rel_u64
 	#define odp_atomic_max_u64 __odp_atomic_max_u64
 	#define odp_atomic_fetch_max_u64 __odp_atomic_fetch_max_u64
 	#define odp_atomic_min_u64 __odp_atomic_min_u64
@@ -149,6 +161,26 @@ _ODP_INLINE uint32_t odp_atomic_xchg_u32(odp_atomic_u32_t *atom,
 					 uint32_t new_val)
 {
 	return __atomic_exchange_n(&atom->v, new_val, __ATOMIC_RELAXED);
+}
+
+_ODP_INLINE void odp_atomic_bit_set_u32(odp_atomic_u32_t *atom, uint32_t bits)
+{
+	(void)__atomic_or_fetch(&atom->v, bits, __ATOMIC_RELAXED);
+}
+
+_ODP_INLINE uint32_t odp_atomic_bit_fetch_set_u32(odp_atomic_u32_t *atom, uint32_t bits)
+{
+	return __atomic_fetch_or(&atom->v, bits, __ATOMIC_RELAXED);
+}
+
+_ODP_INLINE void odp_atomic_bit_clr_u32(odp_atomic_u32_t *atom, uint32_t bits)
+{
+	(void)__atomic_and_fetch(&atom->v, ~bits, __ATOMIC_RELAXED);
+}
+
+_ODP_INLINE uint32_t odp_atomic_bit_fetch_clr_u32(odp_atomic_u32_t *atom, uint32_t bits)
+{
+	return __atomic_fetch_and(&atom->v, ~bits, __ATOMIC_RELAXED);
 }
 
 _ODP_INLINE void odp_atomic_max_u32(odp_atomic_u32_t *atom, uint32_t val)
@@ -278,6 +310,26 @@ _ODP_INLINE uint64_t odp_atomic_xchg_u64(odp_atomic_u64_t *atom,
 	return _ODP_ATOMIC_OP(atom, atom->v = new_val);
 }
 
+_ODP_INLINE void odp_atomic_bit_set_u64(odp_atomic_u64_t *atom, uint64_t bits)
+{
+	(void)_ODP_ATOMIC_OP(atom, atom->v |= bits);
+}
+
+_ODP_INLINE uint64_t odp_atomic_bit_fetch_set_u64(odp_atomic_u64_t *atom, uint64_t bits)
+{
+	return _ODP_ATOMIC_OP(atom, atom->v |= bits);
+}
+
+_ODP_INLINE void odp_atomic_bit_clr_u64(odp_atomic_u64_t *atom, uint64_t bits)
+{
+	(void)_ODP_ATOMIC_OP(atom, atom->v &= ~bits);
+}
+
+_ODP_INLINE uint64_t odp_atomic_bit_fetch_clr_u64(odp_atomic_u64_t *atom, uint64_t bits)
+{
+	return _ODP_ATOMIC_OP(atom, atom->v &= ~bits);
+}
+
 _ODP_INLINE uint64_t odp_atomic_load_acq_u64(odp_atomic_u64_t *atom)
 {
 	return _ODP_ATOMIC_OP(atom, (void)0);
@@ -321,6 +373,16 @@ _ODP_INLINE int odp_atomic_cas_acq_rel_u64(odp_atomic_u64_t *atom,
 	int ret;
 	*old_val = _ODP_ATOMIC_OP(atom, _ODP_ATOMIC_CAS_OP(&ret, *old_val, new_val));
 	return ret;
+}
+
+_ODP_INLINE void odp_atomic_bit_set_rel_u64(odp_atomic_u64_t *atom, uint64_t bits)
+{
+	(void)_ODP_ATOMIC_OP(atom, atom->v |= bits);
+}
+
+_ODP_INLINE void odp_atomic_bit_clr_rel_u64(odp_atomic_u64_t *atom, uint64_t bits)
+{
+	(void)_ODP_ATOMIC_OP(atom, atom->v &= ~bits);
 }
 
 _ODP_INLINE void odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t new_val)
@@ -417,6 +479,26 @@ _ODP_INLINE uint64_t odp_atomic_xchg_u64(odp_atomic_u64_t *atom,
 	return __atomic_exchange_n(&atom->v, new_val, __ATOMIC_RELAXED);
 }
 
+_ODP_INLINE void odp_atomic_bit_set_u64(odp_atomic_u64_t *atom, uint64_t bits)
+{
+	(void)__atomic_or_fetch(&atom->v, bits, __ATOMIC_RELAXED);
+}
+
+_ODP_INLINE uint64_t odp_atomic_bit_fetch_set_u64(odp_atomic_u64_t *atom, uint64_t bits)
+{
+	return __atomic_fetch_or(&atom->v, bits, __ATOMIC_RELAXED);
+}
+
+_ODP_INLINE void odp_atomic_bit_clr_u64(odp_atomic_u64_t *atom, uint64_t bits)
+{
+	(void)__atomic_and_fetch(&atom->v, ~bits, __ATOMIC_RELAXED);
+}
+
+_ODP_INLINE uint64_t odp_atomic_bit_fetch_clr_u64(odp_atomic_u64_t *atom, uint64_t bits)
+{
+	return __atomic_fetch_and(&atom->v, ~bits, __ATOMIC_RELAXED);
+}
+
 _ODP_INLINE uint64_t odp_atomic_load_acq_u64(odp_atomic_u64_t *atom)
 {
 	return __atomic_load_n(&atom->v, __ATOMIC_ACQUIRE);
@@ -463,6 +545,16 @@ _ODP_INLINE int odp_atomic_cas_acq_rel_u64(odp_atomic_u64_t *atom,
 					   0 /* strong */,
 					   __ATOMIC_ACQ_REL,
 					   __ATOMIC_RELAXED);
+}
+
+_ODP_INLINE void odp_atomic_bit_set_rel_u64(odp_atomic_u64_t *atom, uint64_t bits)
+{
+	(void)__atomic_or_fetch(&atom->v, bits, __ATOMIC_RELEASE);
+}
+
+_ODP_INLINE void odp_atomic_bit_clr_rel_u64(odp_atomic_u64_t *atom, uint64_t bits)
+{
+	(void)__atomic_and_fetch(&atom->v, ~bits, __ATOMIC_RELEASE);
 }
 
 _ODP_INLINE void odp_atomic_max_u64(odp_atomic_u64_t *atom, uint64_t val)
@@ -533,6 +625,16 @@ _ODP_INLINE int odp_atomic_cas_acq_rel_u32(odp_atomic_u32_t *atom,
 					   0 /* strong */,
 					   __ATOMIC_ACQ_REL,
 					   __ATOMIC_RELAXED);
+}
+
+_ODP_INLINE void odp_atomic_bit_set_rel_u32(odp_atomic_u32_t *atom, uint32_t bits)
+{
+	(void)__atomic_or_fetch(&atom->v, bits, __ATOMIC_RELEASE);
+}
+
+_ODP_INLINE void odp_atomic_bit_clr_rel_u32(odp_atomic_u32_t *atom, uint32_t bits)
+{
+	(void)__atomic_and_fetch(&atom->v, ~bits, __ATOMIC_RELEASE);
 }
 
 _ODP_INLINE void odp_atomic_init_u128(odp_atomic_u128_t *atom, odp_u128_t val)

--- a/test/performance/odp_atomic_perf.c
+++ b/test/performance/odp_atomic_perf.c
@@ -33,7 +33,7 @@
 #define DEFAULT_MAX_WORKERS 10
 
 /* Maximum number of results to be held */
-#define TEST_MAX_BENCH 60
+#define TEST_MAX_BENCH 70
 
 #define TEST_INFO(name, test, validate, op_type) \
 	{name, test, validate, op_type}
@@ -728,7 +728,87 @@ static inline void test_atomic_xchg_u64(void *val, void *out, uint32_t num_round
 	*result = ret;
 }
 
-static inline void test_atomic_load_acq_u32(void *val, void *out, uint32_t num_round)
+static inline void test_atomic_bit_set_u32(void *val, void *out ODP_UNUSED, uint32_t num_round)
+{
+	odp_atomic_u32_t *atomic_val = val;
+
+	for (uint32_t i = 0; i < num_round; i++)
+		odp_atomic_bit_set_u32(atomic_val, 0x1);
+}
+
+static inline void test_atomic_bit_fetch_set_u32(void *val, void *out, uint32_t num_round)
+{
+	odp_atomic_u32_t *atomic_val = val;
+	uint32_t *result = out;
+	uint32_t ret = 0;
+
+	for (uint32_t i = 0; i < num_round; i++)
+		ret += odp_atomic_bit_fetch_set_u32(atomic_val, 0x1);
+
+	*result = ret;
+}
+
+static inline void test_atomic_bit_clr_u32(void *val, void *out ODP_UNUSED, uint32_t num_round)
+{
+	odp_atomic_u32_t *atomic_val = val;
+
+	for (uint32_t i = 0; i < num_round; i++)
+		odp_atomic_bit_clr_u32(atomic_val, 0x1);
+}
+
+static inline void test_atomic_bit_fetch_clr_u32(void *val, void *out, uint32_t num_round)
+{
+	odp_atomic_u32_t *atomic_val = val;
+	uint32_t *result = out;
+	uint32_t ret = 0;
+
+	for (uint32_t i = 0; i < num_round; i++)
+		ret += odp_atomic_bit_fetch_clr_u32(atomic_val, 0x1);
+
+	*result = ret;
+}
+
+static inline void test_atomic_bit_set_u64(void *val, void *out ODP_UNUSED, uint32_t num_round)
+{
+	odp_atomic_u64_t *atomic_val = val;
+
+	for (uint32_t i = 0; i < num_round; i++)
+		odp_atomic_bit_set_u64(atomic_val, 0x1);
+}
+
+static inline void test_atomic_bit_fetch_set_u64(void *val, void *out, uint32_t num_round)
+{
+	odp_atomic_u64_t *atomic_val = val;
+	uint64_t *result = out;
+	uint64_t ret = 0;
+
+	for (uint32_t i = 0; i < num_round; i++)
+		ret += odp_atomic_bit_fetch_set_u64(atomic_val, 0x1);
+
+	*result = ret;
+}
+
+static inline void test_atomic_bit_clr_u64(void *val, void *out ODP_UNUSED, uint32_t num_round)
+{
+	odp_atomic_u64_t *atomic_val = val;
+
+	for (uint32_t i = 0; i < num_round; i++)
+		odp_atomic_bit_clr_u64(atomic_val, 0x1);
+}
+
+static inline void test_atomic_bit_fetch_clr_u64(void *val, void *out, uint32_t num_round)
+{
+	odp_atomic_u64_t *atomic_val = val;
+	uint64_t *result = out;
+	uint64_t ret = 0;
+
+	for (uint32_t i = 0; i < num_round; i++)
+		ret += odp_atomic_bit_fetch_clr_u64(atomic_val, 0x1);
+
+	*result = ret;
+}
+
+static inline void test_atomic_load_acq_u32(void *val, void *out ODP_UNUSED, uint32_t num_round)
 {
 	odp_atomic_u32_t *atomic_val = val;
 	uint32_t *result = out;
@@ -934,6 +1014,38 @@ static inline void test_atomic_cas_acq_rel_u128(void *val, void *out ODP_UNUSED,
 	}
 }
 
+static inline void test_atomic_bit_set_rel_u32(void *val, void *out ODP_UNUSED, uint32_t num_round)
+{
+	odp_atomic_u32_t *atomic_val = val;
+
+	for (uint32_t i = 0; i < num_round; i++)
+		odp_atomic_bit_set_rel_u32(atomic_val, 0x1);
+}
+
+static inline void test_atomic_bit_clr_rel_u32(void *val, void *out ODP_UNUSED, uint32_t num_round)
+{
+	odp_atomic_u32_t *atomic_val = val;
+
+	for (uint32_t i = 0; i < num_round; i++)
+		odp_atomic_bit_clr_rel_u32(atomic_val, 0x1);
+}
+
+static inline void test_atomic_bit_set_rel_u64(void *val, void *out ODP_UNUSED, uint32_t num_round)
+{
+	odp_atomic_u64_t *atomic_val = val;
+
+	for (uint32_t i = 0; i < num_round; i++)
+		odp_atomic_bit_set_rel_u64(atomic_val, 0x1);
+}
+
+static inline void test_atomic_bit_clr_rel_u64(void *val, void *out ODP_UNUSED, uint32_t num_round)
+{
+	odp_atomic_u64_t *atomic_val = val;
+
+	for (uint32_t i = 0; i < num_round; i++)
+		odp_atomic_bit_clr_rel_u64(atomic_val, 0x1);
+}
+
 static void print_usage(void)
 {
 	printf("\n"
@@ -963,22 +1075,26 @@ static void print_info(test_options_t *test_options)
 	odp_atomic_lock_free_u64(&atomic_ops);
 
 	printf("\nAtomic operations lock-free:\n");
-	printf("  odp_atomic_load_u64:      %" PRIu32 "\n", atomic_ops.op.load);
-	printf("  odp_atomic_store_u64:     %" PRIu32 "\n", atomic_ops.op.store);
-	printf("  odp_atomic_fetch_add_u64: %" PRIu32 "\n", atomic_ops.op.fetch_add);
-	printf("  odp_atomic_add_u64:       %" PRIu32 "\n", atomic_ops.op.add);
-	printf("  odp_atomic_fetch_sub_u64: %" PRIu32 "\n", atomic_ops.op.fetch_sub);
-	printf("  odp_atomic_sub_u64:       %" PRIu32 "\n", atomic_ops.op.sub);
-	printf("  odp_atomic_fetch_inc_u64: %" PRIu32 "\n", atomic_ops.op.fetch_inc);
-	printf("  odp_atomic_inc_u64:       %" PRIu32 "\n", atomic_ops.op.inc);
-	printf("  odp_atomic_fetch_dec_u64: %" PRIu32 "\n", atomic_ops.op.fetch_dec);
-	printf("  odp_atomic_dec_u64:       %" PRIu32 "\n", atomic_ops.op.dec);
-	printf("  odp_atomic_min_u64:       %" PRIu32 "\n", atomic_ops.op.min);
-	printf("  odp_atomic_fetch_min_u64: %" PRIu32 "\n", atomic_ops.op.fetch_min);
-	printf("  odp_atomic_max_u64:       %" PRIu32 "\n", atomic_ops.op.max);
-	printf("  odp_atomic_fetch_max_u64: %" PRIu32 "\n", atomic_ops.op.fetch_max);
-	printf("  odp_atomic_cas_u64:       %" PRIu32 "\n", atomic_ops.op.cas);
-	printf("  odp_atomic_xchg_u64:      %" PRIu32 "\n", atomic_ops.op.xchg);
+	printf("  odp_atomic_load_u64:          %" PRIu32 "\n", atomic_ops.op.load);
+	printf("  odp_atomic_store_u64:         %" PRIu32 "\n", atomic_ops.op.store);
+	printf("  odp_atomic_fetch_add_u64:     %" PRIu32 "\n", atomic_ops.op.fetch_add);
+	printf("  odp_atomic_add_u64:           %" PRIu32 "\n", atomic_ops.op.add);
+	printf("  odp_atomic_fetch_sub_u64:     %" PRIu32 "\n", atomic_ops.op.fetch_sub);
+	printf("  odp_atomic_sub_u64:           %" PRIu32 "\n", atomic_ops.op.sub);
+	printf("  odp_atomic_fetch_inc_u64:     %" PRIu32 "\n", atomic_ops.op.fetch_inc);
+	printf("  odp_atomic_inc_u64:           %" PRIu32 "\n", atomic_ops.op.inc);
+	printf("  odp_atomic_fetch_dec_u64:     %" PRIu32 "\n", atomic_ops.op.fetch_dec);
+	printf("  odp_atomic_dec_u64:           %" PRIu32 "\n", atomic_ops.op.dec);
+	printf("  odp_atomic_min_u64:           %" PRIu32 "\n", atomic_ops.op.min);
+	printf("  odp_atomic_fetch_min_u64:     %" PRIu32 "\n", atomic_ops.op.fetch_min);
+	printf("  odp_atomic_max_u64:           %" PRIu32 "\n", atomic_ops.op.max);
+	printf("  odp_atomic_fetch_max_u64:     %" PRIu32 "\n", atomic_ops.op.fetch_max);
+	printf("  odp_atomic_cas_u64:           %" PRIu32 "\n", atomic_ops.op.cas);
+	printf("  odp_atomic_xchg_u64:          %" PRIu32 "\n", atomic_ops.op.xchg);
+	printf("  odp_atomic_bit_fetch_set_u64: %" PRIu32 "\n", atomic_ops.op.bit_fetch_set);
+	printf("  odp_atomic_bit_set_u64:       %" PRIu32 "\n", atomic_ops.op.bit_set);
+	printf("  odp_atomic_bit_fetch_clr_u64: %" PRIu32 "\n", atomic_ops.op.bit_fetch_clr);
+	printf("  odp_atomic_bit_clr_u64:       %" PRIu32 "\n", atomic_ops.op.bit_clr);
 
 	atomic_ops.all_bits = 0;
 	odp_atomic_lock_free_u128(&atomic_ops);
@@ -1289,7 +1405,7 @@ static int validate_results(test_global_t *global, validate_fn_t validate, op_bi
 				val = &global->atomic_private[i].u128;
 		}
 
-		if (validate(val, out, num_round, num_cpu, private))
+		if (validate != NULL && validate(val, out, num_round, num_cpu, private))
 			return -1;
 	}
 	return 0;
@@ -1331,6 +1447,14 @@ static test_case_t test_suite[] = {
 		  validate_atomic_cas_u32, OP_32BIT),
 	TEST_INFO("odp_atomic_xchg_u32", test_atomic_xchg_u32,
 		  validate_atomic_num_round_u32, OP_32BIT),
+	TEST_INFO("odp_atomic_bit_set_u32", test_atomic_bit_set_u32,
+		  NULL, OP_32BIT),
+	TEST_INFO("odp_atomic_bit_fetch_set_u32", test_atomic_bit_fetch_set_u32,
+		  NULL, OP_32BIT),
+	TEST_INFO("odp_atomic_bit_clr_u32", test_atomic_bit_clr_u32,
+		  NULL, OP_32BIT),
+	TEST_INFO("odp_atomic_bit_fetch_clr_u32", test_atomic_bit_fetch_clr_u32,
+		  NULL, OP_32BIT),
 	TEST_INFO("odp_atomic_load_acq_u32", test_atomic_load_acq_u32,
 		  validate_atomic_init_val_u32, OP_32BIT),
 	TEST_INFO("odp_atomic_store_rel_u32", test_atomic_store_rel_u32,
@@ -1345,6 +1469,10 @@ static test_case_t test_suite[] = {
 		  validate_atomic_cas_u32, OP_32BIT),
 	TEST_INFO("odp_atomic_cas_acq_rel_u32", test_atomic_cas_acq_rel_u32,
 		  validate_atomic_cas_u32, OP_32BIT),
+	TEST_INFO("odp_atomic_bit_set_rel_u32", test_atomic_bit_set_rel_u32,
+		  NULL, OP_32BIT),
+	TEST_INFO("odp_atomic_bit_clr_rel_u32", test_atomic_bit_clr_rel_u32,
+		  NULL, OP_32BIT),
 	TEST_INFO("odp_atomic_load_u64", test_atomic_load_u64,
 		  validate_atomic_init_val_u64, OP_64BIT),
 	TEST_INFO("odp_atomic_store_u64", test_atomic_store_u64,
@@ -1377,6 +1505,14 @@ static test_case_t test_suite[] = {
 		  validate_atomic_cas_u64, OP_64BIT),
 	TEST_INFO("odp_atomic_xchg_u64", test_atomic_xchg_u64,
 		  validate_atomic_num_round_u64, OP_64BIT),
+	TEST_INFO("odp_atomic_bit_set_u64", test_atomic_bit_set_u64,
+		  NULL, OP_64BIT),
+	TEST_INFO("odp_atomic_bit_fetch_set_u64", test_atomic_bit_fetch_set_u64,
+		  NULL, OP_64BIT),
+	TEST_INFO("odp_atomic_bit_clr_u64", test_atomic_bit_clr_u64,
+		  NULL, OP_64BIT),
+	TEST_INFO("odp_atomic_bit_fetch_clr_u64", test_atomic_bit_fetch_clr_u64,
+		  NULL, OP_64BIT),
 	TEST_INFO("odp_atomic_load_acq_u64", test_atomic_load_acq_u64,
 		  validate_atomic_init_val_u64, OP_64BIT),
 	TEST_INFO("odp_atomic_store_rel_u64", test_atomic_store_rel_u64,
@@ -1391,6 +1527,10 @@ static test_case_t test_suite[] = {
 		  validate_atomic_cas_u64, OP_64BIT),
 	TEST_INFO("odp_atomic_cas_acq_rel_u64", test_atomic_cas_acq_rel_u64,
 		  validate_atomic_cas_u64, OP_64BIT),
+	TEST_INFO("odp_atomic_bit_set_rel_u64", test_atomic_bit_set_rel_u64,
+		  NULL, OP_64BIT),
+	TEST_INFO("odp_atomic_bit_clr_rel_u64", test_atomic_bit_clr_rel_u64,
+		  NULL, OP_64BIT),
 	TEST_INFO("odp_atomic_load_u128", test_atomic_load_u128,
 		  validate_atomic_init_val_u128, OP_128BIT),
 	TEST_INFO("odp_atomic_store_u128", test_atomic_store_u128,


### PR DESCRIPTION
Add functions to atomically set and clear bits in 32-bit and 64-bit variables.

v2:
- Comments addressed

v3:
- Comments addressed

v4:
- Added reviewed-by tags

v6:
- Comments addressed

v8:
- Rebased