### PR TITLE
[PATCH v5] api: timer: add timer pool priority

### DIFF
--- a/include/odp/api/spec/timer_types.h
+++ b/include/odp/api/spec/timer_types.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2019-2023 Nokia
+ * Copyright (c) 2019-2025 Nokia
  */
 
 /**
@@ -131,6 +131,9 @@ typedef struct {
 	/** Maximum number of timer pools for single shot timers (per clock source) */
 	uint32_t max_pools;
 
+	/** Maximum single shot timer pool priority */
+	uint16_t max_priority;
+
 	/** Maximum number of single shot timers in a pool
 	 *
 	 * The value of zero means that limited only by the available
@@ -202,6 +205,9 @@ typedef struct {
 		 *  When zero, periodic timers (#ODP_TIMER_TYPE_PERIODIC) are not supported.
 		 */
 		uint32_t max_pools;
+
+		/** Maximum periodic timer pool priority */
+		uint16_t max_priority;
 
 		/** Maximum number of periodic timers in a pool */
 		uint32_t max_timers;
@@ -371,6 +377,16 @@ typedef struct {
 
 	/** Number of timers in the pool. */
 	uint32_t num_timers;
+
+	/** Timer pool priority
+	 *
+	 *  Timers allocated from pools with a higher priority value are served with higher priority
+	 *  than timers allocated from pools with a lower priority value. The prioritization
+	 *  algorithm is implementation specific. Note that lower priority timers may get delayed
+	 *  due to higher priority timer processing. All values between zero and 'max_priority'
+	 *  (see odp_timer_capability_t) are valid. The default value is zero.
+	 */
+	uint16_t priority;
 
 	/** Thread private timer pool. When zero, multiple thread may use the
 	 *  timer pool concurrently. When non-zero, only single thread uses the

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1460,6 +1460,11 @@ odp_timer_pool_t odp_timer_pool_create(const char *name,
 	if (param->res_ns == 0 && param->res_hz > timer_global->highest_res_hz)
 		return ODP_TIMER_POOL_INVALID;
 
+	if (param->priority > 0) {
+		_ODP_ERR("Only default timer pool priority supported.\n");
+		return ODP_TIMER_POOL_INVALID;
+	}
+
 	return timer_pool_new(name, param);
 }
 


### PR DESCRIPTION
Add new timer pool parameter odp_timer_pool_param_t.priority and related capabilities.

V2:
- Note that lower priority timers may get delayed due to higher priority timer processing

V3:
- Fixed Petri's comments
- Added validation tests
- Added parameter check in the implementation

V4:
- Added reviewed/acked-by tags