### PR TITLE
validation: timer: add new tests

### DIFF
--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -1465,6 +1465,80 @@ static void timer_pool_tick_info(void)
 	odp_timer_pool_destroy(tp);
 }
 
+static void timer_alloc_max(void)
+{
+	odp_timer_capability_t capa;
+	odp_shm_t shm_tmr;
+	odp_timer_pool_t pool;
+	odp_timer_t *timer;
+	odp_timer_pool_param_t tp_param;
+	odp_queue_param_t queue_param;
+	odp_queue_t queue;
+	/* Use some sane value in case of memory-capped or very large max timer count. */
+	uint32_t num = MAX_TIMER_POOLS;
+	int ret;
+	uint64_t tmo_ns = ODP_TIME_SEC_IN_NS;
+	uint64_t res_ns = ODP_TIME_SEC_IN_NS / 10;
+	odp_timer_clk_src_t clk_src = test_global->clk_src;
+
+	ret = odp_timer_capability(clk_src, &capa);
+
+	CU_ASSERT_FATAL(ret == 0);
+
+	if (capa.max_timers > 0 && num > capa.max_timers)
+		num = capa.max_timers;
+
+	shm_tmr = odp_shm_reserve("test_max_alloc", num * sizeof(*timer), ODP_CACHE_LINE_SIZE, 0);
+
+	CU_ASSERT_FATAL(shm_tmr != ODP_SHM_INVALID);
+
+	timer = odp_shm_addr(shm_tmr);
+
+	CU_ASSERT_FATAL(timer != NULL);
+
+	if (capa.max_tmo.max_tmo < tmo_ns) {
+		tmo_ns = capa.max_tmo.max_tmo;
+		res_ns = capa.max_tmo.res_ns;
+	}
+
+	odp_queue_param_init(&queue_param);
+
+	if (capa.queue_type_sched)
+		queue_param.type = ODP_QUEUE_TYPE_SCHED;
+
+	queue = odp_queue_create("test_max_alloc", &queue_param);
+
+	CU_ASSERT_FATAL(queue != ODP_QUEUE_INVALID);
+
+	odp_timer_pool_param_init(&tp_param);
+	tp_param.res_ns = res_ns;
+	tp_param.min_tmo = tmo_ns / 2;
+	tp_param.max_tmo = tmo_ns;
+	tp_param.num_timers = num;
+	tp_param.clk_src = clk_src;
+	pool = odp_timer_pool_create("test_max_alloc", &tp_param);
+
+	CU_ASSERT_FATAL(pool != ODP_TIMER_POOL_INVALID);
+	CU_ASSERT_FATAL(odp_timer_pool_start_multi(&pool, 1) == 1);
+
+	for (uint32_t i = 0; i < num; i++) {
+		timer[i] = odp_timer_alloc(pool, queue, USER_PTR);
+
+		if (timer[i] == ODP_TIMER_INVALID)
+			ODPH_ERR("Timer alloc failed: %u / %u\n", i, num);
+
+		CU_ASSERT_FATAL(timer[i] != ODP_TIMER_INVALID);
+	}
+
+	for (uint32_t i = 0; i < num; i++)
+		CU_ASSERT(odp_timer_free(timer[i]) == 0);
+
+	odp_timer_pool_destroy(pool);
+
+	CU_ASSERT(odp_queue_destroy(queue) == 0);
+	CU_ASSERT(odp_shm_free(shm_tmr) == 0);
+}
+
 static void timer_test_event_type(odp_queue_type_t queue_type,
 				  odp_event_type_t event_type, int rounds)
 {
@@ -3255,6 +3329,92 @@ static void timer_test_periodic_pool_create_max(void)
 	CU_ASSERT(odp_shm_free(shm_tp) == 0);
 }
 
+static void timer_test_periodic_alloc_max(void)
+{
+	odp_timer_capability_t timer_capa;
+	odp_shm_t shm_tmr;
+	odp_timer_periodic_capability_t periodic_capa;
+	odp_timer_pool_param_t timer_param;
+	odp_timer_pool_t pool;
+	odp_timer_t *timer;
+	odp_queue_param_t queue_param;
+	odp_queue_t queue;
+	double min_freq, max_freq;
+	/* Use some sane value in case of very large max timer count. */
+	uint32_t num = MAX_TIMER_POOLS;
+	odp_fract_u64_t base_freq = {1000, 0, 0};
+	odp_timer_clk_src_t clk_src = test_global->clk_src;
+
+	CU_ASSERT_FATAL(odp_timer_capability(clk_src, &timer_capa) == 0);
+
+	if (num > timer_capa.periodic.max_timers)
+		num = timer_capa.periodic.max_timers;
+
+	shm_tmr = odp_shm_reserve("test_max_periodic", num * sizeof(*timer), ODP_CACHE_LINE_SIZE,
+				  0);
+
+	CU_ASSERT_FATAL(shm_tmr != ODP_SHM_INVALID);
+
+	timer = odp_shm_addr(shm_tmr);
+
+	CU_ASSERT_FATAL(timer != NULL);
+
+	min_freq = odp_fract_u64_to_dbl(&timer_capa.periodic.min_base_freq_hz);
+	max_freq = odp_fract_u64_to_dbl(&timer_capa.periodic.max_base_freq_hz);
+
+	if (odp_fract_u64_to_dbl(&base_freq) < min_freq)
+		base_freq = timer_capa.periodic.min_base_freq_hz;
+	else if (odp_fract_u64_to_dbl(&base_freq) > max_freq)
+		base_freq = timer_capa.periodic.max_base_freq_hz;
+
+	memset(&periodic_capa, 0, sizeof(odp_timer_periodic_capability_t));
+	periodic_capa.base_freq_hz = base_freq;
+	periodic_capa.max_multiplier = 1;
+
+	if (odp_timer_periodic_capability(clk_src, &periodic_capa) < 0) {
+		(void)odp_shm_free(shm_tmr);
+		ODPH_ERR("Periodic timer does not support tested frequency\n");
+		return;
+	}
+
+	base_freq = periodic_capa.base_freq_hz;
+	odp_timer_pool_param_init(&timer_param);
+	timer_param.timer_type = ODP_TIMER_TYPE_PERIODIC;
+	timer_param.res_ns = 2 * periodic_capa.res_ns;
+	timer_param.num_timers = num;
+	timer_param.clk_src = clk_src;
+	timer_param.periodic.base_freq_hz = periodic_capa.base_freq_hz;
+	timer_param.periodic.max_multiplier = periodic_capa.max_multiplier;
+	pool = odp_timer_pool_create("test_max_periodic", &timer_param);
+
+	CU_ASSERT_FATAL(pool != ODP_TIMER_POOL_INVALID);
+	CU_ASSERT_FATAL(odp_timer_pool_start_multi(&pool, 1) == 1);
+
+	odp_queue_param_init(&queue_param);
+
+	if (timer_capa.queue_type_sched)
+		queue_param.type = ODP_QUEUE_TYPE_SCHED;
+
+	queue = odp_queue_create("test_max_alloc", &queue_param);
+
+	for (uint32_t i = 0; i < num; i++) {
+		timer[i] = odp_timer_alloc(pool, queue, USER_PTR);
+
+		if (timer[i] == ODP_TIMER_INVALID)
+			ODPH_ERR("Timer alloc failed: %u / %u\n", i, num);
+
+		CU_ASSERT_FATAL(timer[i] != ODP_TIMER_INVALID);
+	}
+
+	for (uint32_t i = 0; i < num; i++)
+		CU_ASSERT(odp_timer_free(timer[i]) == 0);
+
+	odp_timer_pool_destroy(pool);
+
+	CU_ASSERT(odp_queue_destroy(queue) == 0);
+	CU_ASSERT(odp_shm_free(shm_tmr) == 0);
+}
+
 odp_testinfo_t timer_general_suite[] = {
 	ODP_TEST_INFO(timer_test_param_init),
 	ODP_TEST_INFO(timer_test_timeout_pool_alloc),
@@ -3280,6 +3440,7 @@ odp_testinfo_t timer_suite[] = {
 	ODP_TEST_INFO(timer_pool_current_tick),
 	ODP_TEST_INFO(timer_pool_sample_ticks),
 	ODP_TEST_INFO(timer_pool_tick_info),
+	ODP_TEST_INFO(timer_alloc_max),
 	ODP_TEST_INFO_CONDITIONAL(timer_plain_rel_wait, check_plain_queue_support),
 	ODP_TEST_INFO_CONDITIONAL(timer_plain_abs_wait, check_plain_queue_support),
 	ODP_TEST_INFO_CONDITIONAL(timer_plain_rel_cancel, check_plain_queue_support),
@@ -3368,6 +3529,8 @@ odp_testinfo_t timer_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(timer_test_periodic_event_reuse,
 				  check_periodic_sched_support),
 	ODP_TEST_INFO_CONDITIONAL(timer_test_periodic_pool_create_max,
+				  check_periodic_support),
+	ODP_TEST_INFO_CONDITIONAL(timer_test_periodic_alloc_max,
 				  check_periodic_support),
 	ODP_TEST_INFO_NULL,
 };

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -782,10 +782,13 @@ static void timer_pool_long_name(void)
 static void timer_pool_create_max(void)
 {
 	odp_timer_capability_t capa;
+	odp_shm_t shm_tp, shm_tmr;
+	odp_timer_pool_t *tp;
+	odp_timer_t *timer;
 	odp_timer_pool_param_t tp_param;
 	odp_queue_param_t queue_param;
 	odp_queue_t queue;
-	uint32_t i;
+	uint32_t num, i;
 	int ret;
 	uint64_t tmo_ns = ODP_TIME_SEC_IN_NS;
 	uint64_t res_ns = ODP_TIME_SEC_IN_NS / 10;
@@ -794,13 +797,18 @@ static void timer_pool_create_max(void)
 	ret = odp_timer_capability(clk_src, &capa);
 	CU_ASSERT_FATAL(ret == 0);
 
-	uint32_t num = capa.max_pools;
+	num = capa.max_pools;
+	shm_tp = odp_shm_reserve("test_max_tp", num * sizeof(*tp), ODP_CACHE_LINE_SIZE, 0);
+	shm_tmr = odp_shm_reserve("test_max_tmr", num * sizeof(*timer), ODP_CACHE_LINE_SIZE, 0);
 
-	if (num > MAX_TIMER_POOLS)
-		num = MAX_TIMER_POOLS;
+	CU_ASSERT_FATAL(shm_tp != ODP_SHM_INVALID);
+	CU_ASSERT_FATAL(shm_tmr != ODP_SHM_INVALID);
 
-	odp_timer_pool_t tp[num];
-	odp_timer_t timer[num];
+	tp = odp_shm_addr(shm_tp);
+	timer = odp_shm_addr(shm_tmr);
+
+	CU_ASSERT_FATAL(tp != NULL);
+	CU_ASSERT_FATAL(timer != NULL);
 
 	if (capa.max_tmo.max_tmo < tmo_ns) {
 		tmo_ns = capa.max_tmo.max_tmo;
@@ -852,6 +860,8 @@ static void timer_pool_create_max(void)
 		odp_timer_pool_destroy(tp[i]);
 
 	CU_ASSERT(odp_queue_destroy(queue) == 0);
+	CU_ASSERT(odp_shm_free(shm_tmr) == 0);
+	CU_ASSERT(odp_shm_free(shm_tp) == 0);
 }
 
 static void timer_pool_max_res(void)
@@ -3178,6 +3188,73 @@ static void timer_test_periodic_event_reuse(void)
 	timer_test_periodic(ODP_QUEUE_TYPE_SCHED, 0, 2, 1, 0);
 }
 
+static void timer_test_periodic_pool_create_max(void)
+{
+	odp_timer_capability_t timer_capa;
+	odp_shm_t shm_tp;
+	odp_timer_periodic_capability_t periodic_capa;
+	odp_timer_pool_param_t timer_param;
+	odp_timer_pool_t *tp;
+	double min_freq, max_freq;
+	uint32_t num;
+	odp_fract_u64_t base_freq = {1000, 0, 0};
+	odp_timer_clk_src_t clk_src = test_global->clk_src;
+
+	CU_ASSERT_FATAL(odp_timer_capability(clk_src, &timer_capa) == 0);
+
+	num = timer_capa.periodic.max_pools;
+	shm_tp = odp_shm_reserve("test_max_periodic", num * sizeof(*tp), ODP_CACHE_LINE_SIZE, 0);
+
+	CU_ASSERT_FATAL(shm_tp != ODP_SHM_INVALID);
+
+	tp = odp_shm_addr(shm_tp);
+
+	CU_ASSERT_FATAL(tp != NULL);
+
+	min_freq = odp_fract_u64_to_dbl(&timer_capa.periodic.min_base_freq_hz);
+	max_freq = odp_fract_u64_to_dbl(&timer_capa.periodic.max_base_freq_hz);
+
+	if (odp_fract_u64_to_dbl(&base_freq) < min_freq)
+		base_freq = timer_capa.periodic.min_base_freq_hz;
+	else if (odp_fract_u64_to_dbl(&base_freq) > max_freq)
+		base_freq = timer_capa.periodic.max_base_freq_hz;
+
+	memset(&periodic_capa, 0, sizeof(odp_timer_periodic_capability_t));
+	periodic_capa.base_freq_hz = base_freq;
+	periodic_capa.max_multiplier = 1;
+
+	if (odp_timer_periodic_capability(clk_src, &periodic_capa) < 0) {
+		(void)odp_shm_free(shm_tp);
+		ODPH_ERR("Periodic timer does not support tested frequency\n");
+		return;
+	}
+
+	base_freq = periodic_capa.base_freq_hz;
+	odp_timer_pool_param_init(&timer_param);
+	timer_param.timer_type = ODP_TIMER_TYPE_PERIODIC;
+	timer_param.res_ns = 2 * periodic_capa.res_ns;
+	timer_param.num_timers = 1;
+	timer_param.clk_src = clk_src;
+	timer_param.periodic.base_freq_hz = periodic_capa.base_freq_hz;
+	timer_param.periodic.max_multiplier = periodic_capa.max_multiplier;
+
+	for (uint32_t i = 0; i < num; i++) {
+		tp[i] = odp_timer_pool_create("test_max_periodic", &timer_param);
+
+		if (tp[i] == ODP_TIMER_POOL_INVALID)
+			ODPH_ERR("Timer pool create failed: %u / %u\n", i, num);
+
+		CU_ASSERT_FATAL(tp[i] != ODP_TIMER_POOL_INVALID);
+	}
+
+	CU_ASSERT(odp_timer_pool_start_multi(tp, num) == (int)num);
+
+	for (uint32_t i = 0; i < num; i++)
+		odp_timer_pool_destroy(tp[i]);
+
+	CU_ASSERT(odp_shm_free(shm_tp) == 0);
+}
+
 odp_testinfo_t timer_general_suite[] = {
 	ODP_TEST_INFO(timer_test_param_init),
 	ODP_TEST_INFO(timer_test_timeout_pool_alloc),
@@ -3290,6 +3367,8 @@ odp_testinfo_t timer_suite[] = {
 				  check_periodic_sched_support),
 	ODP_TEST_INFO_CONDITIONAL(timer_test_periodic_event_reuse,
 				  check_periodic_sched_support),
+	ODP_TEST_INFO_CONDITIONAL(timer_test_periodic_pool_create_max,
+				  check_periodic_support),
 	ODP_TEST_INFO_NULL,
 };
 

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -1465,6 +1465,139 @@ static void timer_pool_tick_info(void)
 	odp_timer_pool_destroy(tp);
 }
 
+static void timer_pool_mixed_params(void)
+{
+	odp_timer_capability_t capa;
+	const uint32_t max_mixed = 5; /* A few differently parameterized pools. */
+	uint32_t num_pools, max_timers = MAX_TIMER_POOLS, num_timers;
+	uint64_t min_res_ns, max_res_ns, res_ns, max_tmo, max_steps,
+	steps = 100 /* Just use some stepping value to get different timeout ranges. */, tmo,
+	time_limit;
+	odp_timer_pool_param_t tp_param;
+	int num_config = 0, num_recv = 0;
+	odp_timer_clk_src_t clk_src = test_global->clk_src;
+	odp_queue_param_t queue_param;
+	odp_queue_t queue;
+	odp_pool_t tmo_pool;
+	odp_pool_param_t pool_param;
+	odp_timer_start_t start_param;
+	odp_timer_t tmr;
+	odp_timer_pool_info_t info;
+	odp_timeout_t tmo_ev;
+	odp_event_t ev;
+
+	CU_ASSERT_FATAL(odp_timer_capability(clk_src, &capa) == 0);
+
+	num_pools = capa.max_pools > max_mixed ? max_mixed : capa.max_pools;
+
+	if (capa.max_timers > 0)
+		max_timers = capa.max_timers;
+
+	min_res_ns = capa.max_tmo.res_ns;
+	max_res_ns = capa.max_res.res_ns;
+	res_ns = capa.max_res.res_ns;
+	max_tmo = capa.max_tmo.max_tmo;
+	max_steps = capa.max_res.max_tmo / capa.max_res.res_ns;
+
+	if (steps > max_steps)
+		steps = max_steps;
+
+	odp_timer_pool_t tp[num_pools];
+
+	odp_timer_pool_param_init(&tp_param);
+	tp_param.clk_src = clk_src;
+
+	/* Bump the resolution, min/max range and timer count up for every timer pool, resulting in
+	 * a set of varyingly parameterized timer pools. Subsequently, check that timers from these
+	 * pools work. */
+	for (uint32_t i = 0; i < num_pools; i++) {
+		res_ns = (i + 1) * max_res_ns;
+		tmo = res_ns * steps;
+
+		if (tmo > max_tmo) {
+			res_ns = min_res_ns;
+			tmo = max_tmo;
+		}
+
+		tp_param.res_ns = res_ns;
+		tp_param.min_tmo = res_ns;
+		tp_param.max_tmo = tmo;
+		num_timers = (i + 1) * 10;
+		tp_param.num_timers = num_timers > max_timers ? max_timers : num_timers;
+		printf("Timer pool configuration, res_ns: %" PRIu64 ", min_tmo: %" PRIu64 ", "
+		       "max_tmo: %" PRIu64 ", num_timers: %u\n", tp_param.res_ns, tp_param.min_tmo,
+		       tp_param.max_tmo, tp_param.num_timers);
+		tp[num_config] = odp_timer_pool_create("test_mixed", &tp_param);
+
+		if (tp[num_config] == ODP_TIMER_POOL_INVALID) {
+			ODPH_ERR("Timer pool create failed for configuration\n");
+			continue;
+		}
+
+		num_config++;
+	}
+
+	odp_queue_param_init(&queue_param);
+
+	if (capa.queue_type_sched)
+		queue_param.type = ODP_QUEUE_TYPE_SCHED;
+
+	queue = odp_queue_create("test_mixed", &queue_param);
+
+	CU_ASSERT_FATAL(queue != ODP_QUEUE_INVALID);
+
+	odp_pool_param_init(&pool_param);
+	pool_param.type = ODP_POOL_TIMEOUT;
+	pool_param.tmo.num = num_config;
+	tmo_pool = odp_pool_create("test_mixed", &pool_param);
+
+	CU_ASSERT_FATAL(tmo_pool != ODP_POOL_INVALID);
+	CU_ASSERT_FATAL(odp_timer_pool_start_multi(tp, num_config) == num_config);
+
+	start_param.tick_type = ODP_TIMER_TICK_REL;
+
+	for (int i = 0; i < num_config; i++) {
+		tmr = odp_timer_alloc(tp[i], queue, NULL);
+
+		CU_ASSERT_FATAL(tmr != ODP_TIMER_INVALID);
+		CU_ASSERT_FATAL(odp_timer_pool_info(tp[i], &info) == 0);
+
+		tmo_ev = odp_timeout_alloc(tmo_pool);
+
+		CU_ASSERT_FATAL(tmo_ev != ODP_TIMEOUT_INVALID);
+
+		start_param.tick = odp_timer_ns_to_tick(tp[i], info.param.res_ns);
+		start_param.tmo_ev = odp_timeout_to_event(tmo_ev);
+
+		CU_ASSERT_FATAL(odp_timer_start(tmr, &start_param) == ODP_TIMER_SUCCESS);
+	}
+
+	time_limit = odp_time_local_strict_ns() + res_ns * steps;
+
+	while (odp_time_local_strict_ns() < time_limit) {
+		ev = capa.queue_type_sched ? odp_schedule(NULL, ODP_SCHED_NO_WAIT) :
+					     odp_queue_deq(queue);
+
+		if (ev == ODP_EVENT_INVALID)
+			continue;
+
+		tmr = odp_timeout_timer(odp_timeout_from_event(ev));
+		odp_timer_free(tmr);
+		odp_event_free(ev);
+		num_recv++;
+
+		if (num_config == num_recv)
+			break;
+	}
+
+	CU_ASSERT(num_config == num_recv);
+	CU_ASSERT(odp_pool_destroy(tmo_pool) == 0);
+	CU_ASSERT(odp_queue_destroy(queue) == 0);
+
+	for (int i = 0; i < num_config; i++)
+		odp_timer_pool_destroy(tp[i]);
+}
+
 static void timer_alloc_max(void)
 {
 	odp_timer_capability_t capa;
@@ -3440,6 +3573,7 @@ odp_testinfo_t timer_suite[] = {
 	ODP_TEST_INFO(timer_pool_current_tick),
 	ODP_TEST_INFO(timer_pool_sample_ticks),
 	ODP_TEST_INFO(timer_pool_tick_info),
+	ODP_TEST_INFO(timer_pool_mixed_params),
 	ODP_TEST_INFO(timer_alloc_max),
 	ODP_TEST_INFO_CONDITIONAL(timer_plain_rel_wait, check_plain_queue_support),
 	ODP_TEST_INFO_CONDITIONAL(timer_plain_abs_wait, check_plain_queue_support),


### PR DESCRIPTION
Add new tests to check ability to create maximum amount of oneshot and periodic timer pools, maximum/large amount of timers from these pools and ability for implementations to handle timer pools with varying parameterization.