### PR TITLE
[PATCH v7] api: event: add event type metadata to event vectors

### DIFF
--- a/include/odp/api/spec/event_vector.h
+++ b/include/odp/api/spec/event_vector.h
@@ -88,7 +88,10 @@ void odp_event_vector_free(odp_event_vector_t evv);
  * The event_tbl points to the event vector table. Application can edit the
  * event handles in the table directly (up to odp_pool_param_t::event_vector.max_size).
  * Application must update the size of the table using odp_event_vector_size_set()
- * when there is a change in the size of the vector.
+ * when there is a change in the size of the vector. An application must also
+ * update the type of the event vector using odp_event_vector_type_set(), as
+ * necessary, after modifying the event vector and before passing the event
+ * vector to any ODP API function that takes a generic event parameter.
  *
  * Invalid event handles (ODP_EVENT_INVALID) are not allowed to be stored in the
  * table to allow consumers of odp_event_vector_t handle to have optimized
@@ -119,9 +122,12 @@ uint32_t odp_event_vector_size(odp_event_vector_t evv);
 /**
  * Type of events stored in event vector
  *
- * If all events in the vector are of the same type, function returns the
- * particular event type. If the vector is empty or includes multiple event
- * types, ODP_EVENT_ANY is returned instead.
+ * Return the event type stored in event vector metadata. After event vector
+ * allocation the event type is ODP_EVENT_ANY. Event aggregators set the
+ * event type to the type of the events stored in the event vector or to
+ * ODP_EVENT_ANY if the vector contains events of multiple types or if the
+ * aggregator was not able to determine that all the event are of the same
+ * type. The event type can also be set through odp_event_vector_type_set().
  *
  * @param      evv        Event vector handle
  *
@@ -130,15 +136,40 @@ uint32_t odp_event_vector_size(odp_event_vector_t evv);
 odp_event_type_t odp_event_vector_type(odp_event_vector_t evv);
 
 /**
+ * Set type of events stored in event vector
+ *
+ * The specified event type is stored in the event vector metadata and
+ * can be queried later through odp_event_vector_type(). The event type
+ * metadata does not need to match the actual type of events in the vector
+ * at all times but must be valid for the vector content (i.e. either
+ * ODP_EVENT_ANY or the same type as all events in the vector) when the
+ * event vector is passed to any ODP API function as a generic event
+ * (odp_event_t). API functions that take an event vector (odp_event_vector_t)
+ * parameter do not require a valid event vector type metadata.
+ *
+ * Calling odp_event_vector_type_set() is not necessary after modification
+ * of an event vector if the event type already has a valid value for the
+ * new content of the vector.
+ *
+ * @param      evv        Event vector handle
+ * @param      type       Event type
+ */
+void odp_event_vector_type_set(odp_event_vector_t evv, odp_event_type_t type);
+
+/**
  * Set the number of events stored in a vector
  *
  * Update the number of events stored in a vector. When the application is
  * producing an event vector, this function shall be used by the application
  * to set the number of events available in this vector.
  *
+ * An application must update the type of the event vector using
+ * odp_event_vector_type_set(), as necessary, after modifying the event
+ * vector and before passing the event vector to any ODP API function.
+ *
  * The maximum number of events this vector can hold is defined by
  * odp_pool_param_t::event_vector.max_size. The size value must not be greater
- * than odp_pool_param_t::event_vector.max_size
+ * than odp_pool_param_t::event_vector.max_size.
  *
  * All handles in the vector table (0 .. size - 1) need to be valid event
  * handles.

--- a/platform/linux-generic/include/odp/api/plat/event_vector_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/event_vector_inline_types.h
@@ -33,6 +33,7 @@ typedef struct _odp_event_vector_inline_offset_t {
 	uint16_t event;
 	uint16_t pool;
 	uint16_t size;
+	uint16_t event_type;
 	uint16_t uarea_addr;
 	uint16_t flags;
 

--- a/platform/linux-generic/include/odp/api/plat/event_vector_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/event_vector_inlines.h
@@ -35,6 +35,8 @@ extern "C" {
 	#define odp_event_vector_pool __odp_event_vector_pool
 	#define odp_event_vector_size __odp_event_vector_size
 	#define odp_event_vector_size_set __odp_event_vector_size_set
+	#define odp_event_vector_type __odp_event_vector_type
+	#define odp_event_vector_type_set __odp_event_vector_type_set
 	#define odp_event_vector_user_area __odp_event_vector_user_area
 	#define odp_event_vector_user_flag __odp_event_vector_user_flag
 	#define odp_event_vector_user_flag_set __odp_event_vector_user_flag_set
@@ -77,6 +79,18 @@ _ODP_INLINE void odp_event_vector_size_set(odp_event_vector_t evv, uint32_t size
 	uint32_t *vector_size = _odp_event_vect_get_ptr(evv, uint32_t, size);
 
 	*vector_size = size;
+}
+
+_ODP_INLINE odp_event_type_t odp_event_vector_type(odp_event_vector_t evv)
+{
+	return _odp_event_vect_get(evv, odp_event_type_t, event_type);
+}
+
+_ODP_INLINE void odp_event_vector_type_set(odp_event_vector_t evv, odp_event_type_t type)
+{
+	odp_event_type_t *evv_type = _odp_event_vect_get_ptr(evv, odp_event_type_t, event_type);
+
+	*evv_type = type;
 }
 
 _ODP_INLINE void *odp_event_vector_user_area(odp_event_vector_t evv)

--- a/platform/linux-generic/odp_event_vector.c
+++ b/platform/linux-generic/odp_event_vector.c
@@ -24,6 +24,7 @@ const _odp_event_vector_inline_offset_t _odp_event_vector_inline ODP_ALIGNED_CAC
 	.event     = offsetof(odp_event_vector_hdr_t, event),
 	.pool      = offsetof(odp_event_vector_hdr_t, event_hdr.pool),
 	.size      = offsetof(odp_event_vector_hdr_t, size),
+	.event_type = offsetof(odp_event_vector_hdr_t, event_type),
 	.uarea_addr = offsetof(odp_event_vector_hdr_t, uarea_addr),
 	.flags     = offsetof(odp_event_vector_hdr_t, flags)
 };
@@ -51,6 +52,7 @@ odp_event_vector_t odp_event_vector_alloc(odp_pool_t pool_hdl)
 		return ODP_EVENT_VECTOR_INVALID;
 
 	_ODP_ASSERT(event_vector_hdr_from_event(event)->size == 0);
+	_ODP_ASSERT(event_vector_hdr_from_event(event)->event_type == ODP_EVENT_ANY);
 
 	return odp_event_vector_from_event(event);
 }
@@ -61,27 +63,9 @@ void odp_event_vector_free(odp_event_vector_t evv)
 
 	evv_hdr->size = 0;
 	evv_hdr->flags.all_flags = 0;
+	evv_hdr->event_type = ODP_EVENT_ANY;
 
 	_odp_event_free(odp_event_vector_to_event(evv));
-}
-
-odp_event_type_t odp_event_vector_type(odp_event_vector_t evv)
-{
-	odp_event_vector_hdr_t *evv_hdr = _odp_event_vector_hdr(evv);
-	uint32_t num = evv_hdr->size;
-	odp_event_type_t type;
-
-	if (odp_unlikely(num == 0))
-		return ODP_EVENT_ANY;
-
-	type = _odp_event_hdr(evv_hdr->event[0])->event_type;
-	for (uint32_t i = 1; i < num; i++) {
-		if (_odp_event_hdr(evv_hdr->event[i])->event_type != (int8_t)type) {
-			type = ODP_EVENT_ANY;
-			break;
-		}
-	}
-	return type;
 }
 
 void odp_event_vector_print(odp_event_vector_t evv)

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -543,6 +543,7 @@ static void init_event_hdr(pool_t *pool, _odp_event_hdr_t *event_hdr, uint32_t e
 
 		event_hdr->event_type = ODP_EVENT_VECTOR;
 		vect_hdr->uarea_addr = uarea;
+		vect_hdr->event_type = ODP_EVENT_ANY;
 	}
 
 	/* Initialize timeout metadata */


### PR DESCRIPTION
Change odp_event_vector_type() to not return the type of events actually stored in the event vector but the event type stored in event vector metadata and add odp_event_vector_type_set() to set the event type. Specify that event aggregators set the event type according to the event types they put in the event vector and require that applications use odp_event_vector_type_set() to update the event type of a vector after vector table modifications.

This way odp_event_vector_type() can be used largely as before, but an ODP implementation is not forced to loop through the vector every time odp_event_vector_type() is called.