### PR TITLE
[PATCH v2] linux-gen: pktio: fix lso packet alloc error handling

### DIFF
--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -3134,10 +3134,9 @@ int _odp_lso_create_packets(odp_packet_t packet, const odp_packet_lso_opt_t *lso
 	num = odp_packet_alloc_multi(pool, pkt_len, pkt_out, num_full);
 	if (odp_unlikely(num < num_full)) {
 		_ODP_DBG("Alloc failed %i\n", num);
-		if (num > 0) {
+		if (num > 0)
 			num_free = num;
-			goto error;
-		}
+		goto error;
 	}
 
 	if (left_over_len) {


### PR DESCRIPTION
_odp_lso_create_packets() crashes currently with a segmentation fault if odp_packet_alloc_multi() returns zero or a negative value. Fix this by selecting error path always after alloc failure.