### PR TITLE
[PATCH v7] api: cls: add PMR priority to break PMR matching ties

### DIFF
--- a/example/sysinfo/odp_sysinfo.c
+++ b/example/sysinfo/odp_sysinfo.c
@@ -1143,6 +1143,7 @@ int main(int argc, char **argv)
 	printf("    max_pmr:                %u\n", cls_capa.max_pmr);
 	printf("    max_pmr_per_cos:        %u\n", cls_capa.max_pmr_per_cos);
 	printf("    max_terms_per_pmr:      %u\n", cls_capa.max_terms_per_pmr);
+	printf("    max_pmr_priority:       %u\n", cls_capa.max_pmr_priority);
 	printf("    max_cos:                %u\n", cls_capa.max_cos);
 	printf("    max_hash_queues:        %u\n", cls_capa.max_hash_queues);
 	printf("    hash_protocols:         0x%x\n", cls_capa.hash_protocols.all_bits);

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -342,6 +342,18 @@ typedef struct odp_pmr_create_opt_t {
 	 */
 	uint64_t mark;
 
+	/** Rule priority
+	 *
+	 *  When multiple PMRs match a packet, a matching rule with the
+	 *  highest priority is selected. If there are multiple such rules,
+	 *  then it is implementation specific which one is selected.
+	 *
+	 *  Larger priority value corresponds to higher priority. The value
+	 *  must not be larger than odp_cls_capability_t::max_pmr_priority.
+	 *  The default value is 0.
+	 */
+	uint32_t priority;
+
 } odp_pmr_create_opt_t;
 
 /** Random Early Detection (RED)
@@ -584,6 +596,9 @@ typedef struct odp_cls_capability_t {
 
 	/** Maximum number of terms per composite PMR */
 	uint32_t max_terms_per_pmr;
+
+	/** Maximum priority value of a PMR */
+	uint32_t max_pmr_priority;
 
 	/** Maximum number of CoS supported */
 	uint32_t max_cos;
@@ -969,8 +984,11 @@ void odp_cls_pmr_create_opt_init(odp_pmr_create_opt_t *opt);
  *
  * Creates a PMR between source and destination Class of Service (CoS). A packet arriving to
  * a CoS is matched against all the PMRs that define it as their source CoS. A PMR match moves
- * the packet from the source to the destination CoS. If multiple PMRs of a CoS match with
- * the packet, it is implementation specific which PMR is selected.
+ * the packet from the source to the destination CoS.
+ *
+ * This function creates PMRs of priority zero. Use odp_cls_pmr_create_opt() to create PMRs of
+ * any priority. If multiple PMRs of the same priority match the packet, it is implementation
+ * specific which PMR is selected.
  *
  * A composite PMR is created when PMR parameters define more than one term. A composite PMR is
  * considered to match only if a packet matches with all its terms. It is implementation specific

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -156,6 +156,7 @@ int odp_cls_capability(odp_cls_capability_t *capability)
 	capability->max_pmr = CLS_PMR_MAX_ENTRY;
 	capability->max_pmr_per_cos = CLS_PMR_PER_COS_MAX;
 	capability->max_terms_per_pmr = CLS_PMRTERM_MAX;
+	capability->max_pmr_priority = 0;
 	capability->max_cos = CLS_COS_MAX_ENTRY;
 	capability->max_cos_stats = capability->max_cos;
 	capability->pmr_range_supported = false;
@@ -205,6 +206,7 @@ void odp_cls_pmr_create_opt_init(odp_pmr_create_opt_t *opt)
 	opt->terms = NULL;
 	opt->num_terms = 0;
 	opt->mark = 0;
+	opt->priority = 0;
 }
 
 static void _odp_cls_update_hash_proto(cos_t *cos,

--- a/test/validation/api/classification/odp_classification_basic.c
+++ b/test/validation/api/classification/odp_classification_basic.c
@@ -36,6 +36,7 @@ static void test_defaults(uint8_t fill)
 	memset(&pmr_opt, fill, sizeof(pmr_opt));
 	odp_cls_pmr_create_opt_init(&pmr_opt);
 	CU_ASSERT(pmr_opt.mark == 0);
+	CU_ASSERT(pmr_opt.priority == 0);
 }
 
 static void cls_default_values(void)


### PR DESCRIPTION
Add configurable priority to PMRs so that when multiple PMRs match a packet a PMR with the highest priority is selected. If multiple PMRs of the same priority match a packet, leave it implementation specific which PMR gets selected. Add a capability for the maximum priority value.