### PR TITLE
[PATCH v7] api: add event aggregator enqueue profile to CLS and a new queue enqueuing function

### DIFF
--- a/example/sysinfo/odp_sysinfo.c
+++ b/example/sysinfo/odp_sysinfo.c
@@ -1113,6 +1113,11 @@ int main(int argc, char **argv)
 	printf("    threshold_bp:           0x%" PRIx8 "\n", cls_capa.threshold_bp.all_bits);
 	printf("    max_mark:               %" PRIu64 "\n", cls_capa.max_mark);
 	printf("    stats.queue:            0x%" PRIx64 "\n", cls_capa.stats.queue.all_counters);
+	#define aep_type cls_capa.aggr.enq_profile_type
+	printf("    aggr.enq_profile_type.ipv4_frag: %u\n", aep_type.ipv4_frag);
+	printf("    aggr.enq_profile_type.ipv6_frag: %u\n", aep_type.ipv6_frag);
+	printf("    aggr.enq_profile_type.custom:    %u\n", aep_type.custom);
+	#undef aep_type
 
 	printf("\n");
 	printf("  COMPRESSION\n");

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -544,6 +544,24 @@ typedef struct odp_cls_stats_capability_t {
 
 } odp_cls_stats_capability_t;
 
+/** Event aggregator related capabilities */
+typedef struct odp_cls_aggr_capability_t {
+	/** Supported enqueuing profile types in addition to ODP_AEP_TYPE_NONE,
+	 *  which is always supported. See odp_aggr_enq_profile_t. */
+	struct {
+		/** IPv4 fragment profile (ODP_AEP_TYPE_IPV4_FRAG) */
+		uint64_t ipv4_frag : 1;
+
+		/** IPv6 fragment profile (ODP_AEP_TYPE_IPV6_FRAG) */
+		uint64_t ipv6_frag : 1;
+
+		/** Custom profile (ODP_AEP_TYPE_CUSTOM) */
+		uint64_t custom : 1;
+
+	} enq_profile_type;
+
+} odp_cls_aggr_capability_t;
+
 /**
  * Classification capabilities
  * This capability structure defines system level classification capability
@@ -605,6 +623,9 @@ typedef struct odp_cls_capability_t {
 
 	/** Statistics counters capabilities */
 	odp_cls_stats_capability_t stats;
+
+	/** Event aggregator related capabilities */
+	odp_cls_aggr_capability_t aggr;
 
 } odp_cls_capability_t;
 
@@ -711,6 +732,18 @@ typedef struct odp_cls_cos_param {
 	 * application.
 	 */
 	odp_pktin_vector_config_t vector;
+
+	/** Event aggregator enqueuing profile
+	 *
+	 * This parameter has an effect only when a packet is enqueued to
+	 * an aggregator queue by this CoS.
+	 *
+	 * If the profile is not one of the supported types indicated in
+	 * odp_cls_capability_t::aggr.enq_profile_type, or if the profile
+	 * type is supported but the profile cannot be supported in this CoS
+	 * instance (e.g. due to resource constraints), CoS creation will fail.
+	 */
+	odp_aggr_enq_profile_t aggr_enq_profile;
 
 } odp_cls_cos_param_t;
 

--- a/include/odp/api/spec/queue.h
+++ b/include/odp/api/spec/queue.h
@@ -243,6 +243,36 @@ int odp_queue_enq(odp_queue_t queue, odp_event_t ev);
 int odp_queue_enq_multi(odp_queue_t queue, const odp_event_t events[], int num);
 
 /**
+ * Enqueue an event with event aggregation hints
+ *
+ * Similar to odp_queue_enq() but passes an aggregation hint to the queue
+ * if the queue is an event aggregator. If the queue is not an event
+ * aggregator, works the same way as odp_queue_enq().
+ *
+ * Queuing to an event aggregator can be done using the normal enqueueing
+ * functions if an aggregation hint is not needed.
+ *
+ * Use odp_aggr_enq_param_init() to initialize param.
+ *
+ * @param queue   Queue handle
+ * @param ev      Event handle
+ * @param param   Aggregation hint parameters
+ *
+ * @retval 0 on success
+ * @retval <0 on failure
+ */
+int odp_queue_enq_aggr(odp_queue_t queue, odp_event_t ev, const odp_aggr_enq_param_t *param);
+
+/**
+ * Initialize aggregator enqueue parameters to their default values
+ *
+ * Initialize all fields of the parameter structure to their default values
+ *
+ * @param[out] param   Aggregation hint parameters
+ */
+void odp_aggr_enq_param_init(odp_aggr_enq_param_t *param);
+
+/**
  * Dequeue an event from a queue
  *
  * Returns the next event from head of the queue, or ODP_EVENT_INVALID when the

--- a/include/odp/api/spec/queue_types.h
+++ b/include/odp/api/spec/queue_types.h
@@ -382,6 +382,47 @@ typedef struct odp_aggr_enq_param_t {
 } odp_aggr_enq_param_t;
 
 /**
+ * Event aggregator enqueuing profile
+ *
+ * This profile affects how enqueuing to an event aggregator is done.
+ * Depending on the event being enqueued and the profile chosen,
+ * start-of-vector, end-of-vector or other similar hints may
+ * be passed to the aggregator along with the event.
+ *
+ * @see odp_aggr_enq_param_t
+ */
+typedef struct odp_aggr_enq_profile_t {
+	/** Profile type. The default value is ODP_AEP_TYPE_NONE. */
+	enum {
+		/** Default enqueuing behaviour with no hints being passed */
+		ODP_AEP_TYPE_NONE,
+
+		/** Try to get fragments of the same IPv4 packet into the
+		 *  same vector by enqueuing the first and last fragments
+		 *  with the start-of-vector and/or end-of-vector hints.
+		 */
+		ODP_AEP_TYPE_IPV4_FRAG,
+
+		/** Try to get fragments of the same IPv6 packet into the
+		 *  same vector by enqueuing the first and last fragments
+		 *  with the start-of-vector and/or end-of-vector hints.
+		 */
+		ODP_AEP_TYPE_IPV6_FRAG,
+
+		/** Implementation specific behaviour. */
+		ODP_AEP_TYPE_CUSTOM,
+	} type;
+
+	/** Additional implementation specific parameter for the
+	 *  ODP_AEP_TYPE_CUSTOM profile type. Must be zero for the other
+	 *  profile types.
+	 *
+	 *  The default value is zero.
+	 */
+	uintptr_t param;
+} odp_aggr_enq_profile_t;
+
+/**
  * @}
  */
 

--- a/include/odp/api/spec/queue_types.h
+++ b/include/odp/api/spec/queue_types.h
@@ -348,6 +348,40 @@ typedef struct odp_queue_info_t {
 } odp_queue_info_t;
 
 /**
+ * Event aggregator enqueuing parameters
+ */
+typedef struct odp_aggr_enq_param_t {
+	/** The event being enqueued is the first event of related events.
+	  *
+	  * Give a hint to an event aggregator to make room for new events
+	  * in the aggregation queue by generating an event vector of the
+	  * events already in the aggregation queue. This makes it more
+	  * likely that this event and the related events end up in the
+	  * same event vector.
+	  *
+	  * This flag has an effect only when an event is enqueued to an
+	  * event aggregation queue.
+	  *
+	  * Default value is zero.
+	  */
+	uint8_t start_of_vector :1;
+
+	/** The event being enqueued is the last event of related events.
+	  *
+	  * Give a hint to an event aggregator to stop aggregating more
+	  * events before generating an event vector. This reduces the
+	  * delay experienced by the events being aggregated.
+	  *
+	  * This flag has an effect only when an event is enqueued to an
+	  * event aggregation queue.
+	  *
+	  * Default value is zero.
+	  */
+	uint8_t end_of_vector :1;
+
+} odp_aggr_enq_param_t;
+
+/**
  * @}
  */
 

--- a/platform/linux-generic/include/odp/api/plat/queue_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/queue_inlines.h
@@ -1,10 +1,12 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2018 Linaro Limited
- * Copyright (c) 2023 Nokia
+ * Copyright (c) 2023-2025 Nokia
  */
 
 #ifndef ODP_PLAT_QUEUE_INLINES_H_
 #define ODP_PLAT_QUEUE_INLINES_H_
+
+#include <string.h>
 
 #include <odp/api/hints.h>
 
@@ -21,6 +23,8 @@ extern const _odp_queue_api_fn_t *_odp_queue_api;
 	#define odp_queue_context   __odp_queue_context
 	#define odp_queue_enq       __odp_queue_enq
 	#define odp_queue_enq_multi __odp_queue_enq_multi
+	#define odp_queue_enq_aggr  __odp_queue_enq_aggr
+	#define odp_aggr_enq_param_init __odp_aggr_enq_param_init
 	#define odp_queue_deq       __odp_queue_deq
 	#define odp_queue_deq_multi __odp_queue_deq_multi
 #else
@@ -52,6 +56,17 @@ _ODP_INLINE int odp_queue_enq_multi(odp_queue_t queue,
 		return -1;
 
 	return _odp_queue_api->queue_enq_multi(queue, events, num);
+}
+
+_ODP_INLINE int odp_queue_enq_aggr(odp_queue_t queue, odp_event_t ev,
+				   const odp_aggr_enq_param_t *param ODP_UNUSED)
+{
+	return odp_queue_enq(queue, ev);
+}
+
+_ODP_INLINE void odp_aggr_enq_param_init(odp_aggr_enq_param_t *param)
+{
+	memset(param, 0, sizeof(*param));
 }
 
 _ODP_INLINE odp_event_t odp_queue_deq(odp_queue_t queue)

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -273,6 +273,9 @@ odp_cos_t odp_cls_cos_create(const char *name, const odp_cls_cos_param_t *param_
 		}
 	}
 
+	if (param.aggr_enq_profile.type != ODP_AEP_TYPE_NONE)
+		return ODP_COS_INVALID;
+
 	for (i = 0; i < CLS_COS_MAX_ENTRY; i++) {
 		cos = &cos_tbl->cos_entry[i];
 		LOCK(&cos->lock);

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -138,6 +138,7 @@ static void queue_test_capa(void)
 static void test_defaults(uint8_t fill)
 {
 	odp_queue_param_t param;
+	odp_aggr_enq_param_t aggr_enq_param;
 
 	memset(&param, fill, sizeof(param));
 	odp_queue_param_init(&param);
@@ -155,6 +156,11 @@ static void test_defaults(uint8_t fill)
 	CU_ASSERT(param.size == 0);
 	CU_ASSERT(param.num_aggr == 0);
 	CU_ASSERT(param.aggr == NULL);
+
+	memset(&aggr_enq_param, fill, sizeof(aggr_enq_param));
+	odp_aggr_enq_param_init(&aggr_enq_param);
+	CU_ASSERT(aggr_enq_param.start_of_vector == 0);
+	CU_ASSERT(aggr_enq_param.end_of_vector == 0);
 }
 
 static void queue_test_param_init(void)


### PR DESCRIPTION
This is based on PR 2187 even though the code is not included here.

This PR adds a new queue enqueuing function that can be used for passing start-of-vector and end-of-vector hints to an event aggregator (if the queue is, in fact, an event aggregator). This PR also adds a new classifier CoS parameter to select aggregator profile, which in turn causes the CoS to generate aggregation hints if it enqueues a packet to an event aggregator.
