### PR TITLE
[PATCH v2] linux-gen: timer: fix expiration enqueueing error handling

### DIFF
--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -752,10 +752,8 @@ static inline void timer_expire(timer_pool_t *tp, uint32_t idx, uint64_t tick)
 		/* Post the timeout to the destination queue */
 		int rc = odp_queue_enq(queue, tmo_event);
 
-		if (odp_unlikely(rc != 0)) {
-			_odp_event_free(tmo_event);
+		if (odp_unlikely(rc != 0))
 			_ODP_ABORT("Failed to enqueue timeout event (%d)\n", rc);
-		}
 	}
 }
 


### PR DESCRIPTION
Currently, when handling timer expiration, error while enqueueing timeout event leads to an abort. Before the abort, the timeout event is attempted to be freed. With POSIX timer implementation, where timer expiration is handled in a separate helper thread that has not been locally ODP-initialized, this leads to a NULL pointer access as thread-local pool cache is uninitialized in the helper thread. As the thread (and related worker/process) is about to be aborted anyways, remove the event freeing attempt to fix this.

v2:
- Added reviewed-by tag