### PR TITLE
[PATCH v3] test: performance: add generic pipeline tester

### DIFF
--- a/test/m4/configure.m4
+++ b/test/m4/configure.m4
@@ -16,6 +16,7 @@ m4_include([test/m4/validation.m4])
 AC_CONFIG_FILES([test/common/Makefile
 		 test/miscellaneous/Makefile
 		 test/performance/Makefile
+		 test/performance/pipeline/Makefile
 		 test/validation/Makefile
 		 test/validation/api/align/Makefile
 		 test/validation/api/atomic/Makefile

--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -1,5 +1,7 @@
 include $(top_srcdir)/test/Makefile.inc
 
+SUBDIRS = pipeline
+
 TESTS_ENVIRONMENT += TEST_DIR=${builddir}
 
 EXECUTABLES = odp_atomic_perf \

--- a/test/performance/pipeline/.gitignore
+++ b/test/performance/pipeline/.gitignore
@@ -1,0 +1,1 @@
+odp_pipeline

--- a/test/performance/pipeline/Makefile.am
+++ b/test/performance/pipeline/Makefile.am
@@ -1,0 +1,43 @@
+include $(top_srcdir)/test/Makefile.inc
+
+if LIBCONFIG
+AM_CFLAGS += \
+	$(LIBCONFIG_CFLAGS) \
+	-I$(top_srcdir)/test/performance/pipeline
+
+bin_PROGRAMS = odp_pipeline
+
+odp_pipeline_SOURCES = \
+	cls_parser.c \
+	common.h \
+	config_parser.h \
+	config_parser.c \
+	cpumap.h \
+	cpumap_parser.c \
+	crypto_parser.c \
+	dma_parser.c \
+	flow.h \
+	flow.c \
+	flow_parser.c \
+	helpers.h \
+	main.c \
+	orchestrator.h \
+	orchestrator.c \
+	pktio_parser.c \
+	pool_parser.c \
+	queue_parser.c \
+	sched_parser.c \
+	stash_parser.c \
+	timer_parser.c \
+	work.h \
+	work.c \
+	work_forward.c \
+	work_global_forward.c \
+	work_packet_copy.c \
+	work_packet_source.c \
+	work_sink.c \
+	work_timeout_source.c \
+	work_wait.c \
+	worker.h \
+	worker_parser.c
+endif

--- a/test/performance/pipeline/README.md
+++ b/test/performance/pipeline/README.md
@@ -1,0 +1,662 @@
+# odp_pipeline
+
+Configurable ODP pipeline tester. Takes a `libconfig` compatible configuration file and based on
+the configuration builds an ODP application. Configuration is quite flexible, user can define e.g.
+ODP worker cpu mappings, basic resources to be created, resource dependencies, input and output
+handling for queues, etc. Actual event handling is done in "work" objects which can be chained and
+attached to queue input and output handling. Currently, a few example work objects are provided,
+more can be easily added as required. This enables the tester to be built as e.g. a packet
+generator, an L2 forwarder or something resembling an actual telecom application.
+
+## Configuration structure
+
+The passed configuration is divided into domains which the tester parses at the beginning.
+The domains follow ODP modules (in addition to tester specific domains), e.g. there is a
+domain for configuring queues, one for packet I/Os etc. Currently supported domains:
+
+  - classification
+  - cpumap
+  - crypto
+  - dma
+  - flows
+  - pktios
+  - pools
+  - queues
+  - scheduler
+  - stash
+  - timers
+  - workers
+
+The domains can appear in the configuration file in any order, domain parser plugins are evaluated
+in a predetermined order, set by developer. This defines an ordering for example between pools and
+packet I/Os: packet I/Os require pools so pools are deployed first and packet I/O parser can assume
+that configured pool resources will be available during packet I/O deployment. Resources are always
+named and queried using the configured names (e.g. packet I/O resources can query named pool
+resources).
+
+Tester will abort if a name lookup error is encountered as this typically represents a fatal
+configuration error and should be fixed by the user.
+
+Some domains support entry templates, where a single configuration entry can be defined as a
+template which is instantiated a given number of times. This can save a considerable amount of
+time typing in case application requires e.g. hundreds of queues to be configured.
+
+Domain resource parameterization follows the related ODP module resource creation parameters and
+their defaults. E.g. within classification domain, `cos` and `pmr` configuration end up filling
+`odp_cls_cos_param_t` and `odp_pmr_param_t` structures. Some parameters may not be configurable
+depending on the domain either because infeasibility to support certain logic or support simply not
+existing yet but might in the future. More details in the next section.
+
+A few examples showcasing how one could configure the pipeline:
+
+[pipeline_example1](pipeline_example1)
+[pipeline_example2](pipeline_example2)
+
+## Domains
+
+### Classification
+
+- name in configuration file: `classification`
+- type: group with nested lists `cos` and `pmr` of groups
+- `cos` entries:
+  - element: `template`
+    - necessity: optional
+    - type: integer
+    - values: number of resources to be instantiated based on the template
+  - element: `name`
+    - necessity: required
+    - type: string, max `ODP_COS_NAME_LEN`, or in case of a template, a list of name prefix string,
+            initial index value integer and increment value integer, which will be concatenated to
+            a string, max `ODP_COS_NAME_LEN`
+  - element: `action`
+    - necessity: optional
+    - type: `string`
+    - values: `"drop"`, `"enqueue"`, mapping to `odp_cos_action_t`
+    - default: `odp_cls_cos_param_init()`
+  - element: `default`
+    - necessity: optional
+    - type: string
+    - values: packet I/O domain resource name to attach this CoS as default
+  - element: `num_queues`
+    - necessity: optional
+    - type: integer
+    - default: `odp_cls_cos_param_init()`
+  - element: `queue`
+    - necessity: required if `num_queues` == 1 and `action` == `"enqueue"`
+    - type: string, max `ODP_QUEUE_NAME_LEN`, or in case of a template, a list of name prefix
+            string, initial index value integer and increment value integer, which will be
+            concatenated to a string, max `ODP_QUEUE_NAME_LEN`
+    - values: queue domain resource name
+  - element: `type`
+    - necessity: optional
+    - type: string
+    - values: `"plain"`, `"schedule"`, mapping to `odp_queue_type_t`
+    - default: `odp_queue_param_init()`
+  - element: `hash_ipv4_udp`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_hash_proto_t` bitfield
+    - default: `0`
+  - element: `hash_ipv4_tcp`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_hash_proto_t` bitfield
+    - default: `0`
+  - element: `hash_ipv4`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_hash_proto_t` bitfield
+    - default: `0`
+  - element: `hash_ipv6_udp`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_hash_proto_t` bitfield
+    - default: `0`
+  - element: `hash_ipv6_tcp`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_hash_proto_t` bitfield
+    - default: `0`
+  - element: `hash_ipv6`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_hash_proto_t` bitfield
+    - default: `0`
+  - element: `pool`
+    - necessity: required
+    - type: string, max `ODP_POOL_NAME_LEN`
+    - values: pool domain resource name
+- `pmr` entries:
+  - element: `template`
+    - necessity: optional
+    - type: integer
+    - values: number of resources to be instantiated based on the template
+  - element: `name`
+    - necessity: required
+    - type: string, max `ODP_COS_NAME_LEN`, or in case of a template, a list of name prefix string,
+            initial index value integer and increment value integer, which will be concatenated to
+            a string, max `ODP_COS_NAME_LEN`
+  - element: `src_cos`
+    - necessity: required
+    - type: string, max `ODP_COS_NAME_LEN`, or in case of a template, a list of name prefix string,
+            initial index value integer and increment value integer, which will be concatenated to
+            a string, max `ODP_COS_NAME_LEN`
+    - values: classification domain CoS resource name
+  - element: `dst_cos`
+    - necessity: required
+    - type: string, max `ODP_COS_NAME_LEN`, or in case of a template, a list of name prefix string,
+            initial index value integer and increment value integer, which will be concatenated to
+            a string, max `ODP_COS_NAME_LEN`
+    - values: classification domain CoS resource name
+  - element: `term`
+    - necessity: required
+    - type: string
+    - values: `"len"`, `"eth_0"`, `"eth_x"`, `"vlan_0"`, `"vlan_x"`, `"vlan_pcp"`, `"dmac"`,
+              `"ipproto"`, `"ip_dscp"`, `"udp_dport"`, `"tcp_dport"`, `"udp_sport"`, `"tcp_sport"`,
+              `"sip_addr"`, `"dip_addr"`, `"sip6_addr"`, `"dip6_addr"`, `"ipsec_spi"`, `"ld_vni"`,
+              `"custom_frame"`, `"custom_l3"`, `"sctp_sport"`, `"sctp_dport"`, mapping to
+              `odp_cls_pmr_term_t`
+  - element: `match_value`
+    - necessity: required
+    - type: byte value array, or in case of a template, a list of initial byte value array and
+            increment value integer
+  - element: `match_mask`
+    - necessity: required
+    - type: byte value array
+  - element: `val_sz`
+    - necessity: required
+    - type: integer
+  - element: `offset`
+    - necessity: required if `term` == `"custom_frame"` or `"custom_l3"`
+    - type: integer
+
+### Cpumap
+
+- name in configuration file: `cpumap`
+- type: group
+- `cpumap` entry:
+  - element: `cpumask`
+    - necessity: required
+    - type: string
+    - values: a CPU mask in a string format accepted by `odp_cpumask_to_str()`
+  - element: `workers`
+    - necessity: required
+    - type: string array
+    - values: worker resource names in order they are to be launched to the cores set in `cpumask`
+
+### Crypto
+
+- name in configuration file: `crypto`
+- type: list of groups
+- `crypto` entries:
+  - element: `name`
+    - necessity: required
+    - type: string
+  - element: `op`
+    - necessity: required
+    - type: string
+    - values: `"encode"`, `"decode"`, mapping to `odp_crypto_op_t`
+    - default: `odp_crypto_session_param_init()`
+  - element: `cipher_alg`
+    - necessity: optional
+    - type: string
+    - values: `"null"`, `"des"`, `"3des_cbc"`, `"3des_ecb"`, `"aes_cbc"`, `"aes_ctr"`, `"aes_ecb"`,
+              `"aes_cfb128"`, `"aes_xts"`, `"aes_gcm"`, `"aes_ccm"`, `"chacha20_poly1305"`,
+              `"kasumi_f8"`, `"snow3g_uae2"`, `"aes_eea2"`, `"zuc_eea3"`, `"snow_v"`,
+              `"snow_v_gcm"`, `"sm4_ecb"`, `"sm4_cbc"`, `"sm4_ctr"`, `"sm4_gcm"`, `"sm4_ccm"`,
+              mapping to `odp_cipher_alg_t`
+    - default: `odp_crypto_session_param_init()`
+  - element: `cipher_key_data`
+    - necessity: required if `cipher_alg` != `"null"`
+    - type: byte value array
+  - element: `cipher_key_len`
+    - necessity: required if `cipher_alg` != `"null"`
+    - type: integer
+  - element: `cipher_iv_len`
+    - necessity: optional
+    - type: integer
+    - default: `odp_crypto_session_param_init()`
+  - element: `auth_alg`
+    - necessity: optional
+    - type: string
+    - values: `"null"`, `"md5_hmac"`, `"sha1_hmac"`, `"sha224_hmac"`, `"sha256_hmac"`,
+              `"sha384_hmac"`, `"sha512_hmac"`, `"sha3_224_hmac"`, `"sha3_256_hmac"`,
+              `"sha3_384_hmac"`, `"sha3_512_hmac"`, `"aes_gmac"`, `"aes_cmac"`, `"aed_xcbc_mac"`,
+              `"kasumi_f9"`, `"snow3g_uia2"`, `"aes_eia2"`, `"zuc_eia3"`, `"snow_v_gmac"`,
+              `"sm3_hmac"`, `"sm4_gmac"`, `"md5"`, `"sha1"`, `"sha224"`, `"sha3_256"`,
+              `"sha3_384"`, `"sha3_512"`, `"sm3"`, mapping to `odp_auth_alg_t`
+  - element: `auth_key_data`
+    - necessity: required if `auth_alg` != `"null"`
+    - type: byte value array
+  - element: `auth_key_len`
+    - necessity: required if `auth_alg` != `"null"`
+    - type: integer
+  - element: `auth_iv_len`
+    - necessity: optional
+    - type: integer
+    - default: `odp_crypto_session_param_init()`
+  - element: `auth_digest_len`
+    - necessity: optional
+    - type: integer
+    - values: algorithm and capability dependent
+  - element: `auth_aad_len`
+    - necessity: optional
+    - type: integer
+    - default: `odp_crypto_session_param_init()`
+  - element: `compl_queue`
+    - necessity: required
+    - type: string, max `ODP_QUEUE_NAME_LEN`
+    - values: queue domain resource name
+
+### DMA
+
+- name in configuration file: `dma`
+- type: list of groups
+- `dma` entries:
+  - element: `name`
+    - necessity: required
+    - type: string, max `ODP_DMA_NAME_LEN`
+
+### Flows
+
+- name in configuration file: `flows`
+- type: list of groups
+- `flows` entries:
+  - element: `template`
+    - necessity: optional
+    - type: integer
+    - values: number of resources to be instantiated based on the template
+  - element: `name`
+    - necessity: required
+    - type: string, or in case of a template, a list of name prefix string, initial index value
+            integer and increment value integer, which will be concatenated to a string
+  - element: `input`
+    - necessity: required if no `output`
+    - type: string, max `ODP_QUEUE_NAME_LEN`, or in case of a template, a list of name prefix
+            string, initial index value integer and increment value integer, which will be
+            concatenated to a string, max `ODP_QUEUE_NAME_LEN`
+    - values: queue domain resource name
+  - element: `output`
+    - necessity: required if no `input`
+    - type: string, max `ODP_QUEUE_NAME_LEN`, or in case of a template, a list of name prefix
+            string, initial index value integer and increment value integer, which will be
+            concatenated to a string, max `ODP_QUEUE_NAME_LEN`
+    - values: queue domain resource name
+  - element: `work`
+    - necessity: required
+    - type: list of groups
+- `work` entries:
+  - element: `type`
+    - necessity: required
+    - type: string
+    - values: `"work_forward"`, `"work_global_forward"`, `"work_packet_copy"`,
+              `"work_packet_source"`, `"work_sink"`, `"work_timeout_source"`, `"work_wait"`
+  - element: `param`
+    - necessity: optional
+    - type: list
+    - values: work dependent
+
+### Pktios
+
+- name in configuration file: `pktios`
+- type: list of groups
+- `pktios` entries:
+  - element: `name`
+    - necessity: required
+    - type: string
+  - element: `iface`
+    - necessity: required
+    - type: string
+  - element: `pool`
+    - necessity: required
+    - type: string
+    - values: pool domain resource name
+  - element: `inmode`
+    - necessity: optional
+    - type: string
+    - values: `"queue"`, `"schedule"`, `"direct"`, mapping to `odp_pktin_mode_t`, with `"direct"`,
+              queues have to be manually queried with the related packet I/O handle
+    - default: `"queue"`
+  - element: `priority`
+    - necessity: optional
+    - type: integer
+    - default: `odp_schedule_default_prio()`
+  - element: `group`
+    - necessity: optional
+    - type: string
+    - values: schedule domain group resource name
+    - default: `odp_queue_param_init()`
+  - element: `sync`
+    - necessity: optional
+    - type: string
+    - values: `"parallel"`, `"atomic"`, `"ordered"`, mapping to `odp_schedule_sync_t`
+    - default: `odp_queue_param_init()`
+  - element: `size`
+    - necessity: optional
+    - type: integer
+    - values: size of the queue in non-direct receive modes
+  - element: `outmode`
+    - necessity: optional
+    - type: string
+    - values: `"queue"`, `"direct"`, mapping to `odp_pktout_mode_t`, with `"direct"`, queues have
+              to be manually queried with the related packet I/O handle
+    - default: `"queue"`
+  - element: `classifier_enable`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_queue_param_t` boolean
+    - default: `odp_pktin_queue_param_init()`
+  - element: `parse_layer`
+    - necessity: optional
+    - type: string
+    - values: `"none"`, `"l2"`, `"l3"`, `"l4"`, `"all"`, mapping to `odp_proto_layer_t`
+    - default: `odp_pktio_config_init()`
+  - element: `hash_enable`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_queue_param_t` boolean
+    - default: `odp_pktin_queue_param_init()`
+  - element: `hash_ipv4_udp`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_hash_proto_t` bitfield
+    - default: `0`
+  - element: `hash_ipv4_tcp`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_hash_proto_t` bitfield
+    - default: `0`
+  - element: `hash_ipv4`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_hash_proto_t` bitfield
+    - default: `0`
+  - element: `hash_ipv6_udp`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_hash_proto_t` bitfield
+    - default: `0`
+  - element: `hash_ipv6_tcp`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_hash_proto_t` bitfield
+    - default: `0`
+  - element: `hash_ipv6`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to `odp_pktin_hash_proto_t` bitfield
+    - default: `0`
+  - element: `num_in_queues`
+    - necessity: optional
+    - type: integer
+    - default: `odp_pktio_config_init()`
+  - element: `num_out_queues`
+    - necessity: optional
+    - type: integer
+    - default: `odp_pktout_queue_param_init()`
+  - element: `promisc_enable`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to boolean
+    - default: `0`
+  - element: `lso_enable`
+    - necessity: optional
+    - type: integer
+    - values: `0`, `1`, mapping to boolean
+    - default: `0`
+  - element: `mtu`
+    - necessity: optional
+    - type: integer
+
+### Pools
+
+- name in configuration file: `pools`
+- type: list of groups
+- `pools` entries:
+  - element: `name`
+    - necessity: required
+    - type: string, max `ODP_POOL_NAME_LEN`
+  - element: `type`
+    - necessity: required
+    - type: string
+    - values: `"packet"`, `"buffer"`, `"timeout"`, `"dma_completion"`, mapping to `odp_pool_type_t`
+  - element: `size`
+    - necessity: required if `type` == `"packet"` or `"buffer"`
+    - type: integer
+  - element: `cache_size`
+    - necessity: optional
+    - type: integer
+    - default: `odp_pool_param_init()`, `odp_dma_pool_param_init()`
+  - element: `num`
+    - necessity: required
+    - type: integer
+
+### Queues
+
+- name in configuration file: `queues`
+- type: list of groups
+- `queues` entries:
+  - element: `template`
+    - necessity: optional
+    - type: integer
+    - values: number of resources to be instantiated based on the template
+  - element: `name`
+    - necessity: required
+    - type: string, max `ODP_QUEUE_NAME_LEN`, or in case of a template, a list of name prefix
+            string, initial index value integer and increment value integer, which will be
+            concatenated to a string, max `ODP_QUEUE_NAME_LEN`
+  - element: `type`
+    - necessity: optional
+    - type: string
+    - values: `"plain"`, `"schedule"`, mapping to `odp_queue_type_t` or domain name which provides
+              queues with `name` as the provided queue
+    - default: `odp_queue_param_init()`
+  - element: `priority`
+    - necessity: optional
+    - type: integer
+    - default: `odp_schedule_default_prio()`
+  - element: `group`
+    - necessity: optional
+    - type: string
+    - values: schedule domain group resource name
+    - default: `odp_queue_param_init()`
+  - element: `sync`
+    - necessity: optional
+    - type: string
+    - values: `"parallel"`, `"atomic"`, `"ordered"`, mapping to `odp_schedule_sync_t`
+    - default: `odp_queue_param_init()`
+  - element: `size`
+    - necessity: optional
+    - type: integer
+    - values: size of the queue
+
+### Scheduler
+
+- name in configuration file: `scheduler`
+- type: group with nested list `groups` of groups
+- `groups` entries:
+  - element: `name`
+    - necessity: required
+    - type: string
+
+### Stash
+
+- name in configuration file: `stash`
+- type: list of groups
+- `stash` entries:
+  - element: `name`
+    - necessity: required
+    - type: string
+  - element: `type`
+    - necessity: optional
+    - type: string
+    - values: `"default"`, `"fifo"`, mapping to `odp_stash_type_t`
+    - default: `odp_stash_param_init()`
+  - element: `put_mode`
+    - necessity: optional
+    - type: string
+    - values: `"mt"`, `"st"`, `"local"`, mapping to `odp_stash_op_mode_t`
+    - default: `odp_stash_param_init()`
+  - element: `get_mode`
+    - necessity: optional
+    - type: string
+    - values: `"mt"`, `"st"`, `"local"`, mapping to `odp_stash_op_mode_t`
+    - default: `odp_stash_param_init()`
+  - element: `num`
+    - necessity: required
+    - type: integer
+  - element: `size`
+    - necessity: required
+    - type: integer
+    - values: size of the objects to be stashed
+  - element: `cache_size`
+    - necessity: optional
+    - type: integer
+    - default: `odp_stash_param_init()`
+
+### Timers
+
+- name in configuration file: `timers`
+- type: list of groups
+- `timers` entries:
+  - element: `name`
+    - necessity: required
+    - type: string, max `ODP_TIMER_POOL_NAME_LEN`
+  - element: `clk_src`
+    - necessity: optional
+    - type: integer
+    - values: `"src0"`, `"src1"`, `"src2"`, `"src3"`, `"src4"`, `"src5"`, mapping to
+              `odp_timer_clk_src_t`
+    - default: `odp_timer_pool_param_init()`
+  - element: `res_ns`
+    - necessity: optional
+    - type: integer
+    - default: `odp_timer_pool_param_init()`
+  - element: `res_hz`
+    - necessity: optional
+    - type: integer
+    - default: `odp_timer_pool_param_init()`
+  - element: `min_tmo`
+    - necessity: required
+    - type: integer
+  - element: `max_tmo`
+    - necessity: required
+    - type: integer
+  - element: `num`
+    - necessity: required
+    - type: integer
+
+### Workers
+
+- name in configuration file: `workers`
+- type: list of groups
+- `workers` entries:
+  - element: `name`
+    - necessity: required
+    - type: string
+  - element: `type`
+    - necessity: required
+    - type: string
+    - values: `"plain"`, `"schedule"`
+  - element: `burst_size`
+    - necessity: optional
+    - type: integer
+    - default: `32`
+  - element: `wait_ns`
+    - necessity: optional
+    - type: integer
+    - values: for `"schedule"` workers, the minimum time to wait for an event, `0` for no waiting,
+              `-1` for waiting indefinitely. For `"plain"` workers, the wait time between poll
+	      rounds.
+    - default: for `"schedule"` workers, `1000000000` nanoseconds (`1` second), for `"plain"`
+               workers, `0`.
+  - element: `inputs`
+    - necessity: required if `type` == `"plain"`
+    - type: array
+    - values: for `"schedule"` workers, array of schedule domain group resource names, for
+              `"plain"` workers, array of input queue domain resource names
+  - element: `outputs`
+    - necessity: optional
+    - type: array
+    - values: array of output queue resource names
+
+## Work
+
+Work elements are where actual application work is carried out. Each work is part of a work chain
+which in turn is part of a flow and flows are then finally attached to a queue. Tester then
+either sets up polling or scheduling of events from these queues. Once events are received from a
+queue, flows which has the queue set as "input" gets executed. The events that were received can be
+consumed by the work steps in a flow. The execution of the flow is stopped once all the events are
+consumed and tester moves to poll/schedule additional events. If events remain unconsumed after
+a flow has been fully executed, they are simply freed.
+
+Tester also supports event generation or generic code execution through output flows, where a
+queue is marked as "output" flow, where again a set of events is passed to flow work steps but
+instead of consuming the events, they are produced to the passed event set. Output flows are
+executed once per poll/scheduling round and after input flows have been handled.
+
+### Forward
+
+- name in configuration file: `work_forward`
+- type: input
+- info: forward events to a queue, consumes successfully forwarded events
+- parameter list:
+  - index 0: queue resource name
+    - type: string
+
+### Global forward
+
+- name in configuration file: `work_global_forward`
+- type: input
+- info: forward events to a set of queues based on worker thread ID, consumes successfully
+        forwarded events
+- parameter list:
+  - index 0..N: queue resource names
+    - type: string
+
+### Packet copy
+
+- name in configuration file: `work_packet_copy`
+- type: input
+- info: copies passed events in case of packet events, using given pool, no events consumed
+- parameter list:
+  - index 0: pool resource name
+
+### Packet source
+
+- name in configuration file: `work_packet_source`
+- type: output
+- info: produces events from given pool of given length
+- parameter list:
+  - index 0: pool resource name
+    - type: string
+  - index 1: packet length
+    - type: integer
+
+### Sink
+
+- name in configuration file: `work_sink`
+- type: input
+- info: frees all passed events, all events consumed
+
+### Timeout source
+
+- name in configuration file: `work_timeout_source`
+- type: output
+- info: produces timeouts from given timer with given timeout pool and timeout. Timer is rearmed
+        once timeout is handled and freed to the pool
+- parameter list:
+  - index 0: timer resource name
+    - type: string
+  - index 1: pool resource name
+    - type: string
+  - index 2: timeout in nanoseconds
+    - type: integer
+
+### Wait
+
+- name in configuration file: `work_wait`
+- type: input
+- info: waits a given amount, no events consumed
+- parameter list:
+  - index 0: time to wait in nanoseconds

--- a/test/performance/pipeline/cls_parser.c
+++ b/test/performance/pipeline/cls_parser.c
@@ -1,0 +1,1257 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+
+#define CONF_STR_COS "cos"
+#define CONF_STR_PMR "pmr"
+#define CONF_STR_PARSE_TEMPLATE "template"
+#define CONF_STR_NAME "name"
+#define CONF_STR_ACTION "action"
+#define CONF_STR_NUM_QS "num_queues"
+#define CONF_STR_QUEUE "queue"
+#define CONF_STR_TYPE "type"
+#define CONF_STR_HASH_IPV4_UDP "hash_ipv4_udp"
+#define CONF_STR_HASH_IPV4_TCP "hash_ipv4_tcp"
+#define CONF_STR_HASH_IPV4 "hash_ipv4"
+#define CONF_STR_HASH_IPV6_UDP "hash_ipv6_udp"
+#define CONF_STR_HASH_IPV6_TCP "hash_ipv6_tcp"
+#define CONF_STR_HASH_IPV6 "hash_ipv6"
+#define CONF_STR_POOL "pool"
+#define CONF_STR_DEFAULT "default"
+#define CONF_STR_PREFIX "prefix"
+#define CONF_STR_IDX "start_index"
+#define CONF_STR_INC "index_increment"
+#define CONF_STR_SRC_COS "src_cos"
+#define CONF_STR_DST_COS "dst_cos"
+#define CONF_STR_TERM "term"
+#define CONF_STR_MATCH_VALUE "match_value"
+#define CONF_STR_MATCH_MASK "match_mask"
+#define CONF_STR_VAL_SZ "val_sz"
+#define CONF_STR_OFFSET "offset"
+
+#define DROP "drop"
+#define ENQUEUE "enqueue"
+#define PLAIN "plain"
+#define SCHEDULED "schedule"
+#define LEN "len"
+#define ETH_0 "eth_0"
+#define ETH_X "eth_x"
+#define VLAN_0 "vlan_0"
+#define VLAN_X "vlan_x"
+#define VLAN_PCP "vlan_pcp"
+#define DMAC "dmac"
+#define IPPROTO "ipproto"
+#define IP_DSCP "ip_dscp"
+#define UDP_DPORT "udp_dport"
+#define TCP_DPORT "tcp_dport"
+#define UDP_SPORT "udp_sport"
+#define TCP_SPORT "tcp_sport"
+#define SIP_ADDR "sip_addr"
+#define DIP_ADDR "dip_addr"
+#define SIP6_ADDR "sip6_addr"
+#define DIP6_ADDR "dip6_addr"
+#define IPSEC_SPI "ipsec_spi"
+#define LD_VNI "ld_vni"
+#define CUSTOM_FRAME "custom_frame"
+#define CUSTOM_L3 "custom_l3"
+#define SCTP_SPORT "sctp_sport"
+#define SCTP_DPORT "sctp_dport"
+
+typedef struct {
+	char *name;
+	char *queue;
+	char *pool;
+	char *def;
+	odp_cls_cos_param_t cos_param;
+	odp_queue_param_t q_param;
+	odp_cos_t cos;
+	odp_pktio_t def_pktio;
+} cos_parse_t;
+
+typedef struct {
+	char *name;
+	char *src;
+	char *dst;
+	uint8_t *val_arr;
+	uint8_t *mask_arr;
+	odp_pmr_param_t param;
+	odp_pmr_t pmr;
+} pmr_parse_t;
+
+typedef struct {
+	cos_parse_t *coss;
+	pmr_parse_t *pmrs;
+	uint32_t num_cos;
+	uint32_t num_pmr;
+} cls_parses_t;
+
+typedef struct {
+	char *name_prefix;
+	char *action;
+	char *queue_prefix;
+	char *type;
+	char *pool;
+	uint32_t name_idx;
+	uint32_t name_inc;
+	uint32_t queue_idx;
+	uint32_t queue_inc;
+	uint32_t num_qs;
+	uint32_t h_ipv4_udp;
+	uint32_t h_ipv4_tcp;
+	uint32_t h_ipv4;
+	uint32_t h_ipv6_udp;
+	uint32_t h_ipv6_tcp;
+	uint32_t h_ipv6;
+} cos_parse_template_t;
+
+typedef struct {
+	char *name_prefix;
+	char *src_prefix;
+	char *dst_prefix;
+	char *term;
+	uint8_t *val_arr;
+	uint8_t *mask_arr;
+	uint32_t name_idx;
+	uint32_t name_inc;
+	uint32_t src_idx;
+	uint32_t src_inc;
+	uint32_t dst_idx;
+	uint32_t dst_inc;
+	uint32_t val_arr_inc;
+	uint32_t val_sz;
+	uint32_t offset;
+} pmr_parse_template_t;
+
+typedef enum {
+	PARSE_OK,
+	PARSE_TEMPL,
+	PARSE_NOK
+} res_t;
+
+static cls_parses_t cls;
+
+static res_t parse_cos_entry(config_setting_t *cs, cos_parse_t *cos)
+{
+	const char *val_str;
+	int val_i;
+
+	if (config_setting_lookup(cs, CONF_STR_PARSE_TEMPLATE) != NULL)
+		return PARSE_TEMPL;
+
+	memset(cos, 0, sizeof(*cos));
+	cos->cos = ODP_COS_INVALID;
+	cos->def_pktio = ODP_PKTIO_INVALID;
+	odp_cls_cos_param_init(&cos->cos_param);
+	cos->cos_param.hash_proto.all_bits = 0U;
+	odp_queue_param_init(&cos->q_param);
+
+	if (config_setting_lookup_string(cs, CONF_STR_NAME, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return PARSE_NOK;
+	}
+
+	cos->name = strdup(val_str);
+
+	if (cos->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_ACTION, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, DROP) == 0) {
+			cos->cos_param.action = ODP_COS_ACTION_DROP;
+		} else if (strcmp(val_str, ENQUEUE) == 0) {
+			cos->cos_param.action = ODP_COS_ACTION_ENQUEUE;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_ACTION "\" found\n");
+			return PARSE_NOK;
+		}
+	}
+
+	if (config_setting_lookup_string(cs, CONF_STR_DEFAULT, &val_str) == CONFIG_TRUE) {
+		cos->def = strdup(val_str);
+
+		if (cos->def == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	}
+
+	if (cos->cos_param.action == ODP_COS_ACTION_DROP)
+		return PARSE_OK;
+
+	if (config_setting_lookup_int(cs, CONF_STR_NUM_QS, &val_i) == CONFIG_TRUE)
+		cos->cos_param.num_queue = val_i;
+
+	if (cos->cos_param.num_queue == 1U) {
+		if (config_setting_lookup_string(cs, CONF_STR_QUEUE, &val_str) == CONFIG_FALSE) {
+			ODPH_ERR("No \"" CONF_STR_QUEUE "\" found\n");
+			return PARSE_NOK;
+		}
+
+		cos->queue = strdup(val_str);
+
+		if (cos->queue == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	} else {
+		if (config_setting_lookup_string(cs, CONF_STR_TYPE, &val_str) == CONFIG_TRUE) {
+			if (strcmp(val_str, PLAIN) == 0) {
+				cos->q_param.type = ODP_QUEUE_TYPE_PLAIN;
+			} else if (strcmp(val_str, SCHEDULED) == 0) {
+				cos->q_param.type = ODP_QUEUE_TYPE_SCHED;
+			} else {
+				ODPH_ERR("No valid \"" CONF_STR_TYPE "\" found\n");
+				return PARSE_NOK;
+			}
+		}
+
+		if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV4_UDP, &val_i) == CONFIG_TRUE)
+			cos->cos_param.hash_proto.proto.ipv4_udp = val_i;
+
+		if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV4_TCP, &val_i) == CONFIG_TRUE)
+			cos->cos_param.hash_proto.proto.ipv4_tcp = val_i;
+
+		if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV4, &val_i) == CONFIG_TRUE)
+			cos->cos_param.hash_proto.proto.ipv4 = val_i;
+
+		if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV6_UDP, &val_i) == CONFIG_TRUE)
+			cos->cos_param.hash_proto.proto.ipv6_udp = val_i;
+
+		if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV6_TCP, &val_i) == CONFIG_TRUE)
+			cos->cos_param.hash_proto.proto.ipv6_tcp = val_i;
+
+		if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV6, &val_i) == CONFIG_TRUE)
+			cos->cos_param.hash_proto.proto.ipv6 = val_i;
+	}
+
+	if (config_setting_lookup_string(cs, CONF_STR_POOL, &val_str) == CONFIG_TRUE) {
+		cos->pool = strdup(val_str);
+
+		if (cos->pool == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	}
+
+	return PARSE_OK;
+}
+
+static int parse_cos_entry_template(config_setting_t *cs, cos_parse_template_t *templ)
+{
+	int val_i;
+	uint32_t num;
+	config_setting_t *elem;
+	const char *val_str;
+
+	memset(templ, 0, sizeof(*templ));
+
+	if (config_setting_lookup_int(cs, CONF_STR_PARSE_TEMPLATE, &val_i) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_PARSE_TEMPLATE "\" found\n");
+		return -1;
+	}
+
+	num = val_i;
+
+	if (num == 0U)
+		return -1;
+
+	elem = config_setting_lookup(cs, CONF_STR_NAME);
+
+	if (elem == NULL) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return -1;
+	}
+
+	val_str = config_setting_get_string_elem(elem, 0);
+
+	if (val_str == NULL) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" \"" CONF_STR_PREFIX "\" found\n");
+		return -1;
+	}
+
+	templ->name_prefix = strdup(val_str);
+
+	if (templ->name_prefix == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	val_i = config_setting_get_int_elem(elem, 1);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" \"" CONF_STR_IDX "\" found\n");
+		return -1;
+	}
+
+	templ->name_idx = val_i;
+	val_i = config_setting_get_int_elem(elem, 2);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" \"" CONF_STR_INC "\" found\n");
+		return -1;
+	}
+
+	templ->name_inc = val_i;
+
+	if (config_setting_lookup_string(cs, CONF_STR_ACTION, &val_str) == CONFIG_TRUE) {
+		templ->action = strdup(val_str);
+
+		if (templ->action == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+
+		if (strcmp(templ->action, DROP) == 0)
+			return num;
+	}
+
+	if (config_setting_lookup_int(cs, CONF_STR_NUM_QS, &val_i) == CONFIG_TRUE)
+		templ->num_qs = val_i;
+
+	elem = config_setting_lookup(cs, CONF_STR_QUEUE);
+
+	if (elem == NULL) {
+		ODPH_ERR("No \"" CONF_STR_QUEUE "\" found\n");
+		return -1;
+	}
+
+	val_str = config_setting_get_string_elem(elem, 0);
+
+	if (val_str == NULL) {
+		ODPH_ERR("No \"" CONF_STR_QUEUE "\" \"" CONF_STR_PREFIX "\" found\n");
+		return -1;
+	}
+
+	templ->queue_prefix = strdup(val_str);
+
+	if (templ->queue_prefix == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	val_i = config_setting_get_int_elem(elem, 1);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_QUEUE "\" \"" CONF_STR_IDX "\" found\n");
+		return -1;
+	}
+
+	templ->queue_idx = val_i;
+	val_i = config_setting_get_int_elem(elem, 2);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_QUEUE "\" \"" CONF_STR_INC "\" found\n");
+		return -1;
+	}
+
+	templ->queue_inc = val_i;
+
+	if (config_setting_lookup_string(cs, CONF_STR_TYPE, &val_str) == CONFIG_TRUE) {
+		templ->type = strdup(val_str);
+
+		if (templ->type == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	}
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV4_UDP, &val_i) == CONFIG_TRUE)
+		templ->h_ipv4_udp = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV4_TCP, &val_i) == CONFIG_TRUE)
+		templ->h_ipv4_tcp = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV4, &val_i) == CONFIG_TRUE)
+		templ->h_ipv4 = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV6_UDP, &val_i) == CONFIG_TRUE)
+		templ->h_ipv6_udp = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV6_TCP, &val_i) == CONFIG_TRUE)
+		templ->h_ipv6_tcp = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV6, &val_i) == CONFIG_TRUE)
+		templ->h_ipv6 = val_i;
+
+	if (config_setting_lookup_string(cs, CONF_STR_POOL, &val_str) == CONFIG_TRUE) {
+		templ->pool = strdup(val_str);
+
+		if (templ->pool == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	}
+
+	return num;
+}
+
+static odp_bool_t parse_cos_entry_from_template(cos_parse_template_t *templ, cos_parse_t *cos)
+{
+	char cos_name[ODP_COS_NAME_LEN];
+	char queue_name[ODP_QUEUE_NAME_LEN];
+
+	memset(cos, 0, sizeof(*cos));
+	memset(cos_name, 0, sizeof(cos_name));
+	memset(queue_name, 0, sizeof(queue_name));
+	cos->cos = ODP_COS_INVALID;
+	cos->def_pktio = ODP_PKTIO_INVALID;
+	odp_cls_cos_param_init(&cos->cos_param);
+	cos->cos_param.hash_proto.all_bits = 0U;
+	odp_queue_param_init(&cos->q_param);
+	(void)snprintf(cos_name, sizeof(cos_name), "%s%u", templ->name_prefix, templ->name_idx);
+	templ->name_idx += templ->name_inc;
+	cos->name = strdup(cos_name);
+
+	if (cos->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (templ->action != NULL) {
+		if (strcmp(templ->action, DROP) == 0) {
+			cos->cos_param.action = ODP_COS_ACTION_DROP;
+		} else if (strcmp(templ->action, ENQUEUE) == 0) {
+			cos->cos_param.action = ODP_COS_ACTION_ENQUEUE;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_ACTION "\" found\n");
+			return false;
+		}
+	}
+
+	if (cos->cos_param.action == ODP_COS_ACTION_DROP)
+		return true;
+
+	if (templ->num_qs > 0U)
+		cos->cos_param.num_queue = templ->num_qs;
+
+	if (cos->cos_param.num_queue == 1U) {
+		(void)snprintf(queue_name, sizeof(queue_name), "%s%u", templ->queue_prefix,
+			       templ->queue_idx);
+		templ->queue_idx += templ->queue_inc;
+		cos->queue = strdup(queue_name);
+
+		if (cos->queue == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	} else {
+		if (templ->type != NULL) {
+			if (strcmp(templ->type, PLAIN) == 0) {
+				cos->q_param.type = ODP_QUEUE_TYPE_PLAIN;
+			} else if (strcmp(templ->type, SCHEDULED) == 0) {
+				cos->q_param.type = ODP_QUEUE_TYPE_SCHED;
+			} else {
+				ODPH_ERR("No valid \"" CONF_STR_TYPE "\" found\n");
+				return false;
+			}
+		}
+
+		cos->cos_param.hash_proto.proto.ipv4_udp = templ->h_ipv4_udp;
+		cos->cos_param.hash_proto.proto.ipv4_tcp = templ->h_ipv4_tcp;
+		cos->cos_param.hash_proto.proto.ipv4 = templ->h_ipv4;
+		cos->cos_param.hash_proto.proto.ipv6_udp = templ->h_ipv6_udp;
+		cos->cos_param.hash_proto.proto.ipv6_tcp = templ->h_ipv6_tcp;
+		cos->cos_param.hash_proto.proto.ipv6 = templ->h_ipv6;
+	}
+
+	if (templ->pool != NULL) {
+		cos->pool = strdup(templ->pool);
+
+		if (cos->pool == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	}
+
+	return true;
+}
+
+static void free_cos_entry(cos_parse_t *cos)
+{
+	free(cos->name);
+	free(cos->queue);
+	free(cos->pool);
+	free(cos->def);
+
+	if (cos->def_pktio != ODP_PKTIO_INVALID)
+		(void)odp_pktio_default_cos_set(cos->def_pktio, ODP_COS_INVALID);
+
+	if (cos->cos != ODP_COS_INVALID)
+		(void)odp_cos_destroy(cos->cos);
+}
+
+static void free_cos_template(cos_parse_template_t *templ)
+{
+	free(templ->name_prefix);
+	free(templ->action);
+	free(templ->queue_prefix);
+	free(templ->type);
+	free(templ->pool);
+}
+
+static res_t parse_pmr_entry(config_setting_t *cs, pmr_parse_t *pmr)
+{
+	const char *val_str;
+	int val_i, num;
+	config_setting_t *elem;
+
+	if (config_setting_lookup(cs, CONF_STR_PARSE_TEMPLATE) != NULL)
+		return PARSE_TEMPL;
+
+	memset(pmr, 0, sizeof(*pmr));
+	pmr->pmr = ODP_PMR_INVALID;
+	odp_cls_pmr_param_init(&pmr->param);
+
+	if (config_setting_lookup_string(cs, CONF_STR_NAME, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return PARSE_NOK;
+	}
+
+	pmr->name = strdup(val_str);
+
+	if (pmr->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_SRC_COS, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_SRC_COS "\" found\n");
+		return PARSE_NOK;
+	}
+
+	pmr->src = strdup(val_str);
+
+	if (pmr->src == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_DST_COS, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_DST_COS "\" found\n");
+		return PARSE_NOK;
+	}
+
+	pmr->dst = strdup(val_str);
+
+	if (pmr->dst == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_TERM, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_TERM "\" found\n");
+		return PARSE_NOK;
+	}
+
+	if (strcmp(val_str, LEN) == 0) {
+		pmr->param.term = ODP_PMR_LEN;
+	} else if (strcmp(val_str, ETH_0) == 0) {
+		pmr->param.term = ODP_PMR_ETHTYPE_0;
+	} else if (strcmp(val_str, ETH_X) == 0) {
+		pmr->param.term = ODP_PMR_ETHTYPE_X;
+	} else if (strcmp(val_str, VLAN_0) == 0) {
+		pmr->param.term = ODP_PMR_VLAN_ID_0;
+	} else if (strcmp(val_str, VLAN_X) == 0) {
+		pmr->param.term = ODP_PMR_VLAN_ID_X;
+	} else if (strcmp(val_str, VLAN_PCP) == 0) {
+		pmr->param.term = ODP_PMR_VLAN_PCP_0;
+	} else if (strcmp(val_str, DMAC) == 0) {
+		pmr->param.term = ODP_PMR_DMAC;
+	} else if (strcmp(val_str, IPPROTO) == 0) {
+		pmr->param.term = ODP_PMR_IPPROTO;
+	} else if (strcmp(val_str, IP_DSCP) == 0) {
+		pmr->param.term = ODP_PMR_IP_DSCP;
+	} else if (strcmp(val_str, UDP_DPORT) == 0) {
+		pmr->param.term = ODP_PMR_UDP_DPORT;
+	} else if (strcmp(val_str, TCP_DPORT) == 0) {
+		pmr->param.term = ODP_PMR_TCP_DPORT;
+	} else if (strcmp(val_str, UDP_SPORT) == 0) {
+		pmr->param.term = ODP_PMR_UDP_SPORT;
+	} else if (strcmp(val_str, TCP_SPORT) == 0) {
+		pmr->param.term = ODP_PMR_TCP_SPORT;
+	} else if (strcmp(val_str, SIP_ADDR) == 0) {
+		pmr->param.term = ODP_PMR_SIP_ADDR;
+	} else if (strcmp(val_str, DIP_ADDR) == 0) {
+		pmr->param.term = ODP_PMR_DIP_ADDR;
+	} else if (strcmp(val_str, SIP6_ADDR) == 0) {
+		pmr->param.term = ODP_PMR_SIP6_ADDR;
+	} else if (strcmp(val_str, DIP6_ADDR) == 0) {
+		pmr->param.term = ODP_PMR_DIP6_ADDR;
+	} else if (strcmp(val_str, IPSEC_SPI) == 0) {
+		pmr->param.term = ODP_PMR_IPSEC_SPI;
+	} else if (strcmp(val_str, LD_VNI) == 0) {
+		pmr->param.term = ODP_PMR_LD_VNI;
+	} else if (strcmp(val_str, CUSTOM_FRAME) == 0) {
+		pmr->param.term = ODP_PMR_CUSTOM_FRAME;
+	} else if (strcmp(val_str, CUSTOM_L3) == 0) {
+		pmr->param.term = ODP_PMR_CUSTOM_L3;
+	} else if (strcmp(val_str, SCTP_SPORT) == 0) {
+		pmr->param.term = ODP_PMR_SCTP_SPORT;
+	} else if (strcmp(val_str, SCTP_DPORT) == 0) {
+		pmr->param.term = ODP_PMR_SCTP_DPORT;
+	} else {
+		ODPH_ERR("No valid \"" CONF_STR_TERM "\" found\n");
+		return PARSE_NOK;
+	}
+
+	elem = config_setting_lookup(cs, CONF_STR_MATCH_VALUE);
+
+	if (elem == NULL) {
+		ODPH_ERR("No \"" CONF_STR_MATCH_VALUE "\" entries found\n");
+		return PARSE_NOK;
+	}
+
+	num = config_setting_length(elem);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" CONF_STR_MATCH_VALUE "\" entries found\n");
+		return PARSE_NOK;
+	}
+
+	pmr->val_arr = calloc(1U, num * sizeof(*pmr->val_arr));
+
+	if (pmr->val_arr == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i)
+		pmr->val_arr[i] = (uint8_t)config_setting_get_int_elem(elem, i);
+
+	pmr->param.match.value = pmr->val_arr;
+	elem = config_setting_lookup(cs, CONF_STR_MATCH_MASK);
+
+	if (elem == NULL) {
+		ODPH_ERR("No \"" CONF_STR_MATCH_MASK "\" entries found\n");
+		return PARSE_NOK;
+	}
+
+	num = config_setting_length(elem);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" CONF_STR_MATCH_MASK "\" entries found\n");
+		return PARSE_NOK;
+	}
+
+	pmr->mask_arr = calloc(1U, num * sizeof(*pmr->mask_arr));
+
+	if (pmr->mask_arr == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i)
+		pmr->mask_arr[i] = (uint8_t)config_setting_get_int_elem(elem, i);
+
+	pmr->param.match.mask = pmr->mask_arr;
+
+	if (config_setting_lookup_int(cs, CONF_STR_VAL_SZ, &val_i) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_VAL_SZ "\" found\n");
+		return PARSE_NOK;
+	}
+
+	pmr->param.val_sz = val_i;
+
+	if (pmr->param.term == ODP_PMR_CUSTOM_FRAME || pmr->param.term == ODP_PMR_CUSTOM_L3) {
+		if (config_setting_lookup_int(cs, CONF_STR_OFFSET, &val_i) == CONFIG_FALSE) {
+			ODPH_ERR("No \"" CONF_STR_OFFSET "\" found\n");
+			return PARSE_NOK;
+		}
+
+		pmr->param.offset = val_i;
+	}
+
+	return PARSE_OK;
+}
+
+static int parse_pmr_entry_template(config_setting_t *cs, pmr_parse_template_t *templ)
+{
+	int val_i;
+	uint32_t num;
+	config_setting_t *elem1, *elem2;
+	const char *val_str;
+
+	memset(templ, 0, sizeof(*templ));
+
+	if (config_setting_lookup_int(cs, CONF_STR_PARSE_TEMPLATE, &val_i) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_PARSE_TEMPLATE "\" found\n");
+		return -1;
+	}
+
+	num = val_i;
+
+	if (num == 0U)
+		return -1;
+
+	elem1 = config_setting_lookup(cs, CONF_STR_NAME);
+
+	if (elem1 == NULL) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return -1;
+	}
+
+	val_str = config_setting_get_string_elem(elem1, 0);
+
+	if (val_str == NULL) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" \"" CONF_STR_PREFIX "\" found\n");
+		return -1;
+	}
+
+	templ->name_prefix = strdup(val_str);
+
+	if (templ->name_prefix == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	val_i = config_setting_get_int_elem(elem1, 1);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" \"" CONF_STR_IDX "\" found\n");
+		return -1;
+	}
+
+	templ->name_idx = val_i;
+	val_i = config_setting_get_int_elem(elem1, 2);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" \"" CONF_STR_INC "\" found\n");
+		return -1;
+	}
+
+	templ->name_inc = val_i;
+	elem1 = config_setting_lookup(cs, CONF_STR_SRC_COS);
+
+	if (elem1 == NULL) {
+		ODPH_ERR("No \"" CONF_STR_SRC_COS "\" found\n");
+		return -1;
+	}
+
+	val_str = config_setting_get_string_elem(elem1, 0);
+
+	if (val_str == NULL) {
+		ODPH_ERR("No \"" CONF_STR_SRC_COS "\" \"" CONF_STR_PREFIX "\" found\n");
+		return -1;
+	}
+
+	templ->src_prefix = strdup(val_str);
+
+	if (templ->src_prefix == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	val_i = config_setting_get_int_elem(elem1, 1);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_SRC_COS "\" \"" CONF_STR_IDX "\" found\n");
+		return -1;
+	}
+
+	templ->src_idx = val_i;
+	val_i = config_setting_get_int_elem(elem1, 2);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_SRC_COS "\" \"" CONF_STR_INC "\" found\n");
+		return -1;
+	}
+
+	templ->src_inc = val_i;
+	elem1 = config_setting_lookup(cs, CONF_STR_DST_COS);
+
+	if (elem1 == NULL) {
+		ODPH_ERR("No \"" CONF_STR_DST_COS "\" found\n");
+		return -1;
+	}
+
+	val_str = config_setting_get_string_elem(elem1, 0);
+
+	if (val_str == NULL) {
+		ODPH_ERR("No \"" CONF_STR_DST_COS "\" \"" CONF_STR_PREFIX "\" found\n");
+		return -1;
+	}
+
+	templ->dst_prefix = strdup(val_str);
+
+	if (templ->dst_prefix == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	val_i = config_setting_get_int_elem(elem1, 1);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_DST_COS "\" \"" CONF_STR_IDX "\" found\n");
+		return -1;
+	}
+
+	templ->dst_idx = val_i;
+	val_i = config_setting_get_int_elem(elem1, 2);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_DST_COS "\" \"" CONF_STR_INC "\" found\n");
+		return -1;
+	}
+
+	templ->dst_inc = val_i;
+
+	if (config_setting_lookup_string(cs, CONF_STR_TERM, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_TERM "\" found\n");
+		return -1;
+	}
+
+	templ->term = strdup(val_str);
+
+	if (templ->term == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	elem1 = config_setting_lookup(cs, CONF_STR_MATCH_VALUE);
+
+	if (elem1 == NULL) {
+		ODPH_ERR("No \"" CONF_STR_MATCH_VALUE "\" found\n");
+		return -1;
+	}
+
+	elem2 = config_setting_get_elem(elem1, 0);
+
+	if (elem2 == NULL) {
+		ODPH_ERR("No \"" CONF_STR_MATCH_VALUE "\" found\n");
+		return -1;
+	}
+
+	val_i = config_setting_length(elem2);
+
+	if (val_i == 0) {
+		ODPH_ERR("No valid \"" CONF_STR_MATCH_VALUE "\" entries found\n");
+		return -1;
+	}
+
+	templ->val_arr = calloc(1U, val_i * sizeof(*templ->val_arr));
+
+	if (templ->val_arr == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < val_i; ++i)
+		templ->val_arr[i] = (uint8_t)config_setting_get_int_elem(elem2, i);
+
+	val_i = config_setting_get_int_elem(elem1, 1);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_MATCH_VALUE "\" \"" CONF_STR_INC "\" found\n");
+		return -1;
+	}
+
+	templ->val_arr_inc = val_i;
+	elem1 = config_setting_lookup(cs, CONF_STR_MATCH_MASK);
+
+	if (elem1 == NULL) {
+		ODPH_ERR("No \"" CONF_STR_MATCH_MASK "\" found\n");
+		return -1;
+	}
+
+	val_i = config_setting_length(elem1);
+
+	if (val_i == 0) {
+		ODPH_ERR("No valid \"" CONF_STR_MATCH_MASK "\" entries found\n");
+		return -1;
+	}
+
+	templ->mask_arr = calloc(1U, val_i * sizeof(*templ->mask_arr));
+
+	if (templ->mask_arr == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < val_i; ++i)
+		templ->mask_arr[i] = (uint8_t)config_setting_get_int_elem(elem1, i);
+
+	if (config_setting_lookup_int(cs, CONF_STR_VAL_SZ, &val_i) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_VAL_SZ "\" found\n");
+		return PARSE_NOK;
+	}
+
+	templ->val_sz = val_i;
+
+	if (strcmp(templ->term, CUSTOM_FRAME) == 0 || strcmp(templ->term, CUSTOM_L3) == 0) {
+		if (config_setting_lookup_int(cs, CONF_STR_OFFSET, &val_i) == CONFIG_FALSE) {
+			ODPH_ERR("No \"" CONF_STR_OFFSET "\" found\n");
+			return PARSE_NOK;
+		}
+
+		templ->offset = val_i;
+	}
+
+	return num;
+}
+
+static void increment_value_array(uint8_t data[], uint32_t inc, uint32_t len)
+{
+	int i = len - 1, j = 0;
+	uint32_t carry = inc, digit, sum;
+	uint8_t tmp[len + sizeof(inc) + 1U];
+
+	while (i >= 0 || carry != 0) {
+		digit = i >= 0 ? data[i] : 0;
+		sum = digit + (carry & 0xFFU);
+		tmp[j++] = (uint8_t)(sum & 0xFFU);
+		carry = (carry >> 8U) + (sum >> 8U);
+		i--;
+	}
+
+	for (uint32_t k = 0U; k < len; k++)
+		data[len - 1U - k] = tmp[k];
+}
+
+static odp_bool_t parse_pmr_entry_from_template(pmr_parse_template_t *templ, pmr_parse_t *pmr)
+{
+	char name[ODP_COS_NAME_LEN];
+
+	memset(pmr, 0, sizeof(*pmr));
+	memset(name, 0, sizeof(name));
+	pmr->pmr = ODP_PMR_INVALID;
+	odp_cls_pmr_param_init(&pmr->param);
+	(void)snprintf(name, sizeof(name), "%s%u", templ->name_prefix, templ->name_idx);
+	templ->name_idx += templ->name_inc;
+	pmr->name = strdup(name);
+
+	if (pmr->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	memset(name, 0, sizeof(name));
+	(void)snprintf(name, sizeof(name), "%s%u", templ->src_prefix, templ->src_idx);
+	templ->src_idx += templ->src_inc;
+	pmr->src = strdup(name);
+
+	if (pmr->src == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	memset(name, 0, sizeof(name));
+	(void)snprintf(name, sizeof(name), "%s%u", templ->dst_prefix, templ->dst_idx);
+	templ->dst_idx += templ->dst_inc;
+	pmr->dst = strdup(name);
+
+	if (pmr->dst == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (strcmp(templ->term, LEN) == 0) {
+		pmr->param.term = ODP_PMR_LEN;
+	} else if (strcmp(templ->term, ETH_0) == 0) {
+		pmr->param.term = ODP_PMR_ETHTYPE_0;
+	} else if (strcmp(templ->term, ETH_X) == 0) {
+		pmr->param.term = ODP_PMR_ETHTYPE_X;
+	} else if (strcmp(templ->term, VLAN_0) == 0) {
+		pmr->param.term = ODP_PMR_VLAN_ID_0;
+	} else if (strcmp(templ->term, VLAN_X) == 0) {
+		pmr->param.term = ODP_PMR_VLAN_ID_X;
+	} else if (strcmp(templ->term, VLAN_PCP) == 0) {
+		pmr->param.term = ODP_PMR_VLAN_PCP_0;
+	} else if (strcmp(templ->term, DMAC) == 0) {
+		pmr->param.term = ODP_PMR_DMAC;
+	} else if (strcmp(templ->term, IPPROTO) == 0) {
+		pmr->param.term = ODP_PMR_IPPROTO;
+	} else if (strcmp(templ->term, IP_DSCP) == 0) {
+		pmr->param.term = ODP_PMR_IP_DSCP;
+	} else if (strcmp(templ->term, UDP_DPORT) == 0) {
+		pmr->param.term = ODP_PMR_UDP_DPORT;
+	} else if (strcmp(templ->term, TCP_DPORT) == 0) {
+		pmr->param.term = ODP_PMR_TCP_DPORT;
+	} else if (strcmp(templ->term, UDP_SPORT) == 0) {
+		pmr->param.term = ODP_PMR_UDP_SPORT;
+	} else if (strcmp(templ->term, TCP_SPORT) == 0) {
+		pmr->param.term = ODP_PMR_TCP_SPORT;
+	} else if (strcmp(templ->term, SIP_ADDR) == 0) {
+		pmr->param.term = ODP_PMR_SIP_ADDR;
+	} else if (strcmp(templ->term, DIP_ADDR) == 0) {
+		pmr->param.term = ODP_PMR_DIP_ADDR;
+	} else if (strcmp(templ->term, SIP6_ADDR) == 0) {
+		pmr->param.term = ODP_PMR_SIP6_ADDR;
+	} else if (strcmp(templ->term, DIP6_ADDR) == 0) {
+		pmr->param.term = ODP_PMR_DIP6_ADDR;
+	} else if (strcmp(templ->term, IPSEC_SPI) == 0) {
+		pmr->param.term = ODP_PMR_IPSEC_SPI;
+	} else if (strcmp(templ->term, LD_VNI) == 0) {
+		pmr->param.term = ODP_PMR_LD_VNI;
+	} else if (strcmp(templ->term, CUSTOM_FRAME) == 0) {
+		pmr->param.term = ODP_PMR_CUSTOM_FRAME;
+	} else if (strcmp(templ->term, CUSTOM_L3) == 0) {
+		pmr->param.term = ODP_PMR_CUSTOM_L3;
+	} else if (strcmp(templ->term, SCTP_SPORT) == 0) {
+		pmr->param.term = ODP_PMR_SCTP_SPORT;
+	} else if (strcmp(templ->term, SCTP_DPORT) == 0) {
+		pmr->param.term = ODP_PMR_SCTP_DPORT;
+	} else {
+		ODPH_ERR("No valid \"" CONF_STR_TERM "\" found\n");
+		return false;
+	}
+
+	pmr->val_arr = malloc(templ->val_sz);
+
+	if (pmr->val_arr == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	memcpy(pmr->val_arr, templ->val_arr, templ->val_sz);
+	pmr->mask_arr = malloc(templ->val_sz);
+
+	if (pmr->mask_arr == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	memcpy(pmr->mask_arr, templ->mask_arr, templ->val_sz);
+	pmr->param.match.value = pmr->val_arr;
+	pmr->param.match.mask = pmr->mask_arr;
+	pmr->param.val_sz = templ->val_sz;
+	pmr->param.offset = templ->offset;
+	increment_value_array(templ->val_arr, templ->val_arr_inc, templ->val_sz);
+
+	return true;
+}
+
+static void free_pmr_entry(pmr_parse_t *pmr)
+{
+	free(pmr->name);
+	free(pmr->src);
+	free(pmr->dst);
+	free(pmr->val_arr);
+	free(pmr->mask_arr);
+
+	if (pmr->pmr != ODP_PMR_INVALID)
+		(void)odp_cls_pmr_destroy(pmr->pmr);
+}
+
+static void free_pmr_template(pmr_parse_template_t *templ)
+{
+	free(templ->name_prefix);
+	free(templ->src_prefix);
+	free(templ->dst_prefix);
+	free(templ->term);
+	free(templ->val_arr);
+	free(templ->mask_arr);
+}
+
+static odp_bool_t classifier_parser_init(config_t *config)
+{
+	config_setting_t *cs, *elem1, *elem2, *tmp;
+	int num1, num2, ret;
+	cos_parse_t *cos;
+	res_t res;
+	cos_parse_template_t cos_templ;
+	pmr_parse_t *pmr;
+	pmr_parse_template_t pmr_templ;
+
+	cs = config_lookup(config, CLASSIFICATION_DOMAIN);
+
+	if (cs == NULL)	{
+		printf("Nothing to parse for \"" CLASSIFICATION_DOMAIN "\" domain\n");
+		return true;
+	}
+
+	elem1 = config_setting_lookup(cs, CONF_STR_COS);
+
+	if (elem1 == NULL) {
+		ODPH_ERR("No \"" CONF_STR_COS "\" entries found\n");
+		return false;
+	}
+
+	num1 = config_setting_length(elem1);
+
+	if (num1 == 0) {
+		ODPH_ERR("No valid \"" CONF_STR_COS "\" entries found\n");
+		return false;
+	}
+
+	elem2 = config_setting_lookup(cs, CONF_STR_PMR);
+
+	if (elem2 == NULL) {
+		ODPH_ERR("No \"" CONF_STR_PMR "\" entries found\n");
+		return false;
+	}
+
+	num2 = config_setting_length(elem2);
+
+	if (num2 == 0) {
+		ODPH_ERR("No valid \"" CONF_STR_PMR "\" entries found\n");
+		return false;
+	}
+
+	cls.coss = calloc(1U, num1 * sizeof(*cls.coss));
+
+	if (cls.coss == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num1; ++i) {
+		tmp = config_setting_get_elem(elem1, i);
+
+		if (tmp == NULL) {
+			ODPH_ERR("Unparsable \"" CONF_STR_COS "\" entry (%d)\n", i);
+			return false;
+		}
+
+		cos = &cls.coss[cls.num_cos];
+		res = parse_cos_entry(tmp, cos);
+
+		if (res == PARSE_NOK) {
+			ODPH_ERR("Invalid \"" CONF_STR_COS "\" entry (%d)\n", i);
+			free_cos_entry(cos);
+			return false;
+		} else if (res == PARSE_TEMPL) {
+			ret = parse_cos_entry_template(tmp, &cos_templ);
+
+			if (ret == -1) {
+				ODPH_ERR("Invalid \"" CONF_STR_COS "\" entry (%d)\n", i);
+				return false;
+			}
+
+			cls.coss = realloc(cls.coss, (ret + cls.num_cos  + (num1 - i - 1)) *
+					   sizeof(*cls.coss));
+
+			if (cls.coss == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+
+			for (int j = 0; j < ret; ++j) {
+				cos = &cls.coss[cls.num_cos];
+
+				if (!parse_cos_entry_from_template(&cos_templ, cos)) {
+					ODPH_ERR("Invalid \"" CONF_STR_COS "\" entry (%d)\n", i);
+					free_cos_template(&cos_templ);
+					free_cos_entry(cos);
+					return false;
+				}
+
+				++cls.num_cos;
+			}
+
+			free_cos_template(&cos_templ);
+		} else {
+			++cls.num_cos;
+		}
+	}
+
+	cls.pmrs = calloc(1U, num2 * sizeof(*cls.pmrs));
+
+	if (cls.pmrs == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num2; ++i) {
+		tmp = config_setting_get_elem(elem2, i);
+
+		if (tmp == NULL) {
+			ODPH_ERR("Unparsable \"" CONF_STR_PMR "\" entry (%d)\n", i);
+			return false;
+		}
+
+		pmr = &cls.pmrs[cls.num_pmr];
+		res = parse_pmr_entry(tmp, pmr);
+
+		if (res == PARSE_NOK) {
+			ODPH_ERR("Invalid \"" CONF_STR_PMR "\" entry (%d)\n", i);
+			free_pmr_entry(pmr);
+			return false;
+		} else if (res == PARSE_TEMPL) {
+			ret = parse_pmr_entry_template(tmp, &pmr_templ);
+
+			if (ret == -1) {
+				ODPH_ERR("Invalid \"" CONF_STR_PMR "\" entry (%d)\n", i);
+				return false;
+			}
+
+			cls.pmrs = realloc(cls.pmrs, (ret + cls.num_pmr + (num2 - i - 1)) *
+					   sizeof(*cls.pmrs));
+
+			if (cls.pmrs == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+
+			for (int j = 0; j < ret; ++j) {
+				pmr = &cls.pmrs[cls.num_pmr];
+
+				if (!parse_pmr_entry_from_template(&pmr_templ, pmr)) {
+					ODPH_ERR("Invalid \"" CONF_STR_PMR "\" entry (%d)\n", i);
+					free_pmr_template(&pmr_templ);
+					free_pmr_entry(pmr);
+					return false;
+				}
+
+				++cls.num_pmr;
+			}
+
+			free_pmr_template(&pmr_templ);
+		} else {
+			++cls.num_pmr;
+		}
+	}
+
+	return true;
+}
+
+static odp_bool_t classifier_parser_deploy(void)
+{
+	cos_parse_t *cos;
+	odp_pktio_t pktio;
+	pmr_parse_t *pmr;
+	odp_cos_t src, dst;
+
+	printf("\n*** " CLASSIFICATION_DOMAIN " resources ***\n");
+
+	for (uint32_t i = 0U; i < cls.num_cos; ++i) {
+		cos = &cls.coss[i];
+
+		if (cos->queue != NULL)
+			cos->cos_param.queue = (odp_queue_t)config_parser_get(QUEUE_DOMAIN,
+									      cos->queue);
+
+		if (cos->pool != NULL)
+			cos->cos_param.pool = (odp_pool_t)config_parser_get(POOL_DOMAIN,
+									    cos->pool);
+
+		cos->cos = odp_cls_cos_create(cos->name, &cos->cos_param);
+
+		if (cos->cos == ODP_COS_INVALID) {
+			ODPH_ERR("Error creating CoS (%s)\n", cos->name);
+			return false;
+		}
+
+		if (cos->def != NULL) {
+			pktio = (odp_pktio_t)config_parser_get(PKTIO_DOMAIN, cos->def);
+
+			if (odp_pktio_default_cos_set(pktio, cos->cos) < 0) {
+				ODPH_ERR("Error setting default CoS (%s)\n", cos->name);
+				return false;
+			}
+
+			cos->def_pktio = pktio;
+		}
+
+		printf("\nname: %s\n", cos->name);
+	}
+
+	for (uint32_t i = 0U; i < cls.num_pmr; ++i) {
+		pmr = &cls.pmrs[i];
+		src = (odp_cos_t)config_parser_get(CLASSIFICATION_DOMAIN, pmr->src);
+		dst = (odp_cos_t)config_parser_get(CLASSIFICATION_DOMAIN, pmr->dst);
+		pmr->pmr = odp_cls_pmr_create(&pmr->param, 1, src, dst);
+
+		if (pmr->pmr == ODP_PMR_INVALID) {
+			ODPH_ERR("Error creating PMR (%s)\n", pmr->name);
+			return false;
+		}
+
+		printf("\nname: %s\n", pmr->name);
+	}
+
+	odp_cls_print_all();
+
+	return true;
+}
+
+static void classifier_parser_destroy(void)
+{
+	for (uint32_t i = 0U; i < cls.num_pmr; ++i)
+		free_pmr_entry(&cls.pmrs[i]);
+
+	for (uint32_t i = 0U; i < cls.num_cos; ++i)
+		free_cos_entry(&cls.coss[i]);
+
+	free(cls.pmrs);
+	free(cls.coss);
+}
+
+static uintptr_t classifier_parser_get_resource(const char *resource)
+{
+	cos_parse_t *parse;
+	odp_cos_t cos = ODP_COS_INVALID;
+
+	for (uint32_t i = 0U; i < cls.num_cos; ++i) {
+		parse = &cls.coss[i];
+
+		if (strcmp(parse->name, resource) != 0)
+			continue;
+
+		cos = parse->cos;
+		break;
+	}
+
+	if (cos == ODP_COS_INVALID)
+		ODPH_ABORT("No resource found (%s), aborting\n", resource);
+
+	return (uintptr_t)cos;
+}
+
+CONFIG_PARSER_AUTOREGISTER(LOW_PRIO, CLASSIFICATION_DOMAIN, classifier_parser_init,
+			   classifier_parser_deploy, NULL, classifier_parser_destroy,
+			   classifier_parser_get_resource)

--- a/test/performance/pipeline/common.h
+++ b/test/performance/pipeline/common.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef COMMON_H_
+#define COMMON_H_
+
+#define CLASSIFICATION_DOMAIN "classification"
+#define CPUMAP_DOMAIN "cpumap"
+#define CRYPTO_DOMAIN "crypto"
+#define DMA_DOMAIN "dma"
+#define FLOW_DOMAIN "flows"
+#define	PKTIO_DOMAIN "pktios"
+#define	POOL_DOMAIN "pools"
+#define	QUEUE_DOMAIN "queues"
+#define SCHED_DOMAIN "scheduler"
+#define STASH_DOMAIN "stash"
+#define TIMER_DOMAIN "timers"
+#define	WORKER_DOMAIN "workers"
+
+#define CRIT_PRIO 101
+#define HIGH_PRIO (CRIT_PRIO + 1)
+#define MED_PRIO (HIGH_PRIO + 1)
+#define LOW_PRIO (MED_PRIO + 1)
+
+#endif

--- a/test/performance/pipeline/config_parser.c
+++ b/test/performance/pipeline/config_parser.c
@@ -1,0 +1,138 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#include <stdlib.h>
+
+#include <odp/helper/odph_api.h>
+#include <sys/queue.h>
+
+#include "config_parser.h"
+
+typedef struct parser_s {
+	TAILQ_ENTRY(parser_s) p;
+
+	const char *domain;
+	conf_init_fn_t init_fn;
+	conf_deploy_fn_t deploy_fn;
+	conf_undeploy_fn_t undeploy_fn;
+	conf_destroy_fn_t destroy_fn;
+	conf_resource_fn_t resource_fn;
+} parser_t;
+
+typedef struct {
+	TAILQ_HEAD(, parser_s) p;
+
+	odp_bool_t init_done;
+	config_t config;
+	char *path;
+} parsers_t;
+
+static parsers_t parsers;
+
+odp_bool_t config_parser_init(char *path)
+{
+	int ret;
+	parser_t *parser;
+	odp_bool_t p_ret = true;
+
+	parsers.path = path;
+	config_init(&parsers.config);
+	ret = config_read_file(&parsers.config, parsers.path);
+
+	if (ret == CONFIG_FALSE) {
+		ODPH_ERR("Error opening configuration file, line %d: %s\n",
+			 config_error_line(&parsers.config), config_error_text(&parsers.config));
+		config_destroy(&parsers.config);
+		return false;
+	}
+
+	TAILQ_FOREACH(parser, &parsers.p, p) {
+		if (!parser->init_fn(&parsers.config)) {
+			ODPH_ERR("Error parsing domain: %s\n", parser->domain);
+			p_ret = false;
+			break;
+		}
+	}
+
+	return p_ret;
+}
+
+odp_bool_t config_parser_deploy(void)
+{
+	parser_t *parser;
+
+	TAILQ_FOREACH(parser, &parsers.p, p)
+		if (!parser->deploy_fn())
+			return false;
+
+	return true;
+}
+
+uintptr_t config_parser_get(const char *domain, const char *resource)
+{
+	parser_t *parser;
+
+	TAILQ_FOREACH(parser, &parsers.p, p)
+		if (strcmp(domain, parser->domain) == 0)
+			return parser->resource_fn(resource);
+
+	ODPH_ABORT("No domain found (%s)\n", domain);
+}
+
+void config_parser_register_parser(const char *domain, conf_init_fn_t init_fn,
+				   conf_deploy_fn_t deploy_fn, conf_undeploy_fn_t undeploy_fn,
+				   conf_destroy_fn_t destroy_fn, conf_resource_fn_t resource_fn)
+{
+	parser_t *entry = calloc(1U, sizeof(*entry));
+
+	if (entry == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	entry->domain = domain;
+	entry->init_fn = init_fn;
+	entry->deploy_fn = deploy_fn;
+	entry->undeploy_fn = undeploy_fn;
+	entry->destroy_fn = destroy_fn;
+	entry->resource_fn = resource_fn;
+
+	if (!parsers.init_done) {
+		TAILQ_INIT(&parsers.p);
+		parsers.init_done = true;
+	}
+
+	TAILQ_INSERT_TAIL(&parsers.p, entry, p);
+}
+
+void config_parser_undeploy(void)
+{
+	parser_t *parser;
+
+	TAILQ_HEAD(tailhead, parser_s);
+
+	TAILQ_FOREACH_REVERSE(parser, &parsers.p, tailhead, p)
+		if (parser->undeploy_fn != NULL)
+			parser->undeploy_fn();
+}
+
+void config_parser_destroy(void)
+{
+	parser_t *parser, *drop;
+
+	TAILQ_HEAD(tailhead, parser_s);
+
+	TAILQ_FOREACH_REVERSE(parser, &parsers.p, tailhead, p)
+		parser->destroy_fn();
+
+	for (parser = TAILQ_FIRST(&parsers.p); parser != NULL;) {
+		TAILQ_REMOVE(&parsers.p, parser, p);
+		drop = parser;
+		parser = TAILQ_NEXT(parser, p);
+		free(drop);
+	}
+
+	config_destroy(&parsers.config);
+	free(parsers.path);
+}

--- a/test/performance/pipeline/config_parser.h
+++ b/test/performance/pipeline/config_parser.h
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef CONFIG_PARSER_H_
+#define CONFIG_PARSER_H_
+
+#include <libconfig.h>
+#include <odp_api.h>
+
+#include "helpers.h"
+
+typedef odp_bool_t (*conf_init_fn_t)(config_t *config);
+typedef odp_bool_t (*conf_deploy_fn_t)(void);
+typedef void (*conf_undeploy_fn_t)(void);
+typedef void (*conf_destroy_fn_t)(void);
+typedef uintptr_t (*conf_resource_fn_t)(const char *resource);
+
+odp_bool_t config_parser_init(char *path);
+
+odp_bool_t config_parser_deploy(void);
+
+uintptr_t config_parser_get(const char *domain, const char *resource);
+
+void config_parser_register_parser(const char *domain, conf_init_fn_t init_fn,
+				   conf_deploy_fn_t deploy_fn, conf_undeploy_fn_t undeploy_fn,
+				   conf_destroy_fn_t destroy_fn, conf_resource_fn_t resource_fn);
+
+void config_parser_undeploy(void);
+
+void config_parser_destroy(void);
+
+#define CONFIG_PARSER_AUTOREGISTER(prio, domain, init, deploy, undeploy, destroy, resource)	  \
+	__attribute__((constructor(prio)))							  \
+	static void CONCAT(autoregister, __LINE__)(void) {					  \
+		config_parser_register_parser(domain, init, deploy, undeploy, destroy, resource); \
+	}
+
+#endif

--- a/test/performance/pipeline/cpumap.h
+++ b/test/performance/pipeline/cpumap.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef CPUMAP_H_
+#define CPUMAP_H_
+
+#include <stdint.h>
+
+#include <odp_api.h>
+
+typedef struct {
+	char **workers;
+	uint32_t num;
+	odp_cpumask_t cpumask;
+} cpumap_t;
+
+#endif

--- a/test/performance/pipeline/cpumap_parser.c
+++ b/test/performance/pipeline/cpumap_parser.c
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+#include "cpumap.h"
+
+#define CONF_STR_CPUMASK "cpumask"
+#define CONF_STR_WORKERS "workers"
+
+static cpumap_t cpumap;
+
+static odp_bool_t cpumap_parser_init(config_t *config)
+{
+	config_setting_t *cs;
+	const char *val_str;
+	int num;
+
+	cs = config_lookup(config, CPUMAP_DOMAIN);
+
+	if (cs == NULL)	{
+		printf("Nothing to parse for \"" CPUMAP_DOMAIN "\" domain\n");
+		return true;
+	}
+
+	if (config_setting_lookup_string(cs, CONF_STR_CPUMASK, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_CPUMASK "\" found\n");
+		return false;
+	}
+
+	odp_cpumask_from_str(&cpumap.cpumask, val_str);
+	cs = config_setting_lookup(cs, CONF_STR_WORKERS);
+
+	if (cs == NULL) {
+		ODPH_ERR("No \"" CONF_STR_WORKERS "\" found\n");
+		return false;
+	}
+
+	num = config_setting_length(cs);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" CONF_STR_WORKERS "\" entries found\n");
+		return false;
+	}
+
+	cpumap.workers = calloc(1U, num * sizeof(*cpumap.workers));
+
+	if (cpumap.workers == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i) {
+		val_str = config_setting_get_string_elem(cs, i);
+
+		if (val_str == NULL) {
+			ODPH_ERR("Unparsable \"" CONF_STR_WORKERS "\" entry (%d)\n", i);
+			return false;
+		}
+
+		cpumap.workers[cpumap.num] = strdup(val_str);
+
+		if (cpumap.workers[cpumap.num] == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+
+		++cpumap.num;
+	}
+
+	return true;
+}
+
+static odp_bool_t cpumap_parser_deploy(void)
+{
+	char str[ODP_CPUMASK_STR_SIZE] = { 0 };
+
+	(void)odp_cpumask_to_str(&cpumap.cpumask, str, ODP_CPUMASK_STR_SIZE);
+
+	printf("\n*** " CPUMAP_DOMAIN " resources ***\n\n"
+	       "name: N/A\n"
+	       "info:\n"
+	       "  cpumask: %s\n"
+	       "  workers:\n", str);
+
+	for (uint32_t i = 0U; i < cpumap.num; ++i)
+		printf("    %s\n", cpumap.workers[i]);
+
+	return true;
+}
+
+static void cpumap_parser_destroy(void)
+{
+	for (uint32_t i = 0U; i < cpumap.num; ++i)
+		free(cpumap.workers[i]);
+
+	free(cpumap.workers);
+}
+
+static uintptr_t cpumap_parser_get_resource(const char *resource ODP_UNUSED)
+{
+	return (uintptr_t)&cpumap;
+}
+
+CONFIG_PARSER_AUTOREGISTER(HIGH_PRIO, CPUMAP_DOMAIN, cpumap_parser_init, cpumap_parser_deploy,
+			   NULL, cpumap_parser_destroy, cpumap_parser_get_resource)

--- a/test/performance/pipeline/crypto_parser.c
+++ b/test/performance/pipeline/crypto_parser.c
@@ -1,0 +1,444 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+
+#define CONF_STR_NAME "name"
+#define CONF_STR_OP "op"
+#define CONF_STR_CIPHER_ALG "chiper_alg"
+#define CONF_STR_CIPHER_KEY_DATA "cipher_key_data"
+#define CONF_STR_CIPHER_KEY_LEN "cipher_key_len"
+#define CONF_STR_CIPHER_IV_LEN "cipher_iv_len"
+#define CONF_STR_AUTH_ALG "auth_alg"
+#define CONF_STR_AUTH_KEY_DATA "auth_key_data"
+#define CONF_STR_AUTH_KEY_LEN "auth_key_len"
+#define CONF_STR_AUTH_IV_LEN "auth_iv_len"
+#define CONF_STR_AUTH_DIGEST_LEN "auth_digest_len"
+#define CONF_STR_AUTH_AAD_LEN "auth_aad_len"
+#define CONF_STR_COMPL_Q "compl_queue"
+
+#define ENCODE "encode"
+#define DECODE "decode"
+#define CIPHER_AUTH_NULL "null"
+#define CIPHER_DES "des"
+#define CIPHER_3DES_CBC "3des_cbc"
+#define CIPHER_3DES_ECB "3des_ecb"
+#define CIPHER_AES_CBC "aes_cbc"
+#define CIPHER_AES_CTR "aes_ctr"
+#define CIPHER_AES_ECB "aes_ecb"
+#define CIPHER_AES_CFB128 "aes_cfb128"
+#define CIPHER_AES_XTS "aes_xts"
+#define CIPHER_AUTH_AES_GCM "aes_gcm"
+#define CIPHER_AUTH_AES_CCM "aes_ccm"
+#define CIPHER_AUTH_CHACHA20_POLY1305 "chacha20_poly1305"
+#define CIPHER_KASUMI_F8 "kasumi_f8"
+#define CIPHER_SNOW3G_UEA2 "snow3g_uae2"
+#define CIPHER_AES_EEA2 "aes_eea2"
+#define CIPHER_ZUC_EEA3 "zuc_eea3"
+#define CIPHER_SNOW_V "snow_v"
+#define CIPHER_AUTH_SNOW_V_GCM "snow_v_gcm"
+#define CIPHER_SM4_ECB "sm4_ecb"
+#define CIPHER_SM4_CBC "sm4_cbc"
+#define CIPHER_SM4_CTR "sm4_ctr"
+#define CIPHER_AUTH_SM4_GCM "sm4_gcm"
+#define CIPHER_AUTH_SM4_CCM "sm4_ccm"
+#define AUTH_MD5_HMAC "md5_hmac"
+#define AUTH_SHA1_HMAC "sha1_hmac"
+#define AUTH_SHA224_HMAC "sha224_hmac"
+#define AUTH_SHA256_HMAC "sha256_hmac"
+#define AUTH_SHA384_HMAC "sha384_hmac"
+#define AUTH_SHA512_HMAC "sha512_hmac"
+#define AUTH_SHA3_224_HMAC "sha3_224_hmac"
+#define AUTH_SHA3_256_HMAC "sha3_256_hmac"
+#define AUTH_SHA3_384_HMAC "sha3_384_hmac"
+#define AUTH_SHA3_512_HMAC "sha3_512_hmac"
+#define AUTH_AES_GMAC "aes_gmac"
+#define AUTH_AES_CMAC "aes_cmac"
+#define AUTH_AES_XCBC_MAC "aed_xcbc_mac"
+#define AUTH_KASUMI_F9 "kasumi_f9"
+#define AUTH_SNOW3G_UIA2 "snow3g_uia2"
+#define AUTH_AES_EIA2 "aes_eia2"
+#define AUTH_ZUC_EIA3 "zuc_eia3"
+#define AUTH_SNOW_V_GMAC "snow_v_gmac"
+#define AUTH_SM3_HMAC "sm3_hmac"
+#define AUTH_SM4_GMAC "sm4_gmac"
+#define AUTH_MD5 "md5"
+#define AUTH_SHA1 "sha1"
+#define AUTH_SHA224 "sha224"
+#define AUTH_SHA256 "sha256"
+#define AUTH_SHA384 "sha384"
+#define AUTH_SHA512 "sha512"
+#define AUTH_SHA3_224 "sha3_224"
+#define AUTH_SHA3_256 "sha3_256"
+#define AUTH_SHA3_384 "sha3_384"
+#define AUTH_SHA3_512 "sha3_512"
+#define AUTH_SM3 "sm3"
+
+typedef struct {
+	char *name;
+	char *queue;
+	odp_crypto_session_param_t param;
+	odp_crypto_session_t crypto;
+} crypto_parse_t;
+
+typedef struct {
+	crypto_parse_t *cryptos;
+	uint32_t num;
+} crypto_parses_t;
+
+static crypto_parses_t cryptos;
+
+static odp_bool_t parse_crypto_entry(config_setting_t *cs, crypto_parse_t *crypto)
+{
+	const char *val_str;
+	config_setting_t *elem;
+	int num, val_i;
+
+	crypto->crypto = ODP_CRYPTO_SESSION_INVALID;
+	odp_crypto_session_param_init(&crypto->param);
+	crypto->param.op_mode = ODP_CRYPTO_ASYNC;
+	crypto->param.cipher_key.data = NULL;
+	crypto->param.auth_key.data = NULL;
+	crypto->param.output_pool = ODP_POOL_INVALID;
+
+	if (config_setting_lookup_string(cs, CONF_STR_NAME, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return false;
+	}
+
+	crypto->name = strdup(val_str);
+
+	if (crypto->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_OP, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, ENCODE) == 0) {
+			crypto->param.op = ODP_CRYPTO_OP_ENCODE;
+		} else if (strcmp(val_str, DECODE) == 0)  {
+			crypto->param.op = ODP_CRYPTO_OP_DECODE;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_OP "\" found\n");
+			return false;
+		}
+	}
+
+	if (config_setting_lookup_string(cs, CONF_STR_CIPHER_ALG, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, CIPHER_AUTH_NULL) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_NULL;
+		} else if (strcmp(val_str, CIPHER_DES) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_DES;
+		} else if (strcmp(val_str, CIPHER_3DES_CBC) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_3DES_CBC;
+		} else if (strcmp(val_str, CIPHER_3DES_ECB) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_3DES_ECB;
+		} else if (strcmp(val_str, CIPHER_AES_CBC) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_AES_CBC;
+		} else if (strcmp(val_str, CIPHER_AES_ECB) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_AES_ECB;
+		} else if (strcmp(val_str, CIPHER_AES_CFB128) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_AES_CFB128;
+		} else if (strcmp(val_str, CIPHER_AES_XTS) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_AES_XTS;
+		} else if (strcmp(val_str, CIPHER_AUTH_AES_GCM) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_AES_GCM;
+		} else if (strcmp(val_str, CIPHER_AUTH_AES_CCM) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_AES_CCM;
+		} else if (strcmp(val_str, CIPHER_AUTH_CHACHA20_POLY1305) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_CHACHA20_POLY1305;
+		} else if (strcmp(val_str, CIPHER_KASUMI_F8) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_KASUMI_F8;
+		} else if (strcmp(val_str, CIPHER_SNOW3G_UEA2) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_SNOW3G_UEA2;
+		} else if (strcmp(val_str, CIPHER_AES_EEA2) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_AES_EEA2;
+		} else if (strcmp(val_str, CIPHER_ZUC_EEA3) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_ZUC_EEA3;
+		} else if (strcmp(val_str, CIPHER_SNOW_V) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_SNOW_V;
+		} else if (strcmp(val_str, CIPHER_AUTH_SNOW_V_GCM) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_SNOW_V_GCM;
+		} else if (strcmp(val_str, CIPHER_SM4_ECB) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_SM4_ECB;
+		} else if (strcmp(val_str, CIPHER_SM4_CBC) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_SM4_CBC;
+		} else if (strcmp(val_str, CIPHER_SM4_CTR) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_SM4_CTR;
+		} else if (strcmp(val_str, CIPHER_AUTH_SM4_GCM) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_SM4_GCM;
+		} else if (strcmp(val_str, CIPHER_AUTH_SM4_CCM) == 0) {
+			crypto->param.cipher_alg = ODP_CIPHER_ALG_SM4_CCM;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_CIPHER_ALG "\" found\n");
+			return false;
+		}
+	}
+
+	elem = config_setting_lookup(cs, CONF_STR_CIPHER_KEY_DATA);
+
+	if (elem != NULL) {
+		num = config_setting_length(elem);
+
+		if (num > 0) {
+			crypto->param.cipher_key.data =
+				calloc(1U, num * sizeof(*crypto->param.cipher_key.data));
+
+			if (crypto->param.cipher_key.data == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+
+			for (int i = 0; i < num; ++i)
+				crypto->param.cipher_key.data[i] =
+					config_setting_get_int_elem(elem, i);
+		}
+	}
+
+	if (config_setting_lookup_int(cs, CONF_STR_CIPHER_KEY_LEN, &val_i) == CONFIG_TRUE)
+		crypto->param.cipher_key.length = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_CIPHER_IV_LEN, &val_i) == CONFIG_TRUE)
+		crypto->param.cipher_iv_len = val_i;
+
+	if (config_setting_lookup_string(cs, CONF_STR_AUTH_ALG, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, CIPHER_AUTH_NULL) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_NULL;
+		} else if (strcmp(val_str, AUTH_MD5_HMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_MD5_HMAC;
+		} else if (strcmp(val_str, AUTH_SHA1_HMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA1_HMAC;
+		} else if (strcmp(val_str, AUTH_SHA224_HMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA224_HMAC;
+		} else if (strcmp(val_str, AUTH_SHA256_HMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA256_HMAC;
+		} else if (strcmp(val_str, AUTH_SHA384_HMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA384_HMAC;
+		} else if (strcmp(val_str, AUTH_SHA512_HMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA512_HMAC;
+		} else if (strcmp(val_str, AUTH_SHA3_224_HMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA3_224_HMAC;
+		} else if (strcmp(val_str, AUTH_SHA3_256_HMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA3_256_HMAC;
+		} else if (strcmp(val_str, AUTH_SHA3_384_HMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA3_384_HMAC;
+		} else if (strcmp(val_str, AUTH_SHA3_512_HMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA3_512_HMAC;
+		} else if (strcmp(val_str, AUTH_AES_GMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_AES_GMAC;
+		} else if (strcmp(val_str, AUTH_AES_CMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_AES_CMAC;
+		} else if (strcmp(val_str, AUTH_AES_XCBC_MAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_AES_XCBC_MAC;
+		} else if (strcmp(val_str, AUTH_KASUMI_F9) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_KASUMI_F9;
+		} else if (strcmp(val_str, AUTH_SNOW3G_UIA2) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SNOW3G_UIA2;
+		} else if (strcmp(val_str, AUTH_AES_EIA2) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_AES_EIA2;
+		} else if (strcmp(val_str, AUTH_ZUC_EIA3) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_ZUC_EIA3;
+		} else if (strcmp(val_str, AUTH_SNOW_V_GMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SNOW_V_GMAC;
+		} else if (strcmp(val_str, AUTH_SM3_HMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SM3_HMAC;
+		} else if (strcmp(val_str, AUTH_SM4_GMAC) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SM4_GMAC;
+		} else if (strcmp(val_str, AUTH_MD5) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_MD5;
+		} else if (strcmp(val_str, AUTH_SHA1) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA1;
+		} else if (strcmp(val_str, AUTH_SHA224) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA224;
+		} else if (strcmp(val_str, AUTH_SHA256) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA256;
+		} else if (strcmp(val_str, AUTH_SHA384) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA384;
+		} else if (strcmp(val_str, AUTH_SHA512) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA512;
+		} else if (strcmp(val_str, AUTH_SHA3_224) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA3_224;
+		} else if (strcmp(val_str, AUTH_SHA3_256) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA3_256;
+		} else if (strcmp(val_str, AUTH_SHA3_384) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA3_384;
+		} else if (strcmp(val_str, AUTH_SHA3_512) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SHA3_512;
+		} else if (strcmp(val_str, AUTH_SM3) == 0) {
+			crypto->param.auth_alg = ODP_AUTH_ALG_SM3;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_AUTH_ALG "\" found\n");
+			return false;
+		}
+	}
+
+	elem = config_setting_lookup(cs, CONF_STR_AUTH_KEY_DATA);
+
+	if (elem != NULL) {
+		num = config_setting_length(elem);
+
+		if (num > 0) {
+			crypto->param.auth_key.data =
+				calloc(1U, num * sizeof(*crypto->param.auth_key.data));
+
+			if (crypto->param.auth_key.data == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+
+			for (int i = 0; i < num; ++i)
+				crypto->param.auth_key.data[i] =
+					config_setting_get_int_elem(elem, i);
+		}
+	}
+
+	if (config_setting_lookup_int(cs, CONF_STR_AUTH_KEY_LEN, &val_i) == CONFIG_TRUE)
+		crypto->param.auth_key.length = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_AUTH_IV_LEN, &val_i) == CONFIG_TRUE)
+		crypto->param.auth_iv_len = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_AUTH_DIGEST_LEN, &val_i) == CONFIG_TRUE)
+		crypto->param.auth_digest_len = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_AUTH_AAD_LEN, &val_i) == CONFIG_TRUE)
+		crypto->param.auth_aad_len = val_i;
+
+	if (config_setting_lookup_string(cs, CONF_STR_COMPL_Q, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_COMPL_Q "\" found\n");
+		return false;
+	}
+
+	crypto->queue = strdup(val_str);
+
+	if (crypto->queue == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	return true;
+}
+
+static void free_crypto_entry(crypto_parse_t *crypto)
+{
+	free(crypto->name);
+	free(crypto->queue);
+	free(crypto->param.cipher_key.data);
+	free(crypto->param.auth_key.data);
+
+	if (crypto->crypto != ODP_CRYPTO_SESSION_INVALID)
+		(void)odp_crypto_session_destroy(crypto->crypto);
+}
+
+static odp_bool_t crypto_parser_init(config_t *config)
+{
+	config_setting_t *cs, *elem;
+	int num;
+	crypto_parse_t *crypto;
+
+	cs = config_lookup(config, CRYPTO_DOMAIN);
+
+	if (cs == NULL)	{
+		printf("Nothing to parse for \"" CRYPTO_DOMAIN "\" domain\n");
+		return true;
+	}
+
+	num = config_setting_length(cs);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" CRYPTO_DOMAIN "\" entries found\n");
+		return false;
+	}
+
+	cryptos.cryptos = calloc(1U, num * sizeof(*cryptos.cryptos));
+
+	if (cryptos.cryptos == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i) {
+		elem = config_setting_get_elem(cs, i);
+
+		if (elem == NULL) {
+			ODPH_ERR("Unparsable \"" CRYPTO_DOMAIN "\" entry (%d)\n", i);
+			return false;
+		}
+
+		crypto = &cryptos.cryptos[cryptos.num];
+
+		if (!parse_crypto_entry(elem, crypto)) {
+			ODPH_ERR("Invalid \"" CRYPTO_DOMAIN "\" entry (%d)\n", i);
+			free_crypto_entry(crypto);
+			return false;
+		}
+
+		++cryptos.num;
+	}
+
+	return true;
+}
+
+static odp_bool_t crypto_parser_deploy(void)
+{
+	crypto_parse_t *crypto;
+	odp_queue_t queue;
+	odp_crypto_ses_create_err_t status;
+
+	printf("\n*** " CRYPTO_DOMAIN " resources ***\n");
+
+	for (uint32_t i = 0U; i < cryptos.num; ++i) {
+		crypto = &cryptos.cryptos[i];
+		queue = (odp_queue_t)config_parser_get(QUEUE_DOMAIN, crypto->queue);
+		crypto->param.compl_queue = queue;
+		(void)odp_crypto_session_create(&crypto->param, &crypto->crypto, &status);
+
+		if (crypto->crypto == ODP_CRYPTO_SESSION_INVALID) {
+			ODPH_ERR("Error creating crypto session (%s): %d\n", crypto->name, status);
+			return false;
+		}
+
+		printf("\nname: %s\n"
+		       "info:\n", crypto->name);
+	}
+
+	return true;
+}
+
+static void crypto_parser_destroy(void)
+{
+	for (uint32_t i = 0U; i < cryptos.num; ++i)
+		free_crypto_entry(&cryptos.cryptos[i]);
+
+	free(cryptos.cryptos);
+}
+
+static uintptr_t crypto_parser_get_resource(const char *resource)
+{
+	crypto_parse_t *parse;
+	odp_crypto_session_t crypto = ODP_CRYPTO_SESSION_INVALID;
+
+	for (uint32_t i = 0U; i < cryptos.num; ++i) {
+		parse = &cryptos.cryptos[i];
+
+		if (strcmp(parse->name, resource) != 0)
+			continue;
+
+		crypto = parse->crypto;
+		break;
+	}
+
+	if (crypto == ODP_CRYPTO_SESSION_INVALID)
+		ODPH_ABORT("No resource found (%s), aborting\n", resource);
+
+	return (uintptr_t)crypto;
+}
+
+CONFIG_PARSER_AUTOREGISTER(LOW_PRIO, CRYPTO_DOMAIN, crypto_parser_init, crypto_parser_deploy, NULL,
+			   crypto_parser_destroy, crypto_parser_get_resource)

--- a/test/performance/pipeline/dma_parser.c
+++ b/test/performance/pipeline/dma_parser.c
@@ -1,0 +1,166 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+
+#define CONF_STR_NAME "name"
+
+typedef struct {
+	char *name;
+	odp_dma_param_t param;
+	odp_dma_t dma;
+} dma_parse_t;
+
+typedef struct {
+	dma_parse_t *dmas;
+	uint32_t num;
+} dma_parses_t;
+
+static dma_parses_t dmas;
+
+static odp_bool_t parse_dma_entry(config_setting_t *cs, dma_parse_t *dma)
+{
+	const char *val_str;
+
+	dma->dma = ODP_DMA_INVALID;
+	odp_dma_param_init(&dma->param);
+	dma->param.compl_mode_mask = ODP_DMA_COMPL_EVENT;
+
+	if (config_setting_lookup_string(cs, CONF_STR_NAME, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return false;
+	}
+
+	dma->name = strdup(val_str);
+
+	if (dma->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	return true;
+}
+
+static void free_dma_entry(dma_parse_t *dma)
+{
+	free(dma->name);
+
+	if (dma->dma != ODP_DMA_INVALID)
+		(void)odp_dma_destroy(dma->dma);
+}
+
+static odp_bool_t dma_parser_init(config_t *config)
+{
+	config_setting_t *cs, *elem;
+	int num;
+	dma_parse_t *dma;
+
+	cs = config_lookup(config, DMA_DOMAIN);
+
+	if (cs == NULL)	{
+		printf("Nothing to parse for \"" DMA_DOMAIN "\" domain\n");
+		return true;
+	}
+
+	num = config_setting_length(cs);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" DMA_DOMAIN "\" entries found\n");
+		return false;
+	}
+
+	dmas.dmas = calloc(1U, num * sizeof(*dmas.dmas));
+
+	if (dmas.dmas == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i) {
+		elem = config_setting_get_elem(cs, i);
+
+		if (elem == NULL) {
+			ODPH_ERR("Unparsable \"" DMA_DOMAIN "\" entry (%d)\n", i);
+			return false;
+		}
+
+		dma = &dmas.dmas[dmas.num];
+
+		if (!parse_dma_entry(elem, dma)) {
+			ODPH_ERR("Invalid \"" DMA_DOMAIN "\" entry (%d)\n", i);
+			free_dma_entry(dma);
+			return false;
+		}
+
+		++dmas.num;
+	}
+
+	return true;
+}
+
+static odp_bool_t dma_parser_deploy(void)
+{
+	dma_parse_t *dma;
+
+	printf("\n*** " DMA_DOMAIN " resources ***\n");
+
+	for (uint32_t i = 0U; i < dmas.num; ++i) {
+		dma = &dmas.dmas[i];
+		dma->dma = odp_dma_create(dma->name, &dma->param);
+
+		if (dma->dma == ODP_DMA_INVALID) {
+			ODPH_ERR("Error creating DMA session (%s)\n", dma->name);
+			return false;
+		}
+
+		printf("\nname: %s\n"
+		       "info:\n", dma->name);
+		odp_dma_print(dma->dma);
+	}
+
+	return true;
+}
+
+static void dma_parser_destroy(void)
+{
+	for (uint32_t i = 0U; i < dmas.num; ++i)
+		free_dma_entry(&dmas.dmas[i]);
+
+	free(dmas.dmas);
+}
+
+static uintptr_t dma_parser_get_resource(const char *resource)
+{
+	dma_parse_t *parse;
+	odp_dma_t dma = ODP_DMA_INVALID;
+
+	for (uint32_t i = 0U; i < dmas.num; ++i) {
+		parse = &dmas.dmas[i];
+
+		if (strcmp(parse->name, resource) != 0)
+			continue;
+
+		dma = parse->dma;
+		break;
+	}
+
+	if (dma == ODP_DMA_INVALID)
+		ODPH_ABORT("No resource found (%s), aborting\n", resource);
+
+	return (uintptr_t)dma;
+}
+
+CONFIG_PARSER_AUTOREGISTER(MED_PRIO, DMA_DOMAIN, dma_parser_init, dma_parser_deploy, NULL,
+			   dma_parser_destroy, dma_parser_get_resource)

--- a/test/performance/pipeline/flow.c
+++ b/test/performance/pipeline/flow.c
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#include <odp/helper/odph_api.h>
+
+#include "flow.h"
+
+typedef struct {
+	work_t *work;
+	uint32_t num;
+	odp_bool_t is_set;
+} flow_sub_t;
+
+typedef struct ODP_ALIGNED_CACHE {
+	char *queue;
+	flow_sub_t sub[2U];
+} flow_priv_t;
+
+flow_t flow_create_flow(char *queue)
+{
+	flow_priv_t *flow = calloc(1U, sizeof(*flow));
+
+	if (flow == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	flow->queue = queue;
+
+	return (flow_t)flow;
+}
+
+odp_bool_t flow_add_input(flow_t flow,  work_t *work, uint32_t num)
+{
+	flow_sub_t *sub = &((flow_priv_t *)flow)->sub[F_IN];
+
+	if (sub->is_set)
+		return false;
+
+	sub->work = work;
+	sub->num = num;
+	sub->is_set = true;
+
+	return true;
+}
+
+odp_bool_t flow_add_output(flow_t flow,  work_t *work, uint32_t num)
+{
+	flow_sub_t *sub = &((flow_priv_t *)flow)->sub[F_OUT];
+
+	if (sub->is_set)
+		return false;
+
+	sub->work = work;
+	sub->num = num;
+	sub->is_set = true;
+
+	return true;
+}
+
+int flow_issue(flow_type_t type, flow_t flow, odp_event_t ev[], int num)
+{
+	flow_sub_t *sub = &((flow_priv_t *)flow)->sub[type];
+	int num_procd = 0;
+
+	for (uint32_t i = 0U; i < sub->num; ++i) {
+		num_procd += work_issue(sub->work[i], &ev[num_procd], num - num_procd);
+
+		if (num_procd == num)
+			break;
+	}
+
+	return num_procd;
+}
+
+void flow_destroy_flow(flow_t flow)
+{
+	flow_priv_t *priv = (flow_priv_t *)flow;
+	work_t work;
+
+	if (priv == NULL)
+		return;
+
+	for (uint32_t i = 0U; i < priv->sub[F_IN].num; ++i) {
+		work = priv->sub[F_IN].work[i];
+		work_print_work(work, priv->queue);
+		work_destroy_work(work);
+	}
+
+	for (uint32_t i = 0U; i < priv->sub[F_OUT].num; ++i) {
+		work = priv->sub[F_OUT].work[i];
+		work_print_work(work, priv->queue);
+		work_destroy_work(work);
+	}
+
+	free(priv->queue);
+}

--- a/test/performance/pipeline/flow.h
+++ b/test/performance/pipeline/flow.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef FLOW_H_
+#define FLOW_H_
+
+#include <stdint.h>
+
+#include <odp_api.h>
+
+#include "work.h"
+
+typedef void *flow_t;
+
+typedef enum {
+	F_IN = 0,
+	F_OUT
+} flow_type_t;
+
+flow_t flow_create_flow(char *queue);
+
+odp_bool_t flow_add_input(flow_t flow,  work_t *work, uint32_t num);
+
+odp_bool_t flow_add_output(flow_t flow,  work_t *work, uint32_t num);
+
+int flow_issue(flow_type_t type, flow_t flow, odp_event_t ev[], int num);
+
+void flow_destroy_flow(flow_t flow);
+
+#endif

--- a/test/performance/pipeline/flow_parser.c
+++ b/test/performance/pipeline/flow_parser.c
@@ -1,0 +1,615 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+#include "flow.h"
+#include "work.h"
+
+#define CONF_STR_PARSE_TEMPLATE "template"
+#define CONF_STR_NAME "name"
+#define CONF_STR_INPUT "input"
+#define CONF_STR_OUTPUT "output"
+#define CONF_STR_WORK "work"
+#define CONF_STR_TYPE "type"
+#define CONF_STR_PARAM "param"
+#define CONF_STR_PREFIX "prefix"
+#define CONF_STR_IDX "start_index"
+#define CONF_STR_INC "index_increment"
+
+#define FLOW_NAME_LEN 32U
+
+typedef struct {
+	char *name;
+	char *input;
+	char *output;
+	flow_t flow;
+	work_param_t *work;
+	uint32_t num;
+} flow_parse_t;
+
+typedef struct {
+	flow_parse_t *flows;
+	uint32_t num;
+} flow_parses_t;
+
+typedef struct {
+	char *name_prefix;
+	char *input_prefix;
+	char *output_prefix;
+	work_param_t *work;
+	uint32_t name_idx;
+	uint32_t name_inc;
+	uint32_t input_idx;
+	uint32_t input_inc;
+	uint32_t output_idx;
+	uint32_t output_inc;
+	uint32_t num;
+} flow_parse_template_t;
+
+typedef enum {
+	PARSE_OK,
+	PARSE_TEMPL,
+	PARSE_NOK
+} res_t;
+
+static flow_parses_t flows;
+
+static odp_bool_t parse_work_entry(config_setting_t *cs, work_param_t *work)
+{
+	const char *val_str;
+
+	if (config_setting_lookup_string(cs, CONF_STR_TYPE, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_TYPE "\" found\n");
+		return false;
+	}
+
+	work->type = strdup(val_str);
+
+	if (work->type == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	work->param = config_setting_lookup(cs, CONF_STR_PARAM);
+
+	return true;
+}
+
+static void free_work_entry(work_param_t *work)
+{
+	free(work->type);
+}
+
+static res_t parse_flow_entry(config_setting_t *cs, flow_parse_t *flow)
+{
+	const char *val_str;
+	int num;
+	config_setting_t *elem;
+	work_param_t *work;
+
+	memset(flow, 0, sizeof(*flow));
+
+	if (config_setting_lookup(cs, CONF_STR_PARSE_TEMPLATE) != NULL)
+		return PARSE_TEMPL;
+
+	if (config_setting_lookup_string(cs, CONF_STR_NAME, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return PARSE_NOK;
+	}
+
+	flow->name = strdup(val_str);
+
+	if (flow->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_INPUT, &val_str) == CONFIG_TRUE) {
+		flow->input = strdup(val_str);
+
+		if (flow->input == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	} else if (config_setting_lookup_string(cs, CONF_STR_OUTPUT, &val_str) == CONFIG_TRUE) {
+		flow->output = strdup(val_str);
+
+		if (flow->output == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	} else {
+		ODPH_ERR("No \"" CONF_STR_INPUT "\" or \"" CONF_STR_OUTPUT "\" found\n");
+		return PARSE_NOK;
+	}
+
+	cs = config_setting_lookup(cs, CONF_STR_WORK);
+
+	if (cs == NULL) {
+		ODPH_ERR("No \"" CONF_STR_WORK "\" found\n");
+		return PARSE_NOK;
+	}
+
+	num = config_setting_length(cs);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" CONF_STR_WORK "\" entries found\n");
+		return PARSE_NOK;
+	}
+
+	flow->work = calloc(1U, num * sizeof(*flow->work));
+
+	if (flow->work == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i) {
+		elem = config_setting_get_elem(cs, i);
+
+		if (elem == NULL) {
+			ODPH_ERR("Unparsable \"" CONF_STR_WORK "\" entry (%d)\n", i);
+			return PARSE_NOK;
+		}
+
+		work = &flow->work[i];
+		work->queue = flow->input != NULL ? flow->input : flow->output;
+
+		if (!parse_work_entry(elem, work)) {
+			ODPH_ERR("Invalid \"" CONF_STR_WORK "\" entry (%d)\n", i);
+			free_work_entry(work);
+			return PARSE_NOK;
+		}
+
+		++flow->num;
+	}
+
+	return PARSE_OK;
+}
+
+static int parse_flow_entry_template(config_setting_t *cs, flow_parse_template_t *templ)
+{
+	int val_i;
+	uint32_t num;
+	config_setting_t *elem;
+	const char *val_str;
+	work_param_t *work;
+
+	memset(templ, 0, sizeof(*templ));
+
+	if (config_setting_lookup_int(cs, CONF_STR_PARSE_TEMPLATE, &val_i) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_PARSE_TEMPLATE "\" found\n");
+		return -1;
+	}
+
+	num = val_i;
+
+	if (num == 0U)
+		return -1;
+
+	elem = config_setting_lookup(cs, CONF_STR_NAME);
+
+	if (elem == NULL) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return -1;
+	}
+
+	val_str = config_setting_get_string_elem(elem, 0);
+
+	if (val_str == NULL) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" \"" CONF_STR_PREFIX "\" found\n");
+		return -1;
+	}
+
+	templ->name_prefix = strdup(val_str);
+
+	if (templ->name_prefix == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	val_i = config_setting_get_int_elem(elem, 1);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" \"" CONF_STR_IDX "\" found\n");
+		return -1;
+	}
+
+	templ->name_idx = val_i;
+	val_i = config_setting_get_int_elem(elem, 2);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" \"" CONF_STR_INC "\" found\n");
+		return -1;
+	}
+
+	templ->name_inc = val_i;
+	elem = config_setting_lookup(cs, CONF_STR_INPUT);
+
+	if (elem != NULL) {
+		val_str = config_setting_get_string_elem(elem, 0);
+
+		if (val_str == NULL) {
+			ODPH_ERR("No \"" CONF_STR_INPUT "\" \"" CONF_STR_PREFIX "\" found\n");
+			return -1;
+		}
+
+		templ->input_prefix = strdup(val_str);
+
+		if (templ->input_prefix == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+
+		val_i = config_setting_get_int_elem(elem, 1);
+
+		if (val_i == -1) {
+			ODPH_ERR("No \"" CONF_STR_INPUT "\" \"" CONF_STR_IDX "\" found\n");
+			return -1;
+		}
+
+		templ->input_idx = val_i;
+		val_i = config_setting_get_int_elem(elem, 2);
+
+		if (val_i == -1) {
+			ODPH_ERR("No \"" CONF_STR_INPUT "\" \"" CONF_STR_INC "\" found\n");
+			return -1;
+		}
+
+		templ->input_inc = val_i;
+	}
+
+	if (templ->input_prefix == NULL) {
+		elem = config_setting_lookup(cs, CONF_STR_OUTPUT);
+
+		if (elem == NULL) {
+			ODPH_ERR("No \"" CONF_STR_INPUT "\" or \"" CONF_STR_OUTPUT "\" found\n");
+			return -1;
+		}
+
+		val_str = config_setting_get_string_elem(elem, 0);
+
+		if (val_str == NULL) {
+			ODPH_ERR("No \"" CONF_STR_OUTPUT "\" \"" CONF_STR_PREFIX "\" found\n");
+			return -1;
+		}
+
+		templ->output_prefix = strdup(val_str);
+
+		if (templ->output_prefix == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+
+		val_i = config_setting_get_int_elem(elem, 1);
+
+		if (val_i == -1) {
+			ODPH_ERR("No \"" CONF_STR_OUTPUT "\" \"" CONF_STR_IDX "\" found\n");
+			return -1;
+		}
+
+		templ->output_idx = val_i;
+		val_i = config_setting_get_int_elem(elem, 2);
+
+		if (val_i == -1) {
+			ODPH_ERR("No \"" CONF_STR_OUTPUT "\" \"" CONF_STR_INC "\" found\n");
+			return -1;
+		}
+
+		templ->output_inc = val_i;
+	}
+
+	cs = config_setting_lookup(cs, CONF_STR_WORK);
+
+	if (cs == NULL) {
+		ODPH_ERR("No \"" CONF_STR_WORK "\" found\n");
+		return -1;
+	}
+
+	val_i = config_setting_length(cs);
+
+	if (val_i == 0) {
+		ODPH_ERR("No valid \"" CONF_STR_WORK "\" entries found\n");
+		return -1;
+	}
+
+	templ->work = calloc(1U, val_i * sizeof(*templ->work));
+
+	if (templ->work == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < val_i; ++i) {
+		elem = config_setting_get_elem(cs, i);
+
+		if (elem == NULL) {
+			ODPH_ERR("Unparsable \"" CONF_STR_WORK "\" entry (%d)\n", i);
+			return -1;
+		}
+
+		work = &templ->work[i];
+
+		if (!parse_work_entry(elem, work)) {
+			ODPH_ERR("Invalid \"" CONF_STR_WORK "\" entry (%d)\n", i);
+			free_work_entry(work);
+			return -1;
+		}
+
+		++templ->num;
+	}
+
+	return num;
+}
+
+static odp_bool_t parse_flow_entry_from_template(flow_parse_template_t *templ, flow_parse_t *flow)
+{
+	char flow_name[FLOW_NAME_LEN];
+	char queue_name[ODP_QUEUE_NAME_LEN];
+	work_param_t *work_templ, *work;
+
+	memset(flow, 0, sizeof(*flow));
+	memset(flow_name, 0, sizeof(flow_name));
+	memset(queue_name, 0, sizeof(queue_name));
+	(void)snprintf(flow_name, sizeof(flow_name), "%s%u", templ->name_prefix, templ->name_idx);
+	templ->name_idx += templ->name_inc;
+	flow->name = strdup(flow_name);
+
+	if (flow->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (templ->input_prefix != NULL) {
+		(void)snprintf(queue_name, sizeof(queue_name), "%s%u", templ->input_prefix,
+			       templ->input_idx);
+		templ->input_idx += templ->input_inc;
+		flow->input = strdup(queue_name);
+
+		if (flow->input == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	} else {
+		(void)snprintf(queue_name, sizeof(queue_name), "%s%u", templ->output_prefix,
+			       templ->output_idx);
+		templ->output_idx += templ->output_inc;
+		flow->output = strdup(queue_name);
+
+		if (flow->output == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	}
+
+	flow->work = calloc(1U, templ->num * sizeof(*flow->work));
+
+	if (flow->work == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (uint32_t i = 0; i < templ->num; ++i) {
+		work = &flow->work[i];
+		work_templ = &templ->work[i];
+		work->queue = flow->input != NULL ? flow->input : flow->output;
+		work->type = strdup(work_templ->type);
+
+		if (work->type == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+
+		work->param = work_templ->param;
+	}
+
+	flow->num = templ->num;
+
+	return true;
+}
+
+static void free_flow_entry(flow_parse_t *flow)
+{
+	free(flow->name);
+	flow_destroy_flow(flow->flow);
+
+	for (uint32_t i = 0U; i < flow->num; ++i)
+		free_work_entry(&flow->work[i]);
+
+	free(flow->work);
+}
+
+static void free_flow_template(flow_parse_template_t *templ)
+{
+	free(templ->name_prefix);
+	free(templ->input_prefix);
+	free(templ->output_prefix);
+
+	for (uint32_t i = 0U; i < templ->num; ++i)
+		free_work_entry(&templ->work[i]);
+
+	free(templ->work);
+}
+
+static odp_bool_t flow_parser_init(config_t *config)
+{
+	config_setting_t *cs, *elem;
+	int num, ret;
+	flow_parse_t *flow;
+	res_t res;
+	flow_parse_template_t templ;
+
+	cs = config_lookup(config, FLOW_DOMAIN);
+
+	if (cs == NULL)	{
+		printf("Nothing to parse for \"" FLOW_DOMAIN "\" domain\n");
+		return true;
+	}
+
+	num = config_setting_length(cs);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" FLOW_DOMAIN "\" entries found\n");
+		return false;
+	}
+
+	flows.flows = calloc(1U, num * sizeof(*flows.flows));
+
+	if (flows.flows == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i) {
+		elem = config_setting_get_elem(cs, i);
+
+		if (elem == NULL) {
+			ODPH_ERR("Unparsable \"" FLOW_DOMAIN "\" entry (%d)\n", i);
+			return false;
+		}
+
+		flow = &flows.flows[flows.num];
+		res = parse_flow_entry(elem, flow);
+
+		if (res == PARSE_NOK) {
+			ODPH_ERR("Invalid \"" FLOW_DOMAIN "\" entry (%d)\n", i);
+			free_flow_entry(flow);
+			return false;
+		} else if (res == PARSE_TEMPL) {
+			ret = parse_flow_entry_template(elem, &templ);
+
+			if (ret == -1) {
+				ODPH_ERR("Invalid \"" FLOW_DOMAIN "\" entry (%d)\n", i);
+				return false;
+			}
+
+			flows.flows = realloc(flows.flows, (ret + flows.num + (num - i - 1)) *
+					      sizeof(*flows.flows));
+
+			if (flows.flows == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+
+			for (int j = 0; j < ret; ++j) {
+				flow = &flows.flows[flows.num];
+
+				if (!parse_flow_entry_from_template(&templ, flow)) {
+					ODPH_ERR("Invalid \"" FLOW_DOMAIN "\" entry (%d)\n", i);
+					free_flow_template(&templ);
+					free_flow_entry(flow);
+					return false;
+				}
+
+				++flows.num;
+			}
+
+			free_flow_template(&templ);
+		} else {
+			++flows.num;
+		}
+	}
+
+	return true;
+}
+
+static odp_bool_t flow_parser_deploy(void)
+{
+	flow_parse_t *parse;
+	char *name;
+	odp_queue_t queue;
+	flow_t flow;
+	work_t *work;
+
+	printf("\n*** " FLOW_DOMAIN " resources ***\n");
+
+	for (uint32_t i = 0U; i < flows.num; ++i) {
+		parse = &flows.flows[i];
+		work = calloc(1U, parse->num * sizeof(*work));
+
+		if (work == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+
+		for (uint32_t j = 0U; j < parse->num; ++j)
+			work[j] = work_create_work(&parse->work[j]);
+
+		name = parse->input != NULL ? parse->input : parse->output;
+		queue = (odp_queue_t)config_parser_get(QUEUE_DOMAIN, name);
+		flow = odp_queue_context(queue);
+
+		if (flow == NULL) {
+			parse->flow = flow_create_flow(name);
+
+			if (parse->input != NULL)
+				(void)flow_add_input(parse->flow, work, parse->num);
+			else
+				(void)flow_add_output(parse->flow, work, parse->num);
+
+			if (odp_queue_context_set(queue, parse->flow, sizeof(parse->flow)) < 0) {
+				ODPH_ERR("Error setting queue context\n");
+				return false;
+			}
+		} else {
+			if (parse->input != NULL &&
+			    !flow_add_input(flow, work, parse->num)) {
+				ODPH_ERR("Error setting input flow\n");
+
+				for (uint32_t j = 0U; j < parse->num; ++j) {
+					work_destroy_work(work[j]);
+					free(work);
+				}
+
+				return false;
+			} else if (!flow_add_output(flow, work, parse->num)) {
+				ODPH_ERR("Error setting output flow\n");
+
+				for (uint32_t j = 0U; j < parse->num; ++j) {
+					work_destroy_work(work[j]);
+					free(work);
+				}
+
+				return false;
+			}
+		}
+	}
+
+	for (uint32_t i = 0U; i < flows.num; ++i) {
+		parse = &flows.flows[i];
+		printf("\nname: %s\n"
+		       "info:\n", parse->name);
+
+		if (parse->input != NULL) {
+			printf("  type:  input\n"
+			       "  queue: %s\n"
+			       "  work:\n", parse->input);
+
+			for (uint32_t j = 0U; j < parse->num; ++j)
+				printf("    %s\n", parse->work[j].type);
+		} else {
+			printf("  type:  output\n"
+			       "  queue: %s\n"
+			       "  work:\n", parse->output);
+
+			for (uint32_t j = 0U; j < parse->num; ++j)
+				printf("    %s\n", parse->work[j].type);
+		}
+	}
+
+	return true;
+}
+
+static void flow_parser_destroy(void)
+{
+	for (uint32_t i = 0U; i < flows.num; ++i)
+		free_flow_entry(&flows.flows[i]);
+
+	free(flows.flows);
+}
+
+static uintptr_t flow_parser_get_resource(const char *resource)
+{
+	flow_parse_t *parse;
+	flow_t flow = NULL;
+
+	for (uint32_t i = 0U; i < flows.num; ++i) {
+		parse = &flows.flows[i];
+
+		if (strcmp(parse->name, resource) != 0)
+			continue;
+
+		flow = parse->flow;
+		break;
+	}
+
+	if (flow == NULL)
+		ODPH_ABORT("No resource found (%s), aborting\n", resource);
+
+	return (uintptr_t)flow;
+}
+
+CONFIG_PARSER_AUTOREGISTER(LOW_PRIO, FLOW_DOMAIN, flow_parser_init, flow_parser_deploy, NULL,
+			   flow_parser_destroy, flow_parser_get_resource)

--- a/test/performance/pipeline/helpers.h
+++ b/test/performance/pipeline/helpers.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef HELPERS_H_
+#define HELPERS_H_
+
+#define CONCAT_HELPER(a, b) a##b
+#define CONCAT(a, b) CONCAT_HELPER(a, b)
+
+#endif

--- a/test/performance/pipeline/main.c
+++ b/test/performance/pipeline/main.c
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <getopt.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <odp/helper/odph_api.h>
+
+#include "config_parser.h"
+#include "orchestrator.h"
+
+#define PROG_NAME "odp_pipeline"
+
+typedef enum {
+	PRS_OK,
+	PRS_NOK,
+	PRS_TERM
+} parse_result_t;
+
+static struct {
+	char *path;
+} opts;
+
+static void print_usage(void)
+{
+	printf("\n"
+	       "Generic ODP performance tester. Define pipelines and workflows to be run.\n"
+	       "\n"
+	       "Usage: " PROG_NAME " OPTIONS\n"
+	       "\n"
+	       "  E.g. " PROG_NAME " -f /path/to/config_file\n"
+	       "\n"
+	       "Mandatory OPTIONS:\n"
+	       "\n"
+	       "  -f, --config_file Path to configuration file.\n"
+	       "\n"
+	       "Optional OPTIONS:\n"
+	       "\n"
+	       "  -h, --help        This help.\n"
+	       "\n");
+}
+
+static parse_result_t parse_options(int argc, char **argv)
+{
+	int opt;
+
+	static const struct option longopts[] = {
+		{ "config_file", required_argument, NULL, 'f' },
+		{ "help", no_argument, NULL, 'h' },
+		{ NULL, 0, NULL, 0 }
+	};
+
+	static const char *shortopts = "f:h";
+
+	while (true) {
+		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
+
+		if (opt == -1)
+			break;
+
+		switch (opt) {
+		case 'f':
+			opts.path = strdup(optarg);
+			break;
+		case 'h':
+			print_usage();
+			return PRS_TERM;
+		case '?':
+		default:
+			print_usage();
+			return PRS_NOK;
+		}
+	}
+
+	return PRS_OK;
+}
+
+int main(int argc, char **argv)
+{
+	parse_result_t parse_res;
+	int ret = EXIT_SUCCESS;
+	/* No support for process mode so no helper argument parsing */
+	parse_res = parse_options(argc, argv);
+
+	if (parse_res == PRS_NOK)
+		return EXIT_FAILURE;
+
+	if (parse_res == PRS_TERM)
+		return EXIT_SUCCESS;
+
+	if (orchestrator_init() && config_parser_init(opts.path) && config_parser_deploy()) {
+		orchestrator_deploy();
+	} else {
+		ODPH_ERR("Error initializing pipeline\n");
+		ret = EXIT_FAILURE;
+	}
+
+	config_parser_destroy();
+	orchestrator_destroy();
+
+	return ret;
+}

--- a/test/performance/pipeline/orchestrator.c
+++ b/test/performance/pipeline/orchestrator.c
@@ -1,0 +1,422 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+#include <signal.h>
+
+#include "common.h"
+#include "config_parser.h"
+#include "cpumap.h"
+#include "flow.h"
+#include "orchestrator.h"
+#include "worker.h"
+
+#define MAX_WORKERS (ODP_THREAD_COUNT_MAX - 1)
+
+typedef struct orchestrator_s orchestrator_t;
+
+typedef struct {
+	uint64_t num_unhandled_in;
+	uint64_t num_unhandled_out;
+} stats_t;
+
+typedef struct ODP_ALIGNED_CACHE {
+	union {
+		odp_queue_t *q;
+		odp_schedule_group_t *g;
+	} inputs;
+
+	odp_queue_t *outputs;
+	orchestrator_t *prog_config;
+	worker_t *worker;
+	stats_t stats;
+	uint64_t wait_ns;
+} orchestrator_worker_t;
+
+typedef struct orchestrator_s {
+	odph_thread_t thrs[MAX_WORKERS];
+	orchestrator_worker_t worker[MAX_WORKERS];
+	odp_instance_t instance;
+	odp_shm_t shm;
+	odp_atomic_u32_t is_running;
+	odp_barrier_t init_barrier;
+	odp_barrier_t term_barrier;
+	uint32_t num_workers;
+} orchestrator_t;
+
+typedef int (*worker_fn_t)(void *);
+
+static orchestrator_t *config;
+
+static odp_instance_t init_odp(void)
+{
+	odp_instance_t instance;
+
+	if (odp_init_global(&instance, NULL, NULL) < 0)
+		ODPH_ABORT("ODP global init failed, aborting\n");
+
+	if (odp_init_local(instance, ODP_THREAD_CONTROL) < 0)
+		ODPH_ABORT("ODP local init failed, aborting\n");
+
+	return instance;
+}
+
+static void term_odp(odp_instance_t instance)
+{
+	if (odp_term_local() < 0)
+		ODPH_ABORT("ODP local terminate failed, aborting\n");
+
+	if (odp_term_global(instance) < 0)
+		ODPH_ABORT("ODP global terminate failed, aborting\n");
+}
+
+static void terminate(int signal ODP_UNUSED)
+{
+	odp_atomic_store_u32(&config->is_running, 0U);
+}
+
+static void setup_signals(void)
+{
+	struct sigaction action = { .sa_handler = terminate };
+
+	if (sigemptyset(&action.sa_mask) == -1 || sigaddset(&action.sa_mask, SIGINT) == -1 ||
+	    sigaddset(&action.sa_mask, SIGTERM) == -1 ||
+	    sigaddset(&action.sa_mask, SIGHUP) == -1 || sigaction(SIGINT, &action, NULL) == -1 ||
+	    sigaction(SIGTERM, &action, NULL) == -1 || sigaction(SIGHUP, &action, NULL) == -1)
+		ODPH_ABORT("Error installing signal handler, aborting\n");
+}
+
+odp_bool_t orchestrator_init(void)
+{
+	odp_instance_t instance = init_odp();
+	odp_shm_t shm;
+
+	shm = odp_shm_reserve("orchestrator", sizeof(orchestrator_t), ODP_CACHE_LINE_SIZE, 0U);
+
+	if (shm == ODP_SHM_INVALID) {
+		ODPH_ERR("Error reserving shared memory\n");
+		term_odp(instance);
+		return false;
+	}
+
+	config = odp_shm_addr(shm);
+
+	if (config == NULL) {
+		ODPH_ERR("Error resolving shared memory address\n");
+		odp_shm_free(shm);
+		term_odp(instance);
+		return false;
+	}
+
+	if (odp_schedule_config(NULL) < 0) {
+		ODPH_ERR("Error configuring scheduler\n");
+		odp_shm_free(shm);
+		term_odp(instance);
+		return false;
+	}
+
+	config->instance = instance;
+	config->shm = shm;
+	odp_atomic_init_u32(&config->is_running, 1U);
+	setup_signals();
+
+	return true;
+}
+
+static void drain_events(void)
+{
+	while (true) {
+		odp_event_t  ev;
+
+		ev = odp_schedule(NULL, odp_schedule_wait_time(ODP_TIME_SEC_IN_NS * 4U));
+
+		if (ev == ODP_EVENT_INVALID)
+			break;
+
+		odp_event_free(ev);
+	}
+}
+
+static int schedule_and_handle(void *args)
+{
+	orchestrator_worker_t *worker = args;
+	const uint32_t burst_size = worker->worker->burst_size, num_in = worker->worker->num_in,
+	num_out = worker->worker->num_out;
+	odp_thrmask_t mask;
+	odp_atomic_u32_t *is_running = &worker->prog_config->is_running;
+	const uint64_t wait_ns = worker->wait_ns;
+	odp_event_t evs[burst_size];
+	int num_recv, num_procd;
+	odp_queue_t input, output;
+	stats_t *stats = &worker->stats;
+
+	for (uint32_t i = 0U; i < num_in; ++i) {
+		odp_thrmask_zero(&mask);
+		odp_thrmask_set(&mask, odp_thread_id());
+
+		if (odp_schedule_group_join(worker->inputs.g[i], &mask) < 0)
+			ODPH_ABORT("Error joining schedule group, aborting\n");
+	}
+
+	odp_barrier_wait(&worker->prog_config->init_barrier);
+
+	while (odp_atomic_load_u32(is_running)) {
+		num_recv = odp_schedule_multi(&input, wait_ns, evs, burst_size);
+
+		if (num_recv > 0) {
+			num_procd = flow_issue(F_IN, odp_queue_context(input), evs, num_recv);
+
+			if (odp_unlikely(num_procd < num_recv)) {
+				odp_event_free_multi(&evs[num_procd], num_recv - num_procd);
+				++stats->num_unhandled_in;
+			}
+		}
+
+		for (uint32_t i = 0U; i < num_out; ++i) {
+			output = worker->outputs[i];
+			num_recv = flow_issue(F_OUT, odp_queue_context(output), evs, burst_size);
+
+			if (num_recv == 0U)
+				continue;
+
+			num_procd = odp_queue_enq_multi(output, evs, num_recv);
+
+			if (odp_unlikely(num_procd < 0))
+				ODPH_ABORT("Error enqueueing, aborting\n");
+
+			if (odp_unlikely(num_procd < num_recv)) {
+				odp_event_free_multi(&evs[num_procd], num_recv - num_procd);
+				++stats->num_unhandled_out;
+			}
+		}
+	}
+
+	odp_schedule_pause();
+	drain_events();
+	odp_barrier_wait(&worker->prog_config->term_barrier);
+	odp_schedule_resume();
+	drain_events();
+
+	return 0;
+}
+
+static int poll_and_handle(void *args)
+{
+	orchestrator_worker_t *worker = args;
+	odp_atomic_u32_t *is_running = &worker->prog_config->is_running;
+	odp_queue_t input;
+	const uint32_t burst_size = worker->worker->burst_size, num_in = worker->worker->num_in,
+	num_out = worker->worker->num_out;
+	odp_event_t evs[burst_size];
+	int num_recv, num_procd;
+	odp_queue_t output;
+	stats_t *stats = &worker->stats;
+	const uint64_t wait_ns = worker->wait_ns;
+	odp_time_t start;
+
+	odp_barrier_wait(&worker->prog_config->init_barrier);
+
+	while (odp_atomic_load_u32(is_running)) {
+		for (uint32_t i = 0U; i < num_in; ++i) {
+			input = worker->inputs.q[i];
+			num_recv = odp_queue_deq_multi(input, evs, burst_size);
+
+			if (odp_unlikely(num_recv < 0))
+				ODPH_ABORT("Error dequeuing, aborting\n");
+
+			if (num_recv == 0)
+				continue;
+
+			num_procd = flow_issue(F_IN, odp_queue_context(input), evs, num_recv);
+
+			if (odp_unlikely(num_procd < num_recv)) {
+				odp_event_free_multi(&evs[num_procd], num_recv - num_procd);
+				++stats->num_unhandled_in;
+			}
+		}
+
+		for (uint32_t i = 0U; i < num_out; ++i) {
+			output = worker->outputs[i];
+			num_recv = flow_issue(F_OUT, odp_queue_context(output), evs, burst_size);
+
+			if (num_recv == 0U)
+				continue;
+
+			num_procd = odp_queue_enq_multi(output, evs, num_recv);
+
+			if (odp_unlikely(num_procd < 0))
+				ODPH_ABORT("Error enqueueing, aborting\n");
+
+			if (odp_unlikely(num_procd < num_recv)) {
+				odp_event_free_multi(&evs[num_procd], num_recv - num_procd);
+				++stats->num_unhandled_out;
+			}
+		}
+
+		if (wait_ns > 0U)
+			odp_time_wait_ns(wait_ns);
+	}
+
+	start = odp_time_global();
+
+	while (odp_time_diff_ns(odp_time_global(), start) < ODP_TIME_SEC_IN_NS * 4U) {
+		for (uint32_t i = 0U; i < num_in; ++i) {
+			input = worker->inputs.q[i];
+			num_recv = odp_queue_deq_multi(input, evs, burst_size);
+
+			if (num_recv > 0)
+				odp_event_free_multi(evs, num_recv);
+		}
+	}
+
+	odp_barrier_wait(&worker->prog_config->term_barrier);
+
+	return 0;
+}
+
+static worker_fn_t get_worker(orchestrator_worker_t *orch)
+{
+	worker_t *worker = orch->worker;
+	odp_queue_t *outputs, *qs;
+	odp_schedule_group_t *grps;
+
+	if (worker->num_out > 0U) {
+		outputs = calloc(1U, worker->num_out * sizeof(*outputs));
+
+		if (outputs == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+
+		for (uint32_t i = 0U; i < worker->num_out; ++i)
+			outputs[i] = (odp_queue_t)config_parser_get(QUEUE_DOMAIN,
+								    worker->outputs[i]);
+
+		orch->outputs = outputs;
+	}
+
+	if (worker->num_in > 0U) {
+		if (worker->type == WT_SCHED) {
+			grps = calloc(1U, worker->num_in * sizeof(*grps));
+
+			if (grps == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+
+			for (uint32_t i = 0U; i < worker->num_in; ++i)
+				grps[i] = (odp_schedule_group_t)config_parser_get(SCHED_DOMAIN,
+										worker->inputs[i]);
+
+			orch->inputs.g = grps;
+		} else {
+			qs = calloc(1U, worker->num_in * sizeof(*qs));
+
+			if (qs == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+
+			for (uint32_t i = 0U; i < worker->num_in; ++i)
+				qs[i] = (odp_queue_t)config_parser_get(QUEUE_DOMAIN,
+								       worker->inputs[i]);
+
+			orch->inputs.q = qs;
+		}
+	}
+
+	if (worker->type == WT_SCHED) {
+		if (worker->wait_ns == 0)
+			orch->wait_ns = ODP_SCHED_NO_WAIT;
+		else if (worker->wait_ns == -1)
+			orch->wait_ns = ODP_SCHED_WAIT;
+		else
+			orch->wait_ns = odp_schedule_wait_time(worker->wait_ns);
+	} else {
+		orch->wait_ns = worker->wait_ns;
+	}
+
+	return worker->type == WT_SCHED ? schedule_and_handle : poll_and_handle;
+}
+
+static void print_stats(void)
+{
+	orchestrator_worker_t *worker;
+
+	printf("\n*** pipeline finished ***\n");
+
+	for (uint32_t i = 0U; i < config->num_workers; ++i) {
+		worker = &config->worker[i];
+		printf("\n%s:\n"
+		       "  unhandled input events:  %" PRIu64 "\n"
+		       "  unhandled output events: %" PRIu64 "\n", worker->worker->name,
+		       worker->stats.num_unhandled_in, worker->stats.num_unhandled_out);
+	}
+}
+
+void orchestrator_deploy(void)
+{
+	cpumap_t *map = (cpumap_t *)config_parser_get(CPUMAP_DOMAIN, NULL);
+	odph_thread_common_param_t common;
+	const int num = map->num;
+	odph_thread_param_t params[num], *param;
+	orchestrator_worker_t *worker;
+
+	odp_barrier_init(&config->init_barrier, num + 1);
+	odp_barrier_init(&config->term_barrier, num + 1);
+	odph_thread_common_param_init(&common);
+	common.instance = config->instance;
+	common.cpumask = &map->cpumask;
+
+	for (int i = 0; i < num; ++i) {
+		worker = &config->worker[i];
+		worker->prog_config = config;
+		worker->worker = (worker_t *)config_parser_get(WORKER_DOMAIN, map->workers[i]);
+		param = &params[i];
+		odph_thread_param_init(param);
+		param->start = get_worker(worker);
+		param->thr_type = ODP_THREAD_WORKER;
+		param->arg = worker;
+	}
+
+	if (odph_thread_create(config->thrs, &common, params, num) != num)
+		ODPH_ABORT("Error launching worker threads, aborting\n");
+
+	config->num_workers = num;
+	odp_barrier_wait(&config->init_barrier);
+
+	while (odp_atomic_load_u32(&config->is_running))
+		sleep(1U);
+
+	config_parser_undeploy();
+	odp_barrier_wait(&config->term_barrier);
+	printf("\n*** flushing queues and freeing inflight events ***\n");
+	(void)odph_thread_join(config->thrs, config->num_workers);
+	print_stats();
+}
+
+void orchestrator_destroy(void)
+{
+	odp_instance_t instance = config->instance;
+	orchestrator_worker_t *worker;
+
+	for (uint32_t i = 0U; i < config->num_workers; ++i) {
+		worker = &config->worker[i];
+
+		if (worker->worker->type == WT_SCHED)
+			free(worker->inputs.g);
+		else
+			free(worker->inputs.q);
+
+		free(config->worker[i].outputs);
+	}
+
+	odp_shm_free(config->shm);
+	term_odp(instance);
+}

--- a/test/performance/pipeline/orchestrator.h
+++ b/test/performance/pipeline/orchestrator.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef ORCHESTRATOR_H_
+#define ORCHESTRATOR_H_
+
+#include <odp_api.h>
+
+odp_bool_t orchestrator_init(void);
+
+void orchestrator_deploy(void);
+
+void orchestrator_destroy(void);
+
+#endif

--- a/test/performance/pipeline/pipeline_example1
+++ b/test/performance/pipeline/pipeline_example1
@@ -1,0 +1,259 @@
+# Generic example, showcasing ways to configure resources
+
+scheduler: {
+	groups: (
+		{
+			name: "group1";
+		}
+	);
+};
+
+queues: (
+	{
+		name: "queue1";
+		type: "plain";
+	},
+	{
+		name: "queue2";
+		type: "plain";
+	},
+	{
+		name: "queue3";
+		type: "schedule";
+		priority: 2;
+		group: "group1";
+		sync: "atomic";
+	},
+	{
+		template: 20;
+		name: ( "queuet", 2, 3 );
+		type: "schedule";
+	},
+	{
+		name: "pktio1.in.0";
+		type: "pktios";
+	}
+);
+
+pools: (
+	{
+		name: "pool1";
+		type: "packet";
+		size: 1024;
+		cache_size: 0
+		num: 10240;
+	},
+	{
+		name: "pool2";
+		type: "timeout";
+		cache_size: 0
+		num: 1;
+	},
+	{
+		name: "pool3";
+		type: "dma_completion"
+		cache_size: 0;
+		num: 128;
+	},
+	{
+		name: "pool4";
+		type: "packet";
+		size: 1024;
+		cache_size: 0
+		num: 10240;
+	}
+);
+
+pktios: (
+	{
+		name: "pktio1";
+		iface: "veth1";
+		pool: "pool1";
+		inmode: "schedule";
+		outmode: "queue";
+		num_in_queues: 1;
+		num_out_queues: 1;
+	}
+);
+
+timers: (
+	{
+		name: "timer1";
+		clk_src: "src0"
+		res_ns: 100000000;
+		min_tmo: 100000000;
+		max_tmo: 1000000000;
+		num: 1;
+	}
+);
+
+classification: {
+	cos: (
+		{
+			name: "cos1";
+			action: "enqueue";
+			queue: "queue1";
+			pool: "pool2";
+			default: "pktio1";
+		},
+		{
+			name: "cos2";
+			action: "enqueue";
+			queue: "queue2";
+			pool: "pool2";
+		},
+		{
+			template: 12
+			name: ( "cost", 40, 2 );
+			action: "enqueue";
+			queue: ( "queuet", 2, 3 );
+			pool: "pool2";
+			default: "pktio1";
+		}
+	);
+
+	pmr: (
+		{
+			name: "pmr1";
+			src_cos: "cos1";
+			dst_cos: "cos2";
+			term: "len";
+			match_value: [ 0x1, 0x2, 0x3, 0x4 ];
+			match_mask: [ 0xff, 0xff, 0xff, 0xff ];
+			val_sz: 4;
+		},
+		{
+			template: 6
+			name: ( "pmrt", 3, 6 );
+			src_cos: ( "cost", 40, 2 );
+			dst_cos: ( "cost", 52, 2 );
+			term: "len";
+			match_value: ([ 0x0, 0x0, 0x0, 0xfe ], 25);
+			match_mask: [ 0xff, 0xff, 0xff, 0xff ];
+			val_sz: 4;
+		}
+	);
+};
+
+dma: (
+	{
+		name: "dma1";
+	},
+	{
+		name: "dma2";
+	}
+);
+
+crypto: (
+	{
+		name: "crypto1";
+		op: "encode";
+		cipher_alg: "null";
+		cipher_key_data: [ 0x4, 0x3, 0x2, 0x1 ];
+		cipher_key_len: 4;
+		cipher_iv_len: 2;
+		auth_alg: "null";
+		auth_key_data: [ 0x1, 0x2, 0x3, 0x4 ];
+		auth_key_len: 4;
+		auth_iv_len: 4;
+		auth_digest_len: 1;
+		auth_aad_len: 3;
+		compl_queue: "queue1";
+	}
+);
+
+flows: (
+	{
+		name: "flow1";
+		input: "pktio1.in.0";
+		work: (
+			{
+				type: "packet_copy";
+				param: ( "pool4" );
+			},
+			{
+				type: "forward";
+				param: ( "queue1" );
+			}
+		);
+	},
+	{
+		name: "flow2"
+		input: "queue1"
+		work: (
+			{
+				type: "packet_copy";
+				param: ( "pool4" );
+			},
+			{
+				type: "forward";
+				param: ( "queue1" );
+			}
+		);
+	},
+	{
+		name: "flow3";
+		input: "queue2"
+		work: (
+			{
+				type: "sink";
+			}
+		);
+	},
+	{
+		name: "flow4";
+		output: "queue2"
+		work: (
+			{
+				type: "timeout_source";
+				param: ( "timer1", "pool2", 1000000000 );
+			},
+			{
+				type: "packet_source";
+				param: ( "pool1", 512 );
+			}
+		);
+	},
+	{
+		template: 4;
+		name: ( "flowt", 0, 1 );
+		input: ( "queuet", 2, 3 );
+		work: (
+			{
+				type: "sink";
+			}
+		);
+	}
+);
+
+workers: (
+	{
+		name: "worker1";
+		type: "schedule";
+		burst_size: 24;
+		wait_ns: 1000;
+		inputs: [ "group1" ];
+	},
+	{
+		name: "worker2";
+		type: "plain";
+		inputs: [ "queue1" ];
+	},
+	{
+		name: "worker3";
+		type: "plain";
+		burst_size: 12;
+		inputs: [ "queue2" ];
+	},
+	{
+		name: "worker4";
+		type: "plain";
+		burst_size: 8;
+		outputs: [ "queue2" ];
+	}
+)
+
+cpumap: {
+	cpumask: "0xf0";
+	workers: [ "worker1", "worker2", "worker3", "worker4" ];
+};

--- a/test/performance/pipeline/pipeline_example2
+++ b/test/performance/pipeline/pipeline_example2
@@ -1,0 +1,68 @@
+# L2FWD, packets are received from packet I/O and sent back
+
+queues: (
+	{
+		name: "pktio1.in.0";
+		type: "pktios";
+	},
+	{
+		name: "pktio1.out.0";
+		type: "pktios";
+	}
+);
+
+pools: (
+	{
+		name: "pool1";
+		type: "packet";
+		size: 1024;
+		num: 10240;
+	}
+);
+
+pktios: (
+	{
+		name: "pktio1";
+		iface: "veth1";
+		pool: "pool1";
+		inmode: "schedule";
+		outmode: "queue";
+		num_in_queues: 1;
+		num_out_queues: 1;
+		hash_enable: 1;
+		hash_ipv4_udp: 1;
+		hash_ipv4_tcp: 1;
+		hash_ipv4: 1;
+		hash_ipv6_udp: 1;
+		hash_ipv6_tcp: 1;
+		hash_ipv6: 1;
+		promisc: 1;
+	}
+);
+
+flows: (
+	{
+		name: "flow1";
+		input: "pktio1.in.0";
+		work: (
+			{
+				type: "forward";
+				param: ( "pktio1.out.0" );
+			}
+		);
+	}
+);
+
+workers: (
+	{
+		name: "worker1";
+		type: "schedule";
+	}
+)
+
+cpumap: {
+	cpumask: "0x10";
+	workers: [
+		"worker1"
+	];
+};

--- a/test/performance/pipeline/pktio_parser.c
+++ b/test/performance/pipeline/pktio_parser.c
@@ -1,0 +1,472 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+
+#define CONF_STR_NAME "name"
+#define CONF_STR_IFACE "iface"
+#define CONF_STR_POOL "pool"
+#define CONF_STR_INMODE "inmode"
+#define CONF_STR_PRIO "priority"
+#define CONF_STR_GROUP "group"
+#define CONF_STR_SYNC "sync"
+#define CONF_STR_SIZE "size"
+#define CONF_STR_OUTMODE "outmode"
+#define CONF_STR_CLS_ENABLE "classifier_enable"
+#define CONF_STR_PARSE_LAYER "parse_layer"
+#define CONF_STR_HASH_ENABLE "hash_enable"
+#define CONF_STR_HASH_IPV4_UDP "hash_ipv4_udp"
+#define CONF_STR_HASH_IPV4_TCP "hash_ipv4_tcp"
+#define CONF_STR_HASH_IPV4 "hash_ipv4"
+#define CONF_STR_HASH_IPV6_UDP "hash_ipv6_udp"
+#define CONF_STR_HASH_IPV6_TCP "hash_ipv6_tcp"
+#define CONF_STR_HASH_IPV6 "hash_ipv6"
+#define CONF_STR_NUM_IN_QS "num_in_queues"
+#define CONF_STR_NUM_OUT_QS "num_out_queues"
+#define CONF_STR_PROMISC_ENABLE "promisc_enable"
+#define CONF_STR_LSO_ENABLE "lso_enable"
+#define CONF_STR_MTU "mtu"
+
+#define QUEUED "queue"
+#define SCHEDULED "schedule"
+#define DIRECT "direct"
+#define NONE "none"
+#define PLAIN "plain"
+#define PARALLEL "parallel"
+#define ATOMIC "atomic"
+#define ORDERED "ordered"
+#define L2 "l2"
+#define L3 "l3"
+#define L4 "l4"
+#define ALL "all"
+
+#define IDX_DELIM_CHAR '.'
+#define IN_QS_STR ".in"
+#define OUT_QS_STR ".out"
+
+typedef struct {
+	char *name;
+	char *iface;
+	char *pool;
+	char *group;
+	odp_pktio_param_t param;
+	odp_pktin_queue_param_t in_param;
+	odp_pktout_queue_param_t out_param;
+	odp_pktio_config_t config;
+	int promisc_mode;
+	odp_pktio_t pktio;
+	odp_queue_t in_queues[ODP_PKTIN_MAX_QUEUES];
+	odp_queue_t out_queues[ODP_PKTOUT_MAX_QUEUES];
+	uint32_t mtu;
+	uint32_t mtu_orig_in;
+	uint32_t mtu_orig_out;
+	odp_bool_t is_started;
+} pktio_parse_t;
+
+typedef struct {
+	pktio_parse_t *pktios;
+	uint32_t num;
+} pktio_parses_t;
+
+static pktio_parses_t pktios;
+
+static odp_bool_t parse_pktio_entry(config_setting_t *cs, pktio_parse_t *pktio)
+{
+	const char *val_str;
+	int val_i;
+
+	pktio->pktio = ODP_PKTIO_INVALID;
+	odp_pktio_param_init(&pktio->param);
+	/* No support for direct or TM modes for now, so our default is queued in/out */
+	pktio->param.in_mode = ODP_PKTIN_MODE_QUEUE;
+	pktio->param.out_mode = ODP_PKTOUT_MODE_QUEUE;
+	odp_pktin_queue_param_init(&pktio->in_param);
+	pktio->in_param.hash_proto.all_bits = 0U;
+	odp_pktout_queue_param_init(&pktio->out_param);
+	odp_pktio_config_init(&pktio->config);
+	pktio->config.parser.layer = ODP_PROTO_LAYER_NONE;
+
+	if (config_setting_lookup_string(cs, CONF_STR_NAME, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return false;
+	}
+
+	pktio->name = strdup(val_str);
+
+	if (pktio->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_IFACE, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_IFACE "\" found\n");
+		return false;
+	}
+
+	pktio->iface = strdup(val_str);
+
+	if (pktio->iface == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_POOL, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_POOL "\" found\n");
+		return false;
+	}
+
+	pktio->pool = strdup(val_str);
+
+	if (pktio->pool == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_INMODE, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, QUEUED) == 0) {
+			pktio->param.in_mode = ODP_PKTIN_MODE_QUEUE;
+		} else if (strcmp(val_str, SCHEDULED) == 0) {
+			pktio->param.in_mode = ODP_PKTIN_MODE_SCHED;
+		} else if (strcmp(val_str, DIRECT) == 0) {
+			pktio->param.in_mode = ODP_PKTIN_MODE_DIRECT;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_INMODE "\" found\n");
+			return false;
+		}
+	}
+
+	if (pktio->param.in_mode != ODP_PKTIN_MODE_DIRECT) {
+		if (config_setting_lookup_int(cs, CONF_STR_PRIO, &val_i) == CONFIG_TRUE)
+			pktio->in_param.queue_param.sched.prio = val_i;
+
+		if (config_setting_lookup_string(cs, CONF_STR_GROUP, &val_str) == CONFIG_TRUE) {
+			pktio->group = strdup(val_str);
+
+			if (pktio->group == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+		}
+
+		if (config_setting_lookup_string(cs, CONF_STR_SYNC, &val_str) == CONFIG_TRUE) {
+			if (strcmp(val_str, PARALLEL) == 0) {
+				pktio->in_param.queue_param.sched.sync = ODP_SCHED_SYNC_PARALLEL;
+			} else if (strcmp(val_str, ATOMIC) == 0) {
+				pktio->in_param.queue_param.sched.sync = ODP_SCHED_SYNC_ATOMIC;
+			} else if (strcmp(val_str, ORDERED) == 0) {
+				pktio->in_param.queue_param.sched.sync = ODP_SCHED_SYNC_ORDERED;
+			} else {
+				ODPH_ERR("No valid \"" CONF_STR_SYNC "\" found\n");
+				return false;
+			}
+		}
+
+		if (config_setting_lookup_int(cs, CONF_STR_SIZE, &val_i) == CONFIG_TRUE)
+			pktio->in_param.queue_param.size = val_i;
+	}
+
+	if (config_setting_lookup_string(cs, CONF_STR_OUTMODE, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, QUEUED) == 0) {
+			pktio->param.out_mode = ODP_PKTOUT_MODE_QUEUE;
+		} else if (strcmp(val_str, DIRECT) == 0) {
+			pktio->param.out_mode = ODP_PKTOUT_MODE_DIRECT;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_OUTMODE "\" found\n");
+			return false;
+		}
+	}
+
+	if (config_setting_lookup_int(cs, CONF_STR_CLS_ENABLE, &val_i) == CONFIG_TRUE) {
+		pktio->in_param.classifier_enable = val_i;
+
+		if (pktio->in_param.classifier_enable)
+			pktio->config.parser.layer = ODP_PROTO_LAYER_ALL;
+	}
+
+	if (config_setting_lookup_string(cs, CONF_STR_PARSE_LAYER, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, NONE) == 0) {
+			pktio->config.parser.layer = ODP_PROTO_LAYER_NONE;
+		} else if (strcmp(val_str, L2) == 0) {
+			pktio->config.parser.layer = ODP_PROTO_LAYER_L2;
+		} else if (strcmp(val_str, L3) == 0) {
+			pktio->config.parser.layer = ODP_PROTO_LAYER_L3;
+		} else if (strcmp(val_str, L4) == 0) {
+			pktio->config.parser.layer = ODP_PROTO_LAYER_L4;
+		} else if (strcmp(val_str, ALL) == 0) {
+			pktio->config.parser.layer = ODP_PROTO_LAYER_ALL;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_PARSE_LAYER "\" found\n");
+			return false;
+		}
+	}
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_ENABLE, &val_i) == CONFIG_TRUE)
+		pktio->in_param.hash_enable = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV4_UDP, &val_i) == CONFIG_TRUE)
+		pktio->in_param.hash_proto.proto.ipv4_udp = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV4_TCP, &val_i) == CONFIG_TRUE)
+		pktio->in_param.hash_proto.proto.ipv4_tcp = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV4, &val_i) == CONFIG_TRUE)
+		pktio->in_param.hash_proto.proto.ipv4 = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV6_UDP, &val_i) == CONFIG_TRUE)
+		pktio->in_param.hash_proto.proto.ipv6_udp = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV6_TCP, &val_i) == CONFIG_TRUE)
+		pktio->in_param.hash_proto.proto.ipv6_tcp = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_HASH_IPV6, &val_i) == CONFIG_TRUE)
+		pktio->in_param.hash_proto.proto.ipv6 = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_NUM_IN_QS, &val_i) == CONFIG_TRUE)
+		pktio->in_param.num_queues = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_NUM_OUT_QS, &val_i) == CONFIG_TRUE)
+		pktio->out_param.num_queues = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_PROMISC_ENABLE, &val_i) == CONFIG_TRUE)
+		pktio->promisc_mode = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_LSO_ENABLE, &val_i) == CONFIG_TRUE)
+		pktio->config.enable_lso = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_MTU, &val_i) == CONFIG_TRUE)
+		pktio->mtu = val_i;
+
+	return true;
+}
+
+static void free_pktio_entry(pktio_parse_t *pktio)
+{
+	if (pktio->pktio != ODP_PKTIO_INVALID) {
+		if (pktio->is_started) {
+			(void)odp_pktio_stop(pktio->pktio);
+			pktio->is_started = false;
+
+			if (pktio->mtu > 0U && pktio->mtu_orig_in > 0U && pktio->mtu_orig_out > 0U)
+				(void)odp_pktio_maxlen_set(pktio->pktio, pktio->mtu_orig_in,
+							   pktio->mtu_orig_out);
+		}
+
+		(void)odp_pktio_close(pktio->pktio);
+	}
+
+	free(pktio->name);
+	free(pktio->iface);
+	free(pktio->pool);
+	free(pktio->group);
+}
+
+static odp_bool_t pktio_parser_init(config_t *config)
+{
+	config_setting_t *cs, *elem;
+	int num;
+	pktio_parse_t *pktio;
+
+	cs = config_lookup(config, PKTIO_DOMAIN);
+
+	if (cs == NULL)	{
+		printf("Nothing to parse for \"" PKTIO_DOMAIN "\" domain\n");
+		return true;
+	}
+
+	num = config_setting_length(cs);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" PKTIO_DOMAIN "\" entries found\n");
+		return false;
+	}
+
+	pktios.pktios = calloc(1U, num * sizeof(*pktios.pktios));
+
+	if (pktios.pktios == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i) {
+		elem = config_setting_get_elem(cs, i);
+
+		if (elem == NULL) {
+			ODPH_ERR("Unparsable \"" PKTIO_DOMAIN "\" entry (%d)\n", i);
+			return false;
+		}
+
+		pktio = &pktios.pktios[pktios.num];
+
+		if (!parse_pktio_entry(elem, pktio)) {
+			ODPH_ERR("Invalid \"" PKTIO_DOMAIN "\" entry (%d)\n", i);
+			free_pktio_entry(pktio);
+			return false;
+		}
+
+		++pktios.num;
+	}
+
+	return true;
+}
+
+static odp_bool_t pktio_parser_deploy(void)
+{
+	pktio_parse_t *pktio;
+
+	printf("\n*** " PKTIO_DOMAIN " resources ***\n");
+
+	for (uint32_t i = 0U; i < pktios.num; ++i) {
+		pktio = &pktios.pktios[i];
+
+		if (pktio->group != NULL)
+			pktio->in_param.queue_param.sched.group =
+			       (odp_schedule_group_t)config_parser_get(SCHED_DOMAIN, pktio->group);
+
+		pktio->pktio = odp_pktio_open(pktio->iface,
+					      (odp_pool_t)config_parser_get(POOL_DOMAIN,
+									    pktio->pool),
+					      &pktio->param);
+
+		if (pktio->pktio == ODP_PKTIO_INVALID) {
+			ODPH_ERR("Error opening packet I/O (%s)\n", pktio->name);
+			return false;
+		}
+
+		if (odp_pktin_queue_config(pktio->pktio, &pktio->in_param) < 0) {
+			ODPH_ERR("Error configuring packet I/O input queues (%s)\n", pktio->name);
+			return false;
+		}
+
+		if (odp_pktout_queue_config(pktio->pktio, &pktio->out_param) < 0) {
+			ODPH_ERR("Error configuring packet I/O output queues (%s)\n", pktio->name);
+			return false;
+		}
+
+		if (odp_pktio_config(pktio->pktio, &pktio->config) < 0) {
+			ODPH_ERR("Error configuring packet I/O (%s)\n", pktio->name);
+			return false;
+		}
+
+		if (pktio->param.in_mode != ODP_PKTIN_MODE_DIRECT &&
+		    odp_pktin_event_queue(pktio->pktio, pktio->in_queues,
+					  pktio->in_param.num_queues) < 0) {
+			ODPH_ERR("Error querying packet I/O input event queues (%s)\n",
+				 pktio->name);
+			return false;
+		}
+
+		if (pktio->param.out_mode != ODP_PKTOUT_MODE_DIRECT &&
+		    odp_pktout_event_queue(pktio->pktio, pktio->out_queues,
+					   pktio->out_param.num_queues) < 0) {
+			ODPH_ERR("Error querying packet I/O output event queues (%s)\n",
+				 pktio->name);
+			return false;
+		}
+
+		if (pktio->promisc_mode == 1 &&
+		    odp_pktio_promisc_mode_set(pktio->pktio, pktio->promisc_mode) < 0) {
+			ODPH_ERR("Error setting promiscuous mode (%s)\n", pktio->name);
+			return false;
+		}
+
+		if (pktio->mtu > 0U) {
+			pktio->mtu_orig_in = odp_pktin_maxlen(pktio->pktio);
+			pktio->mtu_orig_out = odp_pktout_maxlen(pktio->pktio);
+
+			if (odp_pktio_maxlen_set(pktio->pktio, pktio->mtu, pktio->mtu) < 0) {
+				pktio->mtu = 0U;
+				ODPH_ERR("Error setting MTU (%s)\n", pktio->name);
+				return false;
+			}
+		}
+
+		if (odp_pktio_start(pktio->pktio) < 0) {
+			ODPH_ERR("Error starting packet I/O (%s)\n", pktio->name);
+			return false;
+		}
+
+		pktio->is_started = true;
+		printf("\nname: %s\n"
+		       "info:\n", pktio->name);
+		odp_pktio_print(pktio->pktio);
+	}
+
+	return true;
+}
+
+static void pktio_parser_destroy(void)
+{
+	for (uint32_t i = 0U; i < pktios.num; ++i)
+		free_pktio_entry(&pktios.pktios[i]);
+
+	free(pktios.pktios);
+}
+
+static void pktio_parser_undeploy(void)
+{
+	pktio_parse_t *pktio;
+
+	for (uint32_t i = 0U; i < pktios.num; ++i) {
+		pktio = &pktios.pktios[i];
+		(void)odp_pktio_stop(pktio->pktio);
+		pktio->is_started = false;
+	}
+}
+
+static uintptr_t pktio_parser_get_resource(const char *resource)
+{
+	pktio_parse_t *parse;
+	char *tmp1, *tmp2;
+	uint32_t idx;
+
+	for (uint32_t i = 0U; i < pktios.num; ++i) {
+		parse = &pktios.pktios[i];
+
+		if (strcmp(parse->name, resource) == 0)
+			return (uintptr_t)parse->pktio;
+
+		tmp1 = strchr(resource, IDX_DELIM_CHAR);
+
+		if (tmp1 == NULL)
+			continue;
+
+		if (strncmp(parse->name, resource, tmp1 - resource) != 0)
+			continue;
+
+		tmp2 = strchr(tmp1 + 1, IDX_DELIM_CHAR);
+
+		if (tmp2 == NULL)
+			continue;
+
+		if (parse->param.in_mode != ODP_PKTIN_MODE_DIRECT &&
+		    strncmp(IN_QS_STR, tmp1, tmp2 - tmp1) == 0) {
+			idx = atoi(tmp2 + 1);
+
+			if (idx >= parse->in_param.num_queues)
+				ODPH_ABORT("Invalid packet I/O input queue index (%s: %d)",
+					   parse->name, idx);
+
+			return (uintptr_t)parse->in_queues[idx];
+		} else if (parse->param.out_mode != ODP_PKTOUT_MODE_DIRECT &&
+			   strncmp(OUT_QS_STR, tmp1, tmp2 - tmp1) == 0) {
+			idx = atoi(tmp2 + 1);
+
+			if (idx >= parse->out_param.num_queues)
+				ODPH_ABORT("Invalid packet I/O output queue index (%s: %d)",
+					   parse->name, idx);
+
+			return (uintptr_t)parse->out_queues[idx];
+		}
+	}
+
+	ODPH_ABORT("No resource found (%s), aborting\n", resource);
+}
+
+CONFIG_PARSER_AUTOREGISTER(MED_PRIO, PKTIO_DOMAIN, pktio_parser_init, pktio_parser_deploy,
+			   pktio_parser_undeploy, pktio_parser_destroy, pktio_parser_get_resource)

--- a/test/performance/pipeline/pool_parser.c
+++ b/test/performance/pipeline/pool_parser.c
@@ -1,0 +1,239 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+
+#define CONF_STR_NAME "name"
+#define CONF_STR_TYPE "type"
+#define CONF_STR_SIZE "size"
+#define CONF_STR_CACHE_SIZE "cache_size"
+#define CONF_STR_NUM "num"
+
+#define PACKET "packet"
+#define BUFFER "buffer"
+#define TIMEOUT "timeout"
+#define DMA_COMPL "dma_completion"
+
+typedef struct {
+	char *name;
+	odp_pool_type_t type;
+	odp_pool_param_t p_param;
+	odp_dma_pool_param_t d_param;
+	odp_pool_t pool;
+} pool_parse_t;
+
+typedef struct {
+	pool_parse_t *pools;
+	uint32_t num;
+} pool_parses_t;
+
+static pool_parses_t pools;
+
+static odp_bool_t parse_pool_entry(config_setting_t *cs, pool_parse_t *pool)
+{
+	const char *val_str;
+	int val_i;
+	uint32_t size = 0U, num;
+
+	pool->pool = ODP_POOL_INVALID;
+	odp_pool_param_init(&pool->p_param);
+	odp_dma_pool_param_init(&pool->d_param);
+
+	if (config_setting_lookup_string(cs, CONF_STR_NAME, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return false;
+	}
+
+	pool->name = strdup(val_str);
+
+	if (pool->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_TYPE, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_TYPE "\" found\n");
+		return false;
+	}
+
+	if (strcmp(val_str, PACKET) == 0) {
+		pool->type = ODP_POOL_PACKET;
+	} else if (strcmp(val_str, BUFFER) == 0) {
+		pool->type = ODP_POOL_BUFFER;
+	} else if (strcmp(val_str, TIMEOUT) == 0) {
+		pool->type = ODP_POOL_TIMEOUT;
+	} else if (strcmp(val_str, DMA_COMPL) == 0) {
+		pool->type = ODP_POOL_DMA_COMPL;
+	} else {
+		ODPH_ERR("No valid \"" CONF_STR_TYPE "\" found\n");
+		return false;
+	}
+
+	if (config_setting_lookup_int(cs, CONF_STR_CACHE_SIZE, &val_i) == CONFIG_TRUE) {
+		pool->p_param.buf.cache_size = val_i;
+		pool->p_param.pkt.cache_size = val_i;
+		pool->p_param.tmo.cache_size = val_i;
+		pool->d_param.cache_size = val_i;
+	}
+
+	if (config_setting_lookup_int(cs, CONF_STR_NUM, &val_i) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NUM "\" found\n");
+		return false;
+	}
+
+	num = val_i;
+
+	if (pool->type == ODP_POOL_PACKET || pool->type == ODP_POOL_BUFFER) {
+		if (config_setting_lookup_int(cs, CONF_STR_SIZE, &val_i) == CONFIG_FALSE) {
+			ODPH_ERR("No \"" CONF_STR_SIZE "\" found\n");
+			return false;
+		}
+
+		size = val_i;
+	}
+
+	pool->p_param.type = pool->type;
+
+	if (pool->type == ODP_POOL_PACKET) {
+		pool->p_param.pkt.len = size;
+		pool->p_param.pkt.seg_len = size;
+		pool->p_param.pkt.num = num;
+	} else if (pool->type == ODP_POOL_BUFFER) {
+		pool->p_param.buf.size = size;
+		pool->p_param.buf.num = num;
+	} else if (pool->type == ODP_POOL_TIMEOUT) {
+		pool->p_param.tmo.num = num;
+	} else {
+		pool->d_param.num = num;
+	}
+
+	return true;
+}
+
+static void free_pool_entry(pool_parse_t *pool)
+{
+	free(pool->name);
+
+	if (pool->pool != ODP_POOL_INVALID)
+		(void)odp_pool_destroy(pool->pool);
+}
+
+static odp_bool_t pool_parser_init(config_t *config)
+{
+	config_setting_t *cs, *elem;
+	int num;
+	pool_parse_t *pool;
+
+	cs = config_lookup(config, POOL_DOMAIN);
+
+	if (cs == NULL)	{
+		printf("Nothing to parse for \"" POOL_DOMAIN "\" domain\n");
+		return true;
+	}
+
+	num = config_setting_length(cs);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" POOL_DOMAIN "\" entries found\n");
+		return false;
+	}
+
+	pools.pools = calloc(1U, num * sizeof(*pools.pools));
+
+	if (pools.pools == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i) {
+		elem = config_setting_get_elem(cs, i);
+
+		if (elem == NULL) {
+			ODPH_ERR("Unparsable \"" POOL_DOMAIN "\" entry (%d)\n", i);
+			return false;
+		}
+
+		pool = &pools.pools[pools.num];
+
+		if (!parse_pool_entry(elem, pool)) {
+			ODPH_ERR("Invalid \"" POOL_DOMAIN "\" entry (%d)\n", i);
+			free_pool_entry(pool);
+			return false;
+		}
+
+		++pools.num;
+	}
+
+	return true;
+}
+
+static odp_bool_t pool_parser_deploy(void)
+{
+	pool_parse_t *pool;
+
+	printf("\n*** " POOL_DOMAIN " resources ***\n");
+
+	for (uint32_t i = 0U; i < pools.num; ++i) {
+		pool = &pools.pools[i];
+
+		if (pool->type != ODP_POOL_DMA_COMPL)
+			pool->pool = odp_pool_create(pool->name, &pool->p_param);
+		else
+			pool->pool = odp_dma_pool_create(pool->name, &pool->d_param);
+
+		if (pool->pool == ODP_POOL_INVALID) {
+			ODPH_ERR("Error creating pool (%s)\n", pool->name);
+			return false;
+		}
+
+		printf("\nname: %s\n"
+		       "info:\n", pool->name);
+		odp_pool_print(pool->pool);
+	}
+
+	return true;
+}
+
+static void pool_parser_destroy(void)
+{
+	for (uint32_t i = 0U; i < pools.num; ++i)
+		free_pool_entry(&pools.pools[i]);
+
+	free(pools.pools);
+}
+
+static uintptr_t pool_parser_get_resource(const char *resource)
+{
+	pool_parse_t *parse;
+	odp_pool_t pool = ODP_POOL_INVALID;
+
+	for (uint32_t i = 0U; i < pools.num; ++i) {
+		parse = &pools.pools[i];
+
+		if (strcmp(parse->name, resource) != 0)
+			continue;
+
+		pool = parse->pool;
+		break;
+	}
+
+	if (pool == ODP_POOL_INVALID)
+		ODPH_ABORT("No resource found (%s), aborting\n", resource);
+
+	return (uintptr_t)pool;
+}
+
+CONFIG_PARSER_AUTOREGISTER(HIGH_PRIO, POOL_DOMAIN, pool_parser_init, pool_parser_deploy, NULL,
+			   pool_parser_destroy, pool_parser_get_resource)

--- a/test/performance/pipeline/queue_parser.c
+++ b/test/performance/pipeline/queue_parser.c
@@ -1,0 +1,436 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+
+#define CONF_STR_PARSE_TEMPLATE "template"
+#define CONF_STR_NAME "name"
+#define CONF_STR_TYPE "type"
+#define CONF_STR_PRIO "priority"
+#define CONF_STR_GROUP "group"
+#define CONF_STR_SYNC "sync"
+#define CONF_STR_SIZE "size"
+#define CONF_STR_PREFIX "prefix"
+#define CONF_STR_IDX "start_index"
+#define CONF_STR_INC "index_increment"
+
+#define PLAIN "plain"
+#define SCHEDULED "schedule"
+#define PARALLEL "parallel"
+#define ATOMIC "atomic"
+#define ORDERED "ordered"
+
+typedef struct {
+	char *name;
+	char *ext;
+	char *group;
+	odp_queue_param_t param;
+	odp_queue_t queue;
+} queue_parse_t;
+
+typedef struct {
+	queue_parse_t *queues;
+	uint32_t num;
+} queue_parses_t;
+
+typedef struct {
+	char *prefix;
+	char *type;
+	char *group;
+	char *sync;
+	uint32_t idx;
+	uint32_t inc;
+	int priority;
+} queue_parse_template_t;
+
+typedef enum {
+	PARSE_OK,
+	PARSE_TEMPL,
+	PARSE_NOK
+} res_t;
+
+static queue_parses_t queues;
+
+static res_t parse_queue_entry(config_setting_t *cs, queue_parse_t *queue)
+{
+	const char *val_str;
+	int val_i;
+
+	if (config_setting_lookup(cs, CONF_STR_PARSE_TEMPLATE) != NULL)
+		return PARSE_TEMPL;
+
+	memset(queue, 0, sizeof(*queue));
+	queue->queue = ODP_QUEUE_INVALID;
+	odp_queue_param_init(&queue->param);
+
+	if (config_setting_lookup_string(cs, CONF_STR_NAME, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return PARSE_NOK;
+	}
+
+	queue->name = strdup(val_str);
+
+	if (queue->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_TYPE, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, PLAIN) == 0) {
+			queue->param.type = ODP_QUEUE_TYPE_PLAIN;
+		} else if (strcmp(val_str, SCHEDULED) == 0) {
+			queue->param.type = ODP_QUEUE_TYPE_SCHED;
+		} else {
+			queue->ext = strdup(val_str);
+
+			if (queue->ext == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+		}
+	}
+
+	if (queue->param.type == ODP_QUEUE_TYPE_PLAIN)
+		return PARSE_OK;
+
+	if (config_setting_lookup_int(cs, CONF_STR_PRIO, &val_i) == CONFIG_TRUE)
+		queue->param.sched.prio = val_i;
+
+	if (config_setting_lookup_string(cs, CONF_STR_GROUP, &val_str) == CONFIG_TRUE) {
+		queue->group = strdup(val_str);
+
+		if (queue->group == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	}
+
+	if (config_setting_lookup_string(cs, CONF_STR_SYNC, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, PARALLEL) == 0) {
+			queue->param.sched.sync = ODP_SCHED_SYNC_PARALLEL;
+		} else if (strcmp(val_str, ATOMIC) == 0) {
+			queue->param.sched.sync = ODP_SCHED_SYNC_ATOMIC;
+		} else if (strcmp(val_str, ORDERED) == 0) {
+			queue->param.sched.sync = ODP_SCHED_SYNC_ORDERED;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_SYNC "\" found\n");
+			return PARSE_NOK;
+		}
+	}
+
+	if (config_setting_lookup_int(cs, CONF_STR_SIZE, &val_i) == CONFIG_TRUE)
+		queue->param.size = val_i;
+
+	return PARSE_OK;
+}
+
+static int parse_queue_entry_template(config_setting_t *cs, queue_parse_template_t *templ)
+{
+	int val_i;
+	uint32_t num;
+	config_setting_t *elem;
+	const char *val_str;
+
+	memset(templ, 0, sizeof(*templ));
+	templ->priority = -1;
+
+	if (config_setting_lookup_int(cs, CONF_STR_PARSE_TEMPLATE, &val_i) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_PARSE_TEMPLATE "\" found\n");
+		return -1;
+	}
+
+	num = val_i;
+
+	if (num == 0U)
+		return -1;
+
+	elem = config_setting_lookup(cs, CONF_STR_NAME);
+
+	if (elem == NULL) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return -1;
+	}
+
+	val_str = config_setting_get_string_elem(elem, 0);
+
+	if (val_str == NULL) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" \"" CONF_STR_PREFIX "\" found\n");
+		return -1;
+	}
+
+	templ->prefix = strdup(val_str);
+
+	if (templ->prefix == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	val_i = config_setting_get_int_elem(elem, 1);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" \"" CONF_STR_IDX "\" found\n");
+		return -1;
+	}
+
+	templ->idx = val_i;
+	val_i = config_setting_get_int_elem(elem, 2);
+
+	if (val_i == -1) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" \"" CONF_STR_INC "\" found\n");
+		return -1;
+	}
+
+	templ->inc = val_i;
+
+	if (config_setting_lookup_string(cs, CONF_STR_TYPE, &val_str) == CONFIG_TRUE) {
+		templ->type = strdup(val_str);
+
+		if (templ->type == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	}
+
+	if (config_setting_lookup_int(cs, CONF_STR_PRIO, &val_i) == CONFIG_TRUE)
+		templ->priority = val_i;
+
+	if (config_setting_lookup_string(cs, CONF_STR_GROUP, &val_str) == CONFIG_TRUE) {
+		templ->group = strdup(val_str);
+
+		if (templ->group == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	}
+
+	if (config_setting_lookup_string(cs, CONF_STR_SYNC, &val_str) == CONFIG_TRUE) {
+		templ->sync = strdup(val_str);
+
+		if (templ->sync == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	}
+
+	return num;
+}
+
+static odp_bool_t parse_queue_entry_from_template(queue_parse_template_t *templ,
+						  queue_parse_t *queue)
+{
+	char name[ODP_QUEUE_NAME_LEN];
+
+	memset(queue, 0, sizeof(*queue));
+	memset(name, 0, sizeof(name));
+	queue->queue = ODP_QUEUE_INVALID;
+	odp_queue_param_init(&queue->param);
+	(void)snprintf(name, sizeof(name), "%s%u", templ->prefix, templ->idx);
+	templ->idx += templ->inc;
+	queue->name = strdup(name);
+
+	if (queue->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (templ->type != NULL) {
+		if (strcmp(templ->type, PLAIN) == 0) {
+			queue->param.type = ODP_QUEUE_TYPE_PLAIN;
+		} else if (strcmp(templ->type, SCHEDULED) == 0) {
+			queue->param.type = ODP_QUEUE_TYPE_SCHED;
+		} else {
+			queue->ext = strdup(templ->type);
+
+			if (queue->ext == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+		}
+	}
+
+	if (templ->priority != -1)
+		queue->param.sched.prio = templ->priority;
+
+	if (templ->group != NULL) {
+		queue->group = strdup(templ->group);
+
+		if (queue->group == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+	}
+
+	if (templ->sync != NULL) {
+		if (strcmp(templ->sync, PARALLEL) == 0) {
+			queue->param.sched.sync = ODP_SCHED_SYNC_PARALLEL;
+		} else if (strcmp(templ->sync, ATOMIC) == 0) {
+			queue->param.sched.sync = ODP_SCHED_SYNC_ATOMIC;
+		} else if (strcmp(templ->sync, ORDERED) == 0) {
+			queue->param.sched.sync = ODP_SCHED_SYNC_ORDERED;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_SYNC "\" found\n");
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static void free_queue_entry(queue_parse_t *queue)
+{
+	free(queue->name);
+	free(queue->ext);
+	free(queue->group);
+
+	if (queue->queue != ODP_QUEUE_INVALID)
+		(void)odp_queue_destroy(queue->queue);
+}
+
+static void free_queue_template(queue_parse_template_t *templ)
+{
+	free(templ->prefix);
+	free(templ->type);
+	free(templ->group);
+	free(templ->sync);
+}
+
+static odp_bool_t queue_parser_init(config_t *config)
+{
+	config_setting_t *cs, *elem;
+	int num, ret;
+	queue_parse_t *queue;
+	res_t res;
+	queue_parse_template_t templ;
+
+	cs = config_lookup(config, QUEUE_DOMAIN);
+
+	if (cs == NULL)	{
+		printf("Nothing to parse for \"" QUEUE_DOMAIN "\" domain\n");
+		return true;
+	}
+
+	num = config_setting_length(cs);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" QUEUE_DOMAIN "\" entries found\n");
+		return false;
+	}
+
+	queues.queues = calloc(1U, num * sizeof(*queues.queues));
+
+	if (queues.queues == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i) {
+		elem = config_setting_get_elem(cs, i);
+
+		if (elem == NULL) {
+			ODPH_ERR("Unparsable \"" QUEUE_DOMAIN "\" entry (%d)\n", i);
+			return false;
+		}
+
+		queue = &queues.queues[queues.num];
+		res = parse_queue_entry(elem, queue);
+
+		if (res == PARSE_NOK) {
+			ODPH_ERR("Invalid \"" QUEUE_DOMAIN "\" entry (%d)\n", i);
+			free_queue_entry(queue);
+			return false;
+		} else if (res == PARSE_TEMPL) {
+			ret = parse_queue_entry_template(elem, &templ);
+
+			if (ret == -1) {
+				ODPH_ERR("Invalid \"" QUEUE_DOMAIN "\" entry (%d)\n", i);
+				return false;
+			}
+
+			queues.queues = realloc(queues.queues, (ret + queues.num + (num - i - 1)) *
+						sizeof(*queues.queues));
+
+			if (queues.queues == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+
+			for (int j = 0; j < ret; ++j) {
+				queue = &queues.queues[queues.num];
+
+				if (!parse_queue_entry_from_template(&templ, queue)) {
+					ODPH_ERR("Invalid \"" QUEUE_DOMAIN "\" entry (%d)\n", i);
+					free_queue_template(&templ);
+					free_queue_entry(queue);
+					return false;
+				}
+
+				++queues.num;
+			}
+
+			free_queue_template(&templ);
+		} else {
+			++queues.num;
+		}
+	}
+
+	return true;
+}
+
+static odp_bool_t queue_parser_deploy(void)
+{
+	queue_parse_t *queue;
+
+	printf("\n*** " QUEUE_DOMAIN " resources ***\n");
+
+	for (uint32_t i = 0U; i < queues.num; ++i) {
+		queue = &queues.queues[i];
+
+		if (queue->ext != NULL)
+			continue;
+
+		if (queue->group != NULL)
+			queue->param.sched.group =
+			       (odp_schedule_group_t)config_parser_get(SCHED_DOMAIN, queue->group);
+
+		queue->queue = odp_queue_create(queue->name, &queue->param);
+
+		if (queue->queue == ODP_QUEUE_INVALID) {
+			ODPH_ERR("Error creating queue (%s)\n", queue->name);
+			return false;
+		}
+
+		printf("\nname: %s\n"
+		       "info:\n", queue->name);
+		odp_queue_print(queue->queue);
+	}
+
+	return true;
+}
+
+static void queue_parser_destroy(void)
+{
+	for (uint32_t i = 0U; i < queues.num; ++i)
+		free_queue_entry(&queues.queues[i]);
+
+	free(queues.queues);
+}
+
+static uintptr_t queue_parser_get_resource(const char *resource)
+{
+	queue_parse_t *parse;
+	odp_queue_t queue = ODP_QUEUE_INVALID;
+
+	for (uint32_t i = 0U; i < queues.num; ++i) {
+		parse = &queues.queues[i];
+
+		if (strcmp(parse->name, resource) != 0)
+			continue;
+
+		if (parse->ext != NULL)
+			queue = (odp_queue_t)config_parser_get(parse->ext, resource);
+		else
+			queue = parse->queue;
+
+		break;
+	}
+
+	if (queue == ODP_QUEUE_INVALID)
+		ODPH_ABORT("No resource found (%s), aborting\n", resource);
+
+	return (uintptr_t)queue;
+}
+
+CONFIG_PARSER_AUTOREGISTER(HIGH_PRIO, QUEUE_DOMAIN, queue_parser_init, queue_parser_deploy, NULL,
+			   queue_parser_destroy, queue_parser_get_resource)

--- a/test/performance/pipeline/sched_parser.c
+++ b/test/performance/pipeline/sched_parser.c
@@ -1,0 +1,175 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+
+#define CONF_STR_GROUPS "groups"
+#define CONF_STR_NAME "name"
+
+typedef struct {
+	char *name;
+	odp_schedule_group_t grp;
+} grp_parse_t;
+
+typedef struct {
+	grp_parse_t *grps;
+	uint32_t num;
+} scd_parse_t;
+
+static scd_parse_t scd;
+
+static odp_bool_t parse_grp_entry(config_setting_t *cs, grp_parse_t *grp)
+{
+	const char *val_str;
+
+	grp->grp = ODP_SCHED_GROUP_INVALID;
+
+	if (config_setting_lookup_string(cs, CONF_STR_NAME, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return false;
+	}
+
+	grp->name = strdup(val_str);
+
+	if (grp->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	return true;
+}
+
+static void free_grp_entry(grp_parse_t *grp)
+{
+	free(grp->name);
+
+	if (grp->grp != ODP_SCHED_GROUP_INVALID)
+		(void)odp_schedule_group_destroy(grp->grp);
+}
+
+static odp_bool_t sched_parser_init(config_t *config)
+{
+	config_setting_t *cs, *elem, *tmp;
+	int num;
+	grp_parse_t *grp;
+
+	cs = config_lookup(config, SCHED_DOMAIN);
+
+	if (cs == NULL)	{
+		printf("Nothing to parse for \"" SCHED_DOMAIN "\" domain\n");
+		return true;
+	}
+
+	elem = config_setting_lookup(cs, CONF_STR_GROUPS);
+
+	if (elem == NULL) {
+		ODPH_ERR("No \"" CONF_STR_GROUPS "\" entries found\n");
+		return false;
+	}
+
+	num = config_setting_length(elem);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" CONF_STR_GROUPS "\" entries found\n");
+		return false;
+	}
+
+	scd.grps = calloc(1U, num * sizeof(*scd.grps));
+
+	if (scd.grps == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i) {
+		tmp = config_setting_get_elem(elem, i);
+
+		if (tmp == NULL) {
+			ODPH_ERR("Unparsable \"" CONF_STR_GROUPS "\" entry (%d)\n", i);
+			return false;
+		}
+
+		grp = &scd.grps[scd.num];
+
+		if (!parse_grp_entry(tmp, grp)) {
+			ODPH_ERR("Invalid \"" CONF_STR_GROUPS "\" entry (%d)\n", i);
+			free_grp_entry(grp);
+			return false;
+		}
+
+		++scd.num;
+	}
+
+	/* TODO: Global schedule config parsing */
+
+	return true;
+}
+
+static odp_bool_t sched_parser_deploy(void)
+{
+	grp_parse_t *grp;
+	odp_thrmask_t mask;
+
+	printf("\n*** " SCHED_DOMAIN " resources ***\n");
+
+	for (uint32_t i = 0U; i < scd.num; ++i) {
+		grp = &scd.grps[i];
+		odp_thrmask_zero(&mask);
+		grp->grp = odp_schedule_group_create(grp->name, &mask);
+
+		if (grp->grp == ODP_SCHED_GROUP_INVALID) {
+			ODPH_ERR("Error creating schedule group (%s)\n", grp->name);
+			return false;
+		}
+
+		printf("\nname: %s\n", grp->name);
+	}
+
+	odp_schedule_print();
+
+	return true;
+}
+
+static void sched_parser_destroy(void)
+{
+	for (uint32_t i = 0U; i < scd.num; ++i)
+		free_grp_entry(&scd.grps[i]);
+
+	free(scd.grps);
+}
+
+static uintptr_t sched_parser_get_resource(const char *resource)
+{
+	grp_parse_t *parse;
+	odp_schedule_group_t grp = ODP_SCHED_GROUP_INVALID;
+
+	for (uint32_t i = 0U; i < scd.num; ++i) {
+		parse = &scd.grps[i];
+
+		if (strcmp(parse->name, resource) != 0)
+			continue;
+
+		grp = parse->grp;
+		break;
+	}
+
+	if (grp == ODP_SCHED_GROUP_INVALID)
+		ODPH_ABORT("No resource found (%s), aborting\n", resource);
+
+	return (uintptr_t)grp;
+}
+
+CONFIG_PARSER_AUTOREGISTER(CRIT_PRIO, SCHED_DOMAIN, sched_parser_init, sched_parser_deploy, NULL,
+			   sched_parser_destroy, sched_parser_get_resource)

--- a/test/performance/pipeline/stash_parser.c
+++ b/test/performance/pipeline/stash_parser.c
@@ -1,0 +1,233 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+
+#define CONF_STR_NAME "name"
+#define CONF_STR_TYPE "type"
+#define CONF_STR_PUT_MODE "put_mode"
+#define CONF_STR_GET_MODE "get_mode"
+#define CONF_STR_NUM "num"
+#define CONF_STR_SIZE "size"
+#define CONF_STR_CACHE_SIZE "cache_size"
+
+#define DEFAULT "default"
+#define FIFO "fifo"
+#define MT "mt"
+#define ST "st"
+#define LC "local"
+
+typedef struct {
+	char *name;
+	odp_stash_param_t param;
+	odp_stash_t stash;
+} stash_parse_t;
+
+typedef struct {
+	stash_parse_t *stashes;
+	uint32_t num;
+} stash_parses_t;
+
+static stash_parses_t stashes;
+
+static odp_bool_t parse_stash_entry(config_setting_t *cs, stash_parse_t *stash)
+{
+	const char *val_str;
+	long long val_ll;
+	int val_i;
+
+	stash->stash = ODP_STASH_INVALID;
+	odp_stash_param_init(&stash->param);
+
+	if (config_setting_lookup_string(cs, CONF_STR_NAME, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return false;
+	}
+
+	stash->name = strdup(val_str);
+
+	if (stash->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_TYPE, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, DEFAULT) == 0) {
+			stash->param.type = ODP_STASH_TYPE_DEFAULT;
+		} else if (strcmp(val_str, FIFO) == 0) {
+			stash->param.type = ODP_STASH_TYPE_FIFO;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_TYPE "\" found\n");
+			return false;
+		}
+	}
+
+	if (config_setting_lookup_string(cs, CONF_STR_PUT_MODE, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, MT) == 0) {
+			stash->param.put_mode = ODP_STASH_OP_MT;
+		} else if (strcmp(val_str, ST) == 0) {
+			stash->param.put_mode = ODP_STASH_OP_ST;
+		} else if (strcmp(val_str, LC) == 0) {
+			stash->param.put_mode = ODP_STASH_OP_LOCAL;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_PUT_MODE "\" found\n");
+			return false;
+		}
+	}
+
+	if (config_setting_lookup_string(cs, CONF_STR_GET_MODE, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, MT) == 0) {
+			stash->param.get_mode = ODP_STASH_OP_MT;
+		} else if (strcmp(val_str, ST) == 0) {
+			stash->param.get_mode = ODP_STASH_OP_ST;
+		} else if (strcmp(val_str, LC) == 0) {
+			stash->param.get_mode = ODP_STASH_OP_LOCAL;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_GET_MODE "\" found\n");
+			return false;
+		}
+	}
+
+	if (config_setting_lookup_int64(cs, CONF_STR_NUM, &val_ll) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NUM "\" found\n");
+		return false;
+	}
+
+	stash->param.num_obj = val_ll;
+
+	if (config_setting_lookup_int(cs, CONF_STR_SIZE, &val_i) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_SIZE "\" found\n");
+		return false;
+	}
+
+	stash->param.obj_size = val_i;
+
+	if (config_setting_lookup_int(cs, CONF_STR_CACHE_SIZE, &val_i) == CONFIG_TRUE)
+		stash->param.cache_size = val_i;
+
+	return true;
+}
+
+static void free_stash_entry(stash_parse_t *stash)
+{
+	free(stash->name);
+
+	if (stash->stash != ODP_STASH_INVALID)
+		(void)odp_stash_destroy(stash->stash);
+}
+
+static odp_bool_t stash_parser_init(config_t *config)
+{
+	config_setting_t *cs, *elem;
+	int num;
+	stash_parse_t *stash;
+
+	cs = config_lookup(config, STASH_DOMAIN);
+
+	if (cs == NULL)	{
+		printf("Nothing to parse for \"" STASH_DOMAIN "\" domain\n");
+		return true;
+	}
+
+	num = config_setting_length(cs);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" STASH_DOMAIN "\" entries found\n");
+		return false;
+	}
+
+	stashes.stashes = calloc(1U, num * sizeof(*stashes.stashes));
+
+	if (stashes.stashes == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i) {
+		elem = config_setting_get_elem(cs, i);
+
+		if (elem == NULL) {
+			ODPH_ERR("Unparsable \"" STASH_DOMAIN "\" entry (%d)\n", i);
+			return false;
+		}
+
+		stash = &stashes.stashes[stashes.num];
+
+		if (!parse_stash_entry(elem, stash)) {
+			ODPH_ERR("Invalid \"" STASH_DOMAIN "\" entry (%d)\n", i);
+			free_stash_entry(stash);
+			return false;
+		}
+
+		++stashes.num;
+	}
+
+	return true;
+}
+
+static odp_bool_t stash_parser_deploy(void)
+{
+	stash_parse_t *stash;
+
+	printf("\n*** " STASH_DOMAIN " resources ***\n");
+
+	for (uint32_t i = 0U; i < stashes.num; ++i) {
+		stash = &stashes.stashes[i];
+		stash->stash = odp_stash_create(stash->name, &stash->param);
+
+		if (stash->stash == ODP_STASH_INVALID) {
+			ODPH_ERR("Error creating pool (%s)\n", stash->name);
+			return false;
+		}
+
+		printf("\nname: %s\n"
+		       "info:\n", stash->name);
+		odp_stash_print(stash->stash);
+	}
+
+	return true;
+}
+
+static void stash_parser_destroy(void)
+{
+	for (uint32_t i = 0U; i < stashes.num; ++i)
+		free_stash_entry(&stashes.stashes[i]);
+
+	free(stashes.stashes);
+}
+
+static uintptr_t stash_parser_get_resource(const char *resource)
+{
+	stash_parse_t *parse;
+	odp_stash_t stash = ODP_STASH_INVALID;
+
+	for (uint32_t i = 0U; i < stashes.num; ++i) {
+		parse = &stashes.stashes[i];
+
+		if (strcmp(parse->name, resource) != 0)
+			continue;
+
+		stash = parse->stash;
+		break;
+	}
+
+	if (stash == ODP_STASH_INVALID)
+		ODPH_ABORT("No resource found (%s), aborting\n", resource);
+
+	return (uintptr_t)stash;
+}
+
+CONFIG_PARSER_AUTOREGISTER(MED_PRIO, STASH_DOMAIN, stash_parser_init, stash_parser_deploy, NULL,
+			   stash_parser_destroy, stash_parser_get_resource)

--- a/test/performance/pipeline/timer_parser.c
+++ b/test/performance/pipeline/timer_parser.c
@@ -1,0 +1,232 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+
+#define CONF_STR_NAME "name"
+#define CONF_STR_CLK_SRC "clk_src"
+#define CONF_STR_RES_NS "res_ns"
+#define CONF_STR_RES_HZ "res_hz"
+#define CONF_STR_MIN_TMO "min_tmo"
+#define CONF_STR_MAX_TMO "max_tmo"
+#define CONF_STR_NUM "num"
+
+#define SRC0 "src0"
+#define SRC1 "src1"
+#define SRC2 "src2"
+#define SRC3 "src3"
+#define SRC4 "src4"
+#define SRC5 "src5"
+
+typedef struct {
+	char *name;
+	odp_timer_pool_param_t param;
+	odp_timer_pool_t tmr_pool;
+} timer_parse_t;
+
+typedef struct {
+	timer_parse_t *timers;
+	uint32_t num;
+} timer_parses_t;
+
+static timer_parses_t timers;
+
+static odp_bool_t parse_timer_entry(config_setting_t *cs, timer_parse_t *timer)
+{
+	const char *val_str;
+	int val_i;
+	long long val_ll;
+
+	timer->tmr_pool = ODP_TIMER_POOL_INVALID;
+	odp_timer_pool_param_init(&timer->param);
+	timer->param.timer_type = ODP_TIMER_TYPE_SINGLE;
+
+	if (config_setting_lookup_string(cs, CONF_STR_NAME, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return false;
+	}
+
+	timer->name = strdup(val_str);
+
+	if (timer->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_CLK_SRC, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, SRC0) == 0) {
+			timer->param.clk_src = ODP_CLOCK_SRC_0;
+		} else if (strcmp(val_str, SRC1) == 0) {
+			timer->param.clk_src = ODP_CLOCK_SRC_1;
+		} else if (strcmp(val_str, SRC2) == 0) {
+			timer->param.clk_src = ODP_CLOCK_SRC_2;
+		} else if (strcmp(val_str, SRC3) == 0) {
+			timer->param.clk_src = ODP_CLOCK_SRC_3;
+		} else if (strcmp(val_str, SRC4) == 0) {
+			timer->param.clk_src = ODP_CLOCK_SRC_4;
+		} else if (strcmp(val_str, SRC5) == 0) {
+			timer->param.clk_src = ODP_CLOCK_SRC_5;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_CLK_SRC "\" found\n");
+			return false;
+		}
+	}
+
+	if (config_setting_lookup_int64(cs, CONF_STR_RES_NS, &val_ll) == CONFIG_TRUE)
+		timer->param.res_ns = val_ll;
+
+	if (config_setting_lookup_int64(cs, CONF_STR_RES_HZ, &val_ll) == CONFIG_TRUE)
+		timer->param.res_hz = val_ll;
+
+	if (config_setting_lookup_int64(cs, CONF_STR_MIN_TMO, &val_ll) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_MIN_TMO "\" found\n");
+		return false;
+	}
+
+	timer->param.min_tmo = val_ll;
+
+	if (config_setting_lookup_int64(cs, CONF_STR_MAX_TMO, &val_ll) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_MAX_TMO "\" found\n");
+		return false;
+	}
+
+	timer->param.max_tmo = val_ll;
+
+	if (config_setting_lookup_int(cs, CONF_STR_NUM, &val_i) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NUM "\" found\n");
+		return false;
+	}
+
+	timer->param.num_timers = val_i;
+
+	return true;
+}
+
+static void free_timer_entry(timer_parse_t *timer)
+{
+	if (timer->tmr_pool != ODP_TIMER_POOL_INVALID)
+		odp_timer_pool_destroy(timer->tmr_pool);
+
+	free(timer->name);
+}
+
+static odp_bool_t timer_parser_init(config_t *config)
+{
+	config_setting_t *cs, *elem;
+	int num;
+	timer_parse_t *timer;
+
+	cs = config_lookup(config, TIMER_DOMAIN);
+
+	if (cs == NULL)	{
+		printf("Nothing to parse for \"" TIMER_DOMAIN "\" domain\n");
+		return true;
+	}
+
+	num = config_setting_length(cs);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" TIMER_DOMAIN "\" entries found\n");
+		return false;
+	}
+
+	timers.timers = calloc(1U, num * sizeof(*timers.timers));
+
+	if (timers.timers == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i) {
+		elem = config_setting_get_elem(cs, i);
+
+		if (elem == NULL) {
+			ODPH_ERR("Unparsable \"" TIMER_DOMAIN "\" entry (%d)\n", i);
+			return false;
+		}
+
+		timer = &timers.timers[timers.num];
+
+		if (!parse_timer_entry(elem, timer)) {
+			ODPH_ERR("Invalid \"" TIMER_DOMAIN "\" entry (%d)\n", i);
+			free_timer_entry(timer);
+			return false;
+		}
+
+		++timers.num;
+	}
+
+	return true;
+}
+
+static odp_bool_t timer_parser_deploy(void)
+{
+	timer_parse_t *timer;
+
+	printf("\n*** " TIMER_DOMAIN " resources ***\n");
+
+	for (uint32_t i = 0U; i < timers.num; ++i) {
+		timer = &timers.timers[i];
+		timer->tmr_pool = odp_timer_pool_create(timer->name, &timer->param);
+
+		if (timer->tmr_pool == ODP_TIMER_POOL_INVALID) {
+			ODPH_ERR("Error creating timer pool (%s)\n", timer->name);
+			return false;
+		}
+
+		if (odp_timer_pool_start_multi(&timer->tmr_pool, 1) != 1) {
+			ODPH_ERR("Error starting timer pool (%s)\n", timer->name);
+			return false;
+		}
+
+		printf("\nname: %s\n"
+		       "info:\n", timer->name);
+		odp_timer_pool_print(timer->tmr_pool);
+	}
+
+	return true;
+}
+
+static void timer_parser_destroy(void)
+{
+	for (uint32_t i = 0U; i < timers.num; ++i)
+		free_timer_entry(&timers.timers[i]);
+
+	free(timers.timers);
+}
+
+static uintptr_t timer_parser_get_resource(const char *resource)
+{
+	timer_parse_t *parse;
+	odp_timer_pool_t pool = ODP_TIMER_POOL_INVALID;
+
+	for (uint32_t i = 0U; i < timers.num; ++i) {
+		parse = &timers.timers[i];
+
+		if (strcmp(parse->name, resource) != 0)
+			continue;
+
+		pool = parse->tmr_pool;
+		break;
+	}
+
+	if (pool == ODP_TIMER_POOL_INVALID)
+		ODPH_ABORT("No resource found (%s), aborting\n", resource);
+
+	return (uintptr_t)pool;
+}
+
+CONFIG_PARSER_AUTOREGISTER(MED_PRIO, TIMER_DOMAIN, timer_parser_init, timer_parser_deploy, NULL,
+			   timer_parser_destroy, timer_parser_get_resource)

--- a/test/performance/pipeline/work.c
+++ b/test/performance/pipeline/work.c
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <odp/helper/odph_api.h>
+#include <sys/queue.h>
+
+#include "common.h"
+#include "config_parser.h"
+#include "work.h"
+
+typedef struct work_entry_s {
+	TAILQ_ENTRY(work_entry_s) w;
+
+	const char *name;
+	work_init_fn_t init_fn;
+	work_print_fn_t print_fn;
+	work_destroy_fn_t destroy_fn;
+} work_entry_t;
+
+typedef struct {
+	TAILQ_HEAD(, work_entry_s) w;
+
+	odp_bool_t init_done;
+} work_entries_t;
+
+typedef struct ODP_ALIGNED_CACHE {
+	work_fn_t fn;
+	uintptr_t data;
+	work_entry_t *entry;
+	work_stats_t stats;
+} work_priv_t;
+
+static work_entries_t entries;
+
+work_t work_create_work(const work_param_t *param)
+{
+	work_priv_t *work = calloc(1U, sizeof(*work));
+	work_entry_t *entry;
+	work_init_t init;
+
+	if (work == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	TAILQ_FOREACH(entry, &entries.w, w) {
+		if (strcmp(entry->name, param->type) != 0)
+			continue;
+
+		entry->init_fn(param, &init);
+		work->fn = init.fn;
+		work->data = init.data;
+		work->entry = entry;
+		return (work_t)work;
+	}
+
+	ODPH_ABORT("No work found (%s), aborting\n", param->type);
+}
+
+int work_issue(work_t work, odp_event_t ev[], int num)
+{
+	work_priv_t *priv = (work_priv_t *)work;
+
+	return priv->fn(priv->data, ev, num, &priv->stats);
+}
+
+void work_register_work(const char *name, work_init_fn_t init_fn, work_print_fn_t print_fn,
+			work_destroy_fn_t destroy_fn)
+{
+	work_entry_t *entry = calloc(1U, sizeof(*entry));
+
+	if (entry == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	entry->name = name;
+	entry->init_fn = init_fn;
+	entry->print_fn = print_fn;
+	entry->destroy_fn = destroy_fn;
+
+	if (!entries.init_done) {
+		TAILQ_INIT(&entries.w);
+		entries.init_done = true;
+	}
+
+	TAILQ_INSERT_TAIL(&entries.w, entry, w);
+}
+
+void work_print_work(work_t work, const char *queue)
+{
+	work_priv_t *priv = (work_priv_t *)work;
+
+	priv->entry->print_fn(queue, &priv->stats);
+}
+
+void work_destroy_work(work_t work)
+{
+	work_priv_t *priv = (work_priv_t *)work;
+
+	priv->entry->destroy_fn(priv->data);
+	free(priv);
+}

--- a/test/performance/pipeline/work.h
+++ b/test/performance/pipeline/work.h
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef WORK_H_
+#define WORK_H_
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+
+#include "helpers.h"
+
+typedef void *work_t;
+
+typedef struct {
+	char *queue;
+	char *type;
+	config_setting_t *param;
+} work_param_t;
+
+typedef struct {
+	uint64_t data1;
+	uint64_t data2;
+	uint64_t data3;
+	uint64_t data4;
+} work_stats_t;
+
+typedef int (*work_fn_t)(uintptr_t data, odp_event_t ev[], int num, work_stats_t *stats);
+
+typedef struct {
+	work_fn_t fn;
+	uintptr_t data;
+} work_init_t;
+
+typedef void (*work_init_fn_t)(const work_param_t *param, work_init_t *init);
+typedef void (*work_print_fn_t)(const char *queue, const work_stats_t *stats);
+typedef void (*work_destroy_fn_t)(uintptr_t data);
+
+work_t work_create_work(const work_param_t *param);
+
+int work_issue(work_t work, odp_event_t ev[], int num);
+
+void work_register_work(const char *name, work_init_fn_t init_fn, work_print_fn_t print_fn,
+			work_destroy_fn_t destroy_fn);
+
+void work_print_work(work_t work, const char *queue);
+
+void work_destroy_work(work_t work);
+
+#define WORK_AUTOREGISTER(name, init, print, destroy)		\
+	__attribute__((constructor))				\
+	static void CONCAT(autoregister, __LINE__)(void) {	\
+		work_register_work(name, init, print, destroy);	\
+	}
+
+#endif

--- a/test/performance/pipeline/work_forward.c
+++ b/test/performance/pipeline/work_forward.c
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+#include "work.h"
+
+#define CONF_STR_OUTPUT "output"
+
+#define WORK_FORWARD "forward"
+
+static int work_forward(uintptr_t data, odp_event_t ev[], int num, work_stats_t *stats)
+{
+	int ret;
+
+	ret = odp_queue_enq_multi((odp_queue_t)data, ev, num);
+	ret = ret < 0 ? 0 : ret;
+	stats->data1 += ret;
+
+	return ret;
+}
+
+static void work_forward_init(const work_param_t *param, work_init_t *init)
+{
+	const char *val_str;
+
+	if (param->param == NULL)
+		ODPH_ABORT("No parameters available\n");
+
+	if (config_setting_length(param->param) != 1)
+		ODPH_ABORT("No valid parameters available\n");
+
+	val_str = config_setting_get_string_elem(param->param, 0);
+
+	if (val_str == NULL)
+		ODPH_ABORT("No \"" CONF_STR_OUTPUT "\" found\n");
+
+	init->fn = work_forward;
+	init->data = config_parser_get(QUEUE_DOMAIN, val_str);
+}
+
+static void work_forward_print(const char *queue, const work_stats_t *stats)
+{
+	printf("\n%s:\n"
+	       "  work:             %s\n"
+	       "  events forwarded: %" PRIu64 "\n", queue, WORK_FORWARD, stats->data1);
+}
+
+static void work_forward_destroy(uintptr_t data ODP_UNUSED)
+{
+}
+
+WORK_AUTOREGISTER(WORK_FORWARD, work_forward_init, work_forward_print, work_forward_destroy)

--- a/test/performance/pipeline/work_global_forward.c
+++ b/test/performance/pipeline/work_global_forward.c
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+#include "work.h"
+
+#define CONF_STR_QS "output_queues"
+
+#define WORK_GLOBAL_FORWARD "global_forward"
+
+typedef struct {
+	uint32_t num;
+	odp_queue_t *out;
+} work_global_forward_data_t;
+
+static work_global_forward_data_t common;
+
+static int work_global_forward(uintptr_t data, odp_event_t ev[], int num, work_stats_t *stats)
+{
+	work_global_forward_data_t *priv = (work_global_forward_data_t *)data;
+	int ret;
+
+	ret = odp_queue_enq_multi((odp_queue_t)priv->out[(odp_thread_id() - 1) % priv->num], ev,
+				  num);
+	ret = ret < 0 ? 0 : ret;
+	stats->data1 += ret;
+
+	return ret;
+}
+
+static void work_global_forward_init(const work_param_t *param, work_init_t *init)
+{
+	const char *val_str;
+	config_setting_t *elem;
+	int num;
+
+	if (param->param == NULL)
+		ODPH_ABORT("No parameters available\n");
+
+	if (common.out == NULL) {
+		if (config_setting_length(param->param) != 1)
+			ODPH_ABORT("No valid parameters available\n");
+
+		elem = config_setting_get_elem(param->param, 0);
+
+		if (elem == NULL)
+			ODPH_ABORT("No \"" CONF_STR_QS "\" found\n");
+
+		num = config_setting_length(elem);
+
+		if (num == 0)
+			ODPH_ABORT("No valid \"" CONF_STR_QS "\" found\n");
+
+		common.out = calloc(1U, num * sizeof(*common.out));
+
+		if (common.out == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+
+		for (int i = 0; i < num; ++i) {
+			val_str = config_setting_get_string_elem(elem, i);
+			common.out[i] = (odp_queue_t)config_parser_get(QUEUE_DOMAIN, val_str);
+		}
+
+		common.num = num;
+	}
+
+	init->fn = work_global_forward;
+	init->data = (uintptr_t)&common;
+}
+
+static void work_global_forward_print(const char *queue, const work_stats_t *stats)
+{
+	printf("\n%s:\n"
+	       "  work:      %s\n"
+	       "  forwarded: %" PRIu64 "\n", queue, WORK_GLOBAL_FORWARD, stats->data1);
+}
+
+static void work_global_forward_destroy(uintptr_t data ODP_UNUSED)
+{
+	if (common.out == NULL)
+		return;
+
+	free(common.out);
+	common.out = NULL;
+}
+
+WORK_AUTOREGISTER(WORK_GLOBAL_FORWARD, work_global_forward_init, work_global_forward_print,
+		  work_global_forward_destroy)

--- a/test/performance/pipeline/work_packet_copy.c
+++ b/test/performance/pipeline/work_packet_copy.c
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+#include "work.h"
+
+#define CONF_STR_POOL "pool"
+
+#define WORK_PACKET_COPY "packet_copy"
+
+static int work_packet_copy(uintptr_t data, odp_event_t ev[], int num, work_stats_t *stats)
+{
+	odp_pool_t pool = (odp_pool_t)data;
+	odp_packet_t dst, src;
+
+	if (odp_unlikely(odp_event_type(ev[0]) != ODP_EVENT_PACKET))
+		return 0;
+
+	for (int i = 0; i < num; ++i) {
+		src = odp_packet_from_event(ev[i]);
+		dst = odp_packet_copy(src, pool);
+
+		if (odp_unlikely(dst == ODP_PACKET_INVALID))
+			continue;
+
+		ev[i] = odp_packet_to_event(dst);
+		odp_packet_free(src);
+		++stats->data1;
+	}
+
+	return 0;
+}
+
+static void work_packet_copy_init(const work_param_t *param, work_init_t *init)
+{
+	const char *val_str;
+
+	if (param->param == NULL)
+		ODPH_ABORT("No parameters available\n");
+
+	if (config_setting_length(param->param) != 1)
+		ODPH_ABORT("No valid parameters available\n");
+
+	val_str = config_setting_get_string_elem(param->param, 0);
+
+	if (val_str == NULL)
+		ODPH_ABORT("No \"" CONF_STR_POOL "\" found\n");
+
+	init->fn = work_packet_copy;
+	init->data = config_parser_get(POOL_DOMAIN, val_str);
+}
+
+static void work_packet_copy_print(const char *queue, const work_stats_t *stats)
+{
+	printf("\n%s:\n"
+	       "  work:   %s\n"
+	       "  copied: %" PRIu64 "\n", queue, WORK_PACKET_COPY, stats->data1);
+}
+
+static void work_packet_copy_destroy(uintptr_t data ODP_UNUSED)
+{
+}
+
+WORK_AUTOREGISTER(WORK_PACKET_COPY, work_packet_copy_init, work_packet_copy_print,
+		  work_packet_copy_destroy)

--- a/test/performance/pipeline/work_packet_source.c
+++ b/test/performance/pipeline/work_packet_source.c
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+#include "work.h"
+
+#define CONF_STR_POOL "pool"
+#define CONF_STR_LEN "len"
+
+#define WORK_PACKET_SOURCE "packet_source"
+
+typedef struct {
+	odp_pool_t pool;
+	uint32_t len;
+} work_packet_source_data_t;
+
+static int work_packet_source(uintptr_t data, odp_event_t ev[], int num, work_stats_t *stats)
+{
+	work_packet_source_data_t *priv = (work_packet_source_data_t *)data;
+	int num_allocd = odp_packet_alloc_multi(priv->pool, priv->len, (odp_packet_t *)ev, num);
+
+	num_allocd = num_allocd < 0 ? 0 : num_allocd;
+	stats->data1 += num_allocd;
+
+	return num_allocd;
+}
+
+static void work_packet_source_init(const work_param_t *param, work_init_t *init)
+{
+	work_packet_source_data_t *data = calloc(1U, sizeof(*data));
+	const char *val_str;
+	int val_i;
+
+	if (data == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (param->param == NULL)
+		ODPH_ABORT("No parameters available\n");
+
+	if (config_setting_length(param->param) != 2)
+		ODPH_ABORT("No valid parameters available\n");
+
+	val_str = config_setting_get_string_elem(param->param, 0);
+
+	if (val_str == NULL)
+		ODPH_ABORT("No \"" CONF_STR_POOL "\" found\n");
+
+	data->pool = (odp_pool_t)config_parser_get(POOL_DOMAIN, val_str);
+	val_i = config_setting_get_int_elem(param->param, 1);
+
+	if (val_i == 0)
+		ODPH_ABORT("No \"" CONF_STR_LEN "\" found\n");
+
+	data->len = val_i;
+	init->fn = work_packet_source;
+	init->data = (uintptr_t)data;
+}
+
+static void work_packet_source_print(const char *queue, const work_stats_t *stats)
+{
+	printf("\n%s:\n"
+	       "  work:         %s\n"
+	       "  packets sent: %" PRIu64 "\n", queue, WORK_PACKET_SOURCE, stats->data1);
+}
+
+static void work_packet_source_destroy(uintptr_t data)
+{
+	free((void *)data);
+}
+
+WORK_AUTOREGISTER(WORK_PACKET_SOURCE, work_packet_source_init, work_packet_source_print,
+		  work_packet_source_destroy)

--- a/test/performance/pipeline/work_sink.c
+++ b/test/performance/pipeline/work_sink.c
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#include <odp_api.h>
+
+#include "common.h"
+#include "work.h"
+
+#define WORK_SINK "sink"
+
+static int work_sink(uintptr_t data ODP_UNUSED, odp_event_t ev[], int num, work_stats_t *stats)
+{
+	odp_event_free_multi(ev, num);
+	stats->data1 += num;
+
+	return num;
+}
+
+static void work_sink_init(const work_param_t *param ODP_UNUSED, work_init_t *init)
+{
+	init->fn = work_sink;
+}
+
+static void work_sink_print(const char *queue, const work_stats_t *stats)
+{
+	printf("\n%s:\n"
+	       "  work:         %s\n"
+	       "  events freed: %" PRIu64 "\n", queue, WORK_SINK, stats->data1);
+}
+
+static void work_sink_destroy(uintptr_t data ODP_UNUSED)
+{
+}
+
+WORK_AUTOREGISTER(WORK_SINK, work_sink_init, work_sink_print, work_sink_destroy)

--- a/test/performance/pipeline/work_timeout_source.c
+++ b/test/performance/pipeline/work_timeout_source.c
@@ -1,0 +1,137 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+#include "work.h"
+
+#define CONF_STR_TIMER "timer"
+#define CONF_STR_POOL "pool"
+#define CONF_STR_TIMEOUT_NS "timeout_ns"
+
+#define WORK_TIMEOUT_SOURCE "timeout_source"
+
+typedef struct {
+	odp_timer_pool_t tmr_pool;
+	odp_pool_t tmo_pool;
+	odp_queue_t queue;
+	uint64_t timeout_ns;
+	odp_timer_t tmr;
+} work_timeout_source_data_t;
+
+static int work_timeout_source(uintptr_t data, odp_event_t ev[] ODP_UNUSED, int num ODP_UNUSED,
+			       work_stats_t *stats)
+{
+	work_timeout_source_data_t *priv = (work_timeout_source_data_t *)data;
+	odp_timeout_t tmo;
+	odp_timer_start_t start;
+	int ret;
+
+	if (priv->tmr == ODP_TIMER_INVALID) {
+		priv->tmr = odp_timer_alloc(priv->tmr_pool, priv->queue, NULL);
+
+		if (priv->tmr == ODP_TIMER_INVALID)
+			ODPH_ABORT("Error allocating timer, aborting\n");
+	}
+
+	tmo = odp_timeout_alloc(priv->tmo_pool);
+
+	if (tmo == ODP_TIMEOUT_INVALID)
+		return 0;
+
+	start.tick_type = ODP_TIMER_TICK_REL;
+	start.tick = odp_timer_ns_to_tick(priv->tmr_pool, priv->timeout_ns);
+	start.tmo_ev = odp_timeout_to_event(tmo);
+	ret = odp_timer_start(priv->tmr, &start);
+
+	if (ret == ODP_TIMER_FAIL)
+		ODPH_ABORT("Error arming timer, aborting\n");
+
+	if (ret == ODP_TIMER_TOO_NEAR) {
+		odp_timeout_free(tmo);
+		++stats->data1;
+	} else if (ret == ODP_TIMER_TOO_FAR) {
+		odp_timeout_free(tmo);
+		++stats->data2;
+	} else {
+		++stats->data3;
+	}
+
+	return 0;
+}
+
+static void work_timeout_source_init(const work_param_t *param, work_init_t *init)
+{
+	work_timeout_source_data_t *data = calloc(1U, sizeof(*data));
+	const char *val_str;
+	long long val_ll;
+
+	if (data == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (param->param == NULL)
+		ODPH_ABORT("No parameters available\n");
+
+	if (config_setting_length(param->param) != 3)
+		ODPH_ABORT("No valid parameters available\n");
+
+	val_str = config_setting_get_string_elem(param->param, 0);
+
+	if (val_str == NULL)
+		ODPH_ABORT("No \"" CONF_STR_TIMER "\" found\n");
+
+	data->tmr_pool = (odp_timer_pool_t)config_parser_get(TIMER_DOMAIN, val_str);
+	val_str = config_setting_get_string_elem(param->param, 1);
+
+	if (val_str == NULL)
+		ODPH_ABORT("No \"" CONF_STR_POOL "\" found\n");
+
+	data->tmo_pool = (odp_pool_t)config_parser_get(POOL_DOMAIN, val_str);
+	val_ll = config_setting_get_int64_elem(param->param, 2);
+
+	if (val_ll == 0)
+		ODPH_ABORT("No \"" CONF_STR_TIMEOUT_NS "\" found\n");
+
+	data->timeout_ns = val_ll;
+	init->fn = work_timeout_source;
+	data->queue = (odp_queue_t)config_parser_get(QUEUE_DOMAIN, param->queue);
+	data->tmr = ODP_TIMER_INVALID;
+	init->data = (uintptr_t)data;
+}
+
+static void work_timeout_source_print(const char *queue, const work_stats_t *stats)
+{
+	printf("\n%s:\n"
+	       "  work:           %s\n"
+	       "  timer too near: %" PRIu64 "\n"
+	       "  timer too far:  %" PRIu64 "\n"
+	       "  timer arms:     %" PRIu64 "\n", queue, WORK_TIMEOUT_SOURCE, stats->data1,
+	       stats->data2, stats->data3);
+}
+
+static void work_timeout_source_destroy(uintptr_t data)
+{
+	work_timeout_source_data_t *priv = (work_timeout_source_data_t *)data;
+	odp_event_t ev;
+	int ret;
+
+	ret = odp_timer_cancel(priv->tmr, &ev);
+
+	if (ret == ODP_TIMER_SUCCESS)
+		odp_event_free(ev);
+
+	(void)odp_timer_free(priv->tmr);
+	free(priv);
+}
+
+WORK_AUTOREGISTER(WORK_TIMEOUT_SOURCE, work_timeout_source_init, work_timeout_source_print,
+		  work_timeout_source_destroy)

--- a/test/performance/pipeline/work_wait.c
+++ b/test/performance/pipeline/work_wait.c
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+#include "work.h"
+
+#define CONF_STR_WAIT_NS "wait_ns"
+
+#define WORK_WAIT "wait"
+
+static int work_wait(uintptr_t data, odp_event_t ev[] ODP_UNUSED, int num ODP_UNUSED,
+		     work_stats_t *stats)
+{
+	odp_time_wait_ns((uint64_t)data);
+	stats->data1 = (uint64_t)data;
+
+	return 0;
+}
+
+static void work_wait_init(const work_param_t *param, work_init_t *init)
+{
+	long long val_ll;
+
+	if (param->param == NULL)
+		ODPH_ABORT("No parameters available\n");
+
+	if (config_setting_length(param->param) != 1)
+		ODPH_ABORT("No valid parameters available\n");
+
+	val_ll = config_setting_get_int64_elem(param->param, 0);
+
+	if (val_ll == -1)
+		ODPH_ABORT("No \"" CONF_STR_WAIT_NS "\" found\n");
+
+	init->fn = work_wait;
+	init->data = (uintptr_t)val_ll;
+}
+
+static void work_wait_print(const char *queue, const work_stats_t *stats)
+{
+	printf("\n%s:\n"
+	       "  work:        %s\n"
+	       "  time waited: %" PRIu64 "\n", queue, WORK_WAIT, stats->data1);
+}
+
+static void work_wait_destroy(uintptr_t data ODP_UNUSED)
+{
+}
+
+WORK_AUTOREGISTER(WORK_WAIT, work_wait_init, work_wait_print, work_wait_destroy)

--- a/test/performance/pipeline/worker.h
+++ b/test/performance/pipeline/worker.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef WORKER_H_
+#define WORKER_H_
+
+#include <stdint.h>
+
+typedef enum {
+	WT_PLAIN,
+	WT_SCHED
+} worker_type_t;
+
+typedef struct {
+	char *name;
+	char **inputs;
+	char **outputs;
+	int64_t wait_ns;
+	uint32_t num_in;
+	uint32_t num_out;
+	uint32_t burst_size;
+	worker_type_t type;
+} worker_t;
+
+#endif

--- a/test/performance/pipeline/worker_parser.c
+++ b/test/performance/pipeline/worker_parser.c
@@ -1,0 +1,278 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+#include <odp/helper/odph_api.h>
+
+#include "common.h"
+#include "config_parser.h"
+#include "worker.h"
+
+#define CONF_STR_NAME "name"
+#define CONF_STR_TYPE "type"
+#define CONF_STR_BURST_SIZE "burst_size"
+#define CONF_STR_WAIT_NS "wait_ns"
+#define CONF_STR_INPUTS "inputs"
+#define CONF_STR_OUTPUTS "outputs"
+
+#define PLAIN "plain"
+#define SCHEDULED "schedule"
+#define DEF_BURST 32U
+#define DEF_WAIT_NS_S ODP_TIME_SEC_IN_NS
+#define DEF_WAIT_NS_P 0U
+
+typedef struct {
+	worker_t *workers;
+	uint32_t num;
+} worker_parses_t;
+
+static worker_parses_t workers;
+
+static odp_bool_t parse_worker_entry(config_setting_t *cs, worker_t *worker)
+{
+	const char *val_str;
+	config_setting_t *elem;
+	int val_i, num;
+	long long val_ll;
+
+	worker->burst_size = DEF_BURST;
+
+	if (config_setting_lookup_string(cs, CONF_STR_NAME, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_NAME "\" found\n");
+		return false;
+	}
+
+	worker->name = strdup(val_str);
+
+	if (worker->name == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_TYPE, &val_str) == CONFIG_FALSE) {
+		ODPH_ERR("No \"" CONF_STR_TYPE "\" found\n");
+		return false;
+	}
+
+	if (strcmp(val_str, PLAIN) == 0) {
+		worker->type = WT_PLAIN;
+		worker->wait_ns = DEF_WAIT_NS_P;
+	} else if (strcmp(val_str, SCHEDULED) == 0) {
+		worker->type = WT_SCHED;
+		worker->wait_ns = DEF_WAIT_NS_S;
+	} else {
+		ODPH_ERR("No valid \"" CONF_STR_TYPE "\" found\n");
+		return false;
+	}
+
+	if (config_setting_lookup_int(cs, CONF_STR_BURST_SIZE, &val_i) == CONFIG_TRUE)
+		worker->burst_size = val_i;
+
+	if (config_setting_lookup_int64(cs, CONF_STR_WAIT_NS, &val_ll) == CONFIG_TRUE)
+		worker->wait_ns = val_ll;
+
+	elem = config_setting_lookup(cs, CONF_STR_OUTPUTS);
+
+	if (elem != NULL) {
+		num = config_setting_length(elem);
+
+		if (num == 0) {
+			ODPH_ERR("No valid \"" CONF_STR_OUTPUTS "\" entries found\n");
+			return false;
+		}
+
+		worker->outputs = calloc(1U, num * sizeof(*worker->outputs));
+
+		if (worker->outputs == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+
+		for (int i = 0; i < num; ++i) {
+			val_str = config_setting_get_string_elem(elem, i);
+
+			if (val_str == NULL) {
+				ODPH_ERR("Unparsable \"" CONF_STR_OUTPUTS "\" entry (%d)\n", i);
+				return false;
+			}
+
+			worker->outputs[worker->num_out] = strdup(val_str);
+
+			if (worker->outputs[worker->num_out] == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+
+			++worker->num_out;
+		}
+	}
+
+	elem = config_setting_lookup(cs, CONF_STR_INPUTS);
+
+	if (elem != NULL) {
+		num = config_setting_length(elem);
+
+		if (num == 0) {
+			ODPH_ERR("No valid \"" CONF_STR_INPUTS "\" entries found\n");
+			return false;
+		}
+
+		worker->inputs = calloc(1U, num * sizeof(*worker->inputs));
+
+		if (worker->inputs == NULL)
+			ODPH_ABORT("Error allocating memory, aborting\n");
+
+		for (int i = 0; i < num; ++i) {
+			val_str = config_setting_get_string_elem(elem, i);
+
+			if (val_str == NULL) {
+				ODPH_ERR("Unparsable \"" CONF_STR_INPUTS "\" entry (%d)\n", i);
+				return false;
+			}
+
+			worker->inputs[worker->num_in] = strdup(val_str);
+
+			if (worker->inputs[worker->num_in] == NULL)
+				ODPH_ABORT("Error allocating memory, aborting\n");
+
+			++worker->num_in;
+		}
+	}
+
+	if (worker->type == WT_PLAIN && worker->num_in == 0U && worker->num_out == 0U) {
+		ODPH_ERR("No \"" CONF_STR_INPUTS "\" or \"" CONF_STR_OUTPUTS "\" found\n");
+		return false;
+	}
+
+	return true;
+}
+
+static void free_worker_entry(worker_t *worker)
+{
+	free(worker->name);
+
+	for (uint32_t i = 0U; i < worker->num_in; ++i)
+		free(worker->inputs[i]);
+
+	free(worker->inputs);
+
+	for (uint32_t i = 0U; i < worker->num_out; ++i)
+		free(worker->outputs[i]);
+
+	free(worker->outputs);
+}
+
+static odp_bool_t worker_parser_init(config_t *config)
+{
+	config_setting_t *cs, *elem;
+	int num;
+	worker_t *worker;
+
+	cs = config_lookup(config, WORKER_DOMAIN);
+
+	if (cs == NULL)	{
+		printf("Nothing to parse for \"" WORKER_DOMAIN "\" domain\n");
+		return true;
+	}
+
+	num = config_setting_length(cs);
+
+	if (num == 0) {
+		ODPH_ERR("No valid \"" WORKER_DOMAIN "\" entries found\n");
+		return false;
+	}
+
+	workers.workers = calloc(1U, num * sizeof(*workers.workers));
+
+	if (workers.workers == NULL)
+		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	for (int i = 0; i < num; ++i) {
+		elem = config_setting_get_elem(cs, i);
+
+		if (elem == NULL) {
+			ODPH_ERR("Unparsable \"" WORKER_DOMAIN "\" entry (%d)\n", i);
+			return false;
+		}
+
+		worker = &workers.workers[workers.num];
+
+		if (!parse_worker_entry(elem, worker)) {
+			ODPH_ERR("Invalid \"" WORKER_DOMAIN "\" entry (%d)\n", i);
+			free_worker_entry(worker);
+			return false;
+		}
+
+		++workers.num;
+	}
+
+	return true;
+}
+
+static odp_bool_t worker_parser_deploy(void)
+{
+	worker_t *worker;
+
+	printf("\n*** " WORKER_DOMAIN " resources ***\n");
+
+	for (uint32_t i = 0U; i < workers.num; ++i) {
+		worker = &workers.workers[i];
+		printf("\nname: %s\n"
+		       "info:\n"
+		       "  type: %s\n", worker->name,
+		       worker->type == WT_SCHED ? "schedule" : "plain");
+
+		if (worker->inputs != NULL) {
+			printf("  inputs:\n");
+
+			for (uint32_t j = 0U; j < worker->num_in; ++j)
+				printf("    %s\n", worker->inputs[j]);
+		}
+
+		if (worker->outputs != NULL) {
+			printf("  outputs:\n");
+
+			for (uint32_t j = 0U; j < worker->num_out; ++j)
+				printf("    %s\n", worker->outputs[j]);
+		}
+	}
+
+	return true;
+}
+
+static void worker_parser_destroy(void)
+{
+	for (uint32_t i = 0U; i < workers.num; ++i)
+		free_worker_entry(&workers.workers[i]);
+
+	free(workers.workers);
+}
+
+static uintptr_t worker_parser_get_resource(const char *resource)
+{
+	worker_t *parse, *worker = NULL;
+
+	for (uint32_t i = 0U; i < workers.num; ++i) {
+		parse = &workers.workers[i];
+
+		if (strcmp(parse->name, resource) != 0)
+			continue;
+
+		worker = parse;
+		break;
+	}
+
+	if (worker == NULL)
+		ODPH_ABORT("No resource found (%s), aborting\n", resource);
+
+	return (uintptr_t)worker;
+}
+
+CONFIG_PARSER_AUTOREGISTER(LOW_PRIO, WORKER_DOMAIN, worker_parser_init, worker_parser_deploy, NULL,
+			   worker_parser_destroy, worker_parser_get_resource)


### PR DESCRIPTION
Add new `odp_pipeline` tester. Tester takes a `libconfig` compatible configuration file and based on the configuration builds an ODP application.

Configuration is quite flexible, user can define e.g. ODP worker cpu mappings, basic resources to be created, resource dependencies, input and output handling for queues, etc. Actual event handling is done in "work" objects which can be chained and attached to queue input and output handling. Currently, a few example work objects are provided, more can be easily added as required. This enables the tester to be built as e.g. a packet generator or an L2 forwarder.

Resource parsing is divided into domains which parse the passed configuration file and instantiate the configured resources. These resources can be subsequently queried in runtime to build other resources. Currently, parsers are provided for basic ODP modules (e.g. pools and queues), more can be easily added as required.

v2:
- Rebased
- Matias' comments

v3:
- Added reviewed-by tag