### PR TITLE
api: ml: add support for engine id

### DIFF
--- a/include/odp/api/spec/ml_types.h
+++ b/include/odp/api/spec/ml_types.h
@@ -181,6 +181,9 @@ typedef struct odp_ml_compl_pool_param_t {
 
 /** Machine learning capabilities */
 typedef struct odp_ml_capability_t {
+	/** Maximum number of engines */
+	uint32_t max_engines;
+
 	/** Maximum number of models
 	 *
 	 *  Maximum number of models that can be created simultaneously. The value is zero when
@@ -329,6 +332,14 @@ typedef struct odp_ml_capability_t {
 
 /** Machine learning configuration parameters */
 typedef struct odp_ml_config_t {
+	/**
+	 * Engine ID to be configured.
+	 *
+	 * In a system with multiple ML engines, this parameter selects the engine to be configured.
+	 * The default value is 0.
+	 */
+	uint32_t engine_id;
+
 	/**
 	 * Maximum number of models
 	 *
@@ -566,6 +577,9 @@ typedef struct odp_ml_model_info_t {
 	 */
 	uint64_t interface_version;
 
+	/** Engine ID to which the model is assigned */
+	uint32_t engine_id;
+
 	/** Model index assigned by the implementation */
 	uint32_t index;
 
@@ -598,6 +612,13 @@ typedef struct odp_ml_data_format_t {
  * Use odp_ml_model_param_init() to initialize the structure to its default values.
  */
 typedef struct odp_ml_model_param_t {
+	/**
+	 * Engine ID
+	 *
+	 * Engine ID to be used with the model. The default value is 0.
+	 */
+	uint32_t engine_id;
+
 	/**
 	 * Model binary
 	 *

--- a/platform/linux-generic/odp_ml.c
+++ b/platform/linux-generic/odp_ml.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#define ML_MAX_ENGINES 1
 #define ML_MAX_IO_SEGS UINT32_MAX
 #define ML_MAX_COMPL_ID 32
 #define ML_MAX_CONFIG_STR_LEN 65
@@ -151,6 +152,7 @@ int odp_ml_capability(odp_ml_capability_t *capa)
 		return 0;
 	}
 
+	capa->max_engines = 1;
 	capa->max_model_size = ML_MAX_MODEL_SIZE;
 	capa->max_models = ML_MAX_MODELS_CREATED;
 	capa->max_models_loaded = ML_MAX_MODELS_LOADED;
@@ -192,6 +194,7 @@ int odp_ml_capability(odp_ml_capability_t *capa)
 void odp_ml_config_init(odp_ml_config_t *config)
 {
 	memset(config, 0, sizeof(odp_ml_config_t));
+	config->engine_id = 0;
 	config->max_models_created = 1;
 	config->max_models_loaded = 1;
 }
@@ -200,6 +203,12 @@ int odp_ml_config(const odp_ml_config_t *config)
 {
 	if (!config) {
 		_ODP_ERR("Config must not be NULL\n");
+		return -1;
+	}
+
+	if (config->engine_id >= ML_MAX_ENGINES) {
+		_ODP_ERR("Engine ID %u exceeds maximum number of engines %d\n",
+			 config->engine_id, ML_MAX_ENGINES);
 		return -1;
 	}
 
@@ -679,6 +688,7 @@ static int create_ort_model(const odp_ml_model_param_t *param, OrtSession **sess
 		return -1;
 	}
 
+	mdl->info.engine_id = 0;
 	mdl->max_compl_id = param->max_compl_id;
 	mdl->info.num_inputs = num_inputs;
 	mdl->info.num_outputs = num_outputs;
@@ -832,6 +842,12 @@ odp_ml_model_t odp_ml_model_create(const char *name, const odp_ml_model_param_t 
 
 	if (odp_unlikely(odp_global_ro.disable.ml)) {
 		_ODP_ERR("ML is disabled\n");
+		return ODP_ML_MODEL_INVALID;
+	}
+
+	if (odp_unlikely(param->engine_id >= ML_MAX_ENGINES)) {
+		_ODP_ERR("Engine ID %u exceeds maximum number of engines %d\n",
+			 param->engine_id, ML_MAX_ENGINES);
 		return ODP_ML_MODEL_INVALID;
 	}
 


### PR DESCRIPTION
In devices with multiple ML engines, support should be enabled to present the number of engines supported by device and options to select the engine ID to be used to config and load a model. This patch adds the field max_engines to ML capability and engine ID to config and model params.

Added implementation for linux-generic platform.