### PR TITLE
[PATCH v1] linux-gen: shm: do not print an error when huge pages cannot be used

### DIFF
--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -681,7 +681,10 @@ static int create_file(int block_index, huge_flag_t huge, uint64_t len,
 
 	ret = mkdir(dir, 0744);
 	if (ret && errno != EEXIST) {
-		_ODP_ERR("Could not create directory %s: %s\n", dir, strerror(errno));
+		if (use_huge)
+			_ODP_DBG("Could not create directory %s: %s\n", dir, strerror(errno));
+		else
+			_ODP_ERR("Could not create directory %s: %s\n", dir, strerror(errno));
 		return -1;
 	}
 


### PR DESCRIPTION
After the latest change lots of error messages are generated when ODP cannot create a directory in the huge page file system even though a fallback to normal pages works. This happens e.g. when running ODP as a normal user in a system with huge page fs mounted but not writable by normal users.

Get rid of the distracting error messages by changing them to debug prints.
