### PR TITLE
[PATCH v2] linux-gen: dma: fix bogus 'maybe-uninitialized' warning

### DIFF
--- a/platform/linux-generic/odp_dma.c
+++ b/platform/linux-generic/odp_dma.c
@@ -126,7 +126,7 @@ static odp_stash_t create_stash(void)
 	odp_stash_param_t stash_param;
 	odp_stash_t stash;
 	uint32_t id, tmp, i;
-	int32_t ret;
+	int32_t ret = 0;
 
 	odp_stash_param_init(&stash_param);
 	stash_param.num_obj    = MAX_TRANSFERS;


### PR DESCRIPTION
Initialize variable to avoid false positive maybe-uninitialized warning from GCC 14.