### PR TITLE
[PATCH v2] test: small changes for compiling with GCC-15

### DIFF
--- a/test/common/odp_cunit_common.c
+++ b/test/common/odp_cunit_common.c
@@ -240,6 +240,11 @@ int odp_cunit_thread_create(int num, int func_ptr(void *), void *const arg[], in
 
 int odp_cunit_thread_join(int num)
 {
+	if (num <= 0 || num > ODP_THREAD_COUNT_MAX) {
+		fprintf(stderr, "error: odph_thread_join: invalid 'num' parameter: %d\n", num);
+		return -1;
+	}
+
 	odph_thread_join_result_t res[num];
 
 	/* Wait for threads to exit */

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -34,8 +34,8 @@
 #define AAD_LEN 8 /* typical AAD length used in IPsec when ESN is not in use */
 #define MAX_AUTH_DIGEST_LEN 32 /* maximum MAC length in bytes */
 
-static uint8_t test_aad[AAD_LEN] = "01234567";
-static uint8_t test_iv[16] = "0123456789abcdef";
+static uint8_t test_aad[AAD_LEN] = {1, 2, 3, 4, 5, 6, 7, 8};
+static uint8_t test_iv[16] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
 
 static uint8_t test_key16[16] = { 0x01, 0x02, 0x03, 0x04, 0x05,
 				  0x06, 0x07, 0x08, 0x09, 0x0a,

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -35,7 +35,7 @@
 
 #define MAX_DEQUEUE_BURST 16
 
-static uint8_t test_salt[16] = "0123456789abcdef";
+static uint8_t test_salt[16] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
 
 static uint8_t test_key16[16] = { 0x01, 0x02, 0x03, 0x04, 0x05,
 				  0x06, 0x07, 0x08, 0x09, 0x0a,

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -1299,7 +1299,7 @@ static void _verify_tailroom_shift(odp_packet_t *pkt,
 	odp_packet_seg_t seg;
 	uint32_t room;
 	uint32_t seg_data_len, pkt_data_len, seg_len;
-	void *tail;
+	void *tail = NULL;
 	char *tail_orig;
 	int extended, rc;
 


### PR DESCRIPTION
GCC 15.1 emits a couple of new warnings that fail the build due to -Werror. Fix the issues to make compilation work with GCC-15 too.
