### PR TITLE
[PATCH v2] linux-gen: sched: use restrict keyword to help optimizer

### DIFF
--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -1196,7 +1196,7 @@ static inline int balance_spread(int grp, int prio, int cur_spr)
 	return new_spr;
 }
 
-static inline int copy_from_stash(odp_event_t out_ev[], uint32_t max)
+static inline int copy_from_stash(odp_event_t *restrict out_ev, uint32_t max)
 {
 	int i = 0;
 


### PR DESCRIPTION
Now that -fno-strict-aliasing was added in the default compiler flags, the compiler cannot use type based alias analysis when optimizing and has to assume potential aliasing if it cannot prove otherwise. This slowed down scheduling because the compiler could not deduce that the out_ev parameter of copy_from_stash() does not alias sched_local.

Most of the slowdown seems to come from the use of the ev_index and num_ev fields of sched_local.stash in the loop body. Using local variables instead would solve the issue for the most part but it appears that qualifying the out_ev pointer with restrict has a similar effect with gcc and clang even though the problematic accesses have a different type from *out_ev.

Fix the problem by using the restrict keyword to indicate that *out_ev does not alias with anything else within the function.