### PR TITLE
[PATCH v3] api: event: clarify odp_event_free() documentation for packet vectors

### DIFF
--- a/include/odp/api/spec/event.h
+++ b/include/odp/api/spec/event.h
@@ -208,8 +208,11 @@ int odp_event_is_valid(odp_event_t event);
 /**
  * Free event
  *
- * Frees the event based on its type. Results are undefined if event
- * type is unknown.
+ * Frees the event based on its type. Results are undefined if event type is
+ * unknown.
+ *
+ * In case of packet vector events (ODP_EVENT_PACKET_VECTOR) the function frees
+ * the packet vector and all packets stored inside it.
  *
  * @param event    Event handle
  *


### PR DESCRIPTION
Document in odp_event_free() specification that it frees also the packets stored inside packet vectors. Previously this was only documented in odp_packet_vector_free().