### PR TITLE
[PATCH v7] api: pktio: lso: improve the specification of IPv4 and TCP LSO

### DIFF
--- a/test/validation/api/pktio/lso.c
+++ b/test/validation/api/pktio/lso.c
@@ -1076,28 +1076,6 @@ static void lso_send_ipv4(const uint8_t *test_packet, uint32_t pkt_len, uint32_t
 	lso_test(param, max_payload, pkt2, pkt_len, hdr_len, l3_offset, use_opt,
 		 is_ipv4_test_pkt,
 		 update_ipv4_hdr);
-
-	/* Same test with a first fragment */
-	memcpy(pkt2, test_packet, pkt_len);
-	change_ipv4_frag_offset(&pkt2[l3_offset], LSO_TEST_IPV4_FLAG_MF, LSO_TEST_IPV4_FLAG_MF);
-	lso_test(param, max_payload, pkt2, pkt_len, hdr_len, l3_offset, use_opt,
-		 is_ipv4_test_pkt,
-		 update_ipv4_hdr);
-
-	/* Same test with a middle fragment */
-	memcpy(pkt2, test_packet, pkt_len);
-	change_ipv4_frag_offset(&pkt2[l3_offset], 500, LSO_TEST_IPV4_FRAG_OFFS_MASK);
-	change_ipv4_frag_offset(&pkt2[l3_offset], LSO_TEST_IPV4_FLAG_MF, LSO_TEST_IPV4_FLAG_MF);
-	lso_test(param, max_payload, pkt2, pkt_len, hdr_len, l3_offset, use_opt,
-		 is_ipv4_test_pkt,
-		 update_ipv4_hdr);
-
-	/* Same test with a last fragment */
-	memcpy(pkt2, test_packet, pkt_len);
-	change_ipv4_frag_offset(&pkt2[l3_offset], 500, LSO_TEST_IPV4_FRAG_OFFS_MASK);
-	lso_test(param, max_payload, pkt2, pkt_len, hdr_len, l3_offset, use_opt,
-		 is_ipv4_test_pkt,
-		 update_ipv4_hdr);
 }
 
 static void lso_send_ipv4_udp_325(uint32_t max_payload, int use_opt)


### PR DESCRIPTION
Change the DF flag handling in TCP segmentation offload and improve the description in general:

- Specify that the DF flag of the IP header is to be preserved as it was in the original packet and not cleared as the current spec says.

- Specify that TCP segmentation should be done in a way that complies with the TCP standard, without going into details. This entails proper handling of various TCP header flags and TCP options.

- Specify that unique ID values are generated for non-atomic datagrams and leave it unspecified how the ID value is updated for atomic datagrams (packets which are not fragments and have the DF flag set). Suggest that an application should avoid sending packets with ID values that may lead to overlapping IDs after segmentation.

Improve the description of IPv4 fragmentation offload. This does not change the meaning of the specification but makes it clear that the DF flag is not affected by LSO and that IP option fields are processed as specified in the standard.