### PR TITLE
[PATCH v3] crypto: fix output_pool session parameter

### DIFF
--- a/example/ipsec_crypto/odp_ipsec_cache.c
+++ b/example/ipsec_crypto/odp_ipsec_cache.c
@@ -48,8 +48,7 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 			     tun_db_entry_t *tun,
 			     crypto_api_mode_e api_mode,
 			     odp_bool_t in,
-			     odp_queue_t completionq,
-			     odp_pool_t out_pool)
+			     odp_queue_t completionq)
 {
 	odp_crypto_session_param_t params;
 	ipsec_cache_entry_t *entry;
@@ -73,15 +72,14 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 	params.op = (in) ? ODP_CRYPTO_OP_DECODE : ODP_CRYPTO_OP_ENCODE;
 	params.op_type = ODP_CRYPTO_OP_TYPE_BASIC;
 	params.auth_cipher_text = TRUE;
+	params.output_pool = ODP_POOL_INVALID;
 	if (CRYPTO_API_SYNC == api_mode) {
 		params.op_mode = ODP_CRYPTO_SYNC;
 		params.compl_queue = ODP_QUEUE_INVALID;
-		params.output_pool = ODP_POOL_INVALID;
 		entry->async = FALSE;
 	} else {
 		params.op_mode = ODP_CRYPTO_ASYNC;
 		params.compl_queue = completionq;
-		params.output_pool = out_pool;
 		entry->async = TRUE;
 	}
 

--- a/example/ipsec_crypto/odp_ipsec_cache.h
+++ b/example/ipsec_crypto/odp_ipsec_cache.h
@@ -94,8 +94,7 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 			     tun_db_entry_t *tun,
 			     crypto_api_mode_e api_mode,
 			     odp_bool_t in,
-			     odp_queue_t completionq,
-			     odp_pool_t out_pool);
+			     odp_queue_t completionq);
 
 /**
  * Find a matching IPsec cache entry for input packet

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -217,7 +217,7 @@ static int session_create(crypto_session_t *session,
 	ses_params.cipher_alg = ref->cipher;
 	ses_params.auth_alg = ref->auth;
 	ses_params.compl_queue = suite_context.queue;
-	ses_params.output_pool = suite_context.pool;
+	ses_params.output_pool = ODP_POOL_INVALID;
 	ses_params.cipher_key = cipher_key;
 	ses_params.cipher_iv_len = ref->cipher_iv_length;
 	ses_params.auth_iv_len = ref->auth_iv_length;


### PR DESCRIPTION
Fix crypto validation test and ipsec_crypto example to adhere to the API spec which says that the output_pool crypto session parameter must be set to ODP_POOL_INVALID in the basic and OOP operation types.