### PR TITLE
[PATCH v3] api: clean 'extern "C"' usage

### DIFF
--- a/helper/include/odp/helper/chksum.h
+++ b/helper/include/odp/helper/chksum.h
@@ -10,11 +10,11 @@
 #ifndef ODPH_CHKSUM_H_
 #define ODPH_CHKSUM_H_
 
+#include <odp_api.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp_api.h>
 
 /** @defgroup odph_chksum ODPH CHECKSUM
  * TCP/UDP/SCTP checksum

--- a/helper/include/odp/helper/cli.h
+++ b/helper/include/odp/helper/cli.h
@@ -11,12 +11,12 @@
 #ifndef ODPH_CLI_H_
 #define ODPH_CLI_H_
 
+#include <stdarg.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
-#include <stdarg.h>
 
 /**
  * @defgroup odph_cli ODPH CLI

--- a/helper/include/odp/helper/deprecated.h
+++ b/helper/include/odp/helper/deprecated.h
@@ -12,11 +12,11 @@
 #ifndef ODPH_DEPRECATED_H_
 #define ODPH_DEPRECATED_H_
 
+#include <odp/helper/autoheader_external.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/helper/autoheader_external.h>
 
 /**
  * @def ODPH_DEPRECATE

--- a/helper/include/odp/helper/eth.h
+++ b/helper/include/odp/helper/eth.h
@@ -11,11 +11,11 @@
 #ifndef ODPH_ETH_H_
 #define ODPH_ETH_H_
 
+#include <odp_api.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp_api.h>
 
 /**
  * @defgroup odph_protocols ODPH PROTOCOLS

--- a/helper/include/odp/helper/gtp.h
+++ b/helper/include/odp/helper/gtp.h
@@ -10,11 +10,11 @@
 #ifndef _ODPH_GTP_H_
 #define _ODPH_GTP_H_
 
+#include <odp_api.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp_api.h>
 
 /**
  * @addtogroup odph_protocols

--- a/helper/include/odp/helper/icmp.h
+++ b/helper/include/odp/helper/icmp.h
@@ -12,11 +12,11 @@
 #ifndef ODPH_ICMP_H_
 #define ODPH_ICMP_H_
 
+#include <odp_api.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp_api.h>
 
 /**
  * @addtogroup odph_protocols

--- a/helper/include/odp/helper/igmp.h
+++ b/helper/include/odp/helper/igmp.h
@@ -10,11 +10,11 @@
 #ifndef _ODPH_IGMP_H_
 #define _ODPH_IGMP_H_
 
+#include <odp_api.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp_api.h>
 
 /**
  * @addtogroup odph_protocols

--- a/helper/include/odp/helper/ip.h
+++ b/helper/include/odp/helper/ip.h
@@ -11,14 +11,14 @@
 #ifndef ODPH_IP_H_
 #define ODPH_IP_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp_api.h>
 #include <odp/helper/chksum.h>
 
 #include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @addtogroup odph_protocols

--- a/helper/include/odp/helper/ipsec.h
+++ b/helper/include/odp/helper/ipsec.h
@@ -13,11 +13,11 @@
 #ifndef ODPH_IPSEC_H_
 #define ODPH_IPSEC_H_
 
+#include <odp_api.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp_api.h>
 
 /**
  * @addtogroup odph_protocols

--- a/helper/include/odp/helper/linux.h
+++ b/helper/include/odp/helper/linux.h
@@ -12,14 +12,7 @@
 #ifndef ODP_HELPER_LINUX_H_
 #define ODP_HELPER_LINUX_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/helper/linux/process.h>
 #include <odp/helper/linux/pthread.h>
 
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/helper/include/odp/helper/odph_api.h
+++ b/helper/include/odp/helper/odph_api.h
@@ -15,10 +15,6 @@
 #ifndef ODP_HELPER_H_
 #define ODP_HELPER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/helper/autoheader_external.h>
 
 #include <odp/helper/chksum.h>
@@ -43,7 +39,4 @@ extern "C" {
 #include <odp/helper/cli.h>
 #endif
 
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/helper/include/odp/helper/sctp.h
+++ b/helper/include/odp/helper/sctp.h
@@ -11,11 +11,11 @@
 #ifndef ODPH_SCTP_H_
 #define ODPH_SCTP_H_
 
+#include <odp_api.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp_api.h>
 
 /**
  * @addtogroup odph_protocols

--- a/helper/include/odp/helper/tcp.h
+++ b/helper/include/odp/helper/tcp.h
@@ -12,11 +12,11 @@
 #ifndef ODPH_TCP_H_
 #define ODPH_TCP_H_
 
+#include <odp_api.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp_api.h>
 
 /**
  * @addtogroup odph_protocols

--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -17,15 +17,15 @@
 #ifndef ODPH_LINUX_H_
 #define ODPH_LINUX_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp_api.h>
 
 #include <pthread.h>
 #include <getopt.h>
 #include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup odph_thread ODPH THREAD

--- a/helper/include/odp/helper/udp.h
+++ b/helper/include/odp/helper/udp.h
@@ -11,12 +11,12 @@
 #ifndef ODPH_UDP_H_
 #define ODPH_UDP_H_
 
+#include <odp_api.h>
+#include <odp/helper/chksum.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp_api.h>
-#include <odp/helper/chksum.h>
 
 /**
  * @addtogroup odph_protocols

--- a/include/odp/api/abi-default/align.h
+++ b/include/odp/api/abi-default/align.h
@@ -11,11 +11,11 @@
 #ifndef ODP_ABI_ALIGN_H_
 #define ODP_ABI_ALIGN_H_
 
+#include <odp/api/abi/cpu.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/abi/cpu.h>
 
 /** @addtogroup odp_compiler_optim
  *  @{

--- a/include/odp/api/abi-default/atomic.h
+++ b/include/odp/api/abi-default/atomic.h
@@ -12,12 +12,12 @@
 #ifndef ODP_ABI_ATOMIC_H_
 #define ODP_ABI_ATOMIC_H_
 
+#include <odp/api/std_types.h>
+#include <odp/api/align.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/align.h>
 
 /**
  * @internal

--- a/include/odp/api/abi-default/barrier.h
+++ b/include/odp/api/abi-default/barrier.h
@@ -11,12 +11,12 @@
 #ifndef ODP_ABI_BARRIER_H_
 #define ODP_ABI_BARRIER_H_
 
+#include <odp/api/std_types.h>
+#include <odp/api/atomic.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/atomic.h>
 
 /**
  * @internal

--- a/include/odp/api/abi-default/buffer.h
+++ b/include/odp/api/abi-default/buffer.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_BUFFER_H_
 #define ODP_ABI_BUFFER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/byteorder.h
+++ b/include/odp/api/abi-default/byteorder.h
@@ -11,11 +11,11 @@
 #ifndef ODP_ABI_BYTEORDER_H_
 #define ODP_ABI_BYTEORDER_H_
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 #ifndef __BYTE_ORDER__
 #error __BYTE_ORDER__ not defined!

--- a/include/odp/api/abi-default/comp.h
+++ b/include/odp/api/abi-default/comp.h
@@ -5,11 +5,11 @@
 #ifndef ODP_ABI_COMP_H_
 #define ODP_ABI_COMP_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_comp_session_t;

--- a/include/odp/api/abi-default/cpumask.h
+++ b/include/odp/api/abi-default/cpumask.h
@@ -11,6 +11,11 @@
 #ifndef ODP_ABI_CPUMASK_H_
 #define ODP_ABI_CPUMASK_H_
 
+#include <odp/api/align.h>
+#include <odp/api/std_types.h>
+
+#include <sched.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -18,10 +23,6 @@ extern "C" {
 /** @addtogroup odp_cpumask
  *  @{
  */
-
-#include <odp/api/std_types.h>
-#include <odp/api/align.h>
-#include <sched.h>
 
 #define ODP_CPUMASK_SIZE (sizeof(cpu_set_t) * 8)
 

--- a/include/odp/api/abi-default/crypto.h
+++ b/include/odp/api/abi-default/crypto.h
@@ -6,14 +6,6 @@
 #ifndef ODP_ABI_CRYPTO_H_
 #define ODP_ABI_CRYPTO_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/crypto_types.h
+++ b/include/odp/api/abi-default/crypto_types.h
@@ -6,11 +6,11 @@
 #ifndef ODP_ABI_CRYPTO_TYPES_H_
 #define ODP_ABI_CRYPTO_TYPES_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @addtogroup odp_crypto
  *  @{

--- a/include/odp/api/abi-default/dma.h
+++ b/include/odp/api/abi-default/dma.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_DMA_H_
 #define ODP_ABI_DMA_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/dma_types.h
+++ b/include/odp/api/abi-default/dma_types.h
@@ -5,11 +5,11 @@
 #ifndef ODP_ABI_DMA_TYPES_H_
 #define ODP_ABI_DMA_TYPES_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_dma_t;

--- a/include/odp/api/abi-default/event.h
+++ b/include/odp/api/abi-default/event.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_EVENT_H_
 #define ODP_ABI_EVENT_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/event_types.h
+++ b/include/odp/api/abi-default/event_types.h
@@ -6,11 +6,11 @@
 #ifndef ODP_ABI_EVENT_TYPES_H_
 #define ODP_ABI_EVENT_TYPES_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_event_t;

--- a/include/odp/api/abi-default/init.h
+++ b/include/odp/api/abi-default/init.h
@@ -11,11 +11,11 @@
 #ifndef ODP_ABI_INIT_H_
 #define ODP_ABI_INIT_H_
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 typedef uint64_t odp_instance_t;
 

--- a/include/odp/api/abi-default/ipsec.h
+++ b/include/odp/api/abi-default/ipsec.h
@@ -6,14 +6,6 @@
 #ifndef ODP_ABI_IPSEC_H_
 #define ODP_ABI_IPSEC_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the packet inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/ipsec_types.h
+++ b/include/odp/api/abi-default/ipsec_types.h
@@ -6,11 +6,11 @@
 #ifndef ODP_ABI_IPSEC_TYPES_H_
 #define ODP_ABI_IPSEC_TYPES_H_
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_ipsec_sa_t;

--- a/include/odp/api/abi-default/packet.h
+++ b/include/odp/api/abi-default/packet.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_PACKET_H_
 #define ODP_ABI_PACKET_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the packet inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/packet_flags.h
+++ b/include/odp/api/abi-default/packet_flags.h
@@ -11,12 +11,6 @@
 #ifndef ODP_ABI_PACKET_FLAGS_H_
 #define ODP_ABI_PACKET_FLAGS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#ifdef __cplusplus
-}
-#endif
+/* Empty header required due to the inline functions */
 
 #endif

--- a/include/odp/api/abi-default/packet_io.h
+++ b/include/odp/api/abi-default/packet_io.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_PACKET_IO_H_
 #define ODP_ABI_PACKET_IO_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the packet inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/packet_io_types.h
+++ b/include/odp/api/abi-default/packet_io_types.h
@@ -12,11 +12,11 @@
 #ifndef ODP_ABI_PACKET_IO_TYPES_H_
 #define ODP_ABI_PACKET_IO_TYPES_H_
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_pktio_t;

--- a/include/odp/api/abi-default/packet_types.h
+++ b/include/odp/api/abi-default/packet_types.h
@@ -6,11 +6,11 @@
 #ifndef ODP_ABI_PACKET_TYPES_H_
 #define ODP_ABI_PACKET_TYPES_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_packet_t;

--- a/include/odp/api/abi-default/pool.h
+++ b/include/odp/api/abi-default/pool.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_POOL_H_
 #define ODP_ABI_POOL_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the packet inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/proto_stats.h
+++ b/include/odp/api/abi-default/proto_stats.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_PROTO_STATS_H_
 #define ODP_ABI_PROTO_STATS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required to enable API function inlining */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/proto_stats_types.h
+++ b/include/odp/api/abi-default/proto_stats_types.h
@@ -6,11 +6,11 @@
 #ifndef ODP_ABI_PROTO_STATS_TYPES_H_
 #define ODP_ABI_PROTO_STATS_TYPES_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_proto_stats_t;

--- a/include/odp/api/abi-default/queue.h
+++ b/include/odp/api/abi-default/queue.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_QUEUE_H_
 #define ODP_ABI_QUEUE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the queue inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/random.h
+++ b/include/odp/api/abi-default/random.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_RANDOM_H_
 #define ODP_ABI_RANDOM_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the packet inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/rwlock.h
+++ b/include/odp/api/abi-default/rwlock.h
@@ -11,11 +11,11 @@
 #ifndef ODP_ABI_RWLOCK_H_
 #define ODP_ABI_RWLOCK_H_
 
+#include <odp/api/atomic.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/atomic.h>
 
 /** @internal */
 typedef struct odp_rwlock_s {

--- a/include/odp/api/abi-default/rwlock_recursive.h
+++ b/include/odp/api/abi-default/rwlock_recursive.h
@@ -11,13 +11,13 @@
 #ifndef ODP_ABI_RWLOCK_RECURSIVE_H_
 #define ODP_ABI_RWLOCK_RECURSIVE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/rwlock.h>
 #include <odp/api/std_types.h>
 #include <odp/api/thread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @internal */
 typedef struct odp_rwlock_recursive_s {

--- a/include/odp/api/abi-default/schedule.h
+++ b/include/odp/api/abi-default/schedule.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_SCHEDULE_H_
 #define ODP_ABI_SCHEDULE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the schedule inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/schedule_types.h
+++ b/include/odp/api/abi-default/schedule_types.h
@@ -11,11 +11,11 @@
 #ifndef ODP_ABI_SCHEDULE_TYPES_H_
 #define ODP_ABI_SCHEDULE_TYPES_H_
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @addtogroup odp_scheduler
  *  @{

--- a/include/odp/api/abi-default/spinlock_recursive.h
+++ b/include/odp/api/abi-default/spinlock_recursive.h
@@ -11,12 +11,12 @@
 #ifndef ODP_ABI_SPINLOCK_RECURSIVE_H_
 #define ODP_ABI_SPINLOCK_RECURSIVE_H_
 
+#include <odp/api/spinlock.h>
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/spinlock.h>
-#include <odp/api/std_types.h>
 
 /** @internal */
 typedef struct odp_spinlock_recursive_s {

--- a/include/odp/api/abi-default/stash.h
+++ b/include/odp/api/abi-default/stash.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_STASH_H_
 #define ODP_ABI_STASH_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/std.h
+++ b/include/odp/api/abi-default/std.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_STD_H_
 #define ODP_ABI_STD_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/std_types.h
+++ b/include/odp/api/abi-default/std_types.h
@@ -5,10 +5,6 @@
 #ifndef ODP_ABI_STD_TYPES_H_
 #define ODP_ABI_STD_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* uint64_t, uint32_t, etc */
 #include <stdint.h>
 
@@ -17,6 +13,10 @@ extern "C" {
 
 /* true and false for odp_bool_t */
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @addtogroup odp_std
  *  @{

--- a/include/odp/api/abi-default/sync.h
+++ b/include/odp/api/abi-default/sync.h
@@ -11,12 +11,6 @@
 #ifndef ODP_ABI_SYNC_H_
 #define ODP_ABI_SYNC_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#ifdef __cplusplus
-}
-#endif
+/* Empty header required due to inline functions */
 
 #endif

--- a/include/odp/api/abi-default/thread.h
+++ b/include/odp/api/abi-default/thread.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_THREAD_H_
 #define ODP_ABI_THREAD_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/thrmask.h
+++ b/include/odp/api/abi-default/thrmask.h
@@ -11,6 +11,8 @@
 #ifndef ODP_ABI_THRMASK_H_
 #define ODP_ABI_THRMASK_H_
 
+#include <odp/api/cpumask.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -18,8 +20,6 @@ extern "C" {
 /** @addtogroup odp_thread
  *  @{
  */
-
-#include <odp/api/cpumask.h>
 
 /**
  * Minimum size of output buffer for odp_thrmask_to_str()

--- a/include/odp/api/abi-default/ticketlock.h
+++ b/include/odp/api/abi-default/ticketlock.h
@@ -11,11 +11,11 @@
 #ifndef ODP_ABI_TICKETLOCK_H_
 #define ODP_ABI_TICKETLOCK_H_
 
+#include <odp/api/atomic.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/atomic.h>
 
 /** @internal */
 typedef struct odp_ticketlock_s {

--- a/include/odp/api/abi-default/time.h
+++ b/include/odp/api/abi-default/time.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_TIME_H_
 #define ODP_ABI_TIME_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/time_types.h
+++ b/include/odp/api/abi-default/time_types.h
@@ -5,11 +5,11 @@
 #ifndef ODP_ABI_TIME_TYPES_H_
 #define ODP_ABI_TIME_TYPES_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @addtogroup odp_time
  *  @{

--- a/include/odp/api/abi-default/timer.h
+++ b/include/odp/api/abi-default/timer.h
@@ -5,14 +5,6 @@
 #ifndef ODP_ABI_TIMER_H_
 #define ODP_ABI_TIMER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty header required due to the timer inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/abi-default/traffic_mngr.h
+++ b/include/odp/api/abi-default/traffic_mngr.h
@@ -12,11 +12,11 @@
 #ifndef ODP_ABI_TRAFFIC_MNGR_H_
 #define ODP_ABI_TRAFFIC_MNGR_H_
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @addtogroup odp_traffic_mngr
  *  Macros and operations on a TM system.

--- a/include/odp/api/align.h
+++ b/include/odp/api/align.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_ALIGN_H_
 #define ODP_API_ALIGN_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/align.h>
 
 #include <odp/api/spec/align.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/atomic.h
+++ b/include/odp/api/atomic.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_ATOMIC_H_
 #define ODP_API_ATOMIC_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/atomic.h>
 
 #include <odp/api/spec/atomic.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/barrier.h
+++ b/include/odp/api/barrier.h
@@ -11,19 +11,11 @@
 #ifndef ODP_API_BARRIER_H_
 #define ODP_API_BARRIER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/std_types.h>
 #include <odp/api/atomic.h>
 #include <odp/api/abi/shared_memory.h>
 #include <odp/api/abi/barrier.h>
 
 #include <odp/api/spec/barrier.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/buffer.h
+++ b/include/odp/api/buffer.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_BUFFER_H_
 #define ODP_API_BUFFER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/buffer.h>
 
 #include <odp/api/spec/buffer.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/buffer_types.h
+++ b/include/odp/api/buffer_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_BUFFER_TYPES_H_
 #define ODP_API_BUFFER_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/buffer_types.h>
 
 #include <odp/api/spec/buffer_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/byteorder.h
+++ b/include/odp/api/byteorder.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_BYTEORDER_H_
 #define ODP_API_BYTEORDER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/byteorder.h>
 
 #include <odp/api/spec/byteorder.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/chksum.h
+++ b/include/odp/api/chksum.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_CHKSUM_H_
 #define ODP_API_CHKSUM_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/spec/chksum.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/classification.h
+++ b/include/odp/api/classification.h
@@ -11,19 +11,11 @@
 #ifndef ODP_API_CLASSIFICATION_H_
 #define ODP_API_CLASSIFICATION_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/std_types.h>
 #include <odp/api/abi/classification.h>
 #include <odp/api/abi/packet_types.h>
 #include <odp/api/abi/queue_types.h>
 
 #include <odp/api/spec/classification.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/comp.h
+++ b/include/odp/api/comp.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_COMP_H_
 #define ODP_API_COMP_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/comp.h>
 
 #include <odp/api/spec/comp.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/cpu.h
+++ b/include/odp/api/cpu.h
@@ -11,18 +11,10 @@
 #ifndef ODP_API_CPU_H_
 #define ODP_API_CPU_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/cpu.h>
 
 /* Thread inline file implements cpu API function */
 #include <odp/api/thread.h>
 #include <odp/api/spec/cpu.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/cpumask.h
+++ b/include/odp/api/cpumask.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_CPUMASK_H_
 #define ODP_API_CPUMASK_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/cpumask.h>
 
 #include <odp/api/spec/cpumask.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/crypto.h
+++ b/include/odp/api/crypto.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_CRYPTO_H_
 #define ODP_API_CRYPTO_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/crypto.h>
 
 #include <odp/api/spec/crypto.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/crypto_types.h
+++ b/include/odp/api/crypto_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_CRYPTO_TYPES_H_
 #define ODP_API_CRYPTO_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/crypto_types.h>
 
 #include <odp/api/spec/crypto_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/debug.h
+++ b/include/odp/api/debug.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_DEBUG_H_
 #define ODP_API_DEBUG_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/debug.h>
 
 #include <odp/api/spec/debug.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/deprecated.h
+++ b/include/odp/api/deprecated.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_DEPRECATED_H_
 #define ODP_API_DEPRECATED_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/spec/deprecated.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/dma.h
+++ b/include/odp/api/dma.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_DMA_H_
 #define ODP_API_DMA_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/dma.h>
 
 #include <odp/api/spec/dma.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/dma_types.h
+++ b/include/odp/api/dma_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_DMA_TYPES_H_
 #define ODP_API_DMA_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/dma_types.h>
 
 #include <odp/api/spec/dma_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/errno.h
+++ b/include/odp/api/errno.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_ERRNO_H_
 #define ODP_API_ERRNO_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/errno.h>
 
 #include <odp/api/spec/errno.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/event.h
+++ b/include/odp/api/event.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_EVENT_H_
 #define ODP_API_EVENT_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/event.h>
 
 #include <odp/api/spec/event.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/event_types.h
+++ b/include/odp/api/event_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_EVENT_TYPES_H_
 #define ODP_API_EVENT_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/event_types.h>
 
 #include <odp/api/spec/event_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/hash.h
+++ b/include/odp/api/hash.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_HASH_H_
 #define ODP_API_HASH_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/hash.h>
 
 #include <odp/api/spec/hash.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/hints.h
+++ b/include/odp/api/hints.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_HINTS_H_
 #define ODP_API_HINTS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/spec/hints.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/init.h
+++ b/include/odp/api/init.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_INIT_H_
 #define ODP_API_INIT_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/init.h>
 
 #include <odp/api/spec/init.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/ipsec.h
+++ b/include/odp/api/ipsec.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_IPSEC_H_
 #define ODP_API_IPSEC_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/ipsec.h>
 
 #include <odp/api/spec/ipsec.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/ipsec_types.h
+++ b/include/odp/api/ipsec_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_IPSEC_TYPES_H_
 #define ODP_API_IPSEC_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/ipsec_types.h>
 
 #include <odp/api/spec/ipsec_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/ml.h
+++ b/include/odp/api/ml.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_ML_H_
 #define ODP_API_ML_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/spec/ml.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/ml_quantize.h
+++ b/include/odp/api/ml_quantize.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_ML_QUANTIZE_H_
 #define ODP_API_ML_QUANTIZE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/spec/ml_quantize.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/ml_types.h
+++ b/include/odp/api/ml_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_ML_TYPES_H_
 #define ODP_API_ML_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/ml_types.h>
 
 #include <odp/api/spec/ml_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/packet.h
+++ b/include/odp/api/packet.h
@@ -12,16 +12,8 @@
 #ifndef ODP_API_PACKET_H_
 #define ODP_API_PACKET_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/packet.h>
 
 #include <odp/api/spec/packet.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/packet_flags.h
+++ b/include/odp/api/packet_flags.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_PACKET_FLAGS_H_
 #define ODP_API_PACKET_FLAGS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/packet_flags.h>
 
 #include <odp/api/spec/packet_flags.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/packet_io.h
+++ b/include/odp/api/packet_io.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_PACKET_IO_H_
 #define ODP_API_PACKET_IO_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/packet_io.h>
 
 #include <odp/api/spec/packet_io.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/packet_io_stats.h
+++ b/include/odp/api/packet_io_stats.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_PACKET_IO_STATS_H_
 #define ODP_API_PACKET_IO_STATS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/packet_io_types.h>
 
 #include <odp/api/spec/packet_io_stats.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/packet_io_types.h
+++ b/include/odp/api/packet_io_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_PACKET_IO_TYPES_H_
 #define ODP_API_PACKET_IO_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/packet_io_types.h>
 
 #include <odp/api/spec/packet_io_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/packet_types.h
+++ b/include/odp/api/packet_types.h
@@ -11,17 +11,9 @@
 #ifndef ODP_API_PACKET_TYPES_H_
 #define ODP_API_PACKET_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/packet_io_types.h>
 #include <odp/api/abi/packet_types.h>
 
 #include <odp/api/spec/packet_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/pool.h
+++ b/include/odp/api/pool.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_POOL_H_
 #define ODP_API_POOL_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/pool.h>
 
 #include <odp/api/spec/pool.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/pool_types.h
+++ b/include/odp/api/pool_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_POOL_TYPES_H_
 #define ODP_API_POOL_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/pool_types.h>
 
 #include <odp/api/spec/pool_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/proto_stats.h
+++ b/include/odp/api/proto_stats.h
@@ -11,19 +11,11 @@
 #ifndef ODP_API_PROTO_STATS_H_
 #define ODP_API_PROTO_STATS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/std_types.h>
 #include <odp/api/abi/queue.h>
 #include <odp/api/abi/proto_stats_types.h>
 #include <odp/api/abi/proto_stats.h>
 
 #include <odp/api/spec/proto_stats.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/proto_stats_types.h
+++ b/include/odp/api/proto_stats_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_PROTO_STATS_TYPES_H_
 #define ODP_API_PROTO_STATS_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/proto_stats_types.h>
 
 #include <odp/api/spec/proto_stats_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/protocols.h
+++ b/include/odp/api/protocols.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_PROTOCOLS_H_
 #define ODP_API_PROTOCOLS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/spec/protocols.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/queue.h
+++ b/include/odp/api/queue.h
@@ -12,16 +12,8 @@
 #ifndef ODP_API_QUEUE_H_
 #define ODP_API_QUEUE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/queue.h>
 
 #include <odp/api/spec/queue.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/queue_types.h
+++ b/include/odp/api/queue_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_QUEUE_TYPES_H_
 #define ODP_API_QUEUE_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/queue_types.h>
 
 #include <odp/api/spec/queue_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/random.h
+++ b/include/odp/api/random.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_RANDOM_H_
 #define ODP_API_RANDOM_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/random.h>
 
 #include <odp/api/spec/random.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/random_types.h
+++ b/include/odp/api/random_types.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_RANDOM_TYPES_H_
 #define ODP_API_RANDOM_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/spec/random_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/reassembly.h
+++ b/include/odp/api/reassembly.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_REASSEMBLY_H_
 #define ODP_API_REASSEMBLY_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/spec/reassembly.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/rwlock.h
+++ b/include/odp/api/rwlock.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_RWLOCK_H_
 #define ODP_API_RWLOCK_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/rwlock.h>
 
 #include <odp/api/spec/rwlock.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* ODP_RWLOCK_H_ */

--- a/include/odp/api/rwlock_recursive.h
+++ b/include/odp/api/rwlock_recursive.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_RWLOCK_RECURSIVE_H_
 #define ODP_API_RWLOCK_RECURSIVE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/rwlock_recursive.h>
 
 #include <odp/api/spec/rwlock_recursive.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/schedule.h
+++ b/include/odp/api/schedule.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_SCHEDULE_H_
 #define ODP_API_SCHEDULE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/schedule.h>
 
 #include <odp/api/spec/schedule.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/schedule_types.h
+++ b/include/odp/api/schedule_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_SCHEDULE_TYPES_H_
 #define ODP_API_SCHEDULE_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/schedule_types.h>
 
 #include <odp/api/spec/schedule_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/shared_memory.h
+++ b/include/odp/api/shared_memory.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_SHARED_MEMORY_H_
 #define ODP_API_SHARED_MEMORY_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/shared_memory.h>
 
 #include <odp/api/spec/shared_memory.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/spec/buffer.h
+++ b/include/odp/api/spec/buffer.h
@@ -13,14 +13,14 @@
 #define ODP_API_SPEC_BUFFER_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/buffer_types.h>
 #include <odp/api/event_types.h>
 #include <odp/api/pool_types.h>
 #include <odp/api/std_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @addtogroup odp_buffer
  *  Buffer event metadata and operations.

--- a/include/odp/api/spec/chksum.h
+++ b/include/odp/api/spec/chksum.h
@@ -12,11 +12,11 @@
 #define ODP_API_SPEC_CHKSUM_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @defgroup odp_chksum ODP CHECKSUM
  *  Checksum functions.

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -13,14 +13,14 @@
 #define ODP_API_SPEC_CLASSIFICATION_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/packet_io_types.h>
 #include <odp/api/pool_types.h>
 #include <odp/api/std_types.h>
 #include <odp/api/threshold.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @defgroup odp_classification ODP CLASSIFICATION
  *  Packet input classification.

--- a/include/odp/api/spec/cpu.h
+++ b/include/odp/api/spec/cpu.h
@@ -13,11 +13,11 @@
 #define ODP_API_SPEC_CPU_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @defgroup odp_cpu ODP CPU
  *  CPU cycle count, frequency, etc. information.

--- a/include/odp/api/spec/dma.h
+++ b/include/odp/api/spec/dma.h
@@ -12,12 +12,12 @@
 #define ODP_API_SPEC_DMA_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/dma_types.h>
+#include <odp/api/pool_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/dma_types.h>
-#include <odp/api/pool_types.h>
 
 /** @addtogroup odp_dma
  *  @{

--- a/include/odp/api/spec/dma_types.h
+++ b/include/odp/api/spec/dma_types.h
@@ -12,14 +12,14 @@
 #define ODP_API_SPEC_DMA_TYPES_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/event_types.h>
 #include <odp/api/packet_types.h>
 #include <odp/api/queue_types.h>
 #include <odp/api/std_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @defgroup odp_dma ODP DMA
  *  DMA offload
@@ -131,8 +131,16 @@ typedef struct odp_dma_pool_param_t {
 
 } odp_dma_pool_param_t;
 
+#ifdef __cplusplus
+}
+#endif
+
 /* Includes pool_types.h, which depends on odp_dma_pool_param_t. */
 #include <odp/api/pool_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * DMA transfer direction
@@ -706,4 +714,3 @@ typedef struct odp_dma_result_t {
 
 #include <odp/visibility_end.h>
 #endif
-

--- a/include/odp/api/spec/event.h
+++ b/include/odp/api/spec/event.h
@@ -13,13 +13,13 @@
 #define ODP_API_SPEC_EVENT_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/event_types.h>
 #include <odp/api/packet_types.h>
 #include <odp/api/pool_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @addtogroup odp_event
  *  Generic event metadata and operations.

--- a/include/odp/api/spec/hash.h
+++ b/include/odp/api/spec/hash.h
@@ -12,11 +12,11 @@
 #define ODP_API_SPEC_HASH_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @defgroup odp_hash ODP HASH
  *  Hash functions.

--- a/include/odp/api/spec/init.h
+++ b/include/odp/api/spec/init.h
@@ -11,14 +11,14 @@
 #define ODP_API_SPEC_INIT_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/std_types.h>
 #include <odp/api/hints.h>
 #include <odp/api/thread_types.h>
 #include <odp/api/cpumask.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @defgroup odp_initialization ODP INITIALIZATION
  *  ODP instance initialization and termination.

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -13,15 +13,15 @@
 #define ODP_API_SPEC_IPSEC_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/crypto_types.h>
 #include <odp/api/event_types.h>
 #include <odp/api/ipsec_types.h>
 #include <odp/api/packet_types.h>
 #include <odp/api/std_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @addtogroup odp_ipsec
  *  IPSEC protocol offload.

--- a/include/odp/api/spec/ipsec_types.h
+++ b/include/odp/api/spec/ipsec_types.h
@@ -13,16 +13,16 @@
 #define ODP_API_SPEC_IPSEC_TYPES_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/classification.h>
 #include <odp/api/crypto_types.h>
 #include <odp/api/packet_io_types.h>
 #include <odp/api/protocols.h>
 #include <odp/api/std_types.h>
 #include <odp/api/traffic_mngr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @defgroup odp_ipsec ODP IPSEC
  *  @{

--- a/include/odp/api/spec/ml.h
+++ b/include/odp/api/spec/ml.h
@@ -13,14 +13,14 @@
 #define ODP_API_SPEC_ML_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/event_types.h>
 #include <odp/api/ml_types.h>
 #include <odp/api/pool_types.h>
 #include <odp/api/std_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @addtogroup odp_ml

--- a/include/odp/api/spec/ml_quantize.h
+++ b/include/odp/api/spec/ml_quantize.h
@@ -13,11 +13,11 @@
 #define ODP_API_SPEC_ML_QUANTIZE_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @addtogroup odp_ml
  *  @{

--- a/include/odp/api/spec/ml_types.h
+++ b/include/odp/api/spec/ml_types.h
@@ -13,13 +13,13 @@
 #define ODP_API_SPEC_ML_TYPES_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/event_types.h>
 #include <odp/api/queue_types.h>
 #include <odp/api/std_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @defgroup odp_ml ODP ML
  *  @{

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -13,10 +13,6 @@
 #define ODP_API_SPEC_PACKET_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/event_types.h>
 #include <odp/api/packet_types.h>
 #include <odp/api/packet_io_types.h>
@@ -24,6 +20,10 @@ extern "C" {
 #include <odp/api/proto_stats_types.h>
 #include <odp/api/std_types.h>
 #include <odp/api/time_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @addtogroup odp_packet
  *  Packet event metadata and operations.

--- a/include/odp/api/spec/packet_flags.h
+++ b/include/odp/api/spec/packet_flags.h
@@ -13,12 +13,12 @@
 #define ODP_API_SPEC_PACKET_FLAGS_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/packet_types.h>
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/packet_types.h>
 
 /** @addtogroup odp_packet
  *  @par Operations on packet metadata flags

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -13,10 +13,6 @@
 #define ODP_API_SPEC_PACKET_IO_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/classification.h>
 #include <odp/api/packet_types.h>
 #include <odp/api/packet_io_stats.h>
@@ -24,6 +20,10 @@ extern "C" {
 #include <odp/api/queue_types.h>
 #include <odp/api/reassembly.h>
 #include <odp/api/time_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @addtogroup odp_packet_io
  *  Packet IO interfaces.

--- a/include/odp/api/spec/packet_io_stats.h
+++ b/include/odp/api/spec/packet_io_stats.h
@@ -13,11 +13,11 @@
 #define ODP_API_SPEC_PACKET_IO_STATS_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/queue_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/queue_types.h>
 
 /** @addtogroup odp_packet_io
  *  @{

--- a/include/odp/api/spec/packet_io_types.h
+++ b/include/odp/api/spec/packet_io_types.h
@@ -13,10 +13,6 @@
 #define ODP_API_SPEC_PACKET_IO_TYPES_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/deprecated.h>
 #include <odp/api/packet_types.h>
 #include <odp/api/packet_io_stats.h>
@@ -24,6 +20,10 @@ extern "C" {
 #include <odp/api/queue_types.h>
 #include <odp/api/reassembly.h>
 #include <odp/api/std_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @defgroup odp_packet_io ODP PACKET IO
  *  @{

--- a/include/odp/api/spec/packet_types.h
+++ b/include/odp/api/spec/packet_types.h
@@ -13,13 +13,13 @@
 #define ODP_API_SPEC_PACKET_TYPES_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/deprecated.h>
 #include <odp/api/proto_stats_types.h>
 #include <odp/api/queue_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @defgroup odp_packet ODP PACKET
  *  @{

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -13,12 +13,12 @@
 #define ODP_API_SPEC_POOL_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/pool_types.h>
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/pool_types.h>
 
 /** @addtogroup odp_pool
  *  Packet and buffer (event) pools.

--- a/include/odp/api/spec/pool_types.h
+++ b/include/odp/api/spec/pool_types.h
@@ -12,13 +12,13 @@
 #define ODP_API_SPEC_POOL_TYPES_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/std_types.h>
 #include <odp/api/dma_types.h>
 #include <odp/api/ml_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @defgroup odp_pool ODP POOL
  *  @{

--- a/include/odp/api/spec/proto_stats.h
+++ b/include/odp/api/spec/proto_stats.h
@@ -12,11 +12,11 @@
 #define ODP_API_SPEC_PROTO_STATS_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/proto_stats_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/proto_stats_types.h>
 
 /** @addtogroup odp_proto_stats
  *  Flow specific packet statistics.

--- a/include/odp/api/spec/proto_stats_types.h
+++ b/include/odp/api/spec/proto_stats_types.h
@@ -13,11 +13,11 @@
 #define ODP_API_SPEC_PROTO_STATS_TYPES_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @defgroup odp_proto_stats ODP PROTO STATS
  *  @{

--- a/include/odp/api/spec/queue.h
+++ b/include/odp/api/spec/queue.h
@@ -13,13 +13,13 @@
 #define ODP_API_SPEC_QUEUE_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/event_types.h>
 #include <odp/api/queue_types.h>
 #include <odp/api/std_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @addtogroup odp_queue
  *  Queues for event passing and scheduling.

--- a/include/odp/api/spec/queue_types.h
+++ b/include/odp/api/spec/queue_types.h
@@ -13,12 +13,12 @@
 #define ODP_API_SPEC_QUEUE_TYPES_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/event_vector_types.h>
+#include <odp/api/schedule_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/event_vector_types.h>
-#include <odp/api/schedule_types.h>
 
 /** @defgroup odp_queue ODP QUEUE
  *  @{

--- a/include/odp/api/spec/random.h
+++ b/include/odp/api/spec/random.h
@@ -12,12 +12,12 @@
 #define ODP_API_SPEC_RANDOM_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/random_types.h>
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/random_types.h>
-#include <odp/api/std_types.h>
 
 /** @addtogroup odp_random
  *  Random number generation.

--- a/include/odp/api/spec/random_types.h
+++ b/include/odp/api/spec/random_types.h
@@ -13,11 +13,11 @@
 #define ODP_API_SPEC_RANDOM_TYPES_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @defgroup odp_random ODP RANDOM
  *  @{

--- a/include/odp/api/spec/reassembly.h
+++ b/include/odp/api/spec/reassembly.h
@@ -12,11 +12,11 @@
 #define ODP_API_SPEC_REASSEMBLY_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @defgroup odp_reassembly ODP REASSEMBLY
  *  Reassembly

--- a/include/odp/api/spec/schedule.h
+++ b/include/odp/api/spec/schedule.h
@@ -13,15 +13,15 @@
 #define ODP_API_SPEC_SCHEDULE_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/std_types.h>
 #include <odp/api/event_types.h>
 #include <odp/api/queue_types.h>
 #include <odp/api/schedule_types.h>
 #include <odp/api/thrmask.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @addtogroup odp_scheduler
  *  Event scheduler for work load balancing and prioritization.

--- a/include/odp/api/spec/stash.h
+++ b/include/odp/api/spec/stash.h
@@ -12,11 +12,11 @@
 #define ODP_API_SPEC_STASH_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/stash_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/stash_types.h>
 
 /** @addtogroup odp_stash
  *  Stash for storing object handles

--- a/include/odp/api/spec/stash_types.h
+++ b/include/odp/api/spec/stash_types.h
@@ -12,11 +12,11 @@
 #define ODP_API_SPEC_STASH_TYPES_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @defgroup odp_stash ODP STASH
  *  @{

--- a/include/odp/api/spec/std.h
+++ b/include/odp/api/spec/std.h
@@ -13,11 +13,11 @@
 #define ODP_API_SPEC_STD_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @addtogroup odp_std
  *  Standard types and performance optimized versions of selected C library

--- a/include/odp/api/spec/thread.h
+++ b/include/odp/api/spec/thread.h
@@ -13,11 +13,11 @@
 #define ODP_API_SPEC_THREAD_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/thread_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/thread_types.h>
 
 /** @addtogroup odp_thread
  *  Thread types, masks and IDs.

--- a/include/odp/api/spec/thrmask.h
+++ b/include/odp/api/spec/thrmask.h
@@ -12,11 +12,11 @@
 #define ODP_API_SPEC_THRMASK_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 /** @addtogroup odp_thread
  *  Thread mask operations.

--- a/include/odp/api/spec/time.h
+++ b/include/odp/api/spec/time.h
@@ -13,12 +13,12 @@
 #define ODP_API_SPEC_TIME_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/std_types.h>
+#include <odp/api/time_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/time_types.h>
 
 /** @addtogroup odp_time
  *  SoC global and CPU local wall clock time

--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -13,15 +13,15 @@
 #define ODP_API_SPEC_TIMER_H_
 #include <odp/visibility_begin.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/deprecated.h>
 #include <odp/api/timer_types.h>
 #include <odp/api/event_types.h>
 #include <odp/api/pool_types.h>
 #include <odp/api/queue_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @addtogroup odp_timer
  *  @{

--- a/include/odp/api/spec/timer_types.h
+++ b/include/odp/api/spec/timer_types.h
@@ -13,12 +13,12 @@
 #define ODP_API_SPEC_TIMER_TYPES_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/event_types.h>
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/event_types.h>
-#include <odp/api/std_types.h>
 
 /** @defgroup odp_timer ODP TIMER
  *  Timer generating timeout events.

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -8,12 +8,12 @@
 #define ODP_API_SPEC_TRAFFIC_MNGR_H_
 #include <odp/visibility_begin.h>
 
+#include <odp/api/packet_io_types.h>
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/packet_io_types.h>
-#include <odp/api/std_types.h>
 
 /**
  * @file

--- a/include/odp/api/spinlock.h
+++ b/include/odp/api/spinlock.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_SPINLOCK_H_
 #define ODP_API_SPINLOCK_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/spinlock.h>
 
 #include <odp/api/spec/spinlock.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/spinlock_recursive.h
+++ b/include/odp/api/spinlock_recursive.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_SPINLOCK_RECURSIVE_H_
 #define ODP_API_SPINLOCK_RECURSIVE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/spinlock_recursive.h>
 
 #include <odp/api/spec/spinlock_recursive.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/stash.h
+++ b/include/odp/api/stash.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_STASH_H_
 #define ODP_API_STASH_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/stash.h>
 
 #include <odp/api/spec/stash.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/stash_types.h
+++ b/include/odp/api/stash_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_STASH_TYPES_H_
 #define ODP_API_STASH_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/stash_types.h>
 
 #include <odp/api/spec/stash_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/std.h
+++ b/include/odp/api/std.h
@@ -5,17 +5,9 @@
 #ifndef ODP_API_STD_H_
 #define ODP_API_STD_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/std_types.h>
 #include <odp/api/abi/std.h>
 
 #include <odp/api/spec/std.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/std_types.h
+++ b/include/odp/api/std_types.h
@@ -11,17 +11,8 @@
 #ifndef ODP_API_STD_TYPES_H_
 #define ODP_API_STD_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include <odp/api/abi/std_types.h>
 
 #include <odp/api/spec/std_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/sync.h
+++ b/include/odp/api/sync.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_SYNC_H_
 #define ODP_API_SYNC_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/sync.h>
 
 #include <odp/api/spec/sync.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/system_info.h
+++ b/include/odp/api/system_info.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_SYSTEM_INFO_H_
 #define ODP_API_SYSTEM_INFO_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/std_types.h>
 
 #include <odp/api/spec/system_info.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/thread.h
+++ b/include/odp/api/thread.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_THREAD_H_
 #define ODP_API_THREAD_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/thread.h>
 
 #include <odp/api/spec/thread.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/thread_types.h
+++ b/include/odp/api/thread_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_THREAD_TYPES_H_
 #define ODP_API_THREAD_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/thread_types.h>
 
 #include <odp/api/spec/thread_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/threshold.h
+++ b/include/odp/api/threshold.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_THRESHOLD_H_
 #define ODP_API_THRESHOLD_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/spec/threshold.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/thrmask.h
+++ b/include/odp/api/thrmask.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_THRMASK_H_
 #define ODP_API_THRMASK_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/thrmask.h>
 
 #include <odp/api/spec/thrmask.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/ticketlock.h
+++ b/include/odp/api/ticketlock.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_TICKETLOCK_H_
 #define ODP_API_TICKETLOCK_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/ticketlock.h>
 
 #include <odp/api/spec/ticketlock.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/time.h
+++ b/include/odp/api/time.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_TIME_H_
 #define ODP_API_TIME_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/time.h>
 
 #include <odp/api/spec/time.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/time_types.h
+++ b/include/odp/api/time_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_TIME_TYPES_H_
 #define ODP_API_TIME_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/time_types.h>
 
 #include <odp/api/spec/time_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/timer.h
+++ b/include/odp/api/timer.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_TIMER_H_
 #define ODP_API_TIMER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/timer.h>
 
 #include <odp/api/spec/timer.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/timer_types.h
+++ b/include/odp/api/timer_types.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_TIMER_TYPES_H_
 #define ODP_API_TIMER_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/timer_types.h>
 
 #include <odp/api/spec/timer_types.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/traffic_mngr.h
+++ b/include/odp/api/traffic_mngr.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_TRAFFIC_MNGR_H_
 #define ODP_API_TRAFFIC_MNGR_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/traffic_mngr.h>
 
 #include <odp/api/spec/traffic_mngr.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp/api/version.h
+++ b/include/odp/api/version.h
@@ -11,16 +11,8 @@
 #ifndef ODP_API_VERSION_H_
 #define ODP_API_VERSION_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/version.h>
 
 #include <odp/api/spec/version.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/odp_api.h
+++ b/include/odp_api.h
@@ -12,10 +12,6 @@
 #ifndef ODP_API_H_
 #define ODP_API_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/deprecated.h>
 #include <odp/api/version.h>
 #include <odp/api/std_types.h>
@@ -66,7 +62,4 @@ extern "C" {
 #include <odp/api/reassembly.h>
 #include <odp/api/dma.h>
 
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h
@@ -10,6 +10,10 @@
 
 #ifdef _ODP_LOCK_FREE_128BIT_ATOMICS
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @internal
  * Helper macro for lockless atomic CAS operations on 128-bit integers
@@ -306,6 +310,10 @@ static inline void _odp_atomic_sub_rel_u64(odp_atomic_u64_t *atom, uint64_t val)
 			 : [neg_val] "r" (neg_val)
 			 : "memory");
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #else /* !_ODP_LOCK_FREE_128BIT_ATOMICS */
 

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/cpu.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/cpu.h
@@ -5,21 +5,21 @@
 #ifndef ODP_API_ABI_CPU_H_
 #define ODP_API_ABI_CPU_H_
 
+#include <odp/autoheader_external.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/autoheader_external.h>
 
 #ifndef ODP_CACHE_LINE_SIZE
 	#define ODP_CACHE_LINE_SIZE _ODP_CACHE_LINE_SIZE
 #endif
 
-/* Inlined functions for non-ABI compat mode */
-#include <odp/api/plat/cpu_inlines.h>
-
 #ifdef __cplusplus
 }
 #endif
+
+/* Inlined functions for non-ABI compat mode */
+#include <odp/api/plat/cpu_inlines.h>
 
 #endif

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/cpu_inlines.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/cpu_inlines.h
@@ -6,13 +6,13 @@
 #ifndef ODP_ARCH_CPU_INLINES_H_
 #define ODP_ARCH_CPU_INLINES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/time_cpu.h>
 
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* CPU frequency is shifted to decrease integer division error */
 #define _ODP_CPU_FREQ_SHIFT 16

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/hash_crc32.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/hash_crc32.h
@@ -5,11 +5,15 @@
 #ifndef ODP_API_ABI_HASH_CRC32_H_
 #define ODP_API_ABI_HASH_CRC32_H_
 
+#include <stdint.h>
+
+#ifdef __ARM_FEATURE_CRC32
+#include <arm_acle.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 uint32_t _odp_hash_crc32_generic(const void *data, uint32_t data_len,
 				 uint32_t init_val);
@@ -17,8 +21,6 @@ uint32_t _odp_hash_crc32c_generic(const void *data, uint32_t data_len,
 				  uint32_t init_val);
 
 #ifdef __ARM_FEATURE_CRC32
-
-#include <arm_acle.h>
 
 static inline uint32_t _odp_hash_crc32(const void *data_ptr, uint32_t data_len,
 				       uint32_t init_val)

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/time_cpu.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/time_cpu.h
@@ -5,11 +5,11 @@
 #ifndef ODP_API_ABI_TIME_CPU_H_
 #define ODP_API_ABI_TIME_CPU_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 static inline uint64_t _odp_time_cpu_global(void)
 {

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/wait_until.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/wait_until.h
@@ -5,10 +5,6 @@
 #ifndef ODP_API_ABI_WAIT_UNTIL_H_
 #define ODP_API_ABI_WAIT_UNTIL_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/autoheader_external.h>
 
 #ifdef _ODP_WFE_LOCKS
@@ -16,6 +12,10 @@ extern "C" {
 #include <stdint.h>
 
 #include <odp/api/atomic.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 static inline void
 _odp_wait_until_equal_acq_u32(odp_atomic_u32_t *addr, uint32_t expected)
@@ -33,15 +33,15 @@ _odp_wait_until_equal_acq_u32(odp_atomic_u32_t *addr, uint32_t expected)
 	} while (expected != value);
 }
 
+#ifdef __cplusplus
+}
+#endif
+
 #else /* !_ODP_WFE_LOCKS*/
 
 /* Use generic implementation */
 #include <odp/api/abi/wait_until_generic.h>
 
-#endif
-
-#ifdef __cplusplus
-}
 #endif
 
 #endif

--- a/platform/linux-generic/arch/arm/odp/api/abi/cpu.h
+++ b/platform/linux-generic/arch/arm/odp/api/abi/cpu.h
@@ -11,11 +11,11 @@ extern "C" {
 
 #define ODP_CACHE_LINE_SIZE 64
 
-/* Inlined functions for non-ABI compat mode */
-#include <odp/api/plat/cpu_inlines.h>
-
 #ifdef __cplusplus
 }
 #endif
+
+/* Inlined functions for non-ABI compat mode */
+#include <odp/api/plat/cpu_inlines.h>
 
 #endif

--- a/platform/linux-generic/arch/arm/odp/api/abi/cpu_inlines.h
+++ b/platform/linux-generic/arch/arm/odp/api/abi/cpu_inlines.h
@@ -25,11 +25,11 @@ static inline void _odp_prefetch_l1i(const void *addr)
 	(void)addr;
 }
 
-/* Use generic implementations for the rest of the functions */
-#include <odp/api/abi/cpu_generic.h>
-
 #ifdef __cplusplus
 }
 #endif
+
+/* Use generic implementations for the rest of the functions */
+#include <odp/api/abi/cpu_generic.h>
 
 #endif

--- a/platform/linux-generic/arch/common/odp/api/abi/time_cpu_inlines.h
+++ b/platform/linux-generic/arch/common/odp/api/abi/time_cpu_inlines.h
@@ -6,15 +6,15 @@
 #ifndef ODP_ARCH_TIME_CPU_INLINES_H_
 #define ODP_ARCH_TIME_CPU_INLINES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/time_types.h>
 
 #include <odp/api/abi/time_cpu.h>
 
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define _ODP_TIME_GIGA_HZ  1000000000ULL
 

--- a/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/atomic_generic.h
@@ -8,6 +8,10 @@
 
 #include <odp/api/atomic.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static inline void _odp_atomic_add_u32(odp_atomic_u32_t *atom, uint32_t val)
 {
 	(void)__atomic_fetch_add(&atom->v, val, __ATOMIC_RELAXED);
@@ -321,6 +325,10 @@ static inline int _odp_atomic_cas_acq_rel_u128(odp_atomic_u128_t *atom, odp_u128
 					       odp_u128_t new_val)
 {
 	return _odp_atomic_cas_u128(atom, old_val, new_val);
+}
+#endif
+
+#ifdef __cplusplus
 }
 #endif
 

--- a/platform/linux-generic/arch/default/odp/api/abi/cpu.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/cpu.h
@@ -11,11 +11,11 @@ extern "C" {
 
 #define ODP_CACHE_LINE_SIZE 64
 
-/* Inlined functions for non-ABI compat mode */
-#include <odp/api/plat/cpu_inlines.h>
-
 #ifdef __cplusplus
 }
 #endif
+
+/* Inlined functions for non-ABI compat mode */
+#include <odp/api/plat/cpu_inlines.h>
 
 #endif

--- a/platform/linux-generic/arch/default/odp/api/abi/cpu_inlines.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/cpu_inlines.h
@@ -18,10 +18,10 @@ static inline void _odp_prefetch_l1i(const void *addr)
 	(void)addr;
 }
 
-#include <odp/api/abi/cpu_generic.h>
-
 #ifdef __cplusplus
 }
 #endif
+
+#include <odp/api/abi/cpu_generic.h>
 
 #endif

--- a/platform/linux-generic/arch/default/odp/api/abi/hash_crc32.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/hash_crc32.h
@@ -5,11 +5,11 @@
 #ifndef ODP_API_ABI_HASH_CRC32_H_
 #define ODP_API_ABI_HASH_CRC32_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 uint32_t _odp_hash_crc32_generic(const void *data, uint32_t data_len,
 				 uint32_t init_val);

--- a/platform/linux-generic/arch/default/odp/api/abi/wait_until_generic.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/wait_until_generic.h
@@ -5,11 +5,11 @@
 #ifndef ODP_API_ABI_WAIT_UNTIL_GENERIC_H_
 #define ODP_API_ABI_WAIT_UNTIL_GENERIC_H_
 
+#include <odp/api/atomic.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/atomic.h>
 
 static inline void
 _odp_wait_until_equal_acq_u32(odp_atomic_u32_t *addr, uint32_t expected)

--- a/platform/linux-generic/arch/powerpc/odp/api/abi/cpu.h
+++ b/platform/linux-generic/arch/powerpc/odp/api/abi/cpu.h
@@ -12,12 +12,12 @@ extern "C" {
 
 #define ODP_CACHE_LINE_SIZE 128
 
-/* Inlined functions for non-ABI compat mode */
-#include <odp/api/plat/cpu_inlines.h>
-
 #ifdef __cplusplus
 }
 #endif
+
+/* Inlined functions for non-ABI compat mode */
+#include <odp/api/plat/cpu_inlines.h>
 
 #endif
 

--- a/platform/linux-generic/arch/x86/odp/api/abi/cpu.h
+++ b/platform/linux-generic/arch/x86/odp/api/abi/cpu.h
@@ -11,11 +11,11 @@ extern "C" {
 
 #define ODP_CACHE_LINE_SIZE 64
 
-/* Inlined functions for non-ABI compat mode */
-#include <odp/api/plat/cpu_inlines.h>
-
 #ifdef __cplusplus
 }
 #endif
+
+/* Inlined functions for non-ABI compat mode */
+#include <odp/api/plat/cpu_inlines.h>
 
 #endif

--- a/platform/linux-generic/arch/x86/odp/api/abi/cpu_rdtsc.h
+++ b/platform/linux-generic/arch/x86/odp/api/abi/cpu_rdtsc.h
@@ -7,6 +7,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static inline uint64_t _odp_cpu_rdtsc(void)
 {
 	union {
@@ -23,5 +27,9 @@ static inline uint64_t _odp_cpu_rdtsc(void)
 
 	return tsc.tsc_64;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/arch/x86/odp/api/abi/hash_crc32.h
+++ b/platform/linux-generic/arch/x86/odp/api/abi/hash_crc32.h
@@ -5,12 +5,13 @@
 #ifndef ODP_API_ABI_HASH_CRC32_H_
 #define ODP_API_ABI_HASH_CRC32_H_
 
+#include <odp/api/std_types.h>
+
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <stdint.h>
 
 uint32_t _odp_hash_crc32_generic(const void *data, uint32_t data_len,
 				 uint32_t init_val);

--- a/platform/linux-generic/arch/x86/odp/api/abi/time_cpu.h
+++ b/platform/linux-generic/arch/x86/odp/api/abi/time_cpu.h
@@ -5,12 +5,13 @@
 #ifndef ODP_ARCH_TIME_CPU_H_
 #define ODP_ARCH_TIME_CPU_H_
 
+#include <odp/api/abi/cpu_rdtsc.h>
+
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
-#include <odp/api/abi/cpu_rdtsc.h>
 
 static inline uint64_t _odp_time_cpu_global(void)
 {

--- a/platform/linux-generic/include-abi/odp/api/abi/atomic.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/atomic.h
@@ -11,12 +11,12 @@
 #ifndef ODP_API_ABI_ATOMIC_H_
 #define ODP_API_ABI_ATOMIC_H_
 
+#include <odp/api/align.h>
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/align.h>
 
 /**
  * @internal
@@ -78,17 +78,10 @@ typedef struct ODP_ALIGNED(sizeof(odp_u128_t)) odp_atomic_u128_s {
 
 #endif
 
-/** @addtogroup odp_atomic
- *  @{
- */
-
-#include <odp/api/plat/atomic_inlines.h>
-
-/**
- * @}
- */
 #ifdef __cplusplus
 }
 #endif
+
+#include <odp/api/plat/atomic_inlines.h>
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/buffer.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/buffer.h
@@ -12,15 +12,7 @@
 #ifndef ODP_API_ABI_BUFFER_H_
 #define ODP_API_ABI_BUFFER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Inlined API functions */
 #include <odp/api/plat/buffer_inlines.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/buffer_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/buffer_types.h
@@ -12,12 +12,13 @@
 #ifndef ODP_API_ABI_BUFFER_TYPES_H_
 #define ODP_API_ABI_BUFFER_TYPES_H_
 
+#include <odp/api/std_types.h>
+
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/plat/strong_types.h>
 
 /** @addtogroup odp_buffer
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/byteorder.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/byteorder.h
@@ -11,11 +11,11 @@
 #ifndef ODP_API_ABI_BYTEORDER_H_
 #define ODP_API_ABI_BYTEORDER_H_
 
+#include <odp/api/std_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
 
 #ifndef __BYTE_ORDER__
 #error __BYTE_ORDER__ not defined!
@@ -73,8 +73,6 @@ typedef uint64_t __odp_bitwise	odp_u64be_t;
 typedef uint16_t __odp_bitwise  odp_u16sum_t;
 typedef uint32_t __odp_bitwise  odp_u32sum_t;
 
-#include <odp/api/plat/byteorder_inlines.h>
-
 /**
  * @}
  */
@@ -82,5 +80,7 @@ typedef uint32_t __odp_bitwise  odp_u32sum_t;
 #ifdef __cplusplus
 }
 #endif
+
+#include <odp/api/plat/byteorder_inlines.h>
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/classification.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/classification.h
@@ -11,11 +11,11 @@
 #ifndef ODP_API_ABI_CLASSIFICATION_H_
 #define ODP_API_ABI_CLASSIFICATION_H_
 
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/plat/strong_types.h>
 
 /** @addtogroup odp_classification
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/comp.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/comp.h
@@ -7,11 +7,11 @@
 
 #include <odp/api/plat/strong_types.h>
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @addtogroup odp_compression
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/crypto.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/crypto.h
@@ -12,15 +12,7 @@
 #ifndef ODP_API_ABI_CRYPTO_H_
 #define ODP_API_ABI_CRYPTO_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Inlined API functions */
 #include <odp/api/plat/crypto_inlines.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/crypto_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/crypto_types.h
@@ -12,13 +12,13 @@
 #ifndef ODP_API_ABI_CRYPTO_TYPES_H_
 #define ODP_API_ABI_CRYPTO_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/std_types.h>
 
 #include <odp/api/plat/strong_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @addtogroup odp_crypto
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/debug.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/debug.h
@@ -57,10 +57,10 @@ extern "C" {
 
 #endif
 
-#include <odp/api/abi-default/debug.h>
-
 #ifdef __cplusplus
 }
 #endif
+
+#include <odp/api/abi-default/debug.h>
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/dma.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/dma.h
@@ -11,15 +11,7 @@
 #ifndef ODP_API_ABI_DMA_H_
 #define ODP_API_ABI_DMA_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Inlined functions for non-ABI compat mode */
 #include <odp/api/plat/dma_inlines.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/dma_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/dma_types.h
@@ -5,11 +5,11 @@
 #ifndef ODP_API_ABI_DMA_TYPES_H_
 #define ODP_API_ABI_DMA_TYPES_H_
 
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/plat/strong_types.h>
 
 /** @addtogroup odp_dma
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/event.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/event.h
@@ -12,15 +12,7 @@
 #ifndef ODP_API_ABI_EVENT_H_
 #define ODP_API_ABI_EVENT_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Inlined functions for non-ABI compat mode */
 #include <odp/api/plat/event_inlines.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/event_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/event_types.h
@@ -12,11 +12,11 @@
 #ifndef ODP_API_ABI_EVENT_TYPES_H_
 #define ODP_API_ABI_EVENT_TYPES_H_
 
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/plat/strong_types.h>
 
 /** @addtogroup odp_event
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/event_vector.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/event_vector.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_ABI_EVENT_VECTOR_H_
 #define ODP_API_ABI_EVENT_VECTOR_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/plat/event_vector_inlines.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/ipsec.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/ipsec.h
@@ -12,19 +12,7 @@
 #ifndef ODP_API_ABI_IPSEC_H_
 #define ODP_API_ABI_IPSEC_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Inlined API functions */
 #include <odp/api/plat/ipsec_inlines.h>
-
-/**
- * @}
- */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/ipsec_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/ipsec_types.h
@@ -12,13 +12,13 @@
 #ifndef ODP_API_ABI_IPSEC_TYPES_H_
 #define ODP_API_ABI_IPSEC_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/std_types.h>
 
 #include <odp/api/plat/strong_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @addtogroup odp_ipsec
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/ml_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/ml_types.h
@@ -5,12 +5,13 @@
 #ifndef ODP_API_ABI_ML_TYPES_H_
 #define ODP_API_ABI_ML_TYPES_H_
 
+#include <odp/api/std_types.h>
+
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/plat/strong_types.h>
 
 /** @internal Implementation specific ML parameters */
 struct _odp_ml_model_extra_param_t {

--- a/platform/linux-generic/include-abi/odp/api/abi/packet.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet.h
@@ -12,15 +12,7 @@
 #ifndef ODP_API_ABI_PACKET_H_
 #define ODP_API_ABI_PACKET_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/plat/packet_inlines.h>
 #include <odp/api/plat/packet_vector_inlines.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_flags.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_flags.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_ABI_PACKET_FLAGS_H_
 #define ODP_API_ABI_PACKET_FLAGS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/plat/packet_flag_inlines.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_io.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_io.h
@@ -12,15 +12,7 @@
 #ifndef ODP_API_ABI_PACKET_IO_H_
 #define ODP_API_ABI_PACKET_IO_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Inlined functions for non-ABI compat mode */
 #include <odp/api/plat/packet_io_inlines.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_io_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_io_types.h
@@ -12,12 +12,13 @@
 #ifndef ODP_API_ABI_PACKET_IO_TYPES_H_
 #define ODP_API_ABI_PACKET_IO_TYPES_H_
 
+#include <odp/api/std_types.h>
+
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/plat/strong_types.h>
 
 /** @addtogroup odp_packet_io
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_types.h
@@ -12,12 +12,13 @@
 #ifndef ODP_API_ABI_PACKET_TYPES_H_
 #define ODP_API_ABI_PACKET_TYPES_H_
 
+#include <odp/api/std_types.h>
+
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/plat/strong_types.h>
 
 /** @addtogroup odp_packet
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/pool.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/pool.h
@@ -12,15 +12,7 @@
 #ifndef ODP_API_ABI_POOL_H_
 #define ODP_API_ABI_POOL_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Inlined API functions */
 #include <odp/api/plat/pool_inlines.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/pool_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/pool_types.h
@@ -11,11 +11,11 @@
 #ifndef ODP_API_ABI_POOL_TYPES_H_
 #define ODP_API_ABI_POOL_TYPES_H_
 
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/plat/strong_types.h>
 
 /** @addtogroup odp_pool
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/proto_stats.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/proto_stats.h
@@ -12,14 +12,6 @@
 #ifndef ODP_API_ABI_PROTO_STATS_H_
 #define ODP_API_ABI_PROTO_STATS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Placeholder for inlined functions for non-ABI compat mode */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/proto_stats_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/proto_stats_types.h
@@ -12,12 +12,13 @@
 #ifndef ODP_API_ABI_PROTO_STATS_TYPES_H_
 #define ODP_API_ABI_PROTO_STATS_TYPES_H_
 
+#include <odp/api/std_types.h>
+
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/plat/strong_types.h>
 
 /** @addtogroup odp_proto_stats
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/queue.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/queue.h
@@ -11,15 +11,7 @@
 #ifndef ODP_API_ABI_QUEUE_H_
 #define ODP_API_ABI_QUEUE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Inlined functions for non-ABI compat mode */
 #include <odp/api/plat/queue_inlines.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/queue_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/queue_types.h
@@ -12,12 +12,13 @@
 #ifndef ODP_API_ABI_QUEUE_TYPES_H_
 #define ODP_API_ABI_QUEUE_TYPES_H_
 
+#include <odp/api/std_types.h>
+
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/plat/strong_types.h>
 
 /** @addtogroup odp_queue
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/random.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/random.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_ABI_RANDOM_H_
 #define ODP_API_ABI_RANDOM_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty placeholder header for function inlining */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/schedule.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/schedule.h
@@ -12,15 +12,7 @@
 #ifndef ODP_API_ABI_SCHEDULE_H_
 #define ODP_API_ABI_SCHEDULE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Inlined API functions */
 #include <odp/api/plat/schedule_inlines.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/shared_memory.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/shared_memory.h
@@ -12,12 +12,13 @@
 #ifndef ODP_API_ABI_SHARED_MEMORY_H_
 #define ODP_API_ABI_SHARED_MEMORY_H_
 
+#include <odp/api/std_types.h>
+
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/std_types.h>
-#include <odp/api/plat/strong_types.h>
 
 /** @addtogroup odp_shared_memory
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/stash.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/stash.h
@@ -9,14 +9,6 @@
 #ifndef ODP_API_ABI_STASH_H_
 #define ODP_API_ABI_STASH_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Empty placeholder header for inline functions */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/stash_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/stash_types.h
@@ -9,11 +9,11 @@
 #ifndef ODP_API_ABI_STASH_TYPES_H_
 #define ODP_API_ABI_STASH_TYPES_H_
 
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/plat/strong_types.h>
 
 /** @addtogroup odp_stash
  *  @{

--- a/platform/linux-generic/include-abi/odp/api/abi/std.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/std.h
@@ -11,14 +11,6 @@
 #ifndef ODP_API_ABI_STD_H_
 #define ODP_API_ABI_STD_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/plat/std_inlines.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/sync.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/sync.h
@@ -11,22 +11,6 @@
 #ifndef ODP_API_ABI_SYNC_H_
 #define ODP_API_ABI_SYNC_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/** @addtogroup odp_barrier
- *  @{
- */
-
 #include <odp/api/plat/sync_inlines.h>
-
-/**
- * @}
- */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/ticketlock.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/ticketlock.h
@@ -11,11 +11,11 @@
 #ifndef ODP_API_ABI_TICKETLOCK_H_
 #define ODP_API_ABI_TICKETLOCK_H_
 
+#include <odp/api/atomic.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/atomic.h>
 
 /** @addtogroup odp_locks
  *  @{
@@ -27,9 +27,6 @@ typedef struct odp_ticketlock_s {
 	odp_atomic_u32_t  cur_ticket;  /**< Current ticket */
 } odp_ticketlock_t;
 
-/* Include inlined versions of API functions */
-#include <odp/api/plat/ticketlock_inlines.h>
-
 /**
  * @}
  */
@@ -37,5 +34,8 @@ typedef struct odp_ticketlock_s {
 #ifdef __cplusplus
 }
 #endif
+
+/* Include inlined versions of API functions */
+#include <odp/api/plat/ticketlock_inlines.h>
 
 #endif

--- a/platform/linux-generic/include-abi/odp/api/abi/timer_types.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/timer_types.h
@@ -12,11 +12,11 @@
 #ifndef ODP_API_ABI_TIMER_TYPES_H_
 #define ODP_API_ABI_TIMER_TYPES_H_
 
+#include <odp/api/plat/strong_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/plat/strong_types.h>
 
 /** @addtogroup odp_timer
  *  @{

--- a/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/atomic_inlines.h
@@ -14,6 +14,10 @@
 
 #include <odp/api/abi/atomic_inlines.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -677,5 +681,9 @@ _ODP_INLINE int odp_atomic_cas_acq_rel_u128(odp_atomic_u128_t *atom,
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/buffer_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/buffer_inline_types.h
@@ -5,11 +5,11 @@
 #ifndef ODP_PLAT_BUFFER_INLINE_TYPES_H_
 #define ODP_PLAT_BUFFER_INLINE_TYPES_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/buffer_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/buffer_inlines.h
@@ -14,6 +14,10 @@
 #include <odp/api/plat/event_inline_types.h>
 #include <odp/api/plat/pool_inline_types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -78,5 +82,9 @@ _ODP_INLINE void *odp_buffer_user_area(odp_buffer_t buf)
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/byteorder_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/byteorder_inlines.h
@@ -11,11 +11,11 @@
 #ifndef ODP_PLAT_BYTEORDER_INLINES_H_
 #define ODP_PLAT_BYTEORDER_INLINES_H_
 
+#include <odp/api/abi/byteorder.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <odp/api/abi/byteorder.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/crypto_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/crypto_inlines.h
@@ -5,16 +5,16 @@
 #ifndef ODP_PLAT_CRYPTO_INLINES_H_
 #define ODP_PLAT_CRYPTO_INLINES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/crypto_types.h>
 #include <odp/api/event.h>
 #include <odp/api/packet.h>
 
 #include <odp/api/plat/debug_inlines.h>
 #include <odp/api/plat/packet_inline_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/debug_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/debug_inlines.h
@@ -22,11 +22,11 @@
 
 #include <odp/api/plat/thread_inline_types.h>
 
-/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #pragma GCC diagnostic push
 

--- a/platform/linux-generic/include/odp/api/plat/dma_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/dma_inlines.h
@@ -18,6 +18,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -88,5 +92,9 @@ _ODP_INLINE void odp_dma_compl_free(odp_dma_compl_t dma_compl)
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/event_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/event_inline_types.h
@@ -6,11 +6,11 @@
 #ifndef ODP_PLAT_EVENT_INLINE_TYPES_H_
 #define ODP_PLAT_EVENT_INLINE_TYPES_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/event_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/event_inlines.h
@@ -19,6 +19,10 @@
 #include <odp/api/plat/packet_inline_types.h>
 #include <odp/api/plat/timer_inline_types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -224,5 +228,9 @@ _ODP_INLINE void odp_event_flow_id_set(odp_event_t event, uint32_t id)
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/event_validation_external.h
+++ b/platform/linux-generic/include/odp/api/plat/event_validation_external.h
@@ -21,11 +21,11 @@
 #include <odp/api/hints.h>
 #include <odp/api/packet_types.h>
 
-/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 /** Enumerations for identifying ODP API functions */
 typedef enum {

--- a/platform/linux-generic/include/odp/api/plat/event_vector_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/event_vector_inline_types.h
@@ -5,11 +5,11 @@
 #ifndef ODP_PLAT_EVENT_VECTOR_INLINE_TYPES_H_
 #define ODP_PLAT_EVENT_VECTOR_INLINE_TYPES_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/event_vector_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/event_vector_inlines.h
@@ -20,6 +20,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -98,5 +102,9 @@ _ODP_INLINE void odp_event_vector_user_flag_set(odp_event_vector_t evv, int val)
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/hash_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/hash_inlines.h
@@ -5,13 +5,13 @@
 #ifndef ODP_PLAT_HASH_INLINES_H_
 #define ODP_PLAT_HASH_INLINES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/hash_crc32.h>
 
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/ipsec_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/ipsec_inlines.h
@@ -12,6 +12,10 @@
 #include <odp/api/plat/debug_inlines.h>
 #include <odp/api/plat/packet_inline_types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -52,5 +56,9 @@ _ODP_INLINE int odp_ipsec_result(odp_ipsec_packet_result_t *result, odp_packet_t
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/packet_flag_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_flag_inlines.h
@@ -16,6 +16,10 @@
 #include <odp/api/plat/packet_inline_types.h>
 #include <odp/api/hints.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 static inline uint64_t _odp_packet_input_flags(odp_packet_t pkt)
@@ -289,5 +293,9 @@ _ODP_INLINE int odp_packet_has_l4_error(odp_packet_t pkt)
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -13,11 +13,11 @@
 #ifndef ODP_PACKET_INLINE_TYPES_H_
 #define ODP_PACKET_INLINE_TYPES_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -28,6 +28,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -679,5 +683,9 @@ _ODP_INLINE odp_packet_buf_t odp_packet_buf_from_head(odp_pool_t pool, void *hea
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/packet_io_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_io_inlines.h
@@ -6,13 +6,13 @@
 #ifndef ODP_PLAT_PACKET_IO_INLINES_H_
 #define ODP_PLAT_PACKET_IO_INLINES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/abi/packet_io_types.h>
 
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_vector_inlines.h
@@ -20,6 +20,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -98,5 +102,9 @@ _ODP_INLINE void odp_packet_vector_user_flag_set(odp_packet_vector_t pktv, int v
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/pool_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/pool_inline_types.h
@@ -11,11 +11,11 @@
 #ifndef ODP_POOL_INLINE_TYPES_H_
 #define ODP_POOL_INLINE_TYPES_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/pool_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/pool_inlines.h
@@ -5,15 +5,15 @@
 #ifndef ODP_PLAT_POOL_INLINES_H_
 #define ODP_PLAT_POOL_INLINES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/pool_types.h>
 
 #include <odp/api/plat/pool_inline_types.h>
 
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
@@ -6,13 +6,13 @@
 #ifndef ODP_PLAT_QUEUE_INLINE_TYPES_H_
 #define ODP_PLAT_QUEUE_INLINE_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <odp/api/event_types.h>
 #include <odp/api/queue_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/queue_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/queue_inlines.h
@@ -13,6 +13,10 @@
 #include <odp/api/plat/event_validation_external.h>
 #include <odp/api/plat/queue_inline_types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 extern const _odp_queue_api_fn_t *_odp_queue_api;
@@ -81,5 +85,9 @@ _ODP_INLINE int odp_queue_deq_multi(odp_queue_t queue,
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/rwlock_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/rwlock_inlines.h
@@ -13,6 +13,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -99,5 +103,9 @@ _ODP_INLINE void odp_rwlock_write_unlock(odp_rwlock_t *rwlock)
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/rwlock_recursive_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/rwlock_recursive_inlines.h
@@ -16,6 +16,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -136,5 +140,9 @@ _ODP_INLINE void odp_rwlock_recursive_write_unlock(odp_rwlock_recursive_t *rlock
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/schedule_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/schedule_inline_types.h
@@ -5,16 +5,16 @@
 #ifndef ODP_PLAT_SCHEDULE_INLINE_TYPES_H_
 #define ODP_PLAT_SCHEDULE_INLINE_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/event_types.h>
 #include <odp/api/queue_types.h>
 #include <odp/api/schedule_types.h>
 #include <odp/api/thrmask.h>
 
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/schedule_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/schedule_inlines.h
@@ -13,6 +13,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 extern const _odp_schedule_api_fn_t *_odp_sched_api;
@@ -129,5 +133,9 @@ _ODP_INLINE void odp_schedule_order_wait(void)
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/spinlock_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/spinlock_inlines.h
@@ -10,6 +10,10 @@
 
 #include <odp/api/abi/spinlock.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -20,8 +24,6 @@
 	#define odp_spinlock_trylock __odp_spinlock_trylock
 	#define odp_spinlock_unlock __odp_spinlock_unlock
 	#define odp_spinlock_is_locked __odp_spinlock_is_locked
-
-	#include <odp/api/plat/cpu_inlines.h>
 #else
 	#undef _ODP_INLINE
 	#define _ODP_INLINE
@@ -59,5 +61,9 @@ _ODP_INLINE int odp_spinlock_is_locked(odp_spinlock_t *spinlock)
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/spinlock_recursive_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/spinlock_recursive_inlines.h
@@ -15,6 +15,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -25,9 +29,6 @@
 	#define odp_spinlock_recursive_trylock __odp_spinlock_recursive_trylock
 	#define odp_spinlock_recursive_unlock __odp_spinlock_recursive_unlock
 	#define odp_spinlock_recursive_is_locked __odp_spinlock_recursive_is_locked
-
-	#include <odp/api/plat/spinlock_inlines.h>
-	#include <odp/api/plat/thread_inlines.h>
 #else
 	#undef _ODP_INLINE
 	#define _ODP_INLINE
@@ -92,5 +93,9 @@ _ODP_INLINE int odp_spinlock_recursive_is_locked(odp_spinlock_recursive_t *rlock
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/std_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/std_inlines.h
@@ -9,6 +9,10 @@
 
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef _ODP_NO_INLINE
 	/* Inline functions by default */
 	#define _ODP_INLINE static inline
@@ -35,5 +39,9 @@ _ODP_INLINE int odp_memcmp(const void *ptr1, const void *ptr2, size_t num)
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/strong_types.h
+++ b/platform/linux-generic/include/odp/api/plat/strong_types.h
@@ -15,6 +15,10 @@
 
 #include <odp/api/std_types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Use strong typing for ODP types */
 #ifdef __cplusplus
 /* Allow type to be expanded before concatenation with underscore */
@@ -34,5 +38,9 @@
 
 /** Internal macro to convert a scalar to a typed handle */
 #define _odp_cast_scalar(type, val) ((type)(uintptr_t)(val))
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/thread_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/thread_inlines.h
@@ -6,13 +6,13 @@
 #ifndef ODP_PLAT_THREAD_INLINES_H_
 #define ODP_PLAT_THREAD_INLINES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <odp/api/thread_types.h>
 
 #include <odp/api/plat/thread_inline_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/ticketlock_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/ticketlock_inlines.h
@@ -10,6 +10,11 @@
 
 #include <odp/api/abi/ticketlock.h>
 #include <odp/api/abi/wait_until.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -100,5 +105,9 @@ _ODP_INLINE int odp_ticketlock_is_locked(odp_ticketlock_t *ticketlock)
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/time_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/time_inlines.h
@@ -14,6 +14,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -185,5 +189,9 @@ _ODP_INLINE void odp_time_startup(odp_time_startup_t *startup)
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/timer_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/timer_inline_types.h
@@ -5,11 +5,11 @@
 #ifndef ODP_PLAT_TIMER_INLINE_TYPES_H_
 #define ODP_PLAT_TIMER_INLINE_TYPES_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 

--- a/platform/linux-generic/include/odp/api/plat/timer_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/timer_inlines.h
@@ -15,6 +15,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 #ifndef _ODP_NO_INLINE
@@ -100,5 +104,9 @@ _ODP_INLINE odp_event_t odp_timeout_to_event(odp_timeout_t tmo)
 }
 
 /** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Use 'extern "C"' linkage specification only where necessary. The previous
API header level usage caused problems in C++ builds if the ODP
implementation (or its includes) used function overloading.

Always do all includes outside 'extern "C"' to avoid affecting included
headers.
