### PR TITLE
[PATCH v3] configure: enable -fno-strict-aliasing option

### DIFF
--- a/README
+++ b/README
@@ -15,6 +15,9 @@ How to build:
     See DEPENDENCIES file about system requirements and dependencies to external
     libraries/packages. It contains also some more detailed build instructions.
 
+    ODP requires the -fno-strict-aliasing (or equivalent) compiler option. This
+    option is enabled by default in ODP.
+
     Generally, ODP and test applications are built with these three steps:
         ./bootstrap
         ./configure

--- a/configure.ac
+++ b/configure.ac
@@ -125,8 +125,8 @@ AS_IF([test "$GCC" == yes],
       )
 )
 
-ODP_CFLAGS="$ODP_CFLAGS -std=c11"
-ODP_CXXFLAGS="$ODP_CXXFLAGS -std=c++11"
+ODP_CFLAGS="$ODP_CFLAGS -std=c11 -fno-strict-aliasing"
+ODP_CXXFLAGS="$ODP_CXXFLAGS -std=c++11 -fno-strict-aliasing"
 
 # Extra flags for example to suppress certain warning types
 ODP_CFLAGS="$ODP_CFLAGS $ODP_CFLAGS_EXTRA"


### PR DESCRIPTION
Enable the -fno-strict-aliasing compiler option. Some sections of code in ODP deliberately access the same data via pointers to different types, which is undefined behavior in C. The -fno-strict-aliasing option prevents the compiler from making assumptions about aliasing in these instances.