### PR TITLE
[PATCH v4] api: describe parameter lifetimes in API principles

### DIFF
--- a/include/README
+++ b/include/README
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: BSD-3-Clause
 Copyright (c) 2017 Linaro Limited
-Copyright (c) 2023 Nokia
+Copyright (c) 2023-2025 Nokia
 
 # ODP specification
 
@@ -30,6 +30,16 @@ For example, application can receive an odp_event_t handle from `odp_schedule()`
 call. The ownership ends when the handle is passed back to ODP, for example with
 `odp_queue_enq()` call. Application MUST NOT use the handle anymore after it
 has lost the ownership.
+
+Lifetimes of structures passed by reference to ODP API do not need to be
+longer than the duration of the API function being called. In other words,
+an application can free or reuse such parameter structures as soon as the
+API function returns. This principle applies unless otherwise noted.
+This principle applies also recursively to all structures referred to by
+the parameter structures through pointer fields in the structures, unless
+otherwise noted. An ODP implementation must internally copy the content of
+any parameters that it needs to retain after an API call. This principle
+does not apply to objects referenced through handles.
 
 ## API headers
 


### PR DESCRIPTION
Add a paragraph in the API principles section in include/README to describe parameter lifetimes of ODP API functions: Structures passed by reference (and structures referred by them) do not need to outlive the API call, unless otherwise noted in the API.