### PR TITLE
[PATCH v7] api: pktio: lso: promise maximum payload size for custom proto

### DIFF
--- a/include/odp/api/spec/packet_io_types.h
+++ b/include/odp/api/spec/packet_io_types.h
@@ -792,7 +792,11 @@ typedef enum odp_lso_protocol_t {
 	/** Protocol not selected. */
 	ODP_LSO_PROTO_NONE = 0,
 
-	/** Custom protocol. LSO performs only custom field updates to the packet headers. */
+	/** Custom protocol. LSO performs only custom field updates to the packet headers.
+	 *
+	 *  All segments except the last one have exactly the maximum number of payload
+	 *  bytes as given by the max_payload_len parameter in odp_packet_lso_opt_t.
+	 */
 	ODP_LSO_PROTO_CUSTOM,
 
 	/** LSO performs IPv4 fragmentation.

--- a/include/odp/api/spec/packet_types.h
+++ b/include/odp/api/spec/packet_types.h
@@ -407,9 +407,10 @@ typedef struct odp_packet_lso_opt_t {
 	/** Maximum payload length in an LSO segment
 	 *
 	 *  Max_payload_len parameter defines the maximum number of payload bytes in each
-	 *  created segment. Depending on the implementation, segments with less payload may be
-	 *  created. However, this value is used typically to divide packet payload evenly over
-	 *  all segments except the last one, which contains the remaining payload bytes.
+	 *  created segment. Depending on the implementation and the LSO profile, segments
+	 *  with less payload may be created. However, this value is used typically to divide
+	 *  packet payload evenly over all segments except the last one, which contains the
+	 *  remaining payload bytes.
 	 */
 	uint32_t max_payload_len;
 

--- a/test/validation/api/pktio/lso.c
+++ b/test/validation/api/pktio/lso.c
@@ -767,6 +767,7 @@ static void lso_test(odp_lso_profile_param_t param, uint32_t max_payload,
 	uint32_t offset, len, payload_len, payload_sum;
 	odp_packet_t pkt_out[MAX_NUM_SEG];
 	uint32_t sent_payload = pkt_len - hdr_len;
+	const int is_custom_proto = (param.lso_proto == ODP_LSO_PROTO_CUSTOM);
 
 	profile = odp_lso_profile_create(pktio_a->hdl, &param);
 	CU_ASSERT_FATAL(profile != ODP_LSO_PROFILE_INVALID);
@@ -821,6 +822,8 @@ static void lso_test(odp_lso_profile_param_t param, uint32_t max_payload,
 		}
 
 		CU_ASSERT(payload_len <= max_payload);
+		if (is_custom_proto && seg_num < num - 1)
+			CU_ASSERT(payload_len == max_payload);
 
 		if (compare_data(seg, hdr_len, test_packet + offset, payload_len) >= 0) {
 			ODPH_ERR("    Payload compare failed at offset %u\n", offset);


### PR DESCRIPTION
Specify that LSO for the custom protocol produces same-sized segments (except the last segment).

Add a profile parameter to request exactly maximum length payload sizes in the non-last segments produced by the custom protocol LSO.

v2:
Remove configurability and the capability flag and just promise that the custom LSO protocol always produces maximum length segments.

v3:
Added validation test commit.
