### PR TITLE
[PATCH v2] linux-gen: sched: disable ordered queue reorder stash by default

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -233,7 +233,7 @@ sched_basic: {
 	# performance if threads process events in bursts. If 'order_stash_size'
 	# > 0, events may be dropped by the implementation if the target queue
 	# is full. To prevent this set 'order_stash_size' to 0.
-	order_stash_size = 512
+	order_stash_size = 0
 
 	# Power saving options for schedule with wait
 	#

--- a/platform/linux-generic/test/sched-basic.conf
+++ b/platform/linux-generic/test/sched-basic.conf
@@ -2,10 +2,11 @@
 odp_implementation = "linux-generic"
 config_file_version = "0.1.30"
 
-# Test scheduler with an odd spread value and without dynamic load balance
+# Test scheduler with an odd spread value, reorder stash, and without dynamic load balance.
 sched_basic: {
 	prio_spread = 3
 	load_balance = 0
+	order_stash_size = 512
 	powersave: {
 		poll_time_nsec = 5000
 		sleep_time_nsec = 50000


### PR DESCRIPTION
Disable basic scheduler implementation's ordered queue reorder stash by default. Reorder stash usage can cause event drops inside the implementation if the destination queue is full, which is against the ODP spec and can cause difficult to debug application problems.

When enabling reorder stash, application should make sure queues are large enough, so event drops will never occur.