### PR TITLE
[PATCH v8] api: dma: add cache stashing

### DIFF
--- a/include/odp/api/spec/dma_types.h
+++ b/include/odp/api/spec/dma_types.h
@@ -470,26 +470,64 @@ typedef struct odp_dma_seg_t {
 	/** Segment hints
 	 *
 	 *  Depending on the implementation, setting these hints may improve performance.
-	 *  Initialize all unused bits to zero.
 	 */
-	union {
-		/** Segment hints bit field */
-		struct {
-			/** Allow full cache line access
+	struct {
+		union {
+			/** Segment hints bit field
 			 *
-			 *  When set to 1, data on the same cache line with the destination segment
-			 *  is allowed to be overwritten. This hint is ignored on source segments.
+			 *  Initialize all unused bits to zero.
 			 */
-			uint16_t full_lines : 1;
+			struct {
+				/** Allow full cache line access
+				 *
+				 *  When set to 1, data on the same cache line with the destination
+				 *  segment is allowed to be overwritten. This hint is ignored on
+				 *  source segments.
+				 */
+				uint16_t full_lines : 1;
+
+				/** Enable L3 cache stashing
+				 *
+				 *  When set to 1, enables potential cache stashing of destination
+				 *  segment data to L3 according to 'cache_stash'.
+				 */
+				uint16_t cache_stash_l3 : 1;
+			} bit;
+
+			/** All bits of the bit field structure
+			 *
+			 *  This can be used to set/clear all bits, or to perform bitwise
+			 *  operations on those.
+			 */
+			uint16_t all_bits;
 		};
 
-		/** All bits of the bit field structure
+		/** Cache stashing hints
 		 *
-		 *  This can be used to set/clear all bits, or to perform bitwise operations
-		 *  on those.
+		 *  Applicable only to destination segments. Ignored for source segments. Hints
+		 *  implementation to bring specififed cache lines into cache as part of successful
+		 *  transfer completion.
 		 */
-		uint16_t all_hints;
-	};
+		struct {
+			/** L3 cache stashing */
+			struct {
+				/** Byte offset into the segment data to start caching from
+				 *
+				 *  Depending on the implementation, this might be rounded down
+				 *  to a more suitable boundary. In case of #ODP_DMA_FORMAT_PACKET,
+				 *  offset is in addition to the packet data starting offset.
+				 */
+				uint32_t offset;
+
+				/** Length in bytes to cache
+				 *
+				 *  Depending on the implementation, this might be rounded up
+				 *  to a more suitable boundary.
+				 */
+				uint32_t len;
+			} l3;
+		} cache_stash;
+	} hints;
 
 } odp_dma_seg_t;
 

--- a/test/validation/api/dma/dma.c
+++ b/test/validation/api/dma/dma.c
@@ -823,8 +823,14 @@ static void test_dma_addr_to_addr(odp_dma_compl_mode_t compl_mode_mask, uint32_t
 
 		src_seg[i].addr = src + offset;
 		src_seg[i].len  = cur_len;
+		src_seg[i].hints.bit.cache_stash_l3 = 1;
+		src_seg[i].hints.cache_stash.l3.offset = 0;
+		src_seg[i].hints.cache_stash.l3.len = ODP_CACHE_LINE_SIZE;
 		dst_seg[i].addr = dst + offset;
 		dst_seg[i].len  = cur_len;
+		dst_seg[i].hints.bit.cache_stash_l3 = 1;
+		dst_seg[i].hints.cache_stash.l3.offset = 0;
+		dst_seg[i].hints.cache_stash.l3.len = ODP_CACHE_LINE_SIZE;
 		offset += cur_len;
 	}
 
@@ -1150,9 +1156,15 @@ static void test_dma_pkt_to_pkt(odp_dma_compl_mode_t compl_mode_mask, int multi)
 	src_seg.packet = pkt;
 	src_seg.offset = OFFSET;
 	src_seg.len    = len;
+	src_seg.hints.bit.cache_stash_l3 = 1;
+	src_seg.hints.cache_stash.l3.offset = 0;
+	src_seg.hints.cache_stash.l3.len = ODP_CACHE_LINE_SIZE;
 	dst_seg.packet = pkt_2;
 	dst_seg.offset = OFFSET;
 	dst_seg.len    = len;
+	dst_seg.hints.bit.cache_stash_l3 = 1;
+	dst_seg.hints.cache_stash.l3.offset = 0;
+	dst_seg.hints.cache_stash.l3.len = ODP_CACHE_LINE_SIZE;
 
 	odp_dma_transfer_param_init(&trs_param);
 	trs_param.src_format = ODP_DMA_FORMAT_PACKET;
@@ -1847,6 +1859,9 @@ static void setup_segs(odp_dma_seg_t segs[], odp_packet_t pkt, uint32_t len, uin
 		if (use_idx) {
 			seg->pkt_index = 0;
 			seg->pkt_len = len;
+			seg->hints.bit.cache_stash_l3 = 1;
+			seg->hints.cache_stash.l3.offset = 0;
+			seg->hints.cache_stash.l3.len = ODP_CACHE_LINE_SIZE;
 		} else {
 			seg->packet = pkt;
 		}


### PR DESCRIPTION
Enable possibility to configure cache stashing for destination segments. Stashing the data of newly transferred segments may improve performance in some workloads.

The stashing configuration is instantiated as hints. Implementation can utilize the information according to its capabilities.

v2:
- Added a new simple validation test patch

v3:
- Rebased
- Matias' comments

v4:
- Rebased
- Matias' comments

v5:
- Rebased
- Added reviewed-by tags

v6:
- Rebased
- Added reviewed-by tag

v7:
- Rebased
- Added reviewed-by tag