### PR TITLE
[PATCH v7] helper: macros: add new utility macros

### DIFF
--- a/helper/include/odp/helper/macros.h
+++ b/helper/include/odp/helper/macros.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright(C) 2023 Nokia
+ * Copyright(C) 2023-2025 Nokia
  */
 
 /**
@@ -54,6 +54,27 @@ extern "C" {
 	__extension__ ({			\
 		__typeof__(v) abs_v = (v);	\
 		abs_v < 0 ? -abs_v : abs_v;	\
+	})
+
+/**
+ * Return division of two numbers rounded up to the closest integer (positive
+ * values expected)
+ */
+#define ODPH_DIV_ROUNDUP(dividend, divisor)			\
+	__extension__ ({					\
+		__typeof__(dividend) _dividend = (dividend);	\
+		__typeof__(divisor) _divisor = (divisor);	\
+		(_dividend + _divisor - 1) / _divisor;		\
+	})
+
+/**
+ * Round up 'x' to next multiple of 'y' (positive values expected)
+ */
+#define ODPH_ROUNDUP_MULTIPLE(x, y)			\
+	__extension__ ({				\
+		__typeof__(x) _x = (x);			\
+		__typeof__(y) _y = (y);			\
+		_y * (ODPH_DIV_ROUNDUP(_x, _y));	\
 	})
 
 /**

--- a/helper/test/macros.c
+++ b/helper/test/macros.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright(C) 2023 Nokia
+ * Copyright(C) 2023-2025 Nokia
  */
 
 #include <odp_api.h>
@@ -10,7 +10,7 @@
 
 int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 {
-	int a, b;
+	int a, b, tmp;
 	int ret = 0;
 	int arr_1[1];
 	int arr_10[10];
@@ -60,6 +60,24 @@ int main(int argc ODP_UNUSED, char *argv[] ODP_UNUSED)
 
 	a = -1;
 	if (ODPH_ABS(--a) != 2)
+		ret++;
+
+	if (ODPH_DIV_ROUNDUP(1, 2) != 1)
+		ret++;
+
+	a = 128;
+	b = 74;
+	tmp = ODPH_DIV_ROUNDUP(a += 60, b -= 10);
+	if (tmp != 3)
+		ret++;
+
+	if (ODPH_ROUNDUP_MULTIPLE(24, 64) != 64)
+		ret++;
+
+	a = 128;
+	b = 74;
+	tmp = ODPH_ROUNDUP_MULTIPLE(a += 60, b -= 10);
+	if (tmp != 192)
 		ret++;
 
 	if (!ret)

--- a/test/performance/odp_pktio_perf.c
+++ b/test/performance/odp_pktio_perf.c
@@ -59,10 +59,6 @@
 /* Default test duration in T_SCALE units */
 #define DEFAULT_DURATION 1
 
-#define CACHE_ALIGN_ROUNDUP(x)\
-	((ODP_CACHE_LINE_SIZE) * \
-	 (((x) + ODP_CACHE_LINE_SIZE - 1) / (ODP_CACHE_LINE_SIZE)))
-
 #define PKT_HDR_LEN (sizeof(pkt_head_t) + ODPH_UDPHDR_LEN + \
 		     ODPH_IPV4HDR_LEN + ODPH_ETHHDR_LEN)
 

--- a/test/performance/odp_sched_latency.c
+++ b/test/performance/odp_sched_latency.c
@@ -32,10 +32,6 @@
 #define EVENT_POOL_SIZE	  (1024 * 1024) /**< Event pool size */
 #define MAIN_THREAD	  1	/**< Thread ID performing maintenance tasks */
 
-#define CACHE_ALIGN_ROUNDUP(x)\
-	((ODP_CACHE_LINE_SIZE) * \
-	 (((x) + ODP_CACHE_LINE_SIZE - 1) / (ODP_CACHE_LINE_SIZE)))
-
 /* Test priorities */
 #define NUM_PRIOS 2 /**< Number of tested priorities */
 #define HI_PRIO	  0

--- a/test/performance/odp_sched_perf.c
+++ b/test/performance/odp_sched_perf.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2018 Linaro Limited
- * Copyright (c) 2020-2024 Nokia
+ * Copyright (c) 2020-2025 Nokia
  */
 
 /**
@@ -39,9 +39,6 @@
 
 /* Scheduling round interval to check for MAX_SCHED_WAIT_NS */
 #define TIME_CHECK_INTERVAL  (1024 * 1024)
-
-/* Round up 'X' to a multiple of 'NUM' */
-#define ROUNDUP(X, NUM) ((NUM) * (((X) + (NUM) - 1) / (NUM)))
 
 typedef struct test_options_t {
 	uint32_t num_cpu;
@@ -397,7 +394,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	if (test_options->ctx_rd_words || test_options->ctx_rw_words) {
 		/* Round up queue handle size to a multiple of 8 for correct
 		 * context data alignment */
-		ctx_size = ROUNDUP(ctx_size, 8);
+		ctx_size = ODPH_ROUNDUP_MULTIPLE(ctx_size, 8);
 		ctx_size += 8 * test_options->ctx_rd_words;
 		ctx_size += 8 * test_options->ctx_rw_words;
 	}
@@ -405,7 +402,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	/* When context data is modified, round up to cache line size to avoid
 	 * false sharing */
 	if (test_options->fairness || test_options->ctx_rw_words)
-		ctx_size = ROUNDUP(ctx_size, ODP_CACHE_LINE_SIZE);
+		ctx_size = ODP_CACHE_LINE_ROUNDUP(ctx_size);
 
 	test_options->ctx_size = ctx_size;
 	test_options->uarea_size = 8 * (test_options->uarea_rd + test_options->uarea_rw);
@@ -1098,7 +1095,7 @@ static int test_sched(void *arg)
 	thr = odp_thread_id();
 
 	if (forward || fairness)
-		ctx_offset = ROUNDUP(sizeof(queue_context_t), 8);
+		ctx_offset = ODPH_ROUNDUP_MULTIPLE(sizeof(queue_context_t), 8);
 
 	if (num_group > 0) {
 		uint32_t num_join = test_options->num_join;

--- a/test/performance/odp_timer_stress.c
+++ b/test/performance/odp_timer_stress.c
@@ -54,8 +54,6 @@ enum {
 #define DEF_TIME 2U
 #define DEF_WORKERS 1U
 
-#define ROUNDUP_DIV(a, b) (((a) + ((b) - 1)) / (b))
-
 typedef enum {
 	PRS_OK,
 	PRS_NOK,
@@ -489,7 +487,7 @@ static odp_bool_t setup_config(prog_config_t *config)
 	odp_queue_param_t q_param;
 	odp_thrmask_t zero;
 	void *cancel_addr = NULL;
-	uint32_t num_tmr_p_w = ROUNDUP_DIV(opts->num_tmr, opts->num_workers),
+	uint32_t num_tmr_p_w = ODPH_DIV_ROUNDUP(opts->num_tmr, opts->num_workers),
 	num_tmr = opts->num_tmr;
 	worker_config_t *worker;
 


### PR DESCRIPTION
Add two new utility macros:

  - `ODPH_ROUNDUP_DIV()` for dividing two numbers rounded up to the
    closest integer
  - `ODPH_ROUNDUP_ALIGN()` for rounding up a value to a given alignment

v2:
- Matias' comments

v4:
- Rebased
- Macro test improvement

v5:
- Added reviewed-by tags

v6:
- Rebased
- Added reviewed-by tags