### PR TITLE
[PATCH v10] api: sched: add cache stashing

### DIFF
--- a/include/odp/api/spec/schedule.h
+++ b/include/odp/api/spec/schedule.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2024 Nokia
+ * Copyright (c) 2024-2025 Nokia
  */
 
 /**
@@ -340,6 +340,34 @@ int odp_schedule_capability(odp_schedule_capability_t *capa);
  */
 odp_schedule_group_t odp_schedule_group_create(const char *name,
 					       const odp_thrmask_t *mask);
+/**
+ * Initialize schedule group parameters
+ *
+ * Initialize an odp_schedule_group_param_t to its default values.
+ *
+ * @param[out] param  Pointer to parameter structure
+ */
+void odp_schedule_group_param_init(odp_schedule_group_param_t *param);
+
+/**
+ * Schedule group create with parameters
+ *
+ * Otherwise like odp_schedule_group_create() but additionally accepts a set of
+ * parameters.
+ *
+ * @param name    Name of the schedule group or NULL. Maximum string length is
+ *                ODP_SCHED_GROUP_NAME_LEN, including the null character.
+ * @param mask    Thread mask
+ * @param param   Schedule group parameters
+ *
+ * @return Schedule group handle
+ * @retval ODP_SCHED_GROUP_INVALID on failure
+ *
+ * @see odp_schedule_group_create()
+ */
+odp_schedule_group_t odp_schedule_group_create_2(const char *name,
+						 const odp_thrmask_t *mask,
+						 const odp_schedule_group_param_t *param);
 
 /**
  * Schedule group destroy

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -1,9 +1,11 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2016-2018 Linaro Limited
- * Copyright (c) 2021-2024 Nokia
+ * Copyright (c) 2021-2025 Nokia
  */
 
 #include <odp/autoheader_internal.h>
+
+#include <odp/api/hints.h>
 
 #include <odp/api/plat/schedule_inline_types.h>
 #include <odp/api/plat/strong_types.h>
@@ -90,6 +92,18 @@ int odp_schedule_num_prio(void)
 
 odp_schedule_group_t odp_schedule_group_create(const char *name,
 					       const odp_thrmask_t *mask)
+{
+	return _odp_sched_api->schedule_group_create(name, mask);
+}
+
+void odp_schedule_group_param_init(odp_schedule_group_param_t *param)
+{
+	memset(param, 0, sizeof(*param));
+}
+
+odp_schedule_group_t odp_schedule_group_create_2(const char *name,
+						 const odp_thrmask_t *mask,
+						 const odp_schedule_group_param_t *p ODP_UNUSED)
 {
 	return _odp_sched_api->schedule_group_create(name, mask);
 }

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
- * Copyright (c) 2021-2023 Nokia
+ * Copyright (c) 2021-2025 Nokia
  */
 
 #include <odp_api.h>
@@ -12,7 +12,8 @@
 #define MAX_NUM_EVENT           (1 * 1024)
 #define MAX_ITERATION           (100)
 #define MAX_QUEUES              (64 * 1024)
-#define GLOBALS_NAME		"queue_test_globals"
+#define MULTI_QUEUES            (MAX_QUEUES / 2)
+#define GLOBALS_NAME            "queue_test_globals"
 #define DEQ_RETRIES             100
 #define ENQ_RETRIES             100
 
@@ -44,7 +45,7 @@ static odp_pool_t pool;
 
 static void generate_name(char *name, uint32_t index)
 {
-	/* Uniqueue name for up to 300M queues */
+	/* Unique name for up to 300M queues */
 	name[0] = 'A' + ((index / (26 * 26 * 26 * 26 * 26)) % 26);
 	name[1] = 'A' + ((index / (26 * 26 * 26 * 26)) % 26);
 	name[2] = 'A' + ((index / (26 * 26 * 26)) % 26);
@@ -251,15 +252,15 @@ static void queue_test_create_destroy_multi(void)
 {
 	odp_queue_capability_t capa;
 	odp_queue_param_t param_single;
-	odp_queue_param_t param[MAX_QUEUES];
-	odp_queue_t queue[MAX_QUEUES];
-	const char *name[MAX_QUEUES] = {NULL, "aaa", NULL, "bbb", "ccc", NULL, "ddd"};
+	odp_queue_param_t param[MULTI_QUEUES];
+	odp_queue_t queue[MULTI_QUEUES];
+	const char *name[MULTI_QUEUES] = {NULL, "aaa", NULL, "bbb", "ccc", NULL, "ddd"};
 	uint32_t num_queues, num_created;
 
 	CU_ASSERT_FATAL(odp_queue_capability(&capa) == 0);
 	CU_ASSERT_FATAL(capa.plain.max_num != 0);
 
-	num_queues = capa.plain.max_num < MAX_QUEUES ? capa.plain.max_num : MAX_QUEUES;
+	num_queues = capa.plain.max_num < MULTI_QUEUES ? capa.plain.max_num : MULTI_QUEUES;
 	for (uint32_t i = 0; i < num_queues; i++)
 		odp_queue_param_init(&param[i]);
 	odp_queue_param_init(&param_single);


### PR DESCRIPTION
Enable possibility to configure cache stashing at schedule group, priority and/or queue levels. Stashing data of to-be-scheduled events and queues may improve performance in some workloads.

For the moment, the cache stashing configuration is instantiated as hints. Implementation can utilize the information according to its capabilities.

v2:
- Petri's comments

v3:
- Refactored configuration toggle: moved region specific L2/L3 configuration toggle to a bitmap at `odp_cache_stash_config_t` level, this should make filling and parsing of the configuration more convenient

v4:
- Petri's comments

v5:
- Rebased
- Petri's comments
- Added barebone `linux-gen` implementation and validation tests

v6:
- Increased configuration bitfield width to 32 bits
- Added reviewed-by tag

v7:
- Matias' comments

v8:
- Reverted priority function calltime clarification patch

v9:
- Petri's comments
- Added reviewed-by tags