### PR TITLE
[PATCH v13] api: sched: enable additional global and group level configurability

### DIFF
--- a/include/odp/api/spec/schedule.h
+++ b/include/odp/api/spec/schedule.h
@@ -389,7 +389,7 @@ int odp_schedule_group_destroy(odp_schedule_group_t group);
  * @param name   Name of schedule group
  *
  * @return Handle of the first matching schedule group
- * @retval ODP_SCHEDULE_GROUP_INVALID No matching schedule group found
+ * @retval ODP_SCHED_GROUP_INVALID No matching schedule group found
  */
 odp_schedule_group_t odp_schedule_group_lookup(const char *name);
 

--- a/include/odp/api/spec/schedule.h
+++ b/include/odp/api/spec/schedule.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2024 Nokia
+ * Copyright (c) 2024-2025 Nokia
  */
 
 /**
@@ -340,6 +340,34 @@ int odp_schedule_capability(odp_schedule_capability_t *capa);
  */
 odp_schedule_group_t odp_schedule_group_create(const char *name,
 					       const odp_thrmask_t *mask);
+/**
+ * Initialize schedule group parameters
+ *
+ * Initialize an odp_schedule_group_param_t to its default values.
+ *
+ * @param[out] param  Pointer to parameter structure
+ */
+void odp_schedule_group_param_init(odp_schedule_group_param_t *param);
+
+/**
+ * Schedule group create with parameters
+ *
+ * Otherwise like odp_schedule_group_create() but additionally accepts a set of
+ * parameters.
+ *
+ * @param name    Name of the schedule group or NULL. Maximum string length is
+ *                ODP_SCHED_GROUP_NAME_LEN, including the null character.
+ * @param mask    Thread mask
+ * @param param   Schedule group parameters
+ *
+ * @return Schedule group handle
+ * @retval ODP_SCHED_GROUP_INVALID on failure
+ *
+ * @see odp_schedule_group_create()
+ */
+odp_schedule_group_t odp_schedule_group_create_2(const char *name,
+						 const odp_thrmask_t *mask,
+						 const odp_schedule_group_param_t *param);
 
 /**
  * Schedule group destroy

--- a/include/odp/api/spec/schedule.h
+++ b/include/odp/api/spec/schedule.h
@@ -223,10 +223,14 @@ void odp_schedule_prefetch(int num);
 /**
  * Maximum scheduling priority level
  *
- * This is the maximum value that can be set to 'prio' field in
- * odp_schedule_param_t (e.g. odp_queue_create()). Queues with a higher
- * priority value are served with higher priority than queues with a lower
- * priority value.
+ * This is the global maximum value that can be set to 'prio' field in
+ * odp_schedule_param_t (e.g. odp_queue_create()). Configured based on
+ * odp_schedule_config_t::prio. Queues with a higher priority value are
+ * served with higher priority than queues with a lower priority value.
+ *
+ * Schedule group specific maximum priority (see
+ * odp_schedule_group_param_t::prio) can be queried with
+ * odp_schedule_group_max_prio().
  *
  * @return Maximum scheduling priority level
  */
@@ -235,10 +239,14 @@ int odp_schedule_max_prio(void);
 /**
  * Minimum scheduling priority level
  *
- * This is the minimum value that can be set to 'prio' field in
- * odp_schedule_param_t (e.g. odp_queue_create()). Queues with a higher
- * priority value are served with higher priority than queues with a lower
- * priority value.
+ * This is the global minimum value that can be set to 'prio' field in
+ * odp_schedule_param_t (e.g. odp_queue_create()). Configured based on
+ * odp_schedule_config_t::prio. Queues with a higher priority value are
+ * served with higher priority than queues with a lower priority value.
+ *
+ * Schedule group specific minimum priority (see
+ * odp_schedule_group_param_t::prio) can be queried with
+ * odp_schedule_group_min_prio().
  *
  * @return Minimum scheduling priority level
  */
@@ -247,12 +255,17 @@ int odp_schedule_min_prio(void);
 /**
  * Default scheduling priority level
  *
- * This is the default value of 'prio' field in odp_schedule_param_t
- * (e.g. odp_queue_param_init()). The default value should be suitable for
+ * This is the global default value of 'prio' field in odp_schedule_param_t
+ * (e.g. odp_queue_param_init()). Configured based on
+ * odp_schedule_config_t::prio. The default value should be suitable for
  * an application that uses single priority level for all its queues (uses
  * scheduler only for load balancing and synchronization). Typically,
  * the default value is between minimum and maximum values, but with a few
  * priority levels it may be close or equal to those.
+ *
+ * Schedule group specific default priority (see
+ * odp_schedule_group_param_t::prio) can be queried with
+ * odp_schedule_group_default_prio().
  *
  * @return Default scheduling priority level
  */
@@ -261,12 +274,69 @@ int odp_schedule_default_prio(void);
 /**
  * Number of scheduling priorities
  *
- * The number of priority levels support by the scheduler. It equals to
- * odp_schedule_max_prio() - odp_schedule_min_prio() + 1.
+ * The number of global priority levels support by the scheduler. It equals to
+ * odp_schedule_max_prio() - odp_schedule_min_prio() + 1. Configured based on
+ * odp_schedule_config_t::prio.
+ *
+ * Schedule group specific priority count (see
+ * odp_schedule_group_param_t::prio) can be queried with
+ * odp_schedule_group_num_prio().
  *
  * @return Number of scheduling priorities
  */
 int odp_schedule_num_prio(void);
+
+/**
+ * Maximum schedule group specific priority level
+ *
+ * Similar to odp_schedule_max_prio(), but returns group specific maximum
+ * priority level.
+ *
+ * @param group  Schedule group handle
+ *
+ * @return Maximum schedule group specific priority level
+ * @retval <0 on failure
+ */
+int odp_schedule_group_max_prio(odp_schedule_group_t group);
+
+/**
+ * Minimum schedule group specific priority level
+ *
+ * Similar to odp_schedule_min_prio(), but returns group specific minimum
+ * priority level.
+ *
+ * @param group  Schedule group handle
+ *
+ * @return Minimum schedule group specific priority level
+ * @retval <0 on failure
+ */
+int odp_schedule_group_min_prio(odp_schedule_group_t group);
+
+/**
+ * Default schedule group specific priority level
+ *
+ * Similar to odp_schedule_default_prio(), but returns group specific default
+ * priority level.
+ *
+ * @param group  Schedule group handle
+ *
+ * @return Default schedule group specific priority level
+ * @retval <0 on failure
+ */
+int odp_schedule_group_default_prio(odp_schedule_group_t group);
+
+/**
+ * Number of schedule group specific priorities
+ *
+ * Similar to odp_schedule_num_prio(), but returns group specific number of
+ * priority levels.
+ *
+ * @param group  Schedule group handle
+ *
+ * @return Number of schedule group specific priorities
+ * @retval <0 on failure
+ */
+int odp_schedule_group_num_prio(odp_schedule_group_t group);
 
 /**
  * Initialize schedule configuration options

--- a/include/odp/api/spec/schedule_types.h
+++ b/include/odp/api/spec/schedule_types.h
@@ -167,9 +167,10 @@ extern "C" {
 /**
  * Scheduling priority level
  *
- * Priority level is an integer value between odp_schedule_min_prio() and
- * odp_schedule_max_prio(). Queues with a higher priority value are served with
- * higher priority than queues with a lower priority value.
+ * Priority level is a non-negative integer value between
+ * odp_schedule_min_prio() and odp_schedule_max_prio(). Queues with a higher
+ * priority value are served with higher priority than queues with a lower
+ * priority value.
  */
 typedef int odp_schedule_prio_t;
 

--- a/platform/linux-generic/include/odp/api/plat/schedule_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/schedule_inline_types.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2022 Nokia
+ * Copyright (c) 2022-2025 Nokia
  */
 
 #ifndef ODP_PLAT_SCHEDULE_INLINE_TYPES_H_
@@ -37,7 +37,14 @@ typedef struct {
 	int (*schedule_max_prio)(void);
 	int (*schedule_default_prio)(void);
 	int (*schedule_num_prio)(void);
+	int (*schedule_group_min_prio)(odp_schedule_group_t group);
+	int (*schedule_group_max_prio)(odp_schedule_group_t group);
+	int (*schedule_group_default_prio)(odp_schedule_group_t group);
+	int (*schedule_group_num_prio)(odp_schedule_group_t group);
 	odp_schedule_group_t (*schedule_group_create)(const char *name, const odp_thrmask_t *mask);
+	odp_schedule_group_t (*schedule_group_create_2)(const char *name,
+							const odp_thrmask_t *mask,
+							const odp_schedule_group_param_t *param);
 	int (*schedule_group_destroy)(odp_schedule_group_t group);
 	odp_schedule_group_t (*schedule_group_lookup)(const char *name);
 	int (*schedule_group_join)(odp_schedule_group_t group, const odp_thrmask_t *mask);

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2021 Nokia
+ * Copyright (c) 2021-2025 Nokia
  */
 
 #ifndef ODP_SCHEDULE_IF_H_
@@ -29,6 +29,12 @@ typedef struct schedule_config_t {
 		int worker;
 		int control;
 	} group_enable;
+
+	uint32_t num_groups;
+	uint32_t num_prios;
+	int min_prio;
+	int max_prio;
+	int def_prio;
 
 } schedule_config_t;
 

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -90,6 +90,26 @@ int odp_schedule_num_prio(void)
 	return _odp_sched_api->schedule_num_prio();
 }
 
+int odp_schedule_group_min_prio(odp_schedule_group_t group)
+{
+	return _odp_sched_api->schedule_group_min_prio(group);
+}
+
+int odp_schedule_group_max_prio(odp_schedule_group_t group)
+{
+	return _odp_sched_api->schedule_group_max_prio(group);
+}
+
+int odp_schedule_group_default_prio(odp_schedule_group_t group)
+{
+	return _odp_sched_api->schedule_group_default_prio(group);
+}
+
+int odp_schedule_group_num_prio(odp_schedule_group_t group)
+{
+	return _odp_sched_api->schedule_group_num_prio(group);
+}
+
 odp_schedule_group_t odp_schedule_group_create(const char *name,
 					       const odp_thrmask_t *mask)
 {
@@ -103,9 +123,9 @@ void odp_schedule_group_param_init(odp_schedule_group_param_t *param)
 
 odp_schedule_group_t odp_schedule_group_create_2(const char *name,
 						 const odp_thrmask_t *mask,
-						 const odp_schedule_group_param_t *p ODP_UNUSED)
+						 const odp_schedule_group_param_t *param)
 {
-	return _odp_sched_api->schedule_group_create(name, mask);
+	return _odp_sched_api->schedule_group_create_2(name, mask, param);
 }
 
 int odp_schedule_group_destroy(odp_schedule_group_t group)

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -1,9 +1,11 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2016-2018 Linaro Limited
- * Copyright (c) 2021-2024 Nokia
+ * Copyright (c) 2021-2025 Nokia
  */
 
 #include <odp/autoheader_internal.h>
+
+#include <odp/api/hints.h>
 
 #include <odp/api/plat/schedule_inline_types.h>
 #include <odp/api/plat/strong_types.h>
@@ -90,6 +92,18 @@ int odp_schedule_num_prio(void)
 
 odp_schedule_group_t odp_schedule_group_create(const char *name,
 					       const odp_thrmask_t *mask)
+{
+	return _odp_sched_api->schedule_group_create(name, mask);
+}
+
+void odp_schedule_group_param_init(odp_schedule_group_param_t *param)
+{
+	memset(param, 0, sizeof(*param));
+}
+
+odp_schedule_group_t odp_schedule_group_create_2(const char *name,
+						 const odp_thrmask_t *mask,
+						 const odp_schedule_group_param_t *p ODP_UNUSED)
 {
 	return _odp_sched_api->schedule_group_create(name, mask);
 }

--- a/test/validation/api/Makefile.am
+++ b/test/validation/api/Makefile.am
@@ -79,6 +79,7 @@ TESTS = \
 	random/random_main$(EXEEXT) \
 	scheduler/scheduler_main$(EXEEXT) \
 	scheduler/scheduler_no_predef_groups$(EXEEXT) \
+	scheduler/scheduler_group_prio_config$(EXEEXT) \
 	stash/stash_main$(EXEEXT) \
 	std/std_main$(EXEEXT) \
 	thread/thread_main$(EXEEXT) \

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
- * Copyright (c) 2021-2023 Nokia
+ * Copyright (c) 2021-2025 Nokia
  */
 
 #include <odp_api.h>
@@ -12,7 +12,8 @@
 #define MAX_NUM_EVENT           (1 * 1024)
 #define MAX_ITERATION           (100)
 #define MAX_QUEUES              (64 * 1024)
-#define GLOBALS_NAME		"queue_test_globals"
+#define MULTI_QUEUES            (MAX_QUEUES / 2)
+#define GLOBALS_NAME            "queue_test_globals"
 #define DEQ_RETRIES             100
 #define ENQ_RETRIES             100
 
@@ -44,7 +45,7 @@ static odp_pool_t pool;
 
 static void generate_name(char *name, uint32_t index)
 {
-	/* Uniqueue name for up to 300M queues */
+	/* Unique name for up to 300M queues */
 	name[0] = 'A' + ((index / (26 * 26 * 26 * 26 * 26)) % 26);
 	name[1] = 'A' + ((index / (26 * 26 * 26 * 26)) % 26);
 	name[2] = 'A' + ((index / (26 * 26 * 26)) % 26);
@@ -251,15 +252,15 @@ static void queue_test_create_destroy_multi(void)
 {
 	odp_queue_capability_t capa;
 	odp_queue_param_t param_single;
-	odp_queue_param_t param[MAX_QUEUES];
-	odp_queue_t queue[MAX_QUEUES];
-	const char *name[MAX_QUEUES] = {NULL, "aaa", NULL, "bbb", "ccc", NULL, "ddd"};
+	odp_queue_param_t param[MULTI_QUEUES];
+	odp_queue_t queue[MULTI_QUEUES];
+	const char *name[MULTI_QUEUES] = {NULL, "aaa", NULL, "bbb", "ccc", NULL, "ddd"};
 	uint32_t num_queues, num_created;
 
 	CU_ASSERT_FATAL(odp_queue_capability(&capa) == 0);
 	CU_ASSERT_FATAL(capa.plain.max_num != 0);
 
-	num_queues = capa.plain.max_num < MAX_QUEUES ? capa.plain.max_num : MAX_QUEUES;
+	num_queues = capa.plain.max_num < MULTI_QUEUES ? capa.plain.max_num : MULTI_QUEUES;
 	for (uint32_t i = 0; i < num_queues; i++)
 		odp_queue_param_init(&param[i]);
 	odp_queue_param_init(&param_single);

--- a/test/validation/api/scheduler/.gitignore
+++ b/test/validation/api/scheduler/.gitignore
@@ -1,2 +1,3 @@
 scheduler_main
 scheduler_no_predef_groups
+scheduler_group_prio_config

--- a/test/validation/api/scheduler/Makefile.am
+++ b/test/validation/api/scheduler/Makefile.am
@@ -1,5 +1,6 @@
 include ../Makefile.inc
 
-test_PROGRAMS = scheduler_main scheduler_no_predef_groups
+test_PROGRAMS = scheduler_main scheduler_no_predef_groups scheduler_group_prio_config
 scheduler_main_SOURCES = scheduler.c
-scheduler_no_predef_groups = scheduler_no_predef_groups.c
+scheduler_no_predef_groups_SOURCES = scheduler_no_predef_groups.c
+scheduler_group_prio_config_SOURCES = scheduler_group_prio_config.c

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -164,21 +164,31 @@ static void release_context(odp_schedule_sync_t sync)
 
 static void test_init(uint8_t fill)
 {
+	odp_schedule_capability_t sched_capa;
 	odp_schedule_config_t default_config;
+
+	CU_ASSERT_FATAL(odp_schedule_capability(&sched_capa) == 0);
 
 	memset(&default_config, fill, sizeof(default_config));
 	odp_schedule_config_init(&default_config);
 
+	CU_ASSERT(default_config.num_groups == sched_capa.max_groups);
+	CU_ASSERT(default_config.prio.min == sched_capa.min_prio);
+	CU_ASSERT(default_config.prio.num == sched_capa.max_prios);
+	CU_ASSERT(default_config.num_queues == sched_capa.max_queues);
 	CU_ASSERT(default_config.max_flow_id == 0);
 
 	CU_ASSERT(default_config.sched_group.all);
 	CU_ASSERT(default_config.sched_group.control);
 	CU_ASSERT(default_config.sched_group.worker);
+	CU_ASSERT(default_config.sched_group.all_param.prio.num == 0);
 	CU_ASSERT(default_config.sched_group.all_param.cache_stash_hints.common.regions.all == 0);
 	CU_ASSERT(default_config.sched_group.all_param.cache_stash_hints.num == 0);
+	CU_ASSERT(default_config.sched_group.control_param.prio.num == 0);
 	CU_ASSERT(default_config.sched_group.control_param.cache_stash_hints.common.regions.all
 		  == 0);
 	CU_ASSERT(default_config.sched_group.control_param.cache_stash_hints.num == 0);
+	CU_ASSERT(default_config.sched_group.worker_param.prio.num == 0);
 	CU_ASSERT(default_config.sched_group.worker_param.cache_stash_hints.common.regions.all
 		  == 0);
 	CU_ASSERT(default_config.sched_group.worker_param.cache_stash_hints.num == 0);
@@ -1006,6 +1016,7 @@ static void scheduler_test_group_param_init(void)
 
 	memset(&param, 0xff, sizeof(param));
 	odp_schedule_group_param_init(&param);
+	CU_ASSERT(param.prio.num == 0);
 	CU_ASSERT(param.cache_stash_hints.common.regions.all == 0);
 	CU_ASSERT(param.cache_stash_hints.num == 0);
 }

--- a/test/validation/api/scheduler/scheduler_group_prio_config.c
+++ b/test/validation/api/scheduler/scheduler_group_prio_config.c
@@ -1,0 +1,197 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "odp_cunit_common.h"
+
+static struct {
+	const uint32_t num_groups;
+	int min_prio;
+	const uint32_t num_prios;
+	int min_g_prio;
+	uint32_t num_g_prios;
+	odp_bool_t are_groups_constrained;
+	odp_bool_t are_prios_constrained;
+} test_info = { 4U, 0, 2U, 0, 0U, false, false };
+
+static int are_groups_constrained(void)
+{
+	return test_info.are_groups_constrained ? ODP_TEST_ACTIVE : ODP_TEST_INACTIVE;
+}
+
+static void schedule_config_limits_max_groups(void)
+{
+	odp_thrmask_t mask;
+	odp_schedule_group_t group1, group2;
+
+	odp_thrmask_zero(&mask);
+	odp_thrmask_set(&mask, odp_thread_id());
+	group1 = odp_schedule_group_create(NULL, &mask);
+
+	CU_ASSERT_FATAL(group1 != ODP_SCHED_GROUP_INVALID);
+
+	group2 = odp_schedule_group_create(NULL, &mask);
+
+	CU_ASSERT_FATAL(group2 == ODP_SCHED_GROUP_INVALID);
+	CU_ASSERT_FATAL(odp_schedule_group_destroy(group1) == 0);
+}
+
+static int are_prios_constrained(void)
+{
+	return test_info.are_prios_constrained ? ODP_TEST_ACTIVE : ODP_TEST_INACTIVE;
+}
+
+static void check_group_prios(odp_schedule_group_t group)
+{
+	const int min_prio = odp_schedule_group_min_prio(group),
+	max_prio = odp_schedule_group_max_prio(group),
+	def_prio = odp_schedule_group_default_prio(group),
+	num_prio = odp_schedule_group_num_prio(group);
+
+	CU_ASSERT(num_prio == (int)test_info.num_g_prios);
+	CU_ASSERT(min_prio == test_info.min_g_prio);
+	CU_ASSERT(max_prio == min_prio + num_prio - 1);
+	CU_ASSERT(def_prio >= min_prio && def_prio <= max_prio);
+}
+
+static void schedule_config_limits_max_prios(void)
+{
+	const int min_prio = odp_schedule_min_prio(), max_prio = odp_schedule_max_prio(),
+	def_prio = odp_schedule_default_prio(), num_prio = odp_schedule_num_prio();
+
+	CU_ASSERT(num_prio == (int)test_info.num_prios);
+	CU_ASSERT(min_prio == test_info.min_prio)
+	CU_ASSERT(max_prio == min_prio + num_prio - 1);
+	CU_ASSERT(def_prio >= min_prio && def_prio <= max_prio);
+
+	check_group_prios(ODP_SCHED_GROUP_ALL);
+	check_group_prios(ODP_SCHED_GROUP_WORKER);
+	check_group_prios(ODP_SCHED_GROUP_CONTROL);
+}
+
+static void schedule_group_param_limits_group_prios(void)
+{
+	odp_thrmask_t mask;
+	odp_schedule_group_param_t param;
+	odp_schedule_group_t group;
+
+	odp_thrmask_zero(&mask);
+	odp_thrmask_set(&mask, odp_thread_id());
+	odp_schedule_group_param_init(&param);
+	param.prio.min = test_info.min_g_prio;
+	param.prio.num = test_info.num_g_prios;
+	group = odp_schedule_group_create_2(NULL, &mask, &param);
+
+	CU_ASSERT_FATAL(group != ODP_SCHED_GROUP_INVALID);
+
+	check_group_prios(group);
+
+	CU_ASSERT_FATAL(odp_schedule_group_destroy(group) == 0);
+}
+
+static int suite_init(void)
+{
+	odp_schedule_capability_t capa;
+	odp_schedule_config_t config;
+
+	if (odp_schedule_capability(&capa) < 0) {
+		ODPH_ERR("Scheduler capability query failed\n");
+		return -1;
+	}
+
+	odp_schedule_config_init(&config);
+
+	/* Group count will be limited if it is feasible to limit it. */
+	if (config.num_groups > test_info.num_groups) {
+		config.num_groups = test_info.num_groups;
+		test_info.are_groups_constrained = true;
+	}
+
+	/* Prio count will be limited if it is feasible to limit it. */
+	if (config.prio.num > test_info.num_prios) {
+		config.prio.num = test_info.num_prios;
+		test_info.min_prio = capa.min_prio + 1;
+		config.prio.min = test_info.min_prio;
+		test_info.min_g_prio = test_info.min_prio + 1;
+		test_info.num_g_prios = test_info.num_prios - 1;
+		test_info.are_prios_constrained = true;
+	}
+
+	if (test_info.are_prios_constrained) {
+		config.sched_group.all_param.prio.min = test_info.min_g_prio;
+		config.sched_group.all_param.prio.num = test_info.num_g_prios;
+		config.sched_group.worker_param.prio.min = test_info.min_g_prio;
+		config.sched_group.worker_param.prio.num = test_info.num_g_prios;
+		config.sched_group.control_param.prio.min = test_info.min_g_prio;
+		config.sched_group.control_param.prio.num = test_info.num_g_prios;
+	}
+
+	if (odp_schedule_config(&config) < 0) {
+		ODPH_ERR("Scheduler configuration failed\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int suite_term(void)
+{
+	return odp_cunit_print_inactive();
+}
+
+odp_testinfo_t suite[] = {
+	ODP_TEST_INFO_CONDITIONAL(schedule_config_limits_max_groups, are_groups_constrained),
+	ODP_TEST_INFO_CONDITIONAL(schedule_config_limits_max_prios, are_prios_constrained),
+	ODP_TEST_INFO_CONDITIONAL(schedule_group_param_limits_group_prios, are_prios_constrained),
+	ODP_TEST_INFO_NULL,
+};
+
+odp_suiteinfo_t suites[] = {
+	{ "Scheduler group and prio config", suite_init, suite_term, suite },
+	ODP_SUITE_INFO_NULL,
+};
+
+static int global_init(odp_instance_t *inst)
+{
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
+
+	if (odph_options(&helper_options) == -1) {
+		ODPH_ERR("Helper option parsing failed\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (odp_init_global(inst, &init_param, NULL)) {
+		ODPH_ERR("ODP global initialization failed\n");
+		return -1;
+	}
+
+	if (odp_init_local(*inst, ODP_THREAD_CONTROL)) {
+		ODPH_ERR("ODP local initialization failed\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	if (odp_cunit_parse_options(&argc, argv))
+		return -1;
+
+	odp_cunit_register_global_init(global_init);
+	ret = odp_cunit_register(suites);
+
+	if (ret == 0)
+		ret = odp_cunit_run();
+
+	return ret;
+}

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2015-2018 Linaro Limited
- * Copyright (c) 2019-2023 Nokia
+ * Copyright (c) 2019-2025 Nokia
  */
 
 /* For rand_r and nanosleep */
@@ -2563,6 +2563,7 @@ static void timer_test_all(odp_queue_type_t queue_type)
 	odp_timer_pool_t tp;
 	uint32_t num_timers;
 	uint32_t num_workers;
+	uint32_t max_groups;
 	int timers_per_thread;
 	odp_timer_clk_src_t clk_src = test_global->clk_src;
 
@@ -2571,14 +2572,15 @@ static void timer_test_all(odp_queue_type_t queue_type)
 	 * test hopefully can run undisturbed and thus get better timing
 	 * results. */
 	num_workers = odp_cpumask_default_worker(NULL, 0);
+	max_groups = sched_capa.max_groups - 3;
 
 	/* force to max CPU count */
 	if (num_workers > MAX_WORKERS)
 		num_workers = MAX_WORKERS;
 
 	if (queue_type == ODP_QUEUE_TYPE_SCHED &&
-	    num_workers > sched_capa.max_groups)
-		num_workers = sched_capa.max_groups;
+	    num_workers > max_groups)
+		num_workers = max_groups;
 
 	/* On a single-CPU machine run at least one thread */
 	if (num_workers < 1)


### PR DESCRIPTION
Application can now add additional global and group level scheduler configuration to signal maximum number of groups and priorities that need to be supported. These enable potential further resource optimizations.

On top of #2188

v2:
- Matias' comments

v3:
- Matias' comments

v4:
- Matias' comments
- Added a typo fixing patch

v5:
- Added possibility for new group specific priority functions to fail

v6:
- Clarified priority level value space

v7:
- Added reviewed-by tags

v8:
- Petri's comment
- Added reviewed-by tags

v9:
- Rebased
- Added scheduler capability to signal the minimum priority value supported by an implementation, this is to be utilized when creating predefined scheduling groups during global scheduler configuration

v10:
- Rebased
- Petri's comment
- Added implementation and validation tests

v11:
- Matias' comments

v12:
- Petri's comment

v13:
- Matias' comment
- Added reviewed-by tags