### PR TITLE
[PATCH v2] linux-gen: check odp_cpu_id() call return values

### DIFF
--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -927,6 +927,9 @@ dequeue_atomic:
 	}
 
 	cpu_id = odp_cpu_id();
+	if (odp_unlikely(cpu_id < 0))
+		return 0;
+
 	/* Scan our schedq list from beginning to end */
 	for (i = 0; i < ts->num_schedq; i++) {
 		sched_queue_t *schedq = ts->schedq_list[i];

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -9,16 +9,18 @@
 
 #include <odp_posix_extensions.h>
 
+#include <odp/api/align.h>
+#include <odp/api/cpu.h>
+#include <odp/api/hints.h>
 #include <odp/api/system_info.h>
 #include <odp/api/version.h>
+
 #include <odp_global_data.h>
 #include <odp_sysinfo_internal.h>
 #include <odp_init_internal.h>
 #include <odp_libconfig_internal.h>
 #include <odp_debug_internal.h>
 #include <odp_config_internal.h>
-#include <odp/api/align.h>
-#include <odp/api/cpu.h>
 
 #include <errno.h>
 #include <string.h>
@@ -438,6 +440,9 @@ int _odp_system_info_term(void)
 uint64_t odp_cpu_hz(void)
 {
 	int id = odp_cpu_id();
+
+	if (odp_unlikely(id < 0))
+		return -1;
 
 	if (odp_global_ro.system_info.cpu_hz_static)
 		return cpu_hz_static(id);


### PR DESCRIPTION
Check odp_cpu_id() call return values to prevent accidentally using negative return values as array indices. Fixes Coverity warnings.