### PR TITLE
[PATCH v1] build: do not build odp_icache_perf by default

### DIFF
--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -25,7 +25,7 @@ jobs:
                'CFLAGS=-pedantic',
                '--enable-lto',
                '--enable-lto --enable-abi-compat',
-               '--enable-pcapng-support']
+               '--enable-pcapng-support --enable-icache-perf-test']
     steps:
       - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -70,7 +70,7 @@ jobs:
                'CFLAGS=-pedantic',
                '--enable-lto',
                '--enable-lto --enable-abi-compat',
-               '--enable-pcapng-support']
+               '--enable-pcapng-support --enable-icache-perf-test']
     steps:
       - uses: actions/checkout@v4
       - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC=gcc

--- a/test/m4/performance.m4
+++ b/test/m4/performance.m4
@@ -7,3 +7,13 @@ AC_ARG_ENABLE([test-perf],
     [test_perf=$enableval],
     [test_perf=yes])
 AM_CONDITIONAL([test_perf], [test x$test_perf = xyes ])
+
+##########################################################################
+# Enable/disable icache perf test
+##########################################################################
+AC_ARG_ENABLE([icache-perf-test],
+    [AS_HELP_STRING([--enable-icache-perf-test],
+                    [enable odp_icache_perf in build and test [default=disabled]])],
+    [icache_perf_test=$enableval],
+    [icache_perf_test=no])
+AM_CONDITIONAL([icache_perf_test], [test x$icache_perf_test = xyes ])

--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -9,7 +9,6 @@ EXECUTABLES = odp_atomic_perf \
 	      odp_bench_pktio_sp \
 	      odp_bench_timer \
 	      odp_crc \
-	      odp_icache_perf \
 	      odp_lock_perf \
 	      odp_mem_perf \
 	      odp_pktio_perf \
@@ -33,6 +32,10 @@ COMPILE_ONLY = odp_cpu_bench \
 	       odp_sched_pktio \
 	       odp_timer_accuracy \
 	       odp_timer_perf
+
+if icache_perf_test
+EXECUTABLES += odp_icache_perf
+endif
 
 if LIBCONFIG
 COMPILE_ONLY += odp_ipsecfwd


### PR DESCRIPTION
Build odp_icache_perf only when enabled using --enable-icache-perf-test configuration flag. This speeds up builds since the icache performance test takes a long time to compile.
