### PR TITLE
[PATCH v2] test: l2fwd/l2fwd_perf: increase maximum rx/tx queue count to 2048

### DIFF
--- a/test/performance/odp_l2fwd_perf.c
+++ b/test/performance/odp_l2fwd_perf.c
@@ -33,7 +33,7 @@
 #define MAC_COMMON 0x2
 
 #define MAX_IFS 8U
-#define MAX_QS 32U
+#define MAX_QS 2048U
 #define MAX_WORKERS ((uint32_t)(ODP_THREAD_COUNT_MAX - 1))
 
 enum {


### PR DESCRIPTION
Increase maximum supported input/output queue count to enable testing devices with higher core/queue counts.

V2:
- Add checks to prevent MAX_QUEUES value being exceeded in l2fwd application