### PR TITLE
[PATCH v2] test: l2fwd: improve runner script failure detection

### DIFF
--- a/test/performance/odp_l2fwd_run.sh
+++ b/test/performance/odp_l2fwd_run.sh
@@ -91,7 +91,12 @@ run_l2fwd()
 			PASS_PPS=10
 		fi
 		MAX_PPS=$(awk '/TEST RESULT/ {print $3}' $LOG)
-		if [ "$MAX_PPS" -lt "$PASS_PPS" ]; then
+		NUMREG='^[0-9]+$'
+		echo "PARSED PPS: $MAX_PPS"
+		if ! [[ $MAX_PPS =~ $NUMREG ]]; then
+			echo "FAIL: cannot parse $LOG"
+			ret=1
+		elif [ "$MAX_PPS" -lt "$PASS_PPS" ]; then
 			echo -e "\nodp_packet_gen"
 			echo "=============="
 			cat $GEN_LOG


### PR DESCRIPTION
Currently, even if runner script fails to parse the maximum pps value from `odp_l2fwd` test log (e.g. the searched pattern is not found or value is not numerical), runner script reports success.

Improve this by checking that the parsed value is actually found and is an integer. This should help if the searched pattern somehow changes without additionally updating the runner script.

v2:
- Rebased
- Added reviewed-by tag