### PR TITLE
[PATCH v3] api: deprecated API clean-up

### DIFF
--- a/include/odp/api/spec/packet_io_types.h
+++ b/include/odp/api/spec/packet_io_types.h
@@ -17,6 +17,7 @@
 extern "C" {
 #endif
 
+#include <odp/api/deprecated.h>
 #include <odp/api/packet_types.h>
 #include <odp/api/packet_io_stats.h>
 #include <odp/api/pool_types.h>
@@ -1120,7 +1121,7 @@ typedef struct odp_pktio_capability_t {
 		 *
 		 * @deprecated Use mode_event instead.
 		 */
-		uint32_t mode_all   : 1;
+		uint32_t ODP_DEPRECATE(mode_all)   : 1;
 
 		/** Packet transmit completion mode ODP_PACKET_TX_COMPL_EVENT support */
 		uint32_t mode_event : 1;

--- a/include/odp/api/spec/packet_io_types.h
+++ b/include/odp/api/spec/packet_io_types.h
@@ -534,7 +534,7 @@ typedef union odp_pktout_config_opt_t {
 		 *
 		 * @deprecated Use odp_pktio_config_t::mode_event instead.
 		 */
-		uint64_t tx_compl_ena : 1;
+		uint64_t ODP_DEPRECATE(tx_compl_ena) : 1;
 
 		/** Enable packet protocol stats update */
 		uint64_t proto_stats_ena : 1;

--- a/include/odp/api/spec/packet_types.h
+++ b/include/odp/api/spec/packet_types.h
@@ -17,6 +17,7 @@
 extern "C" {
 #endif
 
+#include <odp/api/deprecated.h>
 #include <odp/api/proto_stats_types.h>
 #include <odp/api/queue_types.h>
 
@@ -444,7 +445,9 @@ typedef enum odp_packet_tx_compl_mode_t {
  *
  * @deprecated Use #ODP_PACKET_TX_COMPL_EVENT instead.
  */
+#if ODP_DEPRECATED_API
 #define ODP_PACKET_TX_COMPL_ALL ODP_PACKET_TX_COMPL_EVENT
+#endif
 
 /**
  * Packet transmit completion request options

--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -471,20 +471,6 @@ void odp_timeout_from_event_multi(odp_timeout_t tmo[], const odp_event_t ev[], i
 odp_event_t odp_timeout_to_event(odp_timeout_t tmo);
 
 /**
- * Check for fresh timeout
- *
- * If the corresponding timer has been reset or cancelled since this timeout
- * was enqueued, the timeout is stale (not fresh).
- *
- * @param tmo Timeout handle
- * @retval 1 Timeout is fresh
- * @retval 0 Timeout is stale
- *
- * @deprecated The function will be removed in a future API version.
- */
-int ODP_DEPRECATE(odp_timeout_fresh)(odp_timeout_t tmo);
-
-/**
  * Return timer handle for the timeout
  *
  * @param tmo Timeout handle

--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -17,6 +17,7 @@
 extern "C" {
 #endif
 
+#include <odp/api/deprecated.h>
 #include <odp/api/timer_types.h>
 #include <odp/api/event_types.h>
 #include <odp/api/pool_types.h>
@@ -143,7 +144,7 @@ odp_timer_pool_t odp_timer_pool_create(const char *name, const odp_timer_pool_pa
  *
  * @deprecated Use odp_timer_pool_start_multi() instead
  */
-void odp_timer_pool_start(void);
+void ODP_DEPRECATE(odp_timer_pool_start)(void);
 
 /**
  * Start timer pools

--- a/include/odp/api/spec/timer_types.h
+++ b/include/odp/api/spec/timer_types.h
@@ -17,7 +17,6 @@
 extern "C" {
 #endif
 
-#include <odp/api/deprecated.h>
 #include <odp/api/event_types.h>
 #include <odp/api/std_types.h>
 
@@ -531,13 +530,6 @@ typedef enum {
 	ODP_TIMER_FAIL = -3
 
 } odp_timer_retval_t;
-
-/**
- * For backwards compatibility, odp_timer_set_t is synonym of odp_timer_retval_t
- *
- * @deprecated Use odp_timer_retval_t instead.
- */
-typedef odp_timer_retval_t ODP_DEPRECATE(odp_timer_set_t);
 
 /**
  * Timer tick information

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -7,6 +7,7 @@
 
 #include <odp/api/buffer.h>
 #include <odp/api/debug.h>
+#include <odp/api/deprecated.h>
 #include <odp/api/packet.h>
 #include <odp/api/packet_io.h>
 #include <odp/api/proto_stats.h>
@@ -650,13 +651,13 @@ int odp_pktio_config(odp_pktio_t hdl, const odp_pktio_config_t *config)
 	entry->config = *config;
 
 	entry->enabled.tx_ts = config->pktout.bit.ts_ena;
-	entry->enabled.tx_compl = (config->pktout.bit.tx_compl_ena ||
+	entry->enabled.tx_compl = (config->pktout.bit.ODP_DEPRECATE(tx_compl_ena) ||
 				   config->tx_compl.mode_event ||
 				   config->tx_compl.mode_poll);
 
 	if (entry->enabled.tx_compl) {
-		if ((config->pktout.bit.tx_compl_ena || config->tx_compl.mode_event) &&
-		    configure_tx_event_compl(entry)) {
+		if ((config->pktout.bit.ODP_DEPRECATE(tx_compl_ena) ||
+		     config->tx_compl.mode_event) && configure_tx_event_compl(entry)) {
 			unlock_entry(entry);
 			_ODP_ERR("Unable to configure Tx event completion\n");
 			return -1;

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1815,25 +1815,6 @@ uint64_t odp_timeout_to_u64(odp_timeout_t tmo)
 	return _odp_pri(tmo);
 }
 
-int ODP_DEPRECATE(odp_timeout_fresh)(odp_timeout_t tmo)
-{
-	const odp_timeout_hdr_t *hdr = timeout_hdr(tmo);
-	odp_timer_t hdl = hdr->timer;
-
-	/* Timeout not connected to a timer */
-	if (odp_unlikely(hdl == ODP_TIMER_INVALID))
-		return 0;
-
-	timer_pool_t *tp = handle_to_tp(hdl);
-	uint32_t idx = handle_to_idx(hdl, tp);
-	tick_buf_t *tb = &tp->tick_buf[idx];
-	uint64_t exp_tck = odp_atomic_load_u64(&tb->exp_tck);
-
-	/* Return true if the timer still has the same expiration tick
-	 * (ignoring the inactive/expired bit) as the timeout */
-	return hdr->expiration == (exp_tck & ~TMO_INACTIVE);
-}
-
 odp_timeout_t odp_timeout_alloc(odp_pool_t pool_hdl)
 {
 	odp_timeout_hdr_t *hdr;

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -15,6 +15,7 @@
 #include <odp/api/atomic.h>
 #include <odp/api/cpu.h>
 #include <odp/api/debug.h>
+#include <odp/api/deprecated.h>
 #include <odp/api/event.h>
 #include <odp/api/hints.h>
 #include <odp/api/pool.h>
@@ -1461,7 +1462,7 @@ odp_timer_pool_t odp_timer_pool_create(const char *name,
 	return timer_pool_new(name, param);
 }
 
-void odp_timer_pool_start(void)
+void ODP_DEPRECATE(odp_timer_pool_start)(void)
 {
 	/* Nothing to do here, timer pools are started by the create call */
 }

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -10,6 +10,7 @@
 #include <odp_posix_extensions.h>
 
 #include <odp/api/cpumask.h>
+#include <odp/api/deprecated.h>
 #include <odp/api/hints.h>
 #include <odp/api/packet.h>
 #include <odp/api/packet_io.h>
@@ -1775,7 +1776,9 @@ static int dpdk_init_capability(pktio_entry_t *pktio_entry,
 
 	if (!_ODP_DPDK_ZERO_COPY) {
 		capa->config.pktout.bit.tx_compl_ena = 1;
+#if ODP_DEPRECATED_API
 		capa->tx_compl.mode_all = 1;
+#endif
 		capa->tx_compl.mode_event = 1;
 		capa->tx_compl.mode_poll = 1;
 		capa->free_ctrl.dont_free = 1;

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -1775,8 +1775,8 @@ static int dpdk_init_capability(pktio_entry_t *pktio_entry,
 	capa->config.pktout.bit.ts_ena = 1;
 
 	if (!_ODP_DPDK_ZERO_COPY) {
-		capa->config.pktout.bit.tx_compl_ena = 1;
 #if ODP_DEPRECATED_API
+		capa->config.pktout.bit.tx_compl_ena = 1;
 		capa->tx_compl.mode_all = 1;
 #endif
 		capa->tx_compl.mode_event = 1;

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2019-2022 Nokia
  */
 
+#include <odp/api/deprecated.h>
 #include <odp/api/hints.h>
 #include <odp/api/system_info.h>
 
@@ -922,7 +923,9 @@ static int ipc_capability(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_capab
 	capa->max_input_queues  = 1;
 	capa->max_output_queues = 1;
 	capa->config.pktout.bit.tx_compl_ena = 1;
+#if ODP_DEPRECATED_API
 	capa->tx_compl.mode_all = 1;
+#endif
 	capa->tx_compl.mode_event = 1;
 	capa->tx_compl.mode_poll = 1;
 

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -922,8 +922,8 @@ static int ipc_capability(pktio_entry_t *pktio_entry ODP_UNUSED, odp_pktio_capab
 
 	capa->max_input_queues  = 1;
 	capa->max_output_queues = 1;
-	capa->config.pktout.bit.tx_compl_ena = 1;
 #if ODP_DEPRECATED_API
+	capa->config.pktout.bit.tx_compl_ena = 1;
 	capa->tx_compl.mode_all = 1;
 #endif
 	capa->tx_compl.mode_event = 1;

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -673,8 +673,8 @@ static int loopback_init_capability(pktio_entry_t *pktio_entry)
 	capa->config.pktout.bit.udp_chksum = 1;
 	capa->config.pktout.bit.sctp_chksum = 1;
 	capa->config.pktout.bit.ts_ena = 1;
-	capa->config.pktout.bit.tx_compl_ena = 1;
 #if ODP_DEPRECATED_API
+	capa->config.pktout.bit.tx_compl_ena = 1;
 	capa->tx_compl.mode_all = 1;
 #endif
 	capa->tx_compl.mode_event = 1;

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -4,6 +4,7 @@
  */
 
 #include <odp/api/debug.h>
+#include <odp/api/deprecated.h>
 #include <odp/api/event.h>
 #include <odp/api/hash.h>
 #include <odp/api/hints.h>
@@ -673,7 +674,9 @@ static int loopback_init_capability(pktio_entry_t *pktio_entry)
 	capa->config.pktout.bit.sctp_chksum = 1;
 	capa->config.pktout.bit.ts_ena = 1;
 	capa->config.pktout.bit.tx_compl_ena = 1;
+#if ODP_DEPRECATED_API
 	capa->tx_compl.mode_all = 1;
+#endif
 	capa->tx_compl.mode_event = 1;
 	capa->tx_compl.mode_poll = 1;
 

--- a/platform/linux-generic/pktio/null.c
+++ b/platform/linux-generic/pktio/null.c
@@ -4,6 +4,7 @@
  */
 
 #include <odp/api/debug.h>
+#include <odp/api/deprecated.h>
 #include <odp/api/hints.h>
 #include <odp/api/packet_io.h>
 
@@ -138,7 +139,9 @@ static int null_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 
 	capa->config.pktout.bit.ts_ena = 1;
 	capa->config.pktout.bit.tx_compl_ena = 1;
+#if ODP_DEPRECATED_API
 	capa->tx_compl.mode_all = 1;
+#endif
 	capa->tx_compl.mode_event = 1;
 	capa->tx_compl.mode_poll = 1;
 

--- a/platform/linux-generic/pktio/null.c
+++ b/platform/linux-generic/pktio/null.c
@@ -138,8 +138,8 @@ static int null_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 	capa->config.pktin.bit.ts_ptp = 1;
 
 	capa->config.pktout.bit.ts_ena = 1;
-	capa->config.pktout.bit.tx_compl_ena = 1;
 #if ODP_DEPRECATED_API
+	capa->config.pktout.bit.tx_compl_ena = 1;
 	capa->tx_compl.mode_all = 1;
 #endif
 	capa->tx_compl.mode_event = 1;

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -506,8 +506,8 @@ static int pcapif_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 	capa->config.pktin.bit.ts_ptp = 1;
 
 	capa->config.pktout.bit.ts_ena = 1;
-	capa->config.pktout.bit.tx_compl_ena = 1;
 #if ODP_DEPRECATED_API
+	capa->config.pktout.bit.tx_compl_ena = 1;
 	capa->tx_compl.mode_all = 1;
 #endif
 	capa->tx_compl.mode_event = 1;

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -37,6 +37,7 @@
 #include <odp_posix_extensions.h>
 
 #include <odp/api/debug.h>
+#include <odp/api/deprecated.h>
 #include <odp/api/hints.h>
 #include <odp/api/packet.h>
 #include <odp/api/packet_io.h>
@@ -506,7 +507,9 @@ static int pcapif_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 
 	capa->config.pktout.bit.ts_ena = 1;
 	capa->config.pktout.bit.tx_compl_ena = 1;
+#if ODP_DEPRECATED_API
 	capa->tx_compl.mode_all = 1;
+#endif
 	capa->tx_compl.mode_event = 1;
 	capa->tx_compl.mode_poll = 1;
 

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -586,8 +586,8 @@ static int sock_capability(pktio_entry_t *pktio_entry,
 	capa->config.pktin.bit.ts_ptp = 1;
 
 	capa->config.pktout.bit.ts_ena = 1;
-	capa->config.pktout.bit.tx_compl_ena = 1;
 #if ODP_DEPRECATED_API
+	capa->config.pktout.bit.tx_compl_ena = 1;
 	capa->tx_compl.mode_all = 1;
 #endif
 	capa->tx_compl.mode_event = 1;

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -7,6 +7,7 @@
 
 #include <odp/api/align.h>
 #include <odp/api/debug.h>
+#include <odp/api/deprecated.h>
 #include <odp/api/hints.h>
 #include <odp/api/packet.h>
 #include <odp/api/packet_io.h>
@@ -586,7 +587,9 @@ static int sock_capability(pktio_entry_t *pktio_entry,
 
 	capa->config.pktout.bit.ts_ena = 1;
 	capa->config.pktout.bit.tx_compl_ena = 1;
+#if ODP_DEPRECATED_API
 	capa->tx_compl.mode_all = 1;
+#endif
 	capa->tx_compl.mode_event = 1;
 	capa->tx_compl.mode_poll = 1;
 

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -6,6 +6,7 @@
 #include <odp_posix_extensions.h>
 
 #include <odp/api/debug.h>
+#include <odp/api/deprecated.h>
 #include <odp/api/hints.h>
 #include <odp/api/packet.h>
 #include <odp/api/packet_io.h>
@@ -890,7 +891,9 @@ static int sock_mmap_capability(pktio_entry_t *pktio_entry,
 
 	capa->config.pktout.bit.ts_ena = 1;
 	capa->config.pktout.bit.tx_compl_ena = 1;
+#if ODP_DEPRECATED_API
 	capa->tx_compl.mode_all = 1;
+#endif
 	capa->tx_compl.mode_event = 1;
 	capa->tx_compl.mode_poll = 1;
 

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -890,8 +890,8 @@ static int sock_mmap_capability(pktio_entry_t *pktio_entry,
 	capa->config.pktin.bit.ts_ptp = 1;
 
 	capa->config.pktout.bit.ts_ena = 1;
-	capa->config.pktout.bit.tx_compl_ena = 1;
 #if ODP_DEPRECATED_API
+	capa->config.pktout.bit.tx_compl_ena = 1;
 	capa->tx_compl.mode_all = 1;
 #endif
 	capa->tx_compl.mode_event = 1;

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -535,8 +535,8 @@ static int tap_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 	capa->config.pktin.bit.ts_ptp = 1;
 
 	capa->config.pktout.bit.ts_ena = 1;
-	capa->config.pktout.bit.tx_compl_ena = 1;
 #if ODP_DEPRECATED_API
+	capa->config.pktout.bit.tx_compl_ena = 1;
 	capa->tx_compl.mode_all = 1;
 #endif
 	capa->tx_compl.mode_event = 1;

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -29,6 +29,7 @@
 #include <odp_posix_extensions.h>
 
 #include <odp/api/debug.h>
+#include <odp/api/deprecated.h>
 #include <odp/api/hints.h>
 #include <odp/api/packet_io.h>
 #include <odp/api/random.h>
@@ -535,7 +536,9 @@ static int tap_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 
 	capa->config.pktout.bit.ts_ena = 1;
 	capa->config.pktout.bit.tx_compl_ena = 1;
+#if ODP_DEPRECATED_API
 	capa->tx_compl.mode_all = 1;
+#endif
 	capa->tx_compl.mode_event = 1;
 	capa->tx_compl.mode_poll = 1;
 

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -3606,7 +3606,11 @@ static void pktio_test_pktout_compl_event(bool use_plain_queue)
 
 	/* Check that disable works. Also COMPL_ALL should be still supported. */
 	opt.queue = compl_queue[0];
+#if ODP_DEPRECATED_API
 	opt.mode = ODP_PACKET_TX_COMPL_ALL;
+#else
+	opt.mode = ODP_PACKET_TX_COMPL_EVENT;
+#endif
 	odp_packet_tx_compl_request(pkt_tbl[0], &opt);
 	CU_ASSERT(odp_packet_has_tx_compl_request(pkt_tbl[0]) != 0);
 	opt.mode = ODP_PACKET_TX_COMPL_DISABLED;

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -3567,8 +3567,10 @@ static void pktio_test_pktout_compl_event(bool use_plain_queue)
 		/* Configure Tx completion offload for PKTIO Tx */
 		if (i == 0) {
 			CU_ASSERT_FATAL(pktio_capa.tx_compl.mode_event == 1);
+#if ODP_DEPRECATED_API
 			CU_ASSERT_FATAL(pktio_capa.tx_compl.mode_all ==
 					pktio_capa.tx_compl.mode_event);
+#endif
 			if (use_plain_queue) {
 				/* CU_ASSERT needs these extra braces */
 				CU_ASSERT_FATAL(pktio_capa.tx_compl.queue_type_plain != 0);

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -2256,10 +2256,6 @@ static void handle_tmo(odp_event_t ev, bool stale, uint64_t prev_tick)
 		CU_FAIL("odp_timeout_timer() wrong timer");
 
 	if (!stale) {
-#if ODP_DEPRECATED_API
-		if (!odp_timeout_fresh(tmo))
-			CU_FAIL("Wrong status (stale) for fresh timeout");
-#endif
 		/* tmo tick cannot be smaller than pre-calculated tick */
 		if (tick < ttp->tick) {
 			ODPH_DBG("Too small tick: pre-calculated %" PRIu64 " "

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -1268,7 +1268,11 @@ static void timer_pool_current_tick(void)
 	CU_ASSERT_FATAL(tp != ODP_TIMER_POOL_INVALID);
 
 	/* API to be deprecated */
+#if ODP_DEPRECATED_API
 	odp_timer_pool_start();
+#else
+	CU_ASSERT_FATAL(odp_timer_pool_start_multi(&tp, 1) == 1);
+#endif
 
 	/* Allow +-10% error margin */
 	min = odp_timer_ns_to_tick(tp, 0.9 * nsec);


### PR DESCRIPTION
- Explicitly deprecate APIs which have been deprecated only in documentation
- Remove APIs which have been explicitly deprecated over a year