### PR TITLE
[PATCH v4] api: crypto: add session debug print function

### DIFF
--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
- * Copyright (c) 2021-2023 Nokia
+ * Copyright (c) 2021-2025 Nokia
  */
 
 /**
@@ -124,6 +124,16 @@ int odp_crypto_session_destroy(odp_crypto_session_t session);
  * an odp_crypto_session_t handle.
  */
 uint64_t odp_crypto_session_to_u64(odp_crypto_session_t hdl);
+
+/**
+ * Print debug information about crypto session
+ *
+ * Print implementation defined information about crypto session to the ODP log.
+ * The information is intended to be used for debugging.
+ *
+ * @param hdl  Crypto session handle
+ */
+void odp_crypto_session_print(odp_crypto_session_t hdl);
 
 /**
  * Initialize crypto session parameters

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -138,6 +138,7 @@ noinst_HEADERS = \
 		  include/odp_classification_datamodel.h \
 		  include/odp_classification_internal.h \
 		  include/odp_config_internal.h \
+		  include/odp_crypto_internal.h \
 		  include/odp_debug_internal.h \
 		  include/odp_errno_define.h \
 		  include/odp_event_internal.h \
@@ -217,6 +218,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   miniz/miniz_tinfl.c miniz/miniz_tinfl.h \
 			   odp_cpumask.c \
 			   odp_cpumask_task.c \
+			   odp_crypto.c \
 			   odp_dma.c \
 			   odp_errno.c \
 			   odp_event.c \

--- a/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
+++ b/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
  * Copyright (c) 2021 ARM Limited
- * Copyright (c) 2022-2024 Nokia
+ * Copyright (c) 2022-2025 Nokia
  */
 
 #include <odp_posix_extensions.h>
@@ -20,6 +20,7 @@
 #include <odp/api/plat/queue_inlines.h>
 #include <odp/api/plat/thread_inlines.h>
 
+#include <odp_crypto_internal.h>
 #include <odp_debug_internal.h>
 #include <odp_global_data.h>
 #include <odp_init_internal.h>
@@ -754,6 +755,20 @@ void odp_crypto_session_param_init(odp_crypto_session_param_t *param)
 uint64_t odp_crypto_session_to_u64(odp_crypto_session_t hdl)
 {
 	return (uint64_t)hdl;
+}
+
+void odp_crypto_session_print(odp_crypto_session_t hdl)
+{
+	odp_crypto_generic_session_t *session;
+
+	if (hdl == ODP_CRYPTO_SESSION_INVALID) {
+		_ODP_ERR("Invalid crypto session\n");
+		return;
+	}
+
+	session = (odp_crypto_generic_session_t *)(uintptr_t)hdl;
+
+	_odp_crypto_session_print("armv8", session->idx, &session->p);
 }
 
 #if ODP_DEPRECATED_API

--- a/platform/linux-generic/include/odp_crypto_internal.h
+++ b/platform/linux-generic/include/odp_crypto_internal.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+#ifndef ODP_CRYPTO_INTERNAL_H_
+#define ODP_CRYPTO_INTERNAL_H_
+
+#include <odp/api/crypto.h>
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void _odp_crypto_session_print(const char *type, uint32_t index,
+			       const odp_crypto_session_param_t *param);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -1,0 +1,214 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+#include <odp/api/crypto.h>
+#include <odp/api/pool.h>
+#include <odp/api/queue.h>
+
+#include <odp_crypto_internal.h>
+#include <odp_debug_internal.h>
+#include <odp_string_internal.h>
+
+#include <inttypes.h>
+#include <stdint.h>
+
+static const char *auth_alg_name(odp_auth_alg_t auth)
+{
+	switch (auth) {
+	case ODP_AUTH_ALG_NULL:
+		return "ODP_AUTH_ALG_NULL";
+	case ODP_AUTH_ALG_MD5_HMAC:
+		return "ODP_AUTH_ALG_MD5_HMAC";
+	case ODP_AUTH_ALG_SHA1_HMAC:
+		return "ODP_AUTH_ALG_SHA1_HMAC";
+	case ODP_AUTH_ALG_SHA224_HMAC:
+		return "ODP_AUTH_ALG_SHA224_HMAC";
+	case ODP_AUTH_ALG_SHA256_HMAC:
+		return "ODP_AUTH_ALG_SHA256_HMAC";
+	case ODP_AUTH_ALG_SHA384_HMAC:
+		return "ODP_AUTH_ALG_SHA384_HMAC";
+	case ODP_AUTH_ALG_SHA512_HMAC:
+		return "ODP_AUTH_ALG_SHA512_HMAC";
+	case ODP_AUTH_ALG_SHA3_224_HMAC:
+		return "ODP_AUTH_ALG_SHA3_224_HMAC";
+	case ODP_AUTH_ALG_SHA3_256_HMAC:
+		return "ODP_AUTH_ALG_SHA3_256_HMAC";
+	case ODP_AUTH_ALG_SHA3_384_HMAC:
+		return "ODP_AUTH_ALG_SHA3_384_HMAC";
+	case ODP_AUTH_ALG_SHA3_512_HMAC:
+		return "ODP_AUTH_ALG_SHA3_512_HMAC";
+	case ODP_AUTH_ALG_AES_GCM:
+		return "ODP_AUTH_ALG_AES_GCM";
+	case ODP_AUTH_ALG_AES_GMAC:
+		return "ODP_AUTH_ALG_AES_GMAC";
+	case ODP_AUTH_ALG_AES_CCM:
+		return "ODP_AUTH_ALG_AES_CCM";
+	case ODP_AUTH_ALG_AES_CMAC:
+		return "ODP_AUTH_ALG_AES_CMAC";
+	case ODP_AUTH_ALG_AES_XCBC_MAC:
+		return "ODP_AUTH_ALG_AES_XCBC_MAC";
+	case ODP_AUTH_ALG_CHACHA20_POLY1305:
+		return "ODP_AUTH_ALG_CHACHA20_POLY1305";
+	case ODP_AUTH_ALG_KASUMI_F9:
+		return "ODP_AUTH_ALG_KASUMI_F9";
+	case ODP_AUTH_ALG_SNOW3G_UIA2:
+		return "ODP_AUTH_ALG_SNOW3G_UIA2";
+	case ODP_AUTH_ALG_AES_EIA2:
+		return "ODP_AUTH_ALG_AES_EIA2";
+	case ODP_AUTH_ALG_ZUC_EIA3:
+		return "ODP_AUTH_ALG_ZUC_EIA3";
+	case ODP_AUTH_ALG_SNOW_V_GCM:
+		return "ODP_AUTH_ALG_SNOW_V_GCM";
+	case ODP_AUTH_ALG_SNOW_V_GMAC:
+		return "ODP_AUTH_ALG_SNOW_V_GMAC";
+	case ODP_AUTH_ALG_SM3_HMAC:
+		return "ODP_AUTH_ALG_SM3_HMAC";
+	case ODP_AUTH_ALG_SM4_GCM:
+		return "ODP_AUTH_ALG_SM4_GCM";
+	case ODP_AUTH_ALG_SM4_GMAC:
+		return "ODP_AUTH_ALG_SM4_GMAC";
+	case ODP_AUTH_ALG_SM4_CCM:
+		return "ODP_AUTH_ALG_SM4_CCM";
+	case ODP_AUTH_ALG_MD5:
+		return "ODP_AUTH_ALG_MD5";
+	case ODP_AUTH_ALG_SHA1:
+		return "ODP_AUTH_ALG_SHA1";
+	case ODP_AUTH_ALG_SHA224:
+		return "ODP_AUTH_ALG_SHA224";
+	case ODP_AUTH_ALG_SHA256:
+		return "ODP_AUTH_ALG_SHA256";
+	case ODP_AUTH_ALG_SHA384:
+		return "ODP_AUTH_ALG_SHA384";
+	case ODP_AUTH_ALG_SHA512:
+		return "ODP_AUTH_ALG_SHA512";
+	case ODP_AUTH_ALG_SHA3_224:
+		return "ODP_AUTH_ALG_SHA3_224";
+	case ODP_AUTH_ALG_SHA3_256:
+		return "ODP_AUTH_ALG_SHA3_256";
+	case ODP_AUTH_ALG_SHA3_384:
+		return "ODP_AUTH_ALG_SHA3_384";
+	case ODP_AUTH_ALG_SHA3_512:
+		return "ODP_AUTH_ALG_SHA3_512";
+	case ODP_AUTH_ALG_SM3:
+		return "ODP_AUTH_ALG_SM3";
+	default:
+		return "unknown";
+	}
+}
+
+static const char *cipher_alg_name(odp_cipher_alg_t cipher)
+{
+	switch (cipher) {
+	case ODP_CIPHER_ALG_NULL:
+		return "ODP_CIPHER_ALG_NULL";
+	case ODP_CIPHER_ALG_DES:
+		return "ODP_CIPHER_ALG_DES";
+	case ODP_CIPHER_ALG_3DES_CBC:
+		return "ODP_CIPHER_ALG_3DES_CBC";
+	case ODP_CIPHER_ALG_3DES_ECB:
+		return "ODP_CIPHER_ALG_3DES_ECB";
+	case ODP_CIPHER_ALG_AES_CBC:
+		return "ODP_CIPHER_ALG_AES_CBC";
+	case ODP_CIPHER_ALG_AES_CTR:
+		return "ODP_CIPHER_ALG_AES_CTR";
+	case ODP_CIPHER_ALG_AES_ECB:
+		return "ODP_CIPHER_ALG_AES_ECB";
+	case ODP_CIPHER_ALG_AES_CFB128:
+		return "ODP_CIPHER_ALG_AES_CFB128";
+	case ODP_CIPHER_ALG_AES_XTS:
+		return "ODP_CIPHER_ALG_AES_XTS";
+	case ODP_CIPHER_ALG_AES_GCM:
+		return "ODP_CIPHER_ALG_AES_GCM";
+	case ODP_CIPHER_ALG_AES_CCM:
+		return "ODP_CIPHER_ALG_AES_CCM";
+	case ODP_CIPHER_ALG_CHACHA20_POLY1305:
+		return "ODP_CIPHER_ALG_CHACHA20_POLY1305";
+	case ODP_CIPHER_ALG_KASUMI_F8:
+		return "ODP_CIPHER_ALG_KASUMI_F8";
+	case ODP_CIPHER_ALG_SNOW3G_UEA2:
+		return "ODP_CIPHER_ALG_SNOW3G_UEA2";
+	case ODP_CIPHER_ALG_AES_EEA2:
+		return "ODP_CIPHER_ALG_AES_EEA2";
+	case ODP_CIPHER_ALG_ZUC_EEA3:
+		return "ODP_CIPHER_ALG_ZUC_EEA3";
+	case ODP_CIPHER_ALG_SNOW_V:
+		return "ODP_CIPHER_ALG_SNOW_V";
+	case ODP_CIPHER_ALG_SNOW_V_GCM:
+		return "ODP_CIPHER_ALG_SNOW_V_GCM";
+	case ODP_CIPHER_ALG_SM4_ECB:
+		return "ODP_CIPHER_ALG_SM4_ECB";
+	case ODP_CIPHER_ALG_SM4_CBC:
+		return "ODP_CIPHER_ALG_SM4_CBC";
+	case ODP_CIPHER_ALG_SM4_CTR:
+		return "ODP_CIPHER_ALG_SM4_CTR";
+	case ODP_CIPHER_ALG_SM4_GCM:
+		return "ODP_CIPHER_ALG_SM4_GCM";
+	case ODP_CIPHER_ALG_SM4_CCM:
+		return "ODP_CIPHER_ALG_SM4_CCM";
+	default:
+		return "unknown";
+	}
+}
+
+void _odp_crypto_session_print(const char *type, uint32_t index,
+			       const odp_crypto_session_param_t *param)
+{
+	const int max_len = 4096;
+	char str[max_len];
+	int len = 0;
+	int n = max_len - 1;
+
+	len += _odp_snprint(&str[len], n - len, "Crypto info\n");
+	len += _odp_snprint(&str[len], n - len, "-----------\n");
+	len += _odp_snprint(&str[len], n - len, "  type                      %s\n", type);
+	len += _odp_snprint(&str[len], n - len, "  index                     %" PRIu32 "\n", index);
+	len += _odp_snprint(&str[len], n - len, "  op                        %s\n",
+			    param->op == ODP_CRYPTO_OP_ENCODE ? "ODP_CRYPTO_OP_ENCODE" :
+			    "ODP_CRYPTO_OP_DECODE");
+	len += _odp_snprint(&str[len], n - len, "  op_type                   %s\n",
+			    param->op_type == ODP_CRYPTO_OP_TYPE_BASIC ?
+				"ODP_CRYPTO_OP_TYPE_BASIC" :
+			    param->op_type == ODP_CRYPTO_OP_TYPE_OOP ?
+				"ODP_CRYPTO_OP_TYPE_OOP" :
+			    param->op_type == ODP_CRYPTO_OP_TYPE_BASIC_AND_OOP ?
+				"ODP_CRYPTO_OP_TYPE_BASIC_AND_OOP" : "unknown");
+	len += _odp_snprint(&str[len], n - len, "  cipher_range_in_bits      %s\n",
+			    param->cipher_range_in_bits ? "true" : "false");
+	len += _odp_snprint(&str[len], n - len, "  auth_range_in_bits        %s\n",
+			    param->auth_range_in_bits ? "true" : "false");
+	len += _odp_snprint(&str[len], n - len, "  auth_cipher_text          %s\n",
+			    param->auth_cipher_text ? "true" : "false");
+	len += _odp_snprint(&str[len], n - len, "  hash_result_in_auth_range %s\n",
+			    param->hash_result_in_auth_range ? "true" : "false");
+	len += _odp_snprint(&str[len], n - len, "  null_crypto_enable        %s\n",
+			    param->null_crypto_enable ? "true" : "false");
+	len += _odp_snprint(&str[len], n - len, "  op_mode                   %s\n",
+			    param->op_mode == ODP_CRYPTO_SYNC ? "ODP_CRYPTO_SYNC" :
+			    "ODP_CRYPTO_ASYNC");
+	len += _odp_snprint(&str[len], n - len, "  cipher_alg                %s\n",
+			    cipher_alg_name(param->cipher_alg));
+	len += _odp_snprint(&str[len], n - len, "  cipher_key.data           %p\n",
+			    param->cipher_key.data);
+	len += _odp_snprint(&str[len], n - len, "  cipher_key.length         %" PRIu32 "\n",
+			    param->cipher_key.length);
+	len += _odp_snprint(&str[len], n - len, "  cipher_iv_len             %" PRIu32 "\n",
+			    param->cipher_iv_len);
+	len += _odp_snprint(&str[len], n - len, "  auth_alg                  %s\n",
+			    auth_alg_name(param->auth_alg));
+	len += _odp_snprint(&str[len], n - len, "  auth_key.data             %p\n",
+			    param->auth_key.data);
+	len += _odp_snprint(&str[len], n - len, "  auth_key.length           %" PRIu32 "\n",
+			    param->auth_key.length);
+	len += _odp_snprint(&str[len], n - len, "  auth_iv_len               %" PRIu32 "\n",
+			    param->auth_iv_len);
+	len += _odp_snprint(&str[len], n - len, "  auth_digest_len           %" PRIu32 "\n",
+			    param->auth_digest_len);
+	len += _odp_snprint(&str[len], n - len, "  auth_aad_len              %" PRIu32 "\n",
+			    param->auth_aad_len);
+	len += _odp_snprint(&str[len], n - len, "  compl_queue               %" PRIu64 "\n",
+			    odp_queue_to_u64(param->compl_queue));
+	len += _odp_snprint(&str[len], n - len, "  output_pool               %" PRIu64 "\n",
+			    odp_pool_to_u64(param->output_pool));
+	_ODP_PRINT("%s\n", str);
+}

--- a/platform/linux-generic/odp_crypto_ipsecmb.c
+++ b/platform/linux-generic/odp_crypto_ipsecmb.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
  * Copyright (c) 2021 ARM Limited
- * Copyright (c) 2022-2024 Nokia
+ * Copyright (c) 2022-2025 Nokia
  */
 
 #include <odp_posix_extensions.h>
@@ -19,6 +19,7 @@
 #include <odp/api/plat/queue_inlines.h>
 #include <odp/api/plat/thread_inlines.h>
 
+#include <odp_crypto_internal.h>
 #include <odp_debug_internal.h>
 #include <odp_global_data.h>
 #include <odp_init_internal.h>
@@ -742,6 +743,20 @@ void odp_crypto_session_param_init(odp_crypto_session_param_t *param)
 uint64_t odp_crypto_session_to_u64(odp_crypto_session_t hdl)
 {
 	return (uint64_t)hdl;
+}
+
+void odp_crypto_session_print(odp_crypto_session_t hdl)
+{
+	odp_crypto_generic_session_t *session;
+
+	if (hdl == ODP_CRYPTO_SESSION_INVALID) {
+		_ODP_ERR("Invalid crypto session\n");
+		return;
+	}
+
+	session = (odp_crypto_generic_session_t *)(uintptr_t)hdl;
+
+	_odp_crypto_session_print("ipsecmb", session->idx, &session->p);
 }
 
 #if ODP_DEPRECATED_API

--- a/platform/linux-generic/odp_crypto_null.c
+++ b/platform/linux-generic/odp_crypto_null.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
- * Copyright (c) 2021-2024 Nokia
+ * Copyright (c) 2021-2025 Nokia
  */
 
 #include <odp_posix_extensions.h>
@@ -22,6 +22,8 @@
 
 /* Inlined API functions */
 #include <odp/api/plat/event_inlines.h>
+
+#include <odp_crypto_internal.h>
 
 #define MAX_SESSIONS 32
 
@@ -371,6 +373,20 @@ void odp_crypto_session_param_init(odp_crypto_session_param_t *param)
 uint64_t odp_crypto_session_to_u64(odp_crypto_session_t hdl)
 {
 	return (uint64_t)hdl;
+}
+
+void odp_crypto_session_print(odp_crypto_session_t hdl)
+{
+	odp_crypto_generic_session_t *session;
+
+	if (hdl == ODP_CRYPTO_SESSION_INVALID) {
+		_ODP_ERR("Invalid crypto session\n");
+		return;
+	}
+
+	session = (odp_crypto_generic_session_t *)(uintptr_t)hdl;
+
+	_odp_crypto_session_print("null", session->idx, &session->p);
 }
 
 #if ODP_DEPRECATED_API

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
- * Copyright (c) 2021-2024 Nokia
+ * Copyright (c) 2021-2025 Nokia
  */
 
 #include <odp_posix_extensions.h>
@@ -23,6 +23,8 @@
 
 /* Inlined API functions */
 #include <odp/api/plat/event_inlines.h>
+
+#include <odp_crypto_internal.h>
 
 #include <string.h>
 #include <stdlib.h>
@@ -2524,6 +2526,20 @@ void odp_crypto_session_param_init(odp_crypto_session_param_t *param)
 uint64_t odp_crypto_session_to_u64(odp_crypto_session_t hdl)
 {
 	return (uint64_t)hdl;
+}
+
+void odp_crypto_session_print(odp_crypto_session_t hdl)
+{
+	odp_crypto_generic_session_t *session;
+
+	if (hdl == ODP_CRYPTO_SESSION_INVALID) {
+		_ODP_ERR("Invalid crypto session\n");
+		return;
+	}
+
+	session = (odp_crypto_generic_session_t *)(uintptr_t)hdl;
+
+	_odp_crypto_session_print("openssl", session->idx, &session->p);
 }
 
 #if ODP_DEPRECATED_API

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
- * Copyright (c) 2021-2024 Nokia
+ * Copyright (c) 2021-2025 Nokia
  */
 
 #include <string.h>
@@ -170,6 +170,7 @@ static void alg_test_op(crypto_op_test_param_t *param)
 
 static int combo_warning_shown;
 static int oop_warning_shown;
+static int session_print_shown;
 
 typedef enum {
 	HASH_NO_OVERLAP,
@@ -273,6 +274,11 @@ static int session_create(crypto_session_t *session,
 	CU_ASSERT(status == ODP_CRYPTO_SES_ERR_NONE);
 	CU_ASSERT(odp_crypto_session_to_u64(session->session) !=
 		  odp_crypto_session_to_u64(ODP_CRYPTO_SESSION_INVALID));
+
+	if (!session_print_shown) {
+		odp_crypto_session_print(session->session);
+		session_print_shown = 1;
+	}
 
 	/*
 	 * Clear session creation parameters so that we might notice if

--- a/test/validation/api/crypto/util.c
+++ b/test/validation/api/crypto/util.c
@@ -82,6 +82,14 @@ const char *auth_alg_name(odp_auth_alg_t auth)
 		return "ODP_AUTH_ALG_SHA384";
 	case ODP_AUTH_ALG_SHA512:
 		return "ODP_AUTH_ALG_SHA512";
+	case ODP_AUTH_ALG_SHA3_224:
+		return "ODP_AUTH_ALG_SHA3_224";
+	case ODP_AUTH_ALG_SHA3_256:
+		return "ODP_AUTH_ALG_SHA3_256";
+	case ODP_AUTH_ALG_SHA3_384:
+		return "ODP_AUTH_ALG_SHA3_384";
+	case ODP_AUTH_ALG_SHA3_512:
+		return "ODP_AUTH_ALG_SHA3_512";
 	case ODP_AUTH_ALG_SM3:
 		return "ODP_AUTH_ALG_SM3";
 	default:


### PR DESCRIPTION
Add odp_crypto_session_print() function for printing implementation defined information about a crypto session to the ODP log.

V2:
- Added implementation and validation test change