### PR TITLE
[PATCH v2] validation: pool: make first subparam len greater than len

### DIFF
--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -835,7 +835,7 @@ static void pool_test_alloc_packet_subparam(void)
 
 	for (i = 0; i < num_sub; i++) {
 		param.pkt.sub[i].num = PKT_NUM;
-		param.pkt.sub[i].len = PKT_LEN + (i * 100);
+		param.pkt.sub[i].len = PKT_LEN + (i + 1) * 100;
 	}
 
 	pool = odp_pool_create(NULL, &param);


### PR DESCRIPTION
The API requires sub[0].len > 'len', but in current test, sub[0].len == 'len'. This patch fixes the test.