### PR TITLE
[PATCH v3] scripts: make bash scripts more cross-platform

### DIFF
--- a/doc/implementers-guide/implementers-guide.adoc
+++ b/doc/implementers-guide/implementers-guide.adoc
@@ -387,7 +387,7 @@ Here follows a dummy example of what wrapper-script could be:
 
 [source,bash]
 ----
-#!/bin/bash
+#!/usr/bin/env bash
 
 # The parameter, $1, is the name of the test executable to run
 echo "WRAPPER!!!"

--- a/example/classifier/odp_classifier_run.sh
+++ b/example/classifier/odp_classifier_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2020 Marvell

--- a/example/cli/odp_cli_run.sh
+++ b/example/cli/odp_cli_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Nokia

--- a/example/ipsec_api/odp_ipsec_api_run_ah_in.sh
+++ b/example/ipsec_api/odp_ipsec_api_run_ah_in.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test input AH
 #  - 2 loop interfaces

--- a/example/ipsec_api/odp_ipsec_api_run_ah_out.sh
+++ b/example/ipsec_api/odp_ipsec_api_run_ah_out.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test output AH
 #  - 2 loop interfaces

--- a/example/ipsec_api/odp_ipsec_api_run_ah_tun_in.sh
+++ b/example/ipsec_api/odp_ipsec_api_run_ah_tun_in.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test input AH
 #  - 2 loop interfaces

--- a/example/ipsec_api/odp_ipsec_api_run_ah_tun_out.sh
+++ b/example/ipsec_api/odp_ipsec_api_run_ah_tun_out.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test output AH
 #  - 2 loop interfaces

--- a/example/ipsec_api/odp_ipsec_api_run_esp_in.sh
+++ b/example/ipsec_api/odp_ipsec_api_run_esp_in.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test input ESP
 #  - 2 loop interfaces

--- a/example/ipsec_api/odp_ipsec_api_run_esp_out.sh
+++ b/example/ipsec_api/odp_ipsec_api_run_esp_out.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test output ESP
 #  - 2 loop interfaces

--- a/example/ipsec_api/odp_ipsec_api_run_esp_tun_in.sh
+++ b/example/ipsec_api/odp_ipsec_api_run_esp_tun_in.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test input ESP
 #  - 2 loop interfaces

--- a/example/ipsec_api/odp_ipsec_api_run_esp_tun_out.sh
+++ b/example/ipsec_api/odp_ipsec_api_run_esp_tun_out.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test output ESP
 #  - 2 loop interfaces

--- a/example/ipsec_api/odp_ipsec_api_run_live.sh
+++ b/example/ipsec_api/odp_ipsec_api_run_live.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Live router test
 #  - 2 interfaces interfaces

--- a/example/ipsec_api/odp_ipsec_api_run_router.sh
+++ b/example/ipsec_api/odp_ipsec_api_run_router.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Live router test
 #  - 2 interfaces interfaces

--- a/example/ipsec_api/odp_ipsec_api_run_simple.sh
+++ b/example/ipsec_api/odp_ipsec_api_run_simple.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Simple router test
 #  - 2 loop interfaces

--- a/example/ipsec_crypto/odp_ipsec_crypto_run_ah_in.sh
+++ b/example/ipsec_crypto/odp_ipsec_crypto_run_ah_in.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test input AH
 #  - 2 loop interfaces

--- a/example/ipsec_crypto/odp_ipsec_crypto_run_ah_out.sh
+++ b/example/ipsec_crypto/odp_ipsec_crypto_run_ah_out.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test output AH
 #  - 2 loop interfaces

--- a/example/ipsec_crypto/odp_ipsec_crypto_run_both_in.sh
+++ b/example/ipsec_crypto/odp_ipsec_crypto_run_both_in.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test AH and ESP input
 #  - 2 loop interfaces

--- a/example/ipsec_crypto/odp_ipsec_crypto_run_both_out.sh
+++ b/example/ipsec_crypto/odp_ipsec_crypto_run_both_out.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test AH and ESP output
 #  - 2 loop interfaces

--- a/example/ipsec_crypto/odp_ipsec_crypto_run_esp_in.sh
+++ b/example/ipsec_crypto/odp_ipsec_crypto_run_esp_in.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test input ESP
 #  - 2 loop interfaces

--- a/example/ipsec_crypto/odp_ipsec_crypto_run_esp_out.sh
+++ b/example/ipsec_crypto/odp_ipsec_crypto_run_esp_out.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test output ESP
 #  - 2 loop interfaces

--- a/example/ipsec_crypto/odp_ipsec_crypto_run_live.sh
+++ b/example/ipsec_crypto/odp_ipsec_crypto_run_live.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Live router test
 #  - 2 interfaces interfaces

--- a/example/ipsec_crypto/odp_ipsec_crypto_run_router.sh
+++ b/example/ipsec_crypto/odp_ipsec_crypto_run_router.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Live router test
 #  - 2 interfaces interfaces

--- a/example/ipsec_crypto/odp_ipsec_crypto_run_simple.sh
+++ b/example/ipsec_crypto/odp_ipsec_crypto_run_simple.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Simple router test
 #  - 2 loop interfaces

--- a/example/l3fwd/odp_l3fwd_run.sh
+++ b/example/l3fwd/odp_l3fwd_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2016-2018 Linaro Limited

--- a/example/packet/packet_dump_run.sh
+++ b/example/packet/packet_dump_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2018 Linaro Limited

--- a/example/packet/pktio_run.sh
+++ b/example/packet/pktio_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2016-2018 Linaro Limited

--- a/example/ping/ping_run.sh
+++ b/example/ping/ping_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2019 Nokia

--- a/example/simple_pipeline/simple_pipeline_run.sh
+++ b/example/simple_pipeline/simple_pipeline_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2019 Nokia

--- a/example/switch/switch_run.sh
+++ b/example/switch/switch_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2016-2018 Linaro Limited

--- a/platform/linux-generic/example/ml/odp_ml_run_mnist.sh
+++ b/platform/linux-generic/example/ml/odp_ml_run_mnist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Nokia

--- a/platform/linux-generic/example/ml/odp_ml_run_model_explorer.sh
+++ b/platform/linux-generic/example/ml/odp_ml_run_model_explorer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Nokia

--- a/platform/linux-generic/example/ml/odp_ml_run_simple_linear.sh
+++ b/platform/linux-generic/example/ml/odp_ml_run_simple_linear.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Nokia

--- a/platform/linux-generic/test/validation/api/ml/gen_models.sh
+++ b/platform/linux-generic/test/validation/api/ml/gen_models.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Nokia

--- a/scripts/check-globals.sh
+++ b/scripts/check-globals.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Check that global symbols in a static library conform to a given regex.
 # Only static library is checked, since libtool -export-symbols-regex
@@ -11,6 +11,7 @@
 # lib_LTLIBRARIES       Library .la file.
 # CHECK_GLOBALS_REGEX   Global symbols matching this regex are accepted.
 #
+set -o errexit
 
 tmpfile=$(mktemp)
 

--- a/scripts/ci-checkpatches.sh
+++ b/scripts/ci-checkpatches.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
+
+set -o xtrace
 
 PATCHES=$1
 echo "Run checkpatch for ${PATCHES}"

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cd "$(dirname "$0")"/../..

--- a/scripts/ci/build_arm64.sh
+++ b/scripts/ci/build_arm64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export TARGET_ARCH=aarch64-linux-gnu

--- a/scripts/ci/build_armhf.sh
+++ b/scripts/ci/build_armhf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export TARGET_ARCH=arm-linux-gnueabihf

--- a/scripts/ci/build_i386.sh
+++ b/scripts/ci/build_i386.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export TARGET_ARCH=i686-linux-gnu

--- a/scripts/ci/build_ppc64el.sh
+++ b/scripts/ci/build_ppc64el.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export TARGET_ARCH=powerpc64le-linux-gnu

--- a/scripts/ci/build_riscv64.sh
+++ b/scripts/ci/build_riscv64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export TARGET_ARCH=riscv64-linux-gnu

--- a/scripts/ci/build_static.sh
+++ b/scripts/ci/build_static.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 CONFIG_OPT="--prefix=/opt/odp ${CONF}"

--- a/scripts/ci/build_x86_64.sh
+++ b/scripts/ci/build_x86_64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ "${CC#clang}" != "${CC}" ] ; then

--- a/scripts/ci/check.sh
+++ b/scripts/ci/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo 1500 | tee /proc/sys/vm/nr_hugepages

--- a/scripts/ci/check_inline_timer.sh
+++ b/scripts/ci/check_inline_timer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo 1000 | tee /proc/sys/vm/nr_hugepages

--- a/scripts/ci/check_pktio.sh
+++ b/scripts/ci/check_pktio.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo 1000 | tee /proc/sys/vm/nr_hugepages

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ "${CC#clang}" != "${CC}" ] ; then

--- a/scripts/ci/coverity.sh
+++ b/scripts/ci/coverity.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cd "$(dirname "$0")"/../..

--- a/scripts/ci/distcheck.sh
+++ b/scripts/ci/distcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ "${CC#clang}" != "${CC}" ] ; then

--- a/scripts/ci/out_of_tree.sh
+++ b/scripts/ci/out_of_tree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ "${CC#clang}" != "${CC}" ] ; then

--- a/scripts/odp_check
+++ b/scripts/odp_check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script is a clean up for the ODP project src files.
 #

--- a/test/performance/odp_dmafwd_run.sh
+++ b/test/performance/odp_dmafwd_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Nokia

--- a/test/performance/odp_l2fwd_perf_run.sh
+++ b/test/performance/odp_l2fwd_perf_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2015-2018 Linaro Limited

--- a/test/performance/odp_l2fwd_run.sh
+++ b/test/performance/odp_l2fwd_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2015-2018 Linaro Limited

--- a/test/performance/odp_pktio_ordered_run.sh
+++ b/test/performance/odp_pktio_ordered_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2016-2018 Linaro Limited

--- a/test/performance/odp_timer_accuracy_run.sh
+++ b/test/performance/odp_timer_accuracy_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2024 Nokia


### PR DESCRIPTION
Before this change scripts wrongly assume that `bash` resides at `/bin/bash`. This is not always the case and in fact is not mandated by POSIX. One example of a unix which does not have bash in `/bin/bash` is NixOS.

A workaround for this is to use `/usr/bin/env bash`, which is the standard way to get bash from user environment and works on a wider range of systems than `/bin/bash`

Therefore, this change replaces every `/bin/bash` with `/usr/bin/env bash`. Wherever `/bin/bash` took extra arguments, those arguments were moved out of line, because `env` interprets arguments as part of a program name.

Solves #2243