### PR TITLE
[PATCH v2] linux-gen: sched: optimize slightly the case when stash is disabled

### DIFF
--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -29,7 +29,7 @@ int _odp_schedule_configured(void)
 #include <odp/visibility_end.h>
 
 extern const schedule_fn_t _odp_schedule_sp_fn;
-extern const schedule_fn_t _odp_schedule_basic_fn;
+extern schedule_fn_t _odp_schedule_basic_fn;
 const schedule_fn_t *_odp_sched_fn;
 int _odp_sched_id;
 


### PR DESCRIPTION
Use a simpler ord_enq_multi function in the basic scheduler when event stashing at enqueue is disabled, which is now the default config setting.