### PR TITLE
[PATCH v5] test: export: terminate writing properly

### DIFF
--- a/test/performance/odp_atomic_perf.c
+++ b/test/performance/odp_atomic_perf.c
@@ -1139,6 +1139,9 @@ static int output_summary(test_global_t *global)
 		}
 	}
 
+	if (global->common_options.is_export)
+		test_common_write_term();
+
 	return 0;
 }
 

--- a/test/performance/odp_lock_perf.c
+++ b/test/performance/odp_lock_perf.c
@@ -319,6 +319,10 @@ static int output_summary(test_global_t *global)
 			}
 		}
 	}
+
+	if (global->common_options.is_export)
+		test_common_write_term();
+
 	return 0;
 }
 

--- a/test/performance/odp_pool_perf.c
+++ b/test/performance/odp_pool_perf.c
@@ -674,6 +674,8 @@ static int output_results(test_global_t *global)
 			test_common_write_term();
 			return -1;
 		}
+
+		test_common_write_term();
 	}
 
 	return 0;

--- a/test/performance/odp_sched_latency.c
+++ b/test/performance/odp_sched_latency.c
@@ -358,6 +358,9 @@ static int output_results(test_globals_t *globals)
 		}
 	}
 
+	if (globals->common_options.is_export)
+		test_common_write_term();
+
 	return 0;
 }
 

--- a/test/performance/odp_sched_perf.c
+++ b/test/performance/odp_sched_perf.c
@@ -1485,6 +1485,8 @@ static int output_results(test_global_t *global)
 			test_common_write_term();
 			return -1;
 		}
+
+		test_common_write_term();
 	}
 
 	return 0;

--- a/test/performance/odp_stash_perf.c
+++ b/test/performance/odp_stash_perf.c
@@ -443,6 +443,8 @@ static int output_results(test_global_t *global)
 			test_common_write_term();
 			return -1;
 		}
+
+		test_common_write_term();
 	}
 
 	return 0;

--- a/test/performance/odp_timer_accuracy.c
+++ b/test/performance/odp_timer_accuracy.c
@@ -1043,6 +1043,8 @@ static int print_stat(test_global_t *test_global)
 			test_common_write_term();
 			return -1;
 		}
+
+		test_common_write_term();
 	}
 
 	return 0;


### PR DESCRIPTION
call test_common_write_term() also when exiting and writing is successful.