### PR TITLE
[PATCH v4] linux-gen: cpu: remove static cpu id config file option

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.29"
+config_file_version = "0.1.30"
 
 # System options
 system: {
@@ -37,14 +37,6 @@ system: {
 	# NOTE: This option should only be used on systems where CPU frequency
 	# scaling is disabled.
 	cpu_hz_static = 0
-
-	# When enabled (1), implementation reads the CPU identifier values from
-	# OS only once during ODP initialization. Enabling this option removes
-	# a system call from odp_cpu_id() implementation.
-	#
-	# This option should only be used when ODP threads are not migrated
-	# during application lifetime.
-	cpu_id_static = 1
 
 	# Maximum number of ODP threads that can be created.
 	# odp_thread_count_max() returns this value or the build time

--- a/platform/linux-generic/include/odp/api/plat/thread_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/thread_inline_types.h
@@ -17,10 +17,8 @@ extern "C" {
 
 typedef struct {
 	odp_log_func_t log_fn;
-	int (*cpu_id_fn)(void);
 	odp_thread_type_t type;
 	int thr;
-	int cpu;
 
 } _odp_thread_state_t;
 

--- a/platform/linux-generic/include/odp/api/plat/thread_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/thread_inlines.h
@@ -21,7 +21,6 @@ extern "C" {
 	#define _ODP_INLINE static inline
 	#define odp_thread_id __odp_thread_id
 	#define odp_thread_type __odp_thread_type
-	#define odp_cpu_id __odp_cpu_id
 #else
 	#define _ODP_INLINE
 #endif
@@ -34,14 +33,6 @@ _ODP_INLINE int odp_thread_id(void)
 _ODP_INLINE odp_thread_type_t odp_thread_type(void)
 {
 	return _odp_this_thread->type;
-}
-
-_ODP_INLINE int odp_cpu_id(void)
-{
-	if (_odp_this_thread->cpu >= 0)
-		return _odp_this_thread->cpu;
-
-	return _odp_this_thread->cpu_id_fn();
 }
 
 /** @endcond */

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -33,7 +33,6 @@ typedef struct {
 	uint64_t page_size;
 	int      cache_line_size;
 	uint8_t cpu_hz_static;
-	uint8_t cpu_id_static;
 	uint8_t cpu_constant_tsc;
 	odp_cpu_arch_t cpu_arch;
 	odp_cpu_arch_isa_t cpu_isa_sw;

--- a/platform/linux-generic/m4/odp_libconfig.m4
+++ b/platform/linux-generic/m4/odp_libconfig.m4
@@ -7,7 +7,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [29])
+m4_define([_odp_config_version_minor], [30])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -337,22 +337,13 @@ static int read_config_file(void)
 	}
 	odp_global_ro.system_info.cpu_hz_static = !!val;
 
-	str = "system.cpu_id_static";
-	if (!_odp_libconfig_lookup_int(str, &val)) {
-		_ODP_ERR("Config option '%s' not found.\n", str);
-		return -1;
-	}
-	odp_global_ro.system_info.cpu_id_static = !!val;
-
 	_ODP_PRINT("System config:\n");
 	_ODP_PRINT("  system.cpu_mhz: %" PRIu64 "\n",
 		   odp_global_ro.system_info.default_cpu_hz);
 	_ODP_PRINT("  system.cpu_mhz_max: %" PRIu64 "\n",
 		   odp_global_ro.system_info.default_cpu_hz_max);
-	_ODP_PRINT("  system.cpu_hz_static: %" PRIu8 "\n",
+	_ODP_PRINT("  system.cpu_hz_static: %" PRIu8 "\n\n",
 		   odp_global_ro.system_info.cpu_hz_static);
-	_ODP_PRINT("  system.cpu_id_static: %" PRIu8 "\n\n",
-		   odp_global_ro.system_info.cpu_id_static);
 
 	return 0;
 }

--- a/platform/linux-generic/odp_thread.c
+++ b/platform/linux-generic/odp_thread.c
@@ -7,6 +7,7 @@
 
 #include <odp/api/align.h>
 #include <odp/api/atomic.h>
+#include <odp/api/cpu.h>
 #include <odp/api/hints.h>
 #include <odp/api/shared_memory.h>
 #include <odp/api/spinlock.h>
@@ -158,7 +159,7 @@ static int free_id(int thr)
 	return odp_atomic_fetch_dec_u32(&thread_globals->num) - 1;
 }
 
-static int cpu_id(void)
+int odp_cpu_id(void)
 {
 	int cpu = sched_getcpu();
 
@@ -172,7 +173,6 @@ static int cpu_id(void)
 int _odp_thread_init_local(odp_thread_type_t type)
 {
 	int id;
-	int cpu;
 	int group_all, group_worker, group_control;
 
 	group_all = 1;
@@ -197,13 +197,7 @@ int _odp_thread_init_local(odp_thread_type_t type)
 		return -1;
 	}
 
-	cpu = cpu_id();
-	if (cpu < 0)
-		return -1;
-
 	thread_globals->thr[id].thr  = id;
-	thread_globals->thr[id].cpu  = odp_global_ro.system_info.cpu_id_static ? cpu : -1;
-	thread_globals->thr[id].cpu_id_fn = cpu_id;
 	thread_globals->thr[id].type = type;
 
 	_odp_this_thread = &thread_globals->thr[id];

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.29"
+config_file_version = "0.1.30"
 
 timer: {
 	# Enable inline timer implementation

--- a/platform/linux-generic/test/packet_align.conf
+++ b/platform/linux-generic/test/packet_align.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.29"
+config_file_version = "0.1.30"
 
 pool: {
 	pkt: {

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.29"
+config_file_version = "0.1.30"
 
 # Shared memory options
 shm: {

--- a/platform/linux-generic/test/sched-basic.conf
+++ b/platform/linux-generic/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.29"
+config_file_version = "0.1.30"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {

--- a/platform/linux-generic/test/stash-custom.conf
+++ b/platform/linux-generic/test/stash-custom.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.29"
+config_file_version = "0.1.30"
 
 # Test overflow safe stash variant
 stash: {


### PR DESCRIPTION
Overhead from reading CPU ID in each odp_cpu_id() call is minimal (<10 cycles in local testing). Remove the system:cpu_id_static configuration option to simplify the code and avoid problems if ODP threads are migrated between CPU cores.

V2:
- Removed now unnecessary inline wrapper for `odp_cpu_id()`

V3:
- Added missing include