### PR TITLE
[PATCH v1] spec: dma: support source segment freeing offload

### DIFF
--- a/include/odp/api/spec/dma_types.h
+++ b/include/odp/api/spec/dma_types.h
@@ -336,6 +336,13 @@ typedef struct odp_dma_capability_t {
 	/** DMA completion event pool capabilities */
 	odp_dma_pool_capability_t pool;
 
+	/** Source segment free support for data format type odp_packet_t
+	 *
+	 *  0: Source segment free feature is not supported
+	 *  1: Source segment free feature is supported
+	 */
+	odp_bool_t src_seg_free;
+
 } odp_dma_capability_t;
 
 /**
@@ -491,6 +498,37 @@ typedef struct odp_dma_transfer_param_t {
 	 *  The table has 'num_dst' entries. Data format is defined by 'dst_format'.
 	 */
 	odp_dma_seg_t *dst_seg;
+
+	/** Transfer hints
+	 *
+	 *  Depending on the implementation, adjusting hints bit fields may improve performance.
+	 *  Initialize all unused bits to zero.
+	 */
+	union {
+		/** Hint bit fields */
+		struct {
+			/** Allow freeing all the source segments
+			 *
+			 *  When set to 1, all source segments with data format type odp_packet_t
+			 *  are freed.
+			 */
+			uint16_t free_src_segs : 1;
+
+			/** Allow freeing all source segments to a single pool
+			 *
+			 *  When set to 1, all source segments with data format type odp_packet_t
+			 *  are freed to a single pool.
+			 */
+			uint16_t single_pool : 1;
+		};
+
+		/** Entire bit field structure
+		 *
+		 *  This can be used to set or clear all bits, or to carry out bitwise operations
+		 *  on those.
+		 */
+		uint16_t all;
+	};
 
 } odp_dma_transfer_param_t;
 


### PR DESCRIPTION
This specification change outines the necessary fields for advertising the source segment freeing offload feature for segements with data format type odp_packet_t. It also defines the required fields to enable this feature.

Application can free all the source segments using odp_dma_transfer_t:free_src_segs field.

Additionally, application can use hint bit field
odp_dma_transfer_t:single_pool to free all source segments to a single pool, provided all segments belong to a same pool.