### PR TITLE
[PATCH v3] linux-gen: timer: do not log an error in capability query

### DIFF
--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1324,7 +1324,7 @@ int odp_timer_capability(odp_timer_clk_src_t clk_src,
 			 odp_timer_capability_t *capa)
 {
 	if (clk_src != ODP_CLOCK_DEFAULT) {
-		_ODP_ERR("Only ODP_CLOCK_DEFAULT supported. Requested %i.\n", clk_src);
+		_ODP_DBG("Only ODP_CLOCK_DEFAULT supported. Requested %i.\n", clk_src);
 		return -1;
 	}
 


### PR DESCRIPTION
Do not log an error about an unsupported clock source in odp_timer_capability() since one intended use of the function is to probe which clock sources are supported. Print a debug message instead. This gets rid of an annoying error printout in odp_sysinfo output.