### PR TITLE
[PATCH v3] remove unused longindex

### DIFF
--- a/example/classifier/odp_classifier.c
+++ b/example/classifier/odp_classifier.c
@@ -1161,7 +1161,6 @@ static int parse_policy_ci_pass_count(appl_args_t *appl_args, char *optarg)
 static int parse_args(int argc, char *argv[], appl_args_t *appl_args)
 {
 	int opt;
-	int long_index;
 	size_t len;
 	int i;
 	int interface = 0;
@@ -1198,7 +1197,7 @@ static int parse_args(int argc, char *argv[], appl_args_t *appl_args)
 
 	while (ret == 0) {
 		opt = getopt_long(argc, argv, shortopts,
-				  longopts, &long_index);
+				  longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/example/debug/odp_debug.c
+++ b/example/debug/odp_debug.c
@@ -58,7 +58,7 @@ static void print_usage(void)
 
 static int parse_options(int argc, char *argv[], test_global_t *global)
 {
-	int opt, long_index;
+	int opt;
 	char *str;
 	uint32_t str_len = 0;
 
@@ -78,7 +78,7 @@ static int parse_options(int argc, char *argv[], test_global_t *global)
 	int ret = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/example/ipsec_api/odp_ipsec.c
+++ b/example/ipsec_api/odp_ipsec.c
@@ -1188,7 +1188,6 @@ main(int argc, char *argv[])
 static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 {
 	int opt;
-	int long_index;
 	char *token;
 	size_t len;
 	int rc = 0;
@@ -1216,7 +1215,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	printf("\nParsing command line options\n");
 
 	while (!rc) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (-1 == opt)
 			break;	/* No more options */

--- a/example/ipsec_crypto/odp_ipsec.c
+++ b/example/ipsec_crypto/odp_ipsec.c
@@ -1471,7 +1471,6 @@ main(int argc, char *argv[])
 static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 {
 	int opt;
-	int long_index;
 	char *token;
 	size_t len;
 	int rc = 0;
@@ -1499,7 +1498,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->mode = 0;  /* turn off async crypto API by default */
 
 	while (!rc) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (-1 == opt)
 			break;	/* No more options */

--- a/example/l3fwd/odp_l3fwd.c
+++ b/example/l3fwd/odp_l3fwd.c
@@ -516,7 +516,6 @@ static void print_usage(char *progname)
 static void parse_cmdline_args(int argc, char *argv[], app_args_t *args)
 {
 	int opt;
-	int long_index;
 	char *token, *local;
 	size_t len, route_index = 0;
 	int mem_failure = 0;
@@ -538,7 +537,7 @@ static void parse_cmdline_args(int argc, char *argv[], app_args_t *args)
 
 	while (1) {
 		opt = getopt_long(argc, argv, "+s:t:d:i:r:q:e:h",
-				  longopts, &long_index);
+				  longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/example/packet/odp_packet_dump.c
+++ b/example/packet/odp_packet_dump.c
@@ -109,7 +109,7 @@ static int parse_int_list(char *str, int integer[], int max_num)
 
 static int parse_options(int argc, char *argv[], test_global_t *global)
 {
-	int i, opt, long_index;
+	int i, opt;
 	char *name, *str;
 	int len, str_len, num;
 
@@ -128,7 +128,7 @@ static int parse_options(int argc, char *argv[], test_global_t *global)
 	int ret = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/example/packet/odp_pktio.c
+++ b/example/packet/odp_pktio.c
@@ -585,7 +585,6 @@ static void swap_pkt_addrs(odp_packet_t pkt_tbl[], unsigned len)
 static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 {
 	int opt;
-	int long_index;
 	char *token;
 	size_t len;
 	int i;
@@ -605,7 +604,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->time = 0; /**< loop forever */
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/example/ping/odp_ping.c
+++ b/example/ping/odp_ping.c
@@ -84,7 +84,7 @@ static void print_usage(void)
 
 static int parse_options(int argc, char *argv[], test_global_t *global)
 {
-	int i, opt, long_index;
+	int i, opt;
 	char *name, *str;
 	int len, str_len;
 
@@ -101,7 +101,7 @@ static int parse_options(int argc, char *argv[], test_global_t *global)
 	int ret = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/example/simple_pipeline/odp_simple_pipeline.c
+++ b/example/simple_pipeline/odp_simple_pipeline.c
@@ -563,7 +563,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	char *token;
 	size_t len;
 	int opt;
-	int long_index;
 	int i;
 	int if_count = 0;
 	static const struct option longopts[] = {
@@ -588,7 +587,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->extra_work = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/example/switch/odp_switch.c
+++ b/example/switch/odp_switch.c
@@ -851,7 +851,6 @@ static void usage(char *progname)
 static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 {
 	int opt;
-	int long_index;
 	char *token;
 	size_t len;
 	unsigned int i;
@@ -871,7 +870,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->accuracy = 10; /* get and print pps stats second */
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/example/sysinfo/odp_sysinfo.c
+++ b/example/sysinfo/odp_sysinfo.c
@@ -790,7 +790,6 @@ static void parse_interfaces(appl_args_t *config, const char *optarg)
 static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 {
 	int opt;
-	int long_index;
 	static const struct option longopts[] = {
 		{"interfaces", required_argument, NULL, 'i'},
 		{"help", no_argument, NULL, 'h'},
@@ -799,7 +798,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	static const char *shortopts =  "i:h";
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/platform/linux-generic/test/pktio_ipc/ipc_common.c
+++ b/platform/linux-generic/test/pktio_ipc/ipc_common.c
@@ -96,7 +96,6 @@ odp_pktio_t create_pktio(odp_pool_t pool, int master_pid)
 void parse_args(int argc, char *argv[])
 {
 	int opt;
-	int long_index;
 	static struct option longopts[] = {
 		{"start-timeout", required_argument, NULL, 's'},
 		{"run-time", required_argument, NULL, 't'},
@@ -111,7 +110,7 @@ void parse_args(int argc, char *argv[])
 
 	while (1) {
 		opt = getopt_long(argc, argv, "+s:t:p:h",
-				  longopts, &long_index);
+				  longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/miscellaneous/odp_dyn_workers.c
+++ b/test/miscellaneous/odp_dyn_workers.c
@@ -347,7 +347,7 @@ static parse_result_t check_options(const global_config_t *config)
 
 static parse_result_t parse_options(int argc, char **argv, global_config_t *config)
 {
-	int opt, long_index;
+	int opt;
 
 	static const struct option longopts[] = {
 		{ "cpumasks", required_argument, NULL, 'c' },
@@ -361,7 +361,7 @@ static parse_result_t parse_options(int argc, char **argv, global_config_t *conf
 	init_options(config);
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_atomic_perf.c
+++ b/test/performance/odp_atomic_perf.c
@@ -1148,7 +1148,6 @@ static int output_summary(test_global_t *global)
 static int parse_options(int argc, char *argv[], test_options_t *test_options)
 {
 	int opt;
-	int long_index;
 	int ret = 0;
 
 	static const struct option longopts[] = {
@@ -1167,7 +1166,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	test_options->private   = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_bench_buffer.c
+++ b/test/performance/odp_bench_buffer.c
@@ -589,7 +589,6 @@ static void usage(char *progname)
 static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 {
 	int opt;
-	int long_index;
 	static const struct option longopts[] = {
 		{"burst", required_argument, NULL, 'b'},
 		{"cache_size", required_argument, NULL, 'c'},
@@ -609,7 +608,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->time = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_bench_misc.c
+++ b/test/performance/odp_bench_misc.c
@@ -886,7 +886,6 @@ static void usage(void)
 static int parse_args(int argc, char *argv[])
 {
 	int opt;
-	int long_index;
 	appl_args_t *appl_args = &gbl_args->appl;
 	static const struct option longopts[] = {
 		{"time", required_argument, NULL, 't'},
@@ -903,7 +902,7 @@ static int parse_args(int argc, char *argv[])
 	appl_args->rounds = ROUNDS;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_bench_packet.c
+++ b/test/performance/odp_bench_packet.c
@@ -1556,7 +1556,6 @@ static void usage(char *progname)
 static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 {
 	int opt;
-	int long_index;
 	static const struct option longopts[] = {
 		{"burst", required_argument, NULL, 'b'},
 		{"cache_size", required_argument, NULL, 'c'},
@@ -1576,7 +1575,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->time = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_bench_pktio_sp.c
+++ b/test/performance/odp_bench_pktio_sp.c
@@ -876,7 +876,6 @@ static int parse_args(int argc, char *argv[])
 {
 	int i;
 	int opt;
-	int long_index;
 	static const struct option longopts[] = {
 		{"interface", required_argument, NULL, 'i'},
 		{"in_mode", required_argument, NULL, 'm'},
@@ -901,7 +900,7 @@ static int parse_args(int argc, char *argv[])
 	gbl_args->opt.num_pmr = 1;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_bench_timer.c
+++ b/test/performance/odp_bench_timer.c
@@ -335,7 +335,6 @@ static void usage(void)
 static int parse_args(int argc, char *argv[])
 {
 	int opt;
-	int long_index;
 	static const struct option longopts[] = {
 		{"clk_src", required_argument, NULL, 's'},
 		{"time", required_argument, NULL, 't'},
@@ -353,7 +352,7 @@ static int parse_args(int argc, char *argv[])
 	gbl_args->opt.rounds = ROUNDS;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_cpu_bench.c
+++ b/test/performance/odp_cpu_bench.c
@@ -377,7 +377,6 @@ static void usage(char *progname)
 static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 {
 	int opt;
-	int long_index;
 
 	static const struct option longopts[] = {
 		{"accuracy", required_argument, NULL, 'a'},
@@ -396,7 +395,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->time = 10; /* Loop forever if time to run is 0 */
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_crc.c
+++ b/test/performance/odp_crc.c
@@ -62,7 +62,6 @@ static void print_usage(void)
 static int parse_options(int argc, char *argv[])
 {
 	int opt;
-	int long_index;
 	int ret = 0;
 
 	static const struct option longopts[] = {
@@ -79,7 +78,7 @@ static int parse_options(int argc, char *argv[])
 	options = options_def;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -1384,7 +1384,6 @@ int main(int argc, char *argv[])
 static void parse_args(int argc, char *argv[], crypto_args_t *cargs)
 {
 	int opt;
-	int long_index;
 	static const struct option longopts[] = {
 		{"algorithm", optional_argument, NULL, 'a'},
 		{"debug",  no_argument, NULL, 'd'},
@@ -1410,7 +1409,7 @@ static void parse_args(int argc, char *argv[], crypto_args_t *cargs)
 	cargs->schedule = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_dma_perf.c
+++ b/test/performance/odp_dma_perf.c
@@ -553,7 +553,7 @@ static parse_result_t check_options(prog_config_t *config)
 
 static parse_result_t parse_options(int argc, char **argv, prog_config_t *config)
 {
-	int opt, long_index;
+	int opt;
 	static const struct option longopts[] = {
 		{ "trs_type", required_argument, NULL, 't' },
 		{ "num_in_seg", required_argument, NULL, 'i' },
@@ -574,7 +574,7 @@ static parse_result_t parse_options(int argc, char **argv, prog_config_t *config
 	init_config(config);
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_dmafwd.c
+++ b/test/performance/odp_dmafwd.c
@@ -461,7 +461,7 @@ static parse_result_t check_options(prog_config_t *config)
 
 static parse_result_t parse_options(int argc, char **argv, prog_config_t *config)
 {
-	int opt, long_index;
+	int opt;
 
 	static const struct option longopts[] = {
 		{ "interfaces", required_argument, NULL, 'i' },
@@ -481,7 +481,7 @@ static parse_result_t parse_options(int argc, char **argv, prog_config_t *config
 	init_config(config);
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_icache_perf.c
+++ b/test/performance/odp_icache_perf.c
@@ -15468,7 +15468,6 @@ static void print_usage(void)
 static int parse_options(int argc, char *argv[], test_global_t *global)
 {
 	int opt;
-	int long_index;
 	test_options_t *test_options = &global->test_options;
 	int ret = 0;
 	uint32_t max_func = ODPH_ARRAY_SIZE(work_0);
@@ -15504,7 +15503,7 @@ static int parse_options(int argc, char *argv[], test_global_t *global)
 	test_options->pref_before = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -1057,7 +1057,6 @@ static void usage(char *progname)
 static void parse_args(int argc, char *argv[], ipsec_args_t *cargs)
 {
 	int opt;
-	int long_index;
 	static const struct option longopts[] = {
 		{"algorithm", optional_argument, NULL, 'a'},
 		{"debug",  no_argument, NULL, 'd'},
@@ -1088,7 +1087,7 @@ static void parse_args(int argc, char *argv[], ipsec_args_t *cargs)
 	cargs->ah = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_ipsecfwd.c
+++ b/test/performance/odp_ipsecfwd.c
@@ -1468,7 +1468,7 @@ static parse_result_t check_options(prog_config_t *config)
 
 static parse_result_t parse_options(int argc, char **argv, prog_config_t *config)
 {
-	int opt, long_index;
+	int opt;
 	config_t cfg;
 
 	static const struct option longopts[] = {
@@ -1489,7 +1489,7 @@ static parse_result_t parse_options(int argc, char **argv, prog_config_t *config
 	static const char *shortopts = "i:n:l:c:m:C:I:S:O:dh";
 
 	while (true) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_l2fwd.c
+++ b/test/performance/odp_l2fwd.c
@@ -1970,7 +1970,6 @@ static void usage(char *progname)
 static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 {
 	int opt;
-	int long_index;
 	char *token;
 	char *tmp_str, *tmp;
 	size_t str_len, len;
@@ -2051,7 +2050,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->flow_control = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_l2fwd_perf.c
+++ b/test/performance/odp_l2fwd_perf.c
@@ -373,7 +373,7 @@ static parse_result_t check_options(prog_config_t *config)
 
 static parse_result_t parse_options(int argc, char **argv, prog_config_t *config)
 {
-	int opt, long_index;
+	int opt;
 
 	static const struct option longopts[] = {
 		{ "interfaces", required_argument, NULL, 'i' },
@@ -396,7 +396,7 @@ static parse_result_t parse_options(int argc, char **argv, prog_config_t *config
 	init_config(config);
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_lock_perf.c
+++ b/test/performance/odp_lock_perf.c
@@ -329,7 +329,6 @@ static int output_summary(test_global_t *global)
 static int parse_options(int argc, char *argv[], test_options_t *test_options)
 {
 	int opt;
-	int long_index;
 	int ret = 0;
 
 	static const struct option longopts[] = {
@@ -348,7 +347,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	*test_options = test_options_def;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_mem_perf.c
+++ b/test/performance/odp_mem_perf.c
@@ -76,7 +76,6 @@ static void print_usage(void)
 static int parse_options(int argc, char *argv[], test_options_t *test_options)
 {
 	int opt;
-	int long_index;
 	int ret = 0;
 
 	static const struct option longopts[] = {
@@ -100,7 +99,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	test_options->mode      = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_packet_gen.c
+++ b/test/performance/odp_packet_gen.c
@@ -657,7 +657,7 @@ static int init_bins(test_global_t *global)
 
 static int parse_options(int argc, char *argv[], test_global_t *global)
 {
-	int opt, i, len, str_len, long_index, port;
+	int opt, i, len, str_len, port;
 	unsigned long int count;
 	uint32_t min_packets, num_tx_pkt, num_tx_alloc, pkt_len, req_len, val, bins;
 	char *name, *str, *end;
@@ -751,7 +751,7 @@ static int parse_options(int argc, char *argv[], test_global_t *global)
 	}
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_pktio_ordered.c
+++ b/test/performance/odp_pktio_ordered.c
@@ -854,7 +854,6 @@ static void usage(char *progname)
 static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 {
 	int opt;
-	int long_index;
 	char *token;
 	char *addr_str;
 	size_t len;
@@ -885,7 +884,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->promisc_mode = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_pktio_perf.c
+++ b/test/performance/odp_pktio_perf.c
@@ -946,7 +946,6 @@ static void usage(void)
 static void parse_args(int argc, char *argv[], test_args_t *args)
 {
 	int opt;
-	int long_index;
 
 	static const struct option longopts[] = {
 		{"count",     required_argument, NULL, 'c'},
@@ -977,7 +976,7 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts,
-				  longopts, &long_index);
+				  longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_pool_latency.c
+++ b/test/performance/odp_pool_latency.c
@@ -567,7 +567,7 @@ static parse_result_t check_options(prog_config_t *config)
 
 static parse_result_t parse_options(int argc, char **argv, prog_config_t *config)
 {
-	int opt, long_index;
+	int opt;
 
 	static const struct option longopts[] = {
 		{ "burst_pattern", required_argument, NULL, 'b' },
@@ -589,7 +589,7 @@ static parse_result_t parse_options(int argc, char **argv, prog_config_t *config
 	init_config(config);
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_pool_perf.c
+++ b/test/performance/odp_pool_perf.c
@@ -95,7 +95,6 @@ static void print_usage(void)
 static int parse_options(int argc, char *argv[], test_options_t *test_options)
 {
 	int opt;
-	int long_index;
 	int ret = 0;
 
 	static const struct option longopts[] = {
@@ -125,7 +124,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	test_options->cache_size = UINT32_MAX;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_queue_perf.c
+++ b/test/performance/odp_queue_perf.c
@@ -107,7 +107,7 @@ static void print_usage(void)
 
 static int parse_options(int argc, char *argv[], test_options_t *test_options)
 {
-	int opt, long_index, num_cpu;
+	int opt, num_cpu;
 	int ret = 0;
 
 	static const struct option longopts[] = {
@@ -138,7 +138,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	test_options->private_queues = false;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_random.c
+++ b/test/performance/odp_random.c
@@ -96,7 +96,6 @@ static void print_usage(void)
 static int parse_options(int argc, char *argv[])
 {
 	int opt;
-	int long_index;
 	int ret = 0;
 
 	static const struct option longopts[] = {
@@ -116,7 +115,7 @@ static int parse_options(int argc, char *argv[])
 	options.size = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_sched_latency.c
+++ b/test/performance/odp_sched_latency.c
@@ -624,7 +624,6 @@ static void usage(void)
 static void parse_args(int argc, char *argv[], test_args_t *args)
 {
 	int opt;
-	int long_index;
 	int i;
 
 	static const struct option longopts[] = {
@@ -666,7 +665,7 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 	args->prio[HI_PRIO].sample_events = 1;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_sched_perf.c
+++ b/test/performance/odp_sched_perf.c
@@ -186,7 +186,7 @@ static void print_usage(void)
 
 static int parse_options(int argc, char *argv[], test_options_t *test_options)
 {
-	int opt, long_index, num_group, num_join;
+	int opt, num_group, num_join;
 	int ret = 0;
 	uint32_t ctx_size = 0;
 	int pool_type = 0;
@@ -245,7 +245,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	test_options->verbose    = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -579,7 +579,7 @@ static void print_usage(const char *progname)
 
 static int parse_options(int argc, char *argv[], test_options_t *test_options)
 {
-	int i, opt, long_index;
+	int i, opt;
 	char *name, *str;
 	int len, str_len, sched_mode;
 	const struct option longopts[] = {
@@ -608,7 +608,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	test_options->pipe_queue_size = 256;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_stash_perf.c
+++ b/test/performance/odp_stash_perf.c
@@ -78,7 +78,6 @@ static void print_usage(void)
 static int parse_options(int argc, char *argv[], test_options_t *test_options)
 {
 	int opt;
-	int long_index;
 	int ret = 0;
 
 	static const struct option longopts[] = {
@@ -102,7 +101,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	test_options->strict = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_stress.c
+++ b/test/performance/odp_stress.c
@@ -142,7 +142,6 @@ static void print_usage(void)
 static int parse_options(int argc, char *argv[], test_options_t *test_options)
 {
 	int opt;
-	int long_index;
 	int ret = 0;
 
 	static const struct option longopts[] = {
@@ -168,7 +167,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	test_options->timer_mode  = TMODE_SHARED_REL;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;

--- a/test/performance/odp_timer_accuracy.c
+++ b/test/performance/odp_timer_accuracy.c
@@ -175,7 +175,7 @@ static void print_usage(void)
 
 static int parse_options(int argc, char *argv[], test_opt_t *test_opt)
 {
-	int opt, long_index;
+	int opt;
 	const struct option longopts[] = {
 		{"count",        required_argument, NULL, 'c'},
 		{"period",       required_argument, NULL, 'p'},
@@ -230,7 +230,7 @@ static int parse_options(int argc, char *argv[], test_opt_t *test_opt)
 	test_opt->early_retry = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;	/* No more options */

--- a/test/performance/odp_timer_perf.c
+++ b/test/performance/odp_timer_perf.c
@@ -152,7 +152,6 @@ static void print_usage(void)
 static int parse_options(int argc, char *argv[], test_options_t *test_options)
 {
 	int opt;
-	int long_index;
 	int ret = 0;
 
 	static const struct option longopts[] = {
@@ -180,7 +179,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	test_options->test_rounds = 100000;
 
 	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
 
 		if (opt == -1)
 			break;


### PR DESCRIPTION
When parsing command line arguments with `getopt_long()`, longindex output pointer can be `NULL` if it is not needed.

v2:
- Rebased
- Added reviewed-by tag