### PR TITLE
[PATCH v2] test: common: always build libtest_common

### DIFF
--- a/test/common/Makefile.am
+++ b/test/common/Makefile.am
@@ -1,9 +1,11 @@
 include $(top_srcdir)/test/Makefile.inc
 
 noinst_LTLIBRARIES = \
-	libbench_common.la
+	libbench_common.la \
+	libtest_common.la
 
 libbench_common_la_SOURCES = bench_common.c bench_common.h
+libtest_common_la_SOURCES = export_results.c export_results.h
 
 if cunit_support
 
@@ -11,7 +13,6 @@ noinst_LTLIBRARIES += \
 	libcunit_common.la \
 	libcpumask_common.la \
 	libpacket_common.la \
-	libtest_common.la \
 	libthrmask_common.la
 
 libcunit_common_la_SOURCES = odp_cunit_common.c odp_cunit_common.h
@@ -20,8 +21,6 @@ libcunit_common_la_LIBADD = $(CUNIT_LIBS)
 libcpumask_common_la_SOURCES = mask_common.c mask_common.h
 
 libpacket_common_la_SOURCES = packet_common.c packet_common.h
-
-libtest_common_la_SOURCES = export_results.c export_results.h
 
 libthrmask_common_la_SOURCES = mask_common.c mask_common.h
 libthrmask_common_la_CFLAGS = $(AM_CFLAGS) -DTEST_THRMASK


### PR DESCRIPTION
Instead of depending on presence of `libcunit`, always build `libtest_common`. Otherwise, this will lead to build issues if `libcunit` is not present.

v2:
- Added reviewed-by tag