### PR TITLE
[PATCH v16] api: packet: redefine packet data sharing with packet references

### DIFF
--- a/example/sysinfo/odp_sysinfo.c
+++ b/example/sysinfo/odp_sysinfo.c
@@ -641,6 +641,9 @@ static void print_pktio_capa(appl_args_t *appl_args)
 		printf("    lso.proto.tcp_ipv6:            %u\n", capa->lso.proto.tcp_ipv6);
 		printf("    lso.proto.sctp_ipv4:           %u\n", capa->lso.proto.sctp_ipv4);
 		printf("    lso.proto.sctp_ipv6:           %u\n", capa->lso.proto.sctp_ipv6);
+		printf("    packet_ref.static_ref          %u\n", capa->packet_ref.static_ref);
+		printf("    packet_ref.referenced_pkt      %u\n", capa->packet_ref.referenced_pkt);
+		printf("    packet_ref.referencing_pkt     %u\n", capa->packet_ref.referencing_pkt);
 		printf("    maxlen.equal:                  %i\n", capa->maxlen.equal);
 		printf("    maxlen.min_input:              %u B\n", capa->maxlen.min_input);
 		printf("    maxlen.max_input:              %u B\n", capa->maxlen.max_input);

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2016-2018 Linaro Limited
- * Copyright (c) 2021-2022 Nokia
+ * Copyright (c) 2021-2025 Nokia
  */
 
 /**
@@ -433,6 +433,10 @@ int odp_ipsec_out_enq(const odp_packet_t pkt[], int num,
  * otherwise identical to odp_ipsec_out_enq(), but outputs all successfully
  * transformed packets to the specified output interface (or tm_queue), instead of
  * generating events for those.
+ *
+ * Packets that reference or are referenced by other packets may be sent
+ * using this function only if the pktout to be used has the relevant
+ * capability. See odp_pktio_capability_t::packet_ref.
  *
  * Inline operation parameters are defined per packet. The array of parameters
  * must have 'num' elements and is pointed to by 'inline_param'.

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2021-2024 Nokia
+ * Copyright (c) 2021-2026 Nokia
  */
 
 /**
@@ -268,8 +268,7 @@ int odp_packet_reass_partial_state(odp_packet_t pkt, odp_packet_t frags[],
  * Packet head address
  *
  * Returns start address of the first segment. Packet level headroom starts
- * from here. Use odp_packet_data() or odp_packet_l2_ptr() to return the
- * packet data start address.
+ * from here. Use odp_packet_data() to return the packet data start address.
  *
  * @param pkt  Packet handle
  *

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -94,6 +94,13 @@ int odp_packet_alloc_multi(odp_pool_t pool, uint32_t len,
  *
  * Frees the packet into the packet pool it was allocated from.
  *
+ * A packet being referenced by other packets (see odp_packet_ref() and
+ * odp_packet_ref_static()) continues to consume pool capacity until there
+ * are no more references to it left. Referencing packets are not affected
+ * when a packet they reference is freed.
+ *
+ * The freed packet may not be used in any way after this call.
+ *
  * @param pkt           Packet handle
  */
 void odp_packet_free(odp_packet_t pkt);
@@ -270,6 +277,9 @@ int odp_packet_reass_partial_state(odp_packet_t pkt, odp_packet_t frags[],
  * Returns start address of the first segment. Packet level headroom starts
  * from here. Use odp_packet_data() to return the packet data start address.
  *
+ * This function returns an undefined value if the packet is referencing
+ * other packets.
+ *
  * @param pkt  Packet handle
  *
  * @return Pointer to the start address of the first packet segment
@@ -283,6 +293,9 @@ void *odp_packet_head(odp_packet_t pkt);
  *
  * Returns sum of buffer lengths over all packet segments. Buffer length
  * includes headroom, data, and tailroom lengths.
+ *
+ * This function returns an undefined value if the packet is referencing
+ * other packets.
  *
  * @param pkt  Packet handle
  *
@@ -366,6 +379,9 @@ uint32_t odp_packet_len(odp_packet_t pkt);
  *
  * Returns the current packet level headroom length.
  *
+ * If the packet is a referencing packet and the first data packet byte is
+ * shared with another packet, headroom is zero.
+ *
  * @param pkt  Packet handle
  *
  * @return Headroom length
@@ -376,6 +392,9 @@ uint32_t odp_packet_headroom(odp_packet_t pkt);
  * Packet tailroom length
  *
  * Returns the current packet level tailroom length.
+ *
+ * If the packet is a referencing packet and the last data packet byte is
+ * shared with another packet, tailroom is zero.
  *
  * @param pkt  Packet handle
  *
@@ -464,15 +483,19 @@ void *odp_packet_push_head(odp_packet_t pkt, uint32_t len);
  * Pull in packet head
  *
  * Decrease packet data length by removing data from the head of the packet.
- * Packet headroom is increased with the same amount. Packet head may be pulled
- * in up to seg_len - 1 bytes (i.e. packet data pointer must stay in the
- * first segment). Packet is not modified if there's not enough data.
+ * Packet head may be pulled in up to seg_len - 1 bytes (i.e. packet data
+ * pointer must stay in the first segment). Packet is not modified if there's
+ * not enough data in the first segment.
  *
  * odp_packet_xxx:
  * seg_len  -= len
  * len      -= len
- * headroom += len
  * data     += len
+ * headroom += len, if the packet is not a referencing packet
+ *
+ * If the packet is a referencing packet and the first segment shares data
+ * with another packet, headroom does not increase. Otherwise headroom
+ * increases by len bytes.
  *
  * Operation does not modify packet segmentation or move data. Handles and
  * pointers remain valid. User is responsible to update packet metadata
@@ -531,7 +554,11 @@ void *odp_packet_push_tail(odp_packet_t pkt, uint32_t len);
  * odp_packet_xxx:
  * len      -= len
  * tail     -= len
- * tailroom += len
+ * tailroom += len, if the packet is not a referencing packet
+ *
+ * If the packet is a referencing packet and the last segment shares data
+ * with another packet, tailroom does not increase. Otherwise tailroom
+ * increases by len bytes.
  *
  * Operation does not modify packet segmentation or move data. Handles and
  * pointers remain valid. User is responsible to update packet metadata
@@ -562,6 +589,9 @@ void *odp_packet_pull_tail(odp_packet_t pkt, uint32_t len);
  * user_area) were moved in memory during the operation. If some memory areas
  * were moved, application must use new packet/segment handles to update
  * data pointers. Otherwise, all old pointers remain valid.
+ *
+ * The new packet data added in the packet will always be non-shared, even
+ * when the packet is a reference that shares data with other packets.
  *
  * User is responsible to update packet metadata offsets when needed. Packet
  * is not modified if operation fails.
@@ -636,6 +666,9 @@ int odp_packet_trunc_head(odp_packet_t *pkt, uint32_t len, void **data_ptr,
  * were moved, application must use new packet/segment handles to update
  * data pointers. Otherwise, all old pointers remain valid.
  *
+ * The new packet data added in the packet will always be non-shared, even
+ * when the packet is a reference that shares data with other packets.
+ *
  * User is responsible to update packet metadata offsets when needed. Packet
  * is not modified if operation fails.
  *
@@ -706,6 +739,9 @@ int odp_packet_trunc_tail(odp_packet_t *pkt, uint32_t len, void **tail_ptr,
  * user_area) were moved in memory during the operation. If some memory areas
  * were moved, application must use new packet/segment handles to update
  * data pointers. Otherwise, all old pointers remain valid.
+ *
+ * The new packet data added in the packet will always be non-shared, even
+ * when the packet is a reference that shares data with other packets.
  *
  * User is responsible to update packet metadata offsets when needed. Packet
  * is not modified if operation fails.
@@ -908,6 +944,25 @@ uint32_t odp_packet_seg_data_len(odp_packet_t pkt, odp_packet_seg_t seg);
  * the destination packet. The source packet may have been allocated from
  * any pool.
  *
+ * 'dst' must not be a referenced packet or a static packet reference. It can
+ * be a referencing packet. 'src' may be any kind of packet. The returned
+ * packet will be either a normal packet or referencing packet depending
+ * on the input packets and implementation details as follows:
+ *
+ * If both the destination packet and the source packet are normal packets,
+ * the result packet will also be a normal packet. If the destination packet
+ * is a referencing packet, the result packet will also be a referencing packet.
+ * Otherwise the result packet is either a normal or referencing packet
+ * depending on the packets and the implementation.
+ *
+ *  dst         src             result
+ *  -------------------------------------------------
+ *  normal      normal          normal
+ *  normal      referenced      normal or referencing
+ *  normal      referencing     normal or referencing
+ *  normal      static ref      normal or referencing
+ *  referencing any             referencing
+ *
  * On failure, both handles remain valid and packets are not modified.
  *
  * @param[in, out] dst   Pointer to destination packet handle. A successful
@@ -1050,6 +1105,9 @@ odp_packet_buf_t odp_packet_buf_from_head(odp_pool_t pool, void *head);
  *
  * This call can be used only for packets of an external memory pool (see odp_pool_ext_create()).
  *
+ * This function must not be called for packets that reference other packets or
+ * are referenced by other packets.
+ *
  * @param      pkt      Packet to be disassembled
  * @param[out] pkt_buf  Packet buffer handle array for output
  * @param      num      Number of elements in packet buffer handle array. Must be equal to or
@@ -1108,6 +1166,9 @@ odp_packet_t odp_packet_reassemble(odp_pool_t pool, odp_packet_buf_t pkt_buf[], 
  * e.g., packet retransmissions. Use odp_packet_ref() or odp_packet_ref_pkt()
  * for more flexible, dynamic references.
  *
+ * This function may be called simultaneously in different threads for the
+ * same packet.
+ *
  * Packet is not modified on failure.
  *
  * @param pkt    Handle of the packet for which a static reference is
@@ -1119,65 +1180,121 @@ odp_packet_t odp_packet_reassemble(odp_pool_t pool, odp_packet_buf_t pkt_buf[], 
 odp_packet_t odp_packet_ref_static(odp_packet_t pkt);
 
 /**
- * Create a reference to a packet
+ * Create a packet that references packet data of another packet
  *
- * Returns a new (dynamic) reference to a packet starting the shared part of
- * the data at a specified byte offset. Metadata and data before the offset
- * are not shared with other references of the packet. The rest of the data is
- * shared and must be treated as read only. Initially the returned reference
- * has metadata initialized to default values and does not contain unshared
- * data.  Packet (head) manipulation functions may be used normally to, e.g.,
- * add a unique header onto the shared payload. The shared part of the packet
- * may be modified again when there is a single reference left. Static and
- * dynamic references must not be mixed. Results are undefined if these
- * restrictions are not observed.
+ * Returns a packet that shares packet data with the given packet. 'pkt'
+ * becomes a 'referenced packet' and the returned packet will be a
+ * 'referencing packet'. The referencing packet is allocated from the
+ * same pool as the referenced packet.
  *
- * The packet handle 'pkt' may itself be a (dynamic) reference to a packet.
+ * The packet passed to this function must not be a referencing packet or
+ * a static reference (see odp_packet_ref_static()). It can already be
+ * a referenced packet.
  *
- * If the caller does not intend to modify either the packet or the new
- * reference to it, odp_packet_ref_static() may be used to create
- * a static reference that is more optimized for that use case.
+ * Packet metadata is not shared. The new packet has its metadata initialized
+ * to the default values.
  *
- * Packet is not modified on failure.
+ * Shared packet data starts at the given offset of the referenced packet
+ * and continues to the end of the referenced packet. The referencing packet
+ * may also contain private, non-shared packet data after it has been modified
+ * using packet manipulation operation such as push and extend (see below).
+ * The referencing packet may also be modified to not actually contain any
+ * packet data of the referenced packet.
  *
- * @param pkt    Handle of the packet for which a reference is to be
- *               created.
+ * Packet data and data layout of the referenced packet must not be modified
+ * as long as any packet that references the packet exists. In particular,
+ * a referenced packet must not be passed to odp_packet_{push,pull,extend,
+ * trunc}_{head,tail}(), odp_packet_split(), or as the destination packet to
+ * odp_packet_concat() or to any other ODP API function that could modify
+ * packet data or packet data layout.
  *
- * @param offset Byte offset in the packet at which the shared part is to
- *               begin. This must be in the range 0 ... odp_packet_len(pkt)-1.
+ * odp_packet_has_ref() returns 1 for the referenced packet as long as it is
+ * being referenced by other packets and 0 for the newly created referencing
+ * packet. odp_packet_is_referencing() returns 1 for the created referencing
+ * packet.
  *
- * @return New reference to the packet
+ * The referenced and referencing packets can be freed in any order.
+ * ODP ensures that the packets or packet segments backing the shared packet
+ * data is put back to the packet pool only after there are no references left.
+ * See odp_packet_free().
+ *
+ * Packet data and packet data layout of the returned packet can be modified
+ * as long as the packet data bytes that are shared are not written to. Such
+ * packet manipulation operations do not affect the referenced packet or its
+ * layout.
+ *
+ * Packet data layout manipulation functions can be used for the returned
+ * packet (but not for the referenced packet) as follows:
+ *
+ * - odp_packet_{pull,trunc}_{head,tail}() functions can be used normally.
+ *   Pulling and truncation can include shared packet data, in which case
+ *   the shared packet data area shrinks. It is possible to pull or truncate
+ *   the packet so much that it no longer shares any packet data, but that
+ *   does not stop the referencing relationship between the packets and
+ *   the restrictions that apply to the referencing and referenced packet
+ *   still hold.
+ *
+ * - odp_packet_{push,extend}_{head,tail}() functions can be used normally.
+ *   The new packet data created by the functions is always private, even if
+ *   extending after truncating or pulling shared data. Because of this,
+ *   odp_packet_headroom() and odp_packet_tailroom() return 0 for the newly
+ *   created packet even if the referenced packet has headroom or tailroom.
+ *
+ * - odp_packet_concat() can be used normally but concatenating packet data
+ *   to a destination packet that shares data with another packet may require
+ *   packet data copying if also the source packet shares data with another
+ *   packet. This is because, depending on the implementation, a packet may
+ *   be able to reference only one other packet.
+ *
+ * Packets returned by this function can be used normally in ODP API functions
+ * unless otherwise noted. There are restrictions in packet output.
+ *
+ * Referenced packets can be used in ODP API functions that treat packet data
+ * and layout as read-only. Referenced packets can be used in ODP API functions
+ * that consume packets, unless otherwise noted. Consuming a packet behaves
+ * the same way as freeing a packet with respect to shared packet data.
+ *
+ * This function may be called simultaneously in different threads for the
+ * same packet.
+ *
+ * @param pkt      Handle of the packet to which a reference is to be created.
+ *
+ * @param offset   Byte offset in 'pkt' at which the shared part is to
+ *                 begin. This must be in the range 0 ... odp_packet_len(pkt)-1.
+ *
+ * @return Handle of the newly created referencing packet
  * @retval ODP_PACKET_INVALID On failure
  */
 odp_packet_t odp_packet_ref(odp_packet_t pkt, uint32_t offset);
 
 /**
- * Create a reference to a packet with a header packet
+ * Create a packet with a header and shared data
  *
- * This operation is otherwise identical to odp_packet_ref(), but it prepends
- * a supplied 'hdr' packet as the head of the new reference. The resulting
- * packet consists metadata and data of the 'hdr' packet, followed by the
- * shared part of packet 'pkt'.
+ * This operation is identical to ref = odp_packet_ref(pkt, offset) followed
+ * by odp_packet_concat(&hdr, ref). The same rules and restrictions apply to
+ * this combined operation as to those operations. The resulting packet
+ * consists of metadata and packet data of 'hdr' as unshared data, followed
+ * by the packet data shared with 'pkt'.
  *
- * The packet handle ('pkt') may itself be a (dynamic) reference to a packet,
- * but the header packet handle ('hdr') must be unique. Both packets must be
- * have been allocated from the same pool and the handles must not refer to
- * the same packet. Results are undefined if these restrictions are not
- * observed.
+ * 'pkt' must not be a static reference or a referencing packet but it
+ * may be a referenced packet. 'hdr' must not be a static reference or a
+ * referenced packet. 'pkt' and 'hdr' must not be the same packet.
+ *
+ * This function may be called simultaneously in different threads with the
+ * same 'pkt' but not with the same 'hdr'.
  *
  * Packets are not modified on failure. The header packet 'hdr' is consumed
- * on success.
+ * and 'pkt' becomes a referenced packet on success.
  *
- * @param pkt    Handle of the packet for which a reference is to be
+ * @param pkt    Handle of the packet to which a reference is to be
  *               created.
  *
  * @param offset Byte offset in 'pkt' at which the shared part is to
  *               begin. Must be in the range 0 ... odp_packet_len(pkt)-1.
  *
- * @param hdr    Handle of the header packet to be prefixed onto the new
- *               reference. Must be a unique reference.
+ * @param hdr    Handle of the header packet to be prefixed
  *
- * @return New reference the reference packet
+ * @return Handle of the newly created referencing packet
  * @retval ODP_PACKET_INVALID On failure
  */
 odp_packet_t odp_packet_ref_pkt(odp_packet_t pkt, uint32_t offset,
@@ -1187,16 +1304,20 @@ odp_packet_t odp_packet_ref_pkt(odp_packet_t pkt, uint32_t offset,
  * Test if packet has multiple references
  *
  * A packet that has multiple references share data with other packets. In case
- * of a static reference it also shares metadata. Shared parts must be treated
- * as read only.
+ * of a static reference it also shares metadata. Packet data and data layout
+ * of packets that have references must be treated as read only.
  *
- * New references are created with odp_packet_ref_static(), odp_packet_ref() and
- * odp_packet_ref_pkt() calls. The intent of multiple references is to avoid
- * packet copies, however some implementations may do a packet copy for some of
- * the calls. If a copy is done, the new reference is actually a new, unique
- * packet and this function returns '0' for it. When a real reference is
- * created (instead of a copy), this function returns '1' for both packets
- * (the original packet and the new reference).
+ * Packets created through odp_packet_ref() or odp_packet_ref_pkt() share data
+ * with other packets but they are not referenced by other packets. This
+ * function returns 0 for such packets and 1 for packet referenced by those
+ * packets.
+ *
+ * Static packet references are created using odp_packet_ref_static(). Static
+ * packet references reference the original packet and vice versa, so this
+ * function returns 1 for the original packet and all static references to
+ * it as long as more than one such static packet reference exists.
+ *
+ * See also odp_packet_is_referencing().
  *
  * @param pkt Packet handle
  *
@@ -1204,6 +1325,20 @@ odp_packet_t odp_packet_ref_pkt(odp_packet_t pkt, uint32_t offset,
  * @retval 1  Packet has multiple references
  */
 int odp_packet_has_ref(odp_packet_t pkt);
+
+/**
+ * Test if a packet is a referencing packet
+ *
+ * Return 1 if the packet references another packet but is not a static
+ * reference, 0 otherwise.
+ * See odp_packet_has_ref(), odp_packet_ref(), odp_packet_ref_static()
+ *
+ * @param pkt Packet handle
+ *
+ * @retval 0  The packet is a normal packet, a referenced packet or a static packet reference
+ * @retval 1  The packet is a referencing packet
+ */
+int odp_packet_is_referencing(odp_packet_t pkt);
 
 /*
  *
@@ -1216,8 +1351,9 @@ int odp_packet_has_ref(odp_packet_t pkt);
  * Full copy of a packet
  *
  * Create a new copy of the packet. The new packet is exact copy of the source
- * packet (incl. data and metadata). The pool must have been created with
- * ODP_POOL_PACKET type.
+ * packet (incl. data and metadata). The new packet is always a normal packet,
+ * even if the source packet is a referencing packet. The pool must have been
+ * created with ODP_POOL_PACKET type.
  *
  * @param pkt   Packet handle
  * @param pool  Packet pool for allocation of the new packet.
@@ -2158,8 +2294,7 @@ int odp_packet_has_tx_compl_request(odp_packet_t pkt);
  * (odp_pktio_capability_t.free_ctrl) for the option support. When an interface does not support
  * the option, it ignores the value.
  *
- * The option must not be enabled on packets that have multiple references. The default value is
- * #ODP_PACKET_FREE_CTRL_DISABLED.
+ * The default value is #ODP_PACKET_FREE_CTRL_DISABLED.
  *
  * @param pkt   Packet handle
  * @param ctrl  Packet free control option value

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2020-2025 Nokia
+ * Copyright (c) 2020-2026 Nokia
  */
 
 /**
@@ -264,6 +264,10 @@ int odp_pktin_queue(odp_pktio_t pktio, odp_pktin_queue_t queues[], int num);
  * odp_queue_enq_multi(). Behaviour is undefined if other events than packets
  * are enqueued. Application cannot dequeue from these queues.
  *
+ * Static references, referencing and referenced packets may be sent without
+ * the dont_free option only if the relevant packet_ref capability is set
+ * (see odp_pktio_capability_t::packet_ref and odp_packet_free_ctrl_set()).
+ *
  * @param      pktio    Packet IO handle
  * @param[out] queues   Points to an array of queue handles for output
  * @param      num      Maximum number of queue handles to output
@@ -468,6 +472,10 @@ uint64_t odp_pktin_wait_time(uint64_t nsec);
  * specified e.g. for protocol offload purposes. Link protocol specific frame
  * checksum and padding are added to frames before transmission.
  *
+ * Static references, referencing and referenced packets may be sent without
+ * the dont_free option only if the relevant packet_ref capability is set
+ * (see odp_pktio_capability_t::packet_ref and odp_packet_free_ctrl_set()).
+ *
  * @param queue        Packet output queue handle for sending packets
  * @param packets[]    Array of packets to send
  * @param num          Number of packets to send
@@ -542,6 +550,10 @@ int odp_lso_profile_destroy(odp_lso_profile_t lso_profile);
  * odp_pktout_send() should be more optimal for those than this function.
  *
  * Check LSO support level from packet IO capabilities (odp_pktio_capability_t).
+ *
+ * Static references, referencing and referenced packets may be sent without
+ * the dont_free option only if the relevant packet_ref capability is set
+ * (see odp_pktio_capability_t::packet_ref and odp_packet_free_ctrl_set()).
  *
  * @param queue     Packet output queue handle
  * @param packet[]  Array of packets to be LSO processed and sent

--- a/include/odp/api/spec/packet_io_types.h
+++ b/include/odp/api/spec/packet_io_types.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2020-2025 Nokia
+ * Copyright (c) 2020-2026 Nokia
  */
 
 /**
@@ -519,9 +519,16 @@ typedef union odp_pktout_config_opt_t {
 		/** Packet references not used on packet output
 		 *
 		 * When set, application indicates that it will not transmit
-		 * packet references on this packet IO interface.
-		 * Since every ODP implementation supports it, it is always
-		 * ok to set this flag.
+		 * static packet references, referenced or referencing packets
+		 * on this packet IO interface.
+		 *
+		 * Even if this flag is set to zero, packets which can share
+		 * data may not be sent unless the relevant packet I/O
+		 * capability is set or the packet I/O supports the dont_free
+		 * option and the option is set for the packet being sent.
+		 * See odp_pktio_capability_t::packet_ref
+		 * See odp_pktio_capability_t::free_ctrl
+		 * See odp_packet_free_ctrl_set()
 		 *
 		 * 0: Packet references may be transmitted on the
 		 *    interface (the default value).
@@ -1062,6 +1069,15 @@ typedef struct odp_pktio_capability_t {
 
 	/** LSO capabilities */
 	odp_lso_capability_t lso;
+
+	/** Supported packet reference types
+	 *
+	 *  Types of packet references and referenced packets that can be
+	 *  consumed by the pktio. If a bit is not set for a packet type,
+	 *  then packets of that type may be sent only if the pktout supports
+	 *  the 'dont_free' option and the option is set for the packet.
+	 */
+	odp_packet_ref_types_t packet_ref;
 
 	/** Supported frame lengths for odp_pktio_maxlen_set()
 	 *

--- a/include/odp/api/spec/packet_types.h
+++ b/include/odp/api/spec/packet_types.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2021-2023 Nokia
+ * Copyright (c) 2021-2026 Nokia
  */
 
 /**
@@ -247,6 +247,21 @@ typedef enum odp_proto_layer_t {
 	ODP_PROTO_LAYER_ALL
 
 } odp_proto_layer_t;
+
+/**
+ * Set of packet types that involve packet references. Used in various capabilities.
+ */
+typedef struct odp_packet_ref_types_t {
+	/** Static reference */
+	uint8_t static_ref :1;
+
+	/** Referencing packet, created using odp_packet_ref() */
+	uint8_t referencing_pkt :1;
+
+	/** A packet referenced by another packet (excluding static references) */
+	uint8_t referenced_pkt :1;
+
+} odp_packet_ref_types_t;
 
 /**
  * Packet API data range specifier

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2015-2018 Linaro Limited
- * Copyright (c) 2021-2022 Nokia
+ * Copyright (c) 2021-2026 Nokia
  * Copyright (c) 2022-2025 Marvell
  */
 
@@ -609,6 +609,16 @@ typedef struct {
 	 * The value can vary between 0 and ODP_TM_MAX_PRIORITIES.
 	 */
 	uint8_t max_schedulers_per_node;
+
+	/** Supported packet reference types
+	 *
+	 *  Types of packet references and referenced packets that can be
+	 *  enqueued to TM. If a bit is not set for a packet type, then
+	 *  packets of that type must not be enqueued to TM. Normal packets
+	 *  can always be enqueued.
+	 */
+	odp_packet_ref_types_t packet_ref;
+
 } odp_tm_capabilities_t;
 
 /** Per Level Requirements
@@ -2023,6 +2033,10 @@ int odp_tm_queue_disconnect(odp_tm_queue_t tm_queue);
  *
  * The pkt_color bits are a result of some earlier Metering/Marking/Policing
  * processing.
+ *
+ * Sending packets that reference or are referenced by other packets may
+ * only be sent if the relevant TM capabilities are set.
+ * See odp_tm_capabilities_t::packet_ref.
  *
  * @param tm_queue  Specifies the tm_queue (and indirectly the TM system).
  * @param pkt       Handle to a packet.

--- a/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
+++ b/platform/linux-generic/arch/aarch64/odp_crypto_armv8.c
@@ -779,7 +779,8 @@ int crypto_int(odp_packet_t pkt_in,
 	odp_crypto_generic_session_t *session;
 	odp_packet_t out_pkt;
 
-	if (odp_unlikely(odp_packet_has_ref(pkt_in)))
+	if (odp_unlikely(odp_packet_is_referencing(pkt_in) ||
+			 odp_packet_has_ref(pkt_in)))
 		if (odp_unlikely(_odp_packet_unshare(&pkt_in)))
 			return -1;
 	out_pkt = pkt_in;

--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -117,9 +117,14 @@ typedef union {
 	uint32_t all_flags;
 
 	struct {
-		uint32_t reserved1:      4;
+		uint32_t reserved1:      3;
 
 	/*
+	 * Sharing flags
+	 */
+		uint32_t is_ref:         1; /* packet references other packets */
+
+		/*
 	 * Init flags
 	 */
 		uint32_t user_ptr_set:   1; /* User has set a non-NULL value */
@@ -155,8 +160,8 @@ typedef union {
 
 	/* Flag groups */
 	struct {
-		uint32_t reserved2:      4;
-		uint32_t other:         21; /* All other flags */
+		uint32_t reserved2:      3;
+		uint32_t other:         22; /* All other flags */
 		uint32_t error:          7; /* All error flags */
 	} all;
 

--- a/platform/linux-generic/include/odp_classification_datamodel.h
+++ b/platform/linux-generic/include/odp_classification_datamodel.h
@@ -46,7 +46,9 @@ extern "C" {
 #define CLS_QUEUE_GROUP_MAX		(CLS_COS_MAX_ENTRY * CLS_COS_QUEUE_MAX)
 
 /* CoS index is stored in odp_packet_hdr_t */
-ODP_STATIC_ASSERT(CLS_COS_MAX_ENTRY <= UINT16_MAX, "CoS_does_not_fit_16_bits");
+ODP_STATIC_ASSERT(CLS_COS_MAX_ENTRY <= UINT8_MAX, "cos field in packet header is too small");
+ODP_STATIC_ASSERT(sizeof(((odp_packet_hdr_t *)0)->cos) == sizeof(uint8_t),
+		  "Unexpected cos field size in packet header");
 
 typedef union {
 	/* All proto fields */

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -105,8 +105,10 @@ typedef struct ODP_ALIGNED_CACHE odp_packet_hdr_t {
 
 	uint16_t tailroom;
 
+	uint8_t unused_padding;
+
 	/* Classifier handle index */
-	uint16_t cos;
+	uint8_t cos;
 
 	/* Used as classifier destination queue, in IPsec inline input processing and as Tx
 	 * completion event queue. */

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -105,7 +105,8 @@ typedef struct ODP_ALIGNED_CACHE odp_packet_hdr_t {
 
 	uint16_t tailroom;
 
-	uint8_t unused_padding;
+	/* 1 if segment is indirect, 0 otherwise */
+	uint8_t seg_indirect;
 
 	/* Classifier handle index */
 	uint8_t cos;
@@ -127,6 +128,9 @@ typedef struct ODP_ALIGNED_CACHE odp_packet_hdr_t {
 	const void *user_ptr;
 
 	/* --- 64-byte cache line boundary --- */
+
+	/* Segment that is referenced by this segment if this is an indirect segment */
+	struct odp_packet_hdr_t *seg_referenced;
 
 	/* Timestamp value */
 	odp_time_t timestamp;
@@ -321,6 +325,8 @@ static inline void _odp_packet_copy_md(odp_packet_hdr_t *dst_hdr,
 	 *   .seg_next
 	 *   .seg_len
 	 *   .seg_count
+	 *   .seg_indirect
+	 *   .seg_referenced
 	 */
 	dst_hdr->input = src_hdr->input;
 	dst_hdr->event_hdr.subtype = subtype;
@@ -402,7 +408,9 @@ static inline void push_head(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 
 static inline void pull_head(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 {
-	pkt_hdr->headroom  += len;
+	if (odp_likely(!pkt_hdr->seg_indirect))
+		pkt_hdr->headroom += len;
+
 	pkt_hdr->frame_len -= len;
 	pkt_hdr->seg_data  += len;
 	pkt_hdr->seg_len   -= len;
@@ -412,7 +420,9 @@ static inline void pull_tail(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 {
 	odp_packet_hdr_t *last = packet_last_seg(pkt_hdr);
 
-	pkt_hdr->tailroom  += len;
+	if (odp_likely(!last->seg_indirect))
+		pkt_hdr->tailroom += len;
+
 	pkt_hdr->frame_len -= len;
 	last->seg_len      -= len;
 }

--- a/platform/linux-generic/odp_crypto_ipsecmb.c
+++ b/platform/linux-generic/odp_crypto_ipsecmb.c
@@ -770,7 +770,8 @@ int crypto_int(odp_packet_t pkt_in,
 	odp_packet_t out_pkt;
 	odp_crypto_packet_result_t *op_result;
 
-	if (odp_unlikely(odp_packet_has_ref(pkt_in)))
+	if (odp_unlikely(odp_packet_is_referencing(pkt_in) ||
+			 odp_packet_has_ref(pkt_in)))
 		if (odp_unlikely(_odp_packet_unshare(&pkt_in)))
 			return -1;
 	out_pkt = pkt_in;

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -2553,7 +2553,8 @@ int crypto_int(odp_packet_t pkt_in,
 	odp_packet_t out_pkt;
 	odp_crypto_packet_result_t *op_result;
 
-	if (odp_unlikely(odp_packet_has_ref(pkt_in)))
+	if (odp_unlikely(odp_packet_is_referencing(pkt_in) ||
+			 odp_packet_has_ref(pkt_in)))
 		if (odp_unlikely(_odp_packet_unshare(&pkt_in)))
 			return -1;
 	out_pkt = pkt_in;

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -2260,7 +2260,8 @@ static void ipsec_in_prepare(const odp_packet_t pkt_in[], odp_packet_t pkt_out[]
 		odp_packet_t *pkt = &pkt_out[i];
 		odp_crypto_packet_op_param_t c_p;
 
-		if (odp_unlikely(odp_packet_has_ref(*pkt)))
+		if (odp_unlikely(odp_packet_is_referencing(*pkt) ||
+				 odp_packet_has_ref(*pkt)))
 			if (odp_unlikely(_odp_packet_unshare(pkt))) {
 				*num_in = i;
 				return;
@@ -2441,7 +2442,8 @@ static void ipsec_out_prepare(const odp_packet_t pkt_in[], odp_packet_t pkt_out[
 		odp_packet_t *pkt = &pkt_out[i];
 		odp_crypto_packet_op_param_t c_p;
 
-		if (odp_unlikely(odp_packet_has_ref(*pkt)))
+		if (odp_unlikely(odp_packet_is_referencing(*pkt) ||
+				 odp_packet_has_ref(*pkt)))
 			if (odp_unlikely(_odp_packet_unshare(pkt))) {
 				*num_in = i;
 				return;

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -73,6 +73,8 @@ const _odp_packet_inline_offset_t _odp_packet_inline ODP_ALIGNED_CACHE = {
 
 #include <odp/visibility_end.h>
 
+static inline void free_referenced_seg(odp_packet_hdr_t *hdr);
+
 static inline odp_packet_hdr_t *packet_seg_to_hdr(odp_packet_seg_t seg)
 {
 	return (odp_packet_hdr_t *)(uintptr_t)seg;
@@ -131,6 +133,9 @@ static inline uint32_t seg_headroom(odp_packet_hdr_t *pkt_seg)
 	uint8_t *base = hdr->base_data;
 	uint8_t *head = pkt_seg->seg_data;
 
+	if (odp_unlikely(pkt_seg->seg_indirect))
+		return 0;
+
 	return pool->headroom + (head - base);
 }
 
@@ -138,6 +143,9 @@ static inline uint32_t seg_tailroom(odp_packet_hdr_t *pkt_seg)
 {
 	_odp_event_hdr_t *hdr = &pkt_seg->event_hdr;
 	uint8_t *tail         = pkt_seg->seg_data + pkt_seg->seg_len;
+
+	if (odp_unlikely(pkt_seg->seg_indirect))
+		return 0;
 
 	return hdr->buf_end - tail;
 }
@@ -268,6 +276,7 @@ static inline void link_segments(odp_packet_hdr_t *pkt_hdr[], int num)
 		hdr = pkt_hdr[cur];
 		hdr->seg_data = event_hdr->base_data;
 		hdr->seg_len  = seg_len;
+		hdr->seg_indirect = 0;
 
 		/* init_segments() handles first seg ref_cnt init */
 		if (ODP_DEBUG == 1 && cur > 0) {
@@ -305,6 +314,7 @@ static inline void init_segments(odp_packet_hdr_t *pkt_hdr[], int num)
 	hdr->seg_data = hdr->event_hdr.base_data;
 	hdr->seg_len  = seg_len;
 	hdr->seg_next = NULL;
+	hdr->seg_indirect = 0;
 
 	hdr->seg_count = num;
 
@@ -326,6 +336,10 @@ static inline void reset_segments(odp_packet_hdr_t *pkt_hdr)
 	uint32_t seg_len = _odp_pool_entry(pkt_hdr->event_hdr.pool)->seg_len;
 
 	while (pkt_hdr != NULL) {
+		if (pkt_hdr->seg_indirect) {
+			free_referenced_seg(pkt_hdr);
+			pkt_hdr->seg_indirect = 0;
+		}
 		base = pkt_hdr->event_hdr.base_data;
 
 		pkt_hdr->seg_len  = seg_len;
@@ -458,12 +472,25 @@ static inline int is_multi_ref(uint32_t ref_cnt)
 	return (ref_cnt > 1);
 }
 
+static inline void free_referenced_seg(odp_packet_hdr_t *hdr)
+{
+	odp_packet_hdr_t *referenced = hdr->seg_referenced;
+	uint32_t ref_cnt;
+
+	ref_cnt = segment_ref_dec(referenced);
+	if (!is_multi_ref(ref_cnt))
+		_odp_event_free(_odp_event_from_hdr(&referenced->event_hdr));
+}
+
 static inline int skip_references(odp_packet_hdr_t *hdr[], int num)
 {
 	uint32_t ref_cnt;
 	int num_ref = 0;
 
 	for (int i = 0; i < num; i++) {
+		if (hdr[i]->seg_indirect)
+			free_referenced_seg(hdr[i]);
+
 		/* Zero when reference API has not been used */
 		ref_cnt = segment_ref(hdr[i]);
 
@@ -793,9 +820,14 @@ int odp_packet_reset(odp_packet_t pkt, uint32_t len)
 
 void odp_packet_reset_meta(odp_packet_t pkt)
 {
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
+	uint8_t is_ref;
+
 	_ODP_ASSERT(pkt != ODP_PACKET_INVALID);
 
-	_odp_packet_reset_md(packet_hdr(pkt));
+	is_ref = pkt_hdr->p.flags.is_ref;
+	_odp_packet_reset_md(pkt_hdr);
+	 pkt_hdr->p.flags.is_ref = is_ref;
 }
 
 int odp_event_filter_packet(const odp_event_t event[],
@@ -845,6 +877,8 @@ void *odp_packet_push_head(odp_packet_t pkt, uint32_t len)
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
+	_ODP_ASSERT(odp_packet_has_ref(pkt) == 0);
+
 	if (odp_unlikely(len > pkt_hdr->headroom))
 		return NULL;
 
@@ -857,6 +891,8 @@ int odp_packet_extend_head(odp_packet_t *pkt, uint32_t len,
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(*pkt);
 	const uint32_t headroom  = pkt_hdr->headroom;
+
+	_ODP_ASSERT(odp_packet_has_ref(*pkt) == 0);
 
 	if (len > headroom) {
 		pool_t *pool = _odp_pool_entry(pkt_hdr->event_hdr.pool);
@@ -898,6 +934,8 @@ void *odp_packet_pull_head(odp_packet_t pkt, uint32_t len)
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
+	_ODP_ASSERT(odp_packet_has_ref(pkt) == 0);
+
 	if (odp_unlikely(len >= pkt_hdr->seg_len))
 		return NULL;
 
@@ -910,6 +948,8 @@ int odp_packet_trunc_head(odp_packet_t *pkt, uint32_t len,
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(*pkt);
 	uint32_t seg_len = packet_first_seg_len(pkt_hdr);
+
+	_ODP_ASSERT(odp_packet_has_ref(*pkt) == 0);
 
 	if (odp_unlikely(len >= pkt_hdr->frame_len))
 		return -1;
@@ -1169,6 +1209,55 @@ int odp_packet_rem_data(odp_packet_t *pkt_ptr, uint32_t offset, uint32_t len)
 	return 1;
 }
 
+/*
+ * Align a referencing packet by simply copying it. This assumes that the
+ * aligned range fits in the first segment of the newly allocated packet.
+ */
+static int packet_align_dyn_ref(odp_packet_t *pkt, uint32_t offset,
+				uint32_t len, uint32_t align)
+{
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(*pkt);
+	odp_pool_t pool = pkt_hdr->event_hdr.pool;
+	uint32_t pkt_len = pkt_hdr->frame_len;
+	odp_packet_t new_pkt;
+	odp_packet_hdr_t *new_pkt_hdr;
+	uintptr_t new_addr, misalign;
+	uint32_t shift = 0;
+	int rc;
+
+	new_pkt = odp_packet_alloc(pool, pkt_len + align);
+	if (new_pkt == ODP_PACKET_INVALID)
+		return -1;
+
+	new_pkt_hdr = packet_hdr(new_pkt);
+	new_addr = (uintptr_t)new_pkt_hdr->seg_data + offset;
+	misalign = align == 0 ? 0 : new_addr & (align - 1);
+	if (misalign)
+		shift = align - misalign;
+	if (shift + offset + len > new_pkt_hdr->seg_len) {
+		odp_packet_free(new_pkt);
+		return -1;
+	}
+
+	if (odp_packet_pull_head(new_pkt, shift) == NULL ||
+	    odp_packet_trunc_tail(&new_pkt, align - shift, NULL, NULL) != 0) {
+		odp_packet_free(new_pkt);
+		return -1;
+	}
+
+	rc = odp_packet_copy_from_pkt(new_pkt, 0, *pkt, 0, pkt_len);
+	if (rc < 0) {
+		odp_packet_free(new_pkt);
+		return -1;
+	}
+
+	_odp_packet_copy_md(packet_hdr(new_pkt), pkt_hdr, 0);
+	packet_hdr(new_pkt)->p.flags.is_ref = 0;
+	odp_packet_free(*pkt);
+	*pkt = new_pkt;
+	return 1;
+}
+
 int odp_packet_align(odp_packet_t *pkt, uint32_t offset, uint32_t len,
 		     uint32_t align)
 {
@@ -1203,6 +1292,15 @@ int odp_packet_align(odp_packet_t *pkt, uint32_t offset, uint32_t len,
 			shift += align - misalign;
 	}
 
+	if (odp_packet_is_referencing(*pkt)) {
+		/*
+		 * We cannot move the whole packet data as the packet most
+		 * likely has indirect segments and the data of such segments
+		 * is read-only. So we will do something different.
+		 */
+		return packet_align_dyn_ref(pkt, offset, len, align);
+	}
+
 	rc = odp_packet_extend_head(pkt, shift, NULL, NULL);
 	if (rc < 0)
 		return rc;
@@ -1213,6 +1311,8 @@ int odp_packet_align(odp_packet_t *pkt, uint32_t offset, uint32_t len,
 	(void)odp_packet_trunc_tail(pkt, shift, NULL, NULL);
 	return 1;
 }
+
+static odp_packet_t packet_ref(odp_packet_t pkt);
 
 int odp_packet_concat(odp_packet_t *dst, odp_packet_t src)
 {
@@ -1248,10 +1348,21 @@ int odp_packet_concat(odp_packet_t *dst, odp_packet_t src)
 			 PKT_MAX_SEGS))
 		return -1;
 
+	if (odp_packet_has_ref(src)) {
+		odp_packet_t ref;
+
+		ref = packet_ref(src);
+		if (odp_unlikely(ref == ODP_PACKET_INVALID))
+			return -1;
+		src_hdr = packet_hdr(ref);
+		odp_packet_free(src);
+	}
+
 	add_all_segs(dst_hdr, src_hdr);
 
 	dst_hdr->frame_len = dst_len + src_len;
 	dst_hdr->tailroom  = src_hdr->tailroom;
+	dst_hdr->p.flags.is_ref |= src_hdr->p.flags.is_ref;
 
 	/* Data was not moved in memory */
 	return 0;
@@ -1305,6 +1416,7 @@ odp_packet_t odp_packet_copy(odp_packet_t pkt, odp_pool_t pool)
 	}
 
 	_odp_packet_copy_md(packet_hdr(newpkt), srchdr, 1);
+	packet_hdr(newpkt)->p.flags.is_ref = 0;
 
 	return newpkt;
 }
@@ -1528,6 +1640,10 @@ void odp_packet_print(odp_packet_t pkt)
 	len += _odp_snprint(&str[len], n - len,
 			    "  tailroom       %" PRIu32 "\n", odp_packet_tailroom(pkt));
 	len += _odp_snprint(&str[len], n - len,
+			    "  referencing    %" PRIu32 "\n", odp_packet_is_referencing(pkt));
+	len += _odp_snprint(&str[len], n - len,
+			    "  referenced     %" PRIu32 "\n", odp_packet_has_ref(pkt));
+	len += _odp_snprint(&str[len], n - len,
 			    "  num_segs       %i\n", odp_packet_num_segs(pkt));
 
 	seg = odp_packet_first_seg(pkt);
@@ -1538,9 +1654,20 @@ void odp_packet_print(odp_packet_t pkt)
 		int str_len;
 
 		str_len = _odp_snprint(&seg_str[0], max_len,
-				       "    [%d] seg_len %-4" PRIu32 "  seg_data %p  ref_cnt %u\n",
+				       "    [%d] seg_len %-6" PRIu32 "  seg_data %p  ref_cnt %u\n",
 				       seg_idx, odp_packet_seg_data_len(pkt, seg),
 				       odp_packet_seg_data(pkt, seg), segment_ref(seg_hdr));
+
+		if (seg_hdr->seg_indirect) {
+			odp_packet_hdr_t *ref_seg = seg_hdr->seg_referenced;
+
+			str_len += _odp_snprint(&seg_str[str_len], max_len - str_len,
+						"        referenced seg: seg_data %p "
+						" ref_cnt %-2u seg_len %" PRIu32 "\n",
+						ref_seg->seg_data,
+						segment_ref(ref_seg),
+						ref_seg->seg_len);
+		}
 
 		/* Prevent print buffer overflow */
 		if (n - len - str_len < 10) {
@@ -2149,27 +2276,73 @@ odp_packet_t odp_packet_ref_static(odp_packet_t pkt)
 	return pkt;
 }
 
+/*
+ * Make each segment in the 'ref' chain of segments reference the
+ * packet data of the corresponding segment in the 'base' chain
+ * of segments. The chains must be of equal length.
+ */
+static void ref_segments(odp_packet_hdr_t *ref, odp_packet_hdr_t *base)
+{
+	while (ref) {
+		_ODP_ASSERT(base != NULL);
+		_ODP_ASSERT(!base->seg_indirect);
+		ref->seg_indirect = 1;
+		ref->seg_referenced = base;
+		ref->seg_data = base->seg_data;
+		ref->seg_len = base->seg_len;
+		ref = ref->seg_next;
+		segment_ref_inc(base);
+		base = base->seg_next;
+	}
+	_ODP_ASSERT(base == NULL);
+}
+
+static odp_packet_t packet_ref(odp_packet_t pkt)
+{
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
+	odp_packet_hdr_t *ref;
+	odp_pool_t pool;
+
+	pool = odp_packet_pool(pkt);
+	_ODP_ASSERT(pool != ODP_POOL_INVALID);
+
+	ref = alloc_segments(_odp_pool_entry(pool), pkt_hdr->seg_count);
+	if (odp_unlikely(ref == NULL))
+		return ODP_PACKET_INVALID;
+
+	_odp_packet_reset_md(ref);
+
+	ref_segments(ref, pkt_hdr);
+	ref->p.flags.is_ref = 1;
+
+	ref->frame_len = pkt_hdr->frame_len;
+	ref->seg_count = pkt_hdr->seg_count;
+
+	/* cannot use headroom/tailroom of the referenced packet */
+	ref->headroom  = 0;
+	ref->tailroom  = 0;
+
+	return packet_handle(ref);
+}
+
 odp_packet_t odp_packet_ref(odp_packet_t pkt, uint32_t offset)
 {
-	odp_packet_t new;
-	int ret;
+	odp_packet_t ref;
 
-	new = odp_packet_copy(pkt, odp_packet_pool(pkt));
+	if (odp_unlikely(odp_packet_is_referencing(pkt)))
+		return ODP_PACKET_INVALID;
 
-	if (new == ODP_PACKET_INVALID) {
-		_ODP_ERR("copy failed\n");
+	if (odp_likely(offset == 0))
+		return packet_ref(pkt);
+
+	ref = packet_ref(pkt);
+	if (odp_unlikely(ref == ODP_PACKET_INVALID))
+		return ODP_PACKET_INVALID;
+	if (odp_packet_trunc_head(&ref, offset, NULL, NULL) < 0) {
+		odp_packet_free(ref);
 		return ODP_PACKET_INVALID;
 	}
-
-	ret = odp_packet_trunc_head(&new, offset, NULL, NULL);
-
-	if (ret < 0) {
-		_ODP_ERR("trunk_head failed\n");
-		odp_packet_free(new);
-		return ODP_PACKET_INVALID;
-	}
-
-	return new;
+	return ref;
 }
 
 odp_packet_t odp_packet_ref_pkt(odp_packet_t pkt, uint32_t offset,
@@ -2211,6 +2384,11 @@ int odp_packet_has_ref(odp_packet_t pkt)
 	}
 
 	return 0;
+}
+
+int odp_packet_is_referencing(odp_packet_t pkt)
+{
+	return packet_hdr(pkt)->p.flags.is_ref;
 }
 
 int _odp_packet_unshare(odp_packet_t *pkt)
@@ -2403,10 +2581,20 @@ uint32_t odp_packet_disassemble(odp_packet_t pkt, odp_packet_buf_t pkt_buf[], ui
 		return 0;
 	}
 
+	if (odp_unlikely(odp_packet_is_referencing(pkt))) {
+		_ODP_ERR("Packet references another packet.\n");
+		return 0;
+	}
+
 	seg = odp_packet_first_seg(pkt);
 
 	for (i = 0; i < num_segs; i++) {
-		pkt_buf[i] = (odp_packet_buf_t)(uintptr_t)packet_seg_to_hdr(seg);
+		pkt_hdr = packet_seg_to_hdr(seg);
+		if (odp_unlikely(segment_ref(pkt_hdr) > 1)) {
+			_ODP_ERR("Packet is referenced by another packet.\n");
+			return 0;
+		}
+		pkt_buf[i] = (odp_packet_buf_t)(uintptr_t)pkt_hdr;
 		seg = odp_packet_next_seg(pkt, seg);
 	}
 

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2019-2025 Nokia
+ * Copyright (c) 2019-2026 Nokia
  */
 
 #include <odp_posix_extensions.h>
@@ -1578,6 +1578,11 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 	capa->lso.proto.custom           = 1;
 	capa->lso.mod_op.add_segment_num = 1;
 	capa->lso.mod_op.write_bits      = 1;
+
+	/* all pktios support packet references (by copying if necessary) */
+	capa->packet_ref.static_ref = 1;
+	capa->packet_ref.referencing_pkt = 1;
+	capa->packet_ref.referenced_pkt = 1;
 
 	capa->tx_compl.queue_type_sched = 1;
 	capa->tx_compl.queue_type_plain = 1;

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -2039,7 +2039,8 @@ static int tm_enqueue(tm_system_t *tm_system,
 			return -2;
 	}
 
-	if (odp_unlikely(odp_packet_has_ref(pkt)))
+	if (odp_unlikely(odp_packet_is_referencing(pkt) ||
+			 odp_packet_has_ref(pkt)))
 		if (odp_unlikely(_odp_packet_unshare(&pkt)))
 			return -1;
 
@@ -2653,6 +2654,10 @@ static int tm_capabilities(odp_tm_capabilities_t capabilities[],
 	cap_ptr->queue_stats.counter.discards = 1;
 	cap_ptr->queue_stats.counter.errors = 1;
 	cap_ptr->queue_stats.counter.packets = 1;
+
+	cap_ptr->packet_ref.static_ref = 1;
+	cap_ptr->packet_ref.referencing_pkt = 1;
+	cap_ptr->packet_ref.referenced_pkt = 1;
 
 	return 1;
 }

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -1106,6 +1106,7 @@ static inline int pkt_to_mbuf_zero(pktio_entry_t *pktio_entry,
 			goto fail;
 
 		if (odp_likely(pkt_hdr->seg_count == 1 &&
+			       !pkt_hdr->seg_indirect &&
 			       odp_atomic_load_u32(&pkt_hdr->ref_cnt) <= 1)) {
 			mbuf_update(mbuf, pkt_hdr, pkt_len);
 

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2015-2018 Linaro Limited
- * Copyright (c) 2019-2022 Nokia
+ * Copyright (c) 2019-2026 Nokia
  */
 
 #include <odp/api/hints.h>
@@ -778,6 +778,7 @@ static int ipc_pktio_send_lockless(pktio_entry_t *pktio_entry,
 		pool = _odp_pool_entry(pkt_hdr->event_hdr.pool);
 
 		if (pool->pool_idx != ipc_pool->pool_idx ||
+		    odp_packet_is_referencing(pkt) ||
 		    odp_packet_has_ref(pkt)) {
 			odp_packet_t newpkt;
 

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2013-2025 Nokia Solutions and Networks
+ * Copyright (c) 2013-2026 Nokia Solutions and Networks
  */
 
 #include <odp/api/debug.h>
@@ -562,6 +562,7 @@ static int loopback_send(pktio_entry_t *pktio_entry, int index, const odp_packet
 			break;
 		}
 		if (odp_unlikely(odp_packet_pool(pkt) != pkt_loop->pool ||
+				 odp_packet_is_referencing(pkt) ||
 				 odp_packet_has_ref(pkt))) {
 			pkt = odp_packet_copy(pkt, pkt_loop->pool);
 			if (odp_unlikely(pkt == ODP_PACKET_INVALID)) {

--- a/platform/linux-generic/pktio/socket_xdp.c
+++ b/platform/linux-generic/pktio/socket_xdp.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2022-2023 Nokia
+ * Copyright (c) 2022-2026 Nokia
  */
 
 #include <odp/autoheader_internal.h>
@@ -976,7 +976,9 @@ static int sock_xdp_send(pktio_entry_t *pktio_entry, int index, const odp_packet
 		pkt_hdr = packet_hdr(packets[i]);
 		seg_cnt = pkt_hdr->seg_count;
 
-		if (_odp_pool_entry(pkt_hdr->event_hdr.pool) != pool) {
+		if (_odp_pool_entry(pkt_hdr->event_hdr.pool) != pool ||
+		    odp_packet_is_referencing(packets[i]) ||
+		    odp_packet_has_ref(packets[i])) {
 			pkt = odp_packet_copy(packets[i], pool_hdl);
 
 			if (odp_unlikely(pkt == ODP_PACKET_INVALID)) {

--- a/test/performance/odp_bench_packet.c
+++ b/test/performance/odp_bench_packet.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2017-2018 Linaro Limited
- * Copyright (c) 2022-2025 Nokia
+ * Copyright (c) 2022-2026 Nokia
  */
 
 /**
@@ -1640,6 +1640,18 @@ static int packet_has_ref(void)
 	return i + ret;
 }
 
+static int packet_is_referencing(void)
+{
+	int i;
+	uint32_t ret = 0;
+	odp_packet_t *pkt_tbl = gbl_args->pkt_tbl;
+
+	for (i = 0; i < TEST_REPEAT_COUNT; i++)
+		ret += odp_packet_is_referencing(pkt_tbl[i]);
+
+	return i + ret;
+}
+
 static int packet_subtype(void)
 {
 	int i;
@@ -1954,6 +1966,7 @@ bench_info_t test_suite[] = {
 	BENCH_INFO(packet_ref, create_packets, free_packets_twice, NULL),
 	BENCH_INFO(packet_ref_pkt, alloc_packets_twice, free_packets_twice, NULL),
 	BENCH_INFO(packet_has_ref, alloc_ref_packets, free_packets_twice, NULL),
+	BENCH_INFO(packet_is_referencing, alloc_ref_packets, free_packets_twice, NULL),
 	BENCH_INFO(packet_subtype, create_packets, free_packets, NULL),
 	BENCH_INFO(event_subtype, create_events, free_packets, NULL),
 	BENCH_INFO(packet_parse, alloc_parse_packets_ipv4_tcp, free_packets,

--- a/test/performance/odp_packet_gen.c
+++ b/test/performance/odp_packet_gen.c
@@ -1534,6 +1534,10 @@ static int open_pktios(test_global_t *global)
 			ODPH_ERR("Error (%s): Don't free mode not supported\n", name);
 			return -1;
 		}
+		if (test_options->tx_mode == TX_MODE_REF && !pktio_capa.packet_ref.static_ref) {
+			ODPH_ERR("Error (%s): Static-reference TX mode not supported\n", name);
+			return -1;
+		}
 
 		odp_pktio_config_init(&pktio_config);
 

--- a/test/validation/api/crypto/crypto_op_test.c
+++ b/test/validation/api/crypto/crypto_op_test.c
@@ -484,6 +484,11 @@ static void create_packet_ref(const crypto_op_test_param_t *param,
 	if (param->input_packet_type == PKT_TYPE_STATIC_REF) {
 		state->pkt_ref = *pkt;
 		*pkt = odp_packet_ref_static(*pkt);
+	} else if (param->input_packet_type == PKT_TYPE_REFERENCING_PKT) {
+		state->pkt_ref = *pkt;
+		*pkt = odp_packet_ref(*pkt, 0);
+	} else if (param->input_packet_type == PKT_TYPE_REFERENCED_PKT) {
+		state->pkt_ref = odp_packet_ref(*pkt, 0);
 	} else {
 		return;
 	}

--- a/test/validation/api/crypto/crypto_op_test.h
+++ b/test/validation/api/crypto/crypto_op_test.h
@@ -20,9 +20,11 @@ typedef struct crypto_session_t {
 
 typedef enum packet_type_t {
 	PKT_TYPE_PACKET = 0,
-	PKT_TYPE_STATIC_REF = 1,
+	PKT_TYPE_STATIC_REF,
+	PKT_TYPE_REFERENCING_PKT,
+	PKT_TYPE_REFERENCED_PKT,
 } packet_type_t;
-#define NUM_PKT_TYPES 2
+#define NUM_PKT_TYPES 4
 
 typedef struct crypto_op_test_param_t {
 	crypto_session_t session;

--- a/test/validation/api/packet/Makefile.am
+++ b/test/validation/api/packet/Makefile.am
@@ -1,4 +1,5 @@
 include ../Makefile.inc
 
 test_PROGRAMS = packet_main
-packet_main_SOURCES = packet.c
+packet_main_SOURCES = packet.c packet_ref.c packet_ref.h
+PRELDADD += $(LIBPACKET_COMMON)

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2020 Marvell
  */
 
+#include "packet_ref.h"
+
 #include <odp_api.h>
 #include <odp_cunit_common.h>
 #include <test_packet_ipv4.h>
@@ -400,7 +402,7 @@ static void packet_check_inflags_all(odp_packet_t pkt, int val)
  * allocation and metadata reset. Do not check metadata that does not
  * have well-defined defaults or is related to packet data layout.
  */
-static void packet_check_default_meta(odp_packet_t pkt)
+void packet_check_default_meta(odp_packet_t pkt)
 {
 	odp_event_t ev;
 	odp_event_subtype_t subtype = ODP_EVENT_NO_SUBTYPE;
@@ -4689,6 +4691,10 @@ odp_testinfo_t packet_parse_suite[] = {
 	ODP_TEST_INFO_NULL,
 };
 
+extern odp_testinfo_t packet_ref_suite[];
+int packet_ref_suite_init(void);
+int packet_ref_suite_term(void);
+
 odp_suiteinfo_t packet_suites[] = {
 	{ .name         = "packet tests",
 	  .testinfo_tbl = packet_suite,
@@ -4704,6 +4710,11 @@ odp_suiteinfo_t packet_suites[] = {
 	  .testinfo_tbl = packet_vector_parse_suite,
 	  .init_func    = packet_vector_suite_init,
 	  .term_func    = packet_vector_suite_term,
+	},
+	{ .name         = "packet ref tests",
+	  .testinfo_tbl = packet_ref_suite,
+	  .init_func    = packet_ref_suite_init,
+	  .term_func    = packet_ref_suite_term,
 	},
 	ODP_SUITE_INFO_NULL,
 };

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -2716,18 +2716,6 @@ static void packet_test_extend_ref(void)
 	/* Verify ref lengths */
 	CU_ASSERT(ref != ODP_PACKET_INVALID);
 	CU_ASSERT(odp_packet_len(ref) == max_len - 200);
-	if (odp_packet_has_ref(ref) == 1) {
-		/* And ref's affect on max_pkt */
-		CU_ASSERT(odp_packet_has_ref(max_pkt) == 1);
-	}
-
-	/* Now extend max_pkt and verify effect */
-	CU_ASSERT(odp_packet_extend_head(&max_pkt, 10, NULL, NULL) >= 0);
-	CU_ASSERT(odp_packet_len(max_pkt) == max_len - 90);
-	packet_sanity_check(max_pkt);
-
-	/* Extend on max_pkt should not affect ref */
-	CU_ASSERT(odp_packet_len(ref) == max_len - 200);
 
 	/* Now extend ref and verify effect*/
 	CU_ASSERT(odp_packet_extend_head(&ref, 20, NULL, NULL) >= 0);
@@ -2735,22 +2723,12 @@ static void packet_test_extend_ref(void)
 	packet_sanity_check(max_pkt);
 
 	/* Extend on ref should not affect max_pkt */
-	CU_ASSERT(odp_packet_len(max_pkt) == max_len - 90);
-
-	/* Trunc max_pkt of all unshared len */
-	CU_ASSERT(odp_packet_trunc_head(&max_pkt, 110, NULL, NULL) >= 0);
-	packet_sanity_check(max_pkt);
-
-	/* Verify effect on max_pkt */
-	CU_ASSERT(odp_packet_len(max_pkt) == max_len - 200);
-
-	/* Verify that ref is unchanged */
-	CU_ASSERT(odp_packet_len(ref) == max_len - 180);
+	CU_ASSERT(odp_packet_len(max_pkt) == max_len - 100);
 
 	/* Free ref and verify that max_pkt is back to being unreferenced */
 	odp_packet_free(ref);
 	CU_ASSERT(odp_packet_has_ref(max_pkt) == 0);
-	CU_ASSERT(odp_packet_len(max_pkt) == max_len - 200);
+	CU_ASSERT(odp_packet_len(max_pkt) == max_len - 100);
 	packet_sanity_check(max_pkt);
 
 	odp_packet_free(max_pkt);
@@ -2868,10 +2846,9 @@ static void packet_test_offset(void)
 static void packet_test_ref(void)
 {
 	odp_packet_t base_pkt, segmented_base_pkt, hdr_pkt[4],
-		ref_pkt[4], refhdr_pkt[4], hdr_cpy;
+		ref_pkt[4], refhdr_pkt[4];
 	odp_packet_t pkt, pkt2, pkt3, ref, ref2;
-	uint32_t pkt_len, segmented_pkt_len, hdr_len[4], offset[4], hr[4],
-		base_hr, ref_len[4];
+	uint32_t pkt_len, segmented_pkt_len, hdr_len[4], offset[4], hr[4];
 	int i, ret;
 	odp_pool_t pool;
 
@@ -2953,8 +2930,11 @@ static void packet_test_ref(void)
 	CU_ASSERT_FATAL(ref != ODP_PACKET_INVALID);
 	pkt2 = odp_packet_copy(test_packet, pool);
 	CU_ASSERT_FATAL(pkt2 != ODP_PACKET_INVALID);
-	ref2 = odp_packet_ref_pkt(ref, 0, pkt2);
+	ref2 = odp_packet_ref(pkt, 0);
 	CU_ASSERT_FATAL(ref2 != ODP_PACKET_INVALID);
+	ret = odp_packet_concat(&ref2, ref);
+	CU_ASSERT_FATAL(ret >= 0);
+
 	packet_compare_data(pkt3, ref2);
 
 	/* Try print function on a reference */
@@ -2963,7 +2943,6 @@ static void packet_test_ref(void)
 	odp_packet_print_data(ref2, 0, 100);
 	odp_packet_print_data(ref2, 14, 20);
 
-	odp_packet_free(ref);
 	odp_packet_free(ref2);
 	odp_packet_free(pkt);
 	odp_packet_free(pkt3);
@@ -2971,7 +2950,6 @@ static void packet_test_ref(void)
 	/* Test has_ref, lengths, etc */
 	base_pkt = odp_packet_copy(test_packet, odp_packet_pool(test_packet));
 	CU_ASSERT_FATAL(base_pkt != ODP_PACKET_INVALID);
-	base_hr = odp_packet_headroom(base_pkt);
 	pkt_len = odp_packet_len(test_packet);
 
 	segmented_base_pkt =
@@ -3024,13 +3002,6 @@ static void packet_test_ref(void)
 	CU_ASSERT(refhdr_pkt[0] != ODP_PACKET_INVALID);
 	CU_ASSERT(refhdr_pkt[1] != ODP_PACKET_INVALID);
 
-	/* If base packet has now references, ref packet should be also
-	 * references. */
-	if (odp_packet_has_ref(base_pkt) == 1) {
-		CU_ASSERT(odp_packet_has_ref(refhdr_pkt[0]) == 1);
-		CU_ASSERT(odp_packet_has_ref(refhdr_pkt[1]) == 1);
-	}
-
 	CU_ASSERT(odp_packet_len(refhdr_pkt[0]) ==
 		  hdr_len[0] + pkt_len - offset[0]);
 	CU_ASSERT(odp_packet_len(refhdr_pkt[1]) ==
@@ -3044,22 +3015,9 @@ static void packet_test_ref(void)
 			      base_pkt, offset[1],
 			      pkt_len - offset[1]);
 
-	/* See if compound references are supported and if so that they
-	 * operate properly */
-	hdr_cpy = odp_packet_copy(hdr_pkt[2], odp_packet_pool(hdr_pkt[2]));
-	CU_ASSERT_FATAL(hdr_cpy != ODP_PACKET_INVALID);
-
-	refhdr_pkt[2] = odp_packet_ref_pkt(refhdr_pkt[0], 2, hdr_cpy);
-	CU_ASSERT(refhdr_pkt[2] != ODP_PACKET_INVALID);
-
-	if (odp_packet_has_ref(refhdr_pkt[2]) == 1) {
-		CU_ASSERT(odp_packet_has_ref(refhdr_pkt[0]) == 1);
-	}
-
 	/* Delete the refs */
 	odp_packet_free(refhdr_pkt[0]);
 	odp_packet_free(refhdr_pkt[1]);
-	odp_packet_free(refhdr_pkt[2]);
 
 	/* Verify that base_pkt no longer has a ref */
 	CU_ASSERT(odp_packet_has_ref(base_pkt) == 0);
@@ -3068,13 +3026,8 @@ static void packet_test_ref(void)
 	refhdr_pkt[2] = odp_packet_ref_pkt(base_pkt, offset[2], hdr_pkt[2]);
 	refhdr_pkt[3] = odp_packet_ref_pkt(base_pkt, offset[3], hdr_pkt[3]);
 
-	CU_ASSERT(hdr_pkt[2] != ODP_PACKET_INVALID);
-	CU_ASSERT(hdr_pkt[3] != ODP_PACKET_INVALID);
-
-	if (odp_packet_has_ref(base_pkt) == 1) {
-		CU_ASSERT(odp_packet_has_ref(refhdr_pkt[2]) == 1);
-		CU_ASSERT(odp_packet_has_ref(refhdr_pkt[3]) == 1);
-	}
+	CU_ASSERT(refhdr_pkt[2] != ODP_PACKET_INVALID);
+	CU_ASSERT(refhdr_pkt[3] != ODP_PACKET_INVALID);
 
 	CU_ASSERT(odp_packet_len(refhdr_pkt[2]) ==
 		  odp_packet_len(refhdr_pkt[3]));
@@ -3093,10 +3046,6 @@ static void packet_test_ref(void)
 	/* Create a static reference */
 	ref_pkt[0] = odp_packet_ref_static(base_pkt);
 	CU_ASSERT(ref_pkt[0] != ODP_PACKET_INVALID);
-
-	if (odp_packet_has_ref(base_pkt) == 1) {
-		CU_ASSERT(odp_packet_has_ref(ref_pkt[0]) == 1);
-	}
 
 	CU_ASSERT(odp_packet_len(ref_pkt[0]) == odp_packet_len(base_pkt));
 	packet_compare_offset(ref_pkt[0], 0, base_pkt, 0,
@@ -3156,37 +3105,6 @@ static void packet_test_ref(void)
 			  segmented_pkt_len - offset[1]);
 	}
 
-	odp_packet_free(ref_pkt[0]);
-	odp_packet_free(ref_pkt[1]);
-
-	/* Verify we can modify base packet after reference is created */
-	base_pkt = odp_packet_copy(test_packet, odp_packet_pool(test_packet));
-
-	ref_pkt[1] = odp_packet_ref(base_pkt, offset[1]);
-	CU_ASSERT_FATAL(ref_pkt[1] != ODP_PACKET_INVALID);
-	ref_len[1] = odp_packet_len(ref_pkt[1]);
-	CU_ASSERT(ref_len[1] == odp_packet_len(base_pkt) - offset[1]);
-
-	CU_ASSERT(odp_packet_push_head(base_pkt, base_hr / 2) != NULL);
-
-	CU_ASSERT(odp_packet_len(ref_pkt[1]) == ref_len[1]);
-
-	ref_pkt[0] = odp_packet_ref(base_pkt, offset[0]);
-	CU_ASSERT_FATAL(ref_pkt[0] != ODP_PACKET_INVALID);
-	ref_len[0] = odp_packet_len(ref_pkt[0]);
-	CU_ASSERT(ref_len[0] == odp_packet_len(base_pkt) - offset[0]);
-
-	CU_ASSERT(odp_packet_push_head(base_pkt,
-				       base_hr - base_hr / 2) != NULL);
-	CU_ASSERT(odp_packet_len(ref_pkt[1]) == ref_len[1]);
-	CU_ASSERT(odp_packet_len(ref_pkt[0]) == ref_len[0]);
-
-	hr[0] = odp_packet_headroom(ref_pkt[0]);
-	hr[1] = odp_packet_headroom(ref_pkt[1]);
-	CU_ASSERT(odp_packet_push_head(ref_pkt[0], hr[0]) != NULL);
-	CU_ASSERT(odp_packet_push_head(ref_pkt[1], hr[1]) != NULL);
-
-	odp_packet_free(base_pkt);
 	odp_packet_free(ref_pkt[0]);
 	odp_packet_free(ref_pkt[1]);
 }

--- a/test/validation/api/packet/packet_ref.c
+++ b/test/validation/api/packet/packet_ref.c
@@ -1,0 +1,1628 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2026 Nokia
+ */
+
+#include "packet_ref.h"
+
+#include <odp_api.h>
+#include <odp_cunit_common.h>
+#include <packet_common.h>
+
+#include <odp/helper/odph_api.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#define MAX_SEGS 10
+#define MAX_PKT_NUM 30
+#define MAX_PKT_LEN 100
+static uint32_t uarea_size = 8;
+
+static odp_pool_t packet_pool;
+
+typedef struct {
+	odp_packet_seg_t handle;
+	uint8_t *data;
+	uint32_t len;
+} seg_info_t;
+
+typedef struct {
+	uint32_t total_len;
+	uint32_t num_segs;
+	seg_info_t segs[MAX_SEGS];
+} packet_seg_info_t;
+
+typedef struct {
+	test_packet_md_t metadata;
+	uint32_t len;
+	uint32_t headroom;
+	uint32_t tailroom;
+	uint8_t *head;
+	uint8_t *data;
+	uint8_t *tail;
+	uint8_t *uarea;
+	packet_seg_info_t seg_info;
+	uint8_t pkt_data[MAX_PKT_LEN];
+} pkt_state_t;
+
+typedef enum pkt_type_t {
+	PKT_TYPE_NORMAL,      /* mutable */
+	PKT_TYPE_REFERENCING, /* mutable (but shared data may not be written to) */
+	PKT_TYPE_STATIC_REF,  /* immutable */
+	PKT_TYPE_REFERENCED,  /* immutable (but mutable metadata) */
+} pkt_type_t;
+
+/*
+ * Operation to be done to the dynamic ref or the base packet (depending on
+ * which packet type is being tested) during test packet creation to add
+ * more variation to the test packets. This e.g. can add private packet data
+ * to referencing packets so that the API functions get tested with such
+ * packet too.
+ */
+typedef enum pre_op_t {
+	PRE_OP_NONE,
+	PRE_OP_EXTEND_HEAD,
+	PRE_OP_EXTEND_TAIL,
+	PRE_OP_TRUNC_HEAD,
+	PRE_OP_TRUNC_TAIL,
+} pre_op_t;
+
+#define NUM_PRE_OPS 5
+
+/*
+ * Test packet creation parameters
+ */
+typedef struct pkt_param_t {
+	pkt_type_t pkt_type;    /* normal/static ref/reference/referenced */
+	uint32_t base_len;      /* length of the initial packet created */
+	uint32_t base_num_segs; /* number of segments in the initial packet */
+	uint32_t ref_offset;    /* if dynamic ref, the creation offset */
+	pre_op_t pre_op;        /* operation to be done to the base pkt or its reference */
+	uint32_t pre_op_param;  /* parameter for the pre_op */
+} pkt_param_t;
+
+typedef struct test_pkt_state_t {
+	odp_packet_t pkt;      /* base pkt or reference of the test packet */
+	pkt_state_t pkt_state; /* saved state of the above packet */
+} test_pkt_state_t;
+
+typedef struct {
+	uint32_t len;      /* length of base packet */
+	uint32_t num_segs; /* number of segments in base packet */
+	uint32_t offset;   /* start offset of data to be referenced */
+} pkt_layout_t;
+
+typedef void (*pkt_adj_func_t)(odp_packet_t *pkt, uint32_t len);
+
+typedef void (*pkt_func_t)(const pkt_param_t *pkt_param, const void *ctx);
+
+/* We use this to avoid having to cast function pointers to void pointers */
+typedef struct pkt_adj_param_t {
+	pkt_adj_func_t func;
+} pkt_adj_param_t;
+
+static uint32_t minstd_rand(void)
+{
+	static uint64_t s = 1;
+	uint64_t prime = 0x7fffffff;
+
+	s = (48271 * s) % prime;
+	return s;
+}
+
+static uint32_t random_u32(void)
+{
+	return minstd_rand();
+}
+
+static uint8_t random_u8(void)
+{
+	return minstd_rand();
+}
+
+static void check_metadata_equal(const test_packet_md_t *md_1,
+				 const test_packet_md_t *md_2)
+{
+	CU_ASSERT(test_packet_is_md_equal(md_1, md_2));
+}
+
+static const seg_info_t *last_seg(const packet_seg_info_t *seg_info)
+{
+	CU_ASSERT_FATAL(seg_info->num_segs > 0);
+	return &seg_info->segs[seg_info->num_segs - 1];
+}
+
+static void save_seg_info(odp_packet_t pkt, packet_seg_info_t *seg_info)
+{
+	odp_packet_seg_t seg;
+	uint32_t num_segs = 0;
+	uint32_t total_len = 0;
+
+	for (seg = odp_packet_first_seg(pkt), num_segs = 0;
+	     seg != ODP_PACKET_SEG_INVALID;
+	     seg = odp_packet_next_seg(pkt, seg), num_segs++) {
+		uint8_t *data;
+		uint32_t len;
+
+		CU_ASSERT_FATAL(num_segs < MAX_SEGS);
+
+		data = odp_packet_seg_data(pkt, seg);
+		len = odp_packet_seg_data_len(pkt, seg);
+		CU_ASSERT(data != NULL);
+		CU_ASSERT(len != 0);
+
+		seg_info->segs[num_segs].handle = seg;
+		seg_info->segs[num_segs].data = data;
+		seg_info->segs[num_segs].len = len;
+
+		total_len += len;
+	}
+	seg_info->num_segs = num_segs;
+	seg_info->total_len = total_len;
+}
+
+static void check_seg_info_equal(const packet_seg_info_t *a, const packet_seg_info_t *b)
+{
+	CU_ASSERT(a->total_len == b->total_len);
+	CU_ASSERT(a->num_segs == b->num_segs);
+
+	for (uint32_t n = 0; n < a->num_segs; n++) {
+		CU_ASSERT(a->segs[n].handle == b->segs[n].handle);
+		CU_ASSERT(a->segs[n].data == b->segs[n].data);
+		CU_ASSERT(a->segs[n].len == b->segs[n].len);
+	}
+}
+
+static void check_ptrs_equal(const packet_seg_info_t *a, const packet_seg_info_t *b)
+{
+	CU_ASSERT(a->total_len == b->total_len);
+	CU_ASSERT(a->num_segs == b->num_segs);
+
+	for (uint32_t n = 0; n < a->num_segs; n++) {
+		CU_ASSERT_FATAL(a->segs[n].data == b->segs[n].data);
+		CU_ASSERT_FATAL(a->segs[n].len == b->segs[n].len);
+	}
+}
+
+/* combine consecutive segments with adjacent data areas to make comparisons work */
+static void compact_seg_info(packet_seg_info_t *si)
+{
+	uint32_t num_combined = 0;
+	seg_info_t *seg = si->segs;
+
+	for (uint32_t n = 1; n < si->num_segs; n++) {
+		if (seg->data + seg->len == si->segs[n].data) {
+			seg->len += si->segs[n].len;
+			num_combined++;
+		} else {
+			seg++;
+			if (num_combined > 0)
+				*seg = si->segs[n];
+		}
+	}
+	si->num_segs -= num_combined;
+}
+
+/* truncate seg info as if the packet head were truncated */
+static void seg_info_trunc_head(packet_seg_info_t *seg, uint32_t trunc_len)
+{
+	uint32_t len = 0;
+	int n;
+	int first_seg;
+
+	CU_ASSERT_FATAL(trunc_len < seg->total_len);
+
+	if (trunc_len == 0)
+		return;
+
+	/* find the first segment after truncation */
+	for (n = 0; len <= trunc_len; n++) {
+		CU_ASSERT_FATAL(n < MAX_SEGS);
+		len += seg->segs[n].len;
+	}
+	first_seg = n - 1;
+	seg->num_segs -= first_seg;
+	memmove(&seg->segs[0], &seg->segs[first_seg], seg->num_segs * sizeof(seg->segs[0]));
+	seg->segs[0].data += seg->segs[0].len - len + trunc_len;
+	seg->segs[0].len = len - trunc_len;
+	seg->total_len -= trunc_len;
+}
+
+/* truncate seg info as if the packet tail were truncated */
+static void seg_info_trunc_tail(packet_seg_info_t *seg, uint32_t trunc_len)
+{
+	uint32_t len = 0;
+	uint32_t new_len = seg->total_len - trunc_len;
+	int n;
+
+	CU_ASSERT_FATAL(trunc_len < seg->total_len);
+
+	if (trunc_len == 0)
+		return;
+
+	/* find the last segment after truncation */
+	for (n = 0; len < new_len; n++) {
+		CU_ASSERT_FATAL(n < MAX_SEGS);
+		len += seg->segs[n].len;
+	}
+	seg->num_segs = n;
+	seg->segs[n - 1].len -= len - new_len;
+	seg->total_len = new_len;
+}
+
+static uint8_t *get_data_ptr(const packet_seg_info_t *si, uint32_t offset,
+			     uint32_t *continuous_len)
+{
+	uint32_t len = 0;
+	uint32_t n;
+
+	for (n = 0; ; n++) {
+		CU_ASSERT_FATAL(n < si->num_segs);
+		len += si->segs[n].len;
+		if (len > offset)
+			break;
+	}
+	*continuous_len = len - offset;
+	return si->segs[n].data + si->segs[n].len - *continuous_len;
+}
+
+static void save_pkt_state(odp_packet_t pkt, pkt_state_t *state)
+{
+	int rc;
+
+	state->len      = odp_packet_len(pkt);
+	state->headroom = odp_packet_headroom(pkt);
+	state->tailroom = odp_packet_tailroom(pkt);
+	state->head     = odp_packet_head(pkt);
+	state->data     = odp_packet_data(pkt);
+	state->tail     = odp_packet_tail(pkt);
+	state->uarea    = odp_packet_user_area(pkt);
+
+	test_packet_get_md(pkt, &state->metadata);
+
+	save_seg_info(pkt, &state->seg_info);
+	CU_ASSERT(state->seg_info.num_segs == (uint32_t)odp_packet_num_segs(pkt));
+	CU_ASSERT(state->len == state->seg_info.total_len);
+	CU_ASSERT(state->data == state->seg_info.segs[0].data);
+	CU_ASSERT(state->tail == (last_seg(&state->seg_info)->data +
+				  last_seg(&state->seg_info)->len));
+
+	CU_ASSERT_FATAL(state->len <= sizeof(state->pkt_data));
+	rc = odp_packet_copy_to_mem(pkt, 0, state->len, state->pkt_data);
+	CU_ASSERT(rc == 0);
+}
+
+/* Check that pointers to first 'len' bytes of packet data are the same */
+static void check_ptrs_head(const packet_seg_info_t *a,
+			    const packet_seg_info_t *b, uint32_t len)
+{
+	packet_seg_info_t x = *a;
+	packet_seg_info_t y = *b;
+
+	if (len == 0)
+		return;
+
+	seg_info_trunc_tail(&x, x.total_len - len);
+	seg_info_trunc_tail(&y, y.total_len - len);
+	compact_seg_info(&x);
+	compact_seg_info(&y);
+	check_ptrs_equal(&x, &y);
+}
+
+/* Check that pointers to last 'tail_len' bytes of packet data are the same */
+static void check_ptrs_tail(const packet_seg_info_t *a,
+			    const packet_seg_info_t *b, uint32_t tail_len)
+{
+	packet_seg_info_t x = *a;
+	packet_seg_info_t y = *b;
+
+	if (tail_len == 0)
+		return;
+
+	seg_info_trunc_head(&x, x.total_len - tail_len);
+	seg_info_trunc_head(&y, y.total_len - tail_len);
+	compact_seg_info(&x);
+	compact_seg_info(&y);
+	check_ptrs_equal(&x, &y);
+}
+
+static void check_pkt_data(const pkt_state_t *a, uint32_t a_offs,
+			   const pkt_state_t *b, uint32_t b_offs,
+			   uint32_t len)
+{
+	CU_ASSERT_FATAL(a_offs + len <= a->len);
+	CU_ASSERT_FATAL(b_offs + len <= b->len);
+	if (len == 0)
+		return;
+	CU_ASSERT(memcmp(&a->pkt_data[a_offs], &b->pkt_data[b_offs], len) == 0);
+}
+
+static void check_pkt_data_equal(const pkt_state_t *a, const pkt_state_t *b)
+{
+	CU_ASSERT(a->len == b->len);
+	check_pkt_data(a, 0, b, 0, a->len);
+}
+
+static void check_pkt_state_equal(const pkt_state_t *state_1, const pkt_state_t *state_2)
+{
+	check_metadata_equal(&state_1->metadata, &state_2->metadata);
+
+	CU_ASSERT(state_1->len        == state_2->len);
+	CU_ASSERT(state_1->headroom   == state_2->headroom);
+	CU_ASSERT(state_1->tailroom   == state_2->tailroom);
+	CU_ASSERT(state_1->head       == state_2->head);
+	CU_ASSERT(state_1->data       == state_2->data);
+	CU_ASSERT(state_1->tail       == state_2->tail);
+	CU_ASSERT(state_1->uarea      == state_2->uarea);
+
+	check_seg_info_equal(&state_1->seg_info, &state_2->seg_info);
+	check_pkt_data_equal(state_1, state_2);
+}
+
+/*
+ * Create a packet with one or more segments, rounding up len to make it
+ * divisible by num_segs.
+ *
+ * Make reasonable assumptions on the underlying ODP implementation on
+ * how segmented packets can be created as ODP API does not have any
+ * guaranteed way to do it. Fail if segmented packets cannot be made.
+ */
+static odp_packet_t alloc_packet(uint32_t len, uint32_t num_segs)
+{
+	uint32_t seg_len;
+	odp_packet_t pkt;
+
+	len = ODPH_ROUNDUP_MULTIPLE(len, num_segs);
+	seg_len = len / num_segs;
+	CU_ASSERT(seg_len > 0);
+
+	pkt = odp_packet_alloc(packet_pool, seg_len);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	CU_ASSERT(odp_packet_has_ref(pkt) == 0);
+	CU_ASSERT(odp_packet_is_referencing(pkt) == 0);
+
+	for (uint32_t n = 1; n < num_segs; n++) {
+		odp_packet_t seg = odp_packet_alloc(packet_pool, seg_len);
+
+		CU_ASSERT_FATAL(seg != ODP_PACKET_INVALID);
+		CU_ASSERT(odp_packet_has_ref(seg) == 0);
+		CU_ASSERT(odp_packet_is_referencing(seg) == 0);
+		CU_ASSERT_FATAL(odp_packet_concat(&pkt, seg) >= 0);
+	}
+	CU_ASSERT(odp_packet_is_segmented(pkt) == (num_segs != 1));
+	CU_ASSERT((uint32_t)odp_packet_num_segs(pkt) == num_segs);
+	CU_ASSERT(odp_packet_seg_len(pkt) == seg_len);
+	CU_ASSERT(odp_packet_len(pkt) == len);
+
+	return pkt;
+}
+
+static void write_uarea(odp_packet_t pkt)
+{
+	uint8_t *uarea = odp_packet_user_area(pkt);
+
+	CU_ASSERT(uarea_size == odp_packet_user_area_size(pkt));
+	if (uarea_size == 0) {
+		CU_ASSERT(uarea == NULL);
+		return;
+	}
+	CU_ASSERT_FATAL(uarea != NULL);
+
+	for (uint32_t n = 0; n < uarea_size; n++)
+		uarea[n] = random_u8();
+}
+
+/* set some metadata to random values to better see changes and equality */
+static void set_random_md(odp_packet_t pkt)
+{
+	uint32_t len = odp_packet_len(pkt);
+	uintptr_t addr = random_u32();
+
+	odp_packet_user_ptr_set(pkt, (const void *)addr);
+	odp_packet_l2_offset_set(pkt, random_u8() % len);
+	odp_packet_l3_offset_set(pkt, random_u8() % len);
+	odp_packet_l4_offset_set(pkt, random_u8() % len);
+	odp_packet_flow_hash_set(pkt, random_u32());
+	odp_packet_payload_offset_set(pkt, random_u8() % len);
+}
+
+static odp_packet_t make_packet(uint32_t len, uint32_t num_segs)
+{
+	odp_packet_t pkt;
+	uint8_t data[len];
+	int rc;
+
+	pkt = alloc_packet(len, num_segs);
+
+	for (uint32_t n = 0; n < len; n++)
+		data[n] = random_u8();
+	rc = odp_packet_copy_from_mem(pkt, 0, len, data);
+	CU_ASSERT(rc == 0);
+
+	test_packet_set_md(pkt);
+	set_random_md(pkt);
+	write_uarea(pkt);
+
+	return pkt;
+}
+
+static void check_metadata_default(odp_packet_t pkt)
+{
+	packet_check_default_meta(pkt);
+}
+
+static void check_packet_data(odp_packet_t ref, const pkt_state_t *base_state, uint32_t offset)
+{
+	uint32_t len = odp_packet_len(ref);
+	uint8_t ref_data[len];
+	int rc;
+
+	rc = odp_packet_copy_to_mem(ref, 0, len, ref_data);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT_FATAL(base_state->len >= len + offset);
+	CU_ASSERT(memcmp(ref_data, base_state->pkt_data + offset, len) == 0);
+}
+
+static void write_pkt_data(odp_packet_t pkt, uint32_t offset, uint32_t len)
+{
+	uint8_t w_data[len + 1]; /* +1 to avoid zero length array */
+	uint8_t r_data[len + 1];
+	int rc;
+
+	if (len == 0)
+		return;
+
+	for (uint32_t n = 0; n < len; n++)
+		w_data[n] = random_u8();
+	rc = odp_packet_copy_from_mem(pkt, offset, len, w_data);
+	CU_ASSERT(rc == 0);
+	rc = odp_packet_copy_to_mem(pkt, offset, len, r_data);
+	CU_ASSERT(rc == 0);
+	CU_ASSERT(memcmp(w_data, r_data, len) == 0);
+}
+
+static uint32_t iterate_pkt_layout(pkt_layout_t *layout, uint32_t *iterator)
+{
+	static const pkt_layout_t layouts[] = {
+		{.len = 10, .num_segs = 1, .offset = 0},
+		{.len = 10, .num_segs = 1, .offset = 5},
+		{.len = 10, .num_segs = 1, .offset = 9},
+
+		{.len = 20, .num_segs = 2, .offset = 0},
+		{.len = 20, .num_segs = 2, .offset = 5},
+		{.len = 20, .num_segs = 2, .offset = 9},
+		{.len = 20, .num_segs = 2, .offset = 10},
+		{.len = 20, .num_segs = 2, .offset = 15},
+		{.len = 20, .num_segs = 2, .offset = 19},
+
+		{.len = 30, .num_segs = 3, .offset = 0},
+		{.len = 30, .num_segs = 3, .offset = 5},
+		{.len = 20, .num_segs = 2, .offset = 9},
+		{.len = 30, .num_segs = 3, .offset = 10},
+		{.len = 30, .num_segs = 3, .offset = 15},
+		{.len = 20, .num_segs = 2, .offset = 19},
+		{.len = 30, .num_segs = 3, .offset = 20},
+		{.len = 30, .num_segs = 3, .offset = 25},
+		{.len = 30, .num_segs = 3, .offset = 29},
+	};
+
+	if (*iterator == ODPH_ARRAY_SIZE(layouts))
+		return 0;
+
+	*layout = layouts[*iterator];
+	*iterator += 1;
+	return 1;
+}
+
+static odp_packet_t create_ref(odp_packet_t base, const pkt_state_t *base_state, uint32_t offset)
+{
+	odp_packet_t ref;
+	pkt_state_t after;
+
+	ref = odp_packet_ref(base, offset);
+	CU_ASSERT_FATAL(ref != ODP_PACKET_INVALID);
+	CU_ASSERT(odp_packet_has_ref(base));
+	CU_ASSERT(!odp_packet_has_ref(ref));
+	CU_ASSERT(!odp_packet_is_referencing(base));
+	CU_ASSERT(odp_packet_is_referencing(ref));
+
+	CU_ASSERT(odp_packet_len(ref) + offset == odp_packet_len(base));
+	CU_ASSERT(odp_packet_pool(base) == odp_packet_pool(ref));
+	CU_ASSERT(odp_packet_headroom(ref) == 0);
+	CU_ASSERT(odp_packet_tailroom(ref) == 0);
+
+	check_metadata_default(ref);
+	set_random_md(ref);
+	write_uarea(ref);
+
+	save_pkt_state(base, &after);
+	check_pkt_state_equal(base_state, &after);
+	check_packet_data(ref, base_state, offset);
+
+	return ref;
+}
+
+static void test_ref_creation(uint32_t base_len, uint32_t num_segs, uint32_t offset)
+{
+	odp_packet_t base, ref;
+	pkt_state_t base_state;
+
+	CU_ASSERT(base_len > offset);
+
+	base = make_packet(base_len, num_segs);
+	save_pkt_state(base, &base_state);
+	ref = create_ref(base, &base_state, offset);
+
+	odp_packet_free(ref);
+	odp_packet_free(base);
+}
+
+static void test_basic_ref_creation(void)
+{
+	uint32_t iter = 0;
+	pkt_layout_t layout;
+
+	while (iterate_pkt_layout(&layout, &iter))
+		test_ref_creation(layout.len, layout.num_segs, layout.offset);
+}
+
+static void pkt_extend_head(odp_packet_t *pkt, uint32_t push_len)
+{
+	pkt_state_t before, after;
+	void *data_ptr;
+	uint32_t seg_len;
+	int rc;
+
+	save_pkt_state(*pkt, &before);
+	rc = odp_packet_extend_head(pkt, push_len, &data_ptr, &seg_len);
+	CU_ASSERT(rc >= 0);
+	write_pkt_data(*pkt, 0, push_len);
+	save_pkt_state(*pkt, &after);
+
+	check_metadata_equal(&before.metadata, &after.metadata);
+	check_pkt_data(&before, 0, &after, push_len, before.len);
+	CU_ASSERT(data_ptr == after.seg_info.segs[0].data);
+	CU_ASSERT(seg_len  == after.seg_info.segs[0].len);
+	CU_ASSERT(after.len = before.len + push_len);
+
+	if (before.headroom >= push_len) {
+		CU_ASSERT(rc == 0);
+		CU_ASSERT(after.head == before.head);
+		CU_ASSERT(after.data == before.data - push_len);
+		CU_ASSERT(after.headroom == before.headroom - push_len);
+		CU_ASSERT(after.tailroom == before.tailroom);
+	}
+	if (rc == 0) {
+		CU_ASSERT(after.tail  == before.tail);
+		CU_ASSERT(after.uarea == before.uarea);
+		check_ptrs_tail(&before.seg_info, &after.seg_info, before.len);
+	}
+}
+
+static void pkt_push_head(odp_packet_t *pkt, uint32_t push_len)
+{
+	pkt_state_t before, after;
+	void *data_ptr;
+
+	save_pkt_state(*pkt, &before);
+	data_ptr = odp_packet_push_head(*pkt, push_len);
+	save_pkt_state(*pkt, &after);
+
+	if (before.headroom < push_len) {
+		CU_ASSERT(data_ptr == NULL);
+		check_pkt_state_equal(&before, &after);
+		return;
+	}
+	CU_ASSERT(data_ptr != NULL);
+
+	write_pkt_data(*pkt, 0, push_len);
+
+	check_metadata_equal(&before.metadata, &after.metadata);
+	check_pkt_data(&before, 0, &after, push_len, before.len);
+	CU_ASSERT(data_ptr == after.seg_info.segs[0].data);
+	CU_ASSERT(after.len = before.len + push_len);
+	CU_ASSERT(after.head == before.head);
+	CU_ASSERT(after.data == before.data - push_len);
+	CU_ASSERT(after.tail  == before.tail);
+	CU_ASSERT(after.uarea == before.uarea);
+	CU_ASSERT(after.seg_info.num_segs == before.seg_info.num_segs);
+
+	check_ptrs_tail(&before.seg_info, &after.seg_info, before.len);
+}
+
+static void pkt_trunc_head(odp_packet_t *pkt, uint32_t pull_len)
+{
+	pkt_state_t before, after;
+	void *data_ptr;
+	uint32_t seg_len;
+	int rc;
+
+	save_pkt_state(*pkt, &before);
+	rc = odp_packet_trunc_head(pkt, pull_len, &data_ptr, &seg_len);
+	save_pkt_state(*pkt, &after);
+
+	if (before.len <= pull_len) {
+		CU_ASSERT(rc < 0);
+		check_pkt_state_equal(&before, &after);
+		return;
+	}
+	CU_ASSERT(rc >= 0);
+
+	check_metadata_equal(&before.metadata, &after.metadata);
+	check_pkt_data(&before, pull_len, &after, 0, after.len);
+	CU_ASSERT(data_ptr == after.seg_info.segs[0].data);
+	CU_ASSERT(seg_len  == after.seg_info.segs[0].len);
+	CU_ASSERT(after.len = before.len - pull_len);
+
+	if (before.seg_info.segs[0].len > pull_len) {
+		bool head_data_maybe_shared = (odp_packet_is_referencing(*pkt) &&
+					       before.headroom == 0 &&
+					       after.headroom == 0);
+		CU_ASSERT(rc == 0);
+		CU_ASSERT(after.data == before.data + pull_len);
+		if (!head_data_maybe_shared)
+			CU_ASSERT(after.headroom == before.headroom + pull_len);
+		CU_ASSERT(after.tailroom == before.tailroom);
+	}
+	if (rc == 0) {
+		CU_ASSERT(after.tail  == before.tail);
+		CU_ASSERT(after.uarea == before.uarea);
+		check_ptrs_tail(&before.seg_info, &after.seg_info, after.len);
+	}
+}
+
+static void pkt_pull_head(odp_packet_t *pkt, uint32_t pull_len)
+{
+	pkt_state_t before, after;
+	void *data_ptr;
+
+	save_pkt_state(*pkt, &before);
+	data_ptr = odp_packet_pull_head(*pkt, pull_len);
+	save_pkt_state(*pkt, &after);
+
+	if (before.seg_info.segs[0].len <= pull_len) {
+		CU_ASSERT(data_ptr == NULL);
+		check_pkt_state_equal(&before, &after);
+		return;
+	}
+
+	CU_ASSERT(data_ptr != NULL);
+
+	check_metadata_equal(&before.metadata, &after.metadata);
+	check_pkt_data(&before, pull_len, &after, 0, after.len);
+	CU_ASSERT(data_ptr == after.seg_info.segs[0].data);
+	CU_ASSERT(after.len = before.len - pull_len);
+	CU_ASSERT(after.data == before.data + pull_len);
+	CU_ASSERT(after.tail  == before.tail);
+	CU_ASSERT(after.uarea == before.uarea);
+	CU_ASSERT(after.seg_info.num_segs == before.seg_info.num_segs);
+
+	check_ptrs_tail(&before.seg_info, &after.seg_info, after.len);
+}
+
+static void pkt_extend_tail(odp_packet_t *pkt, uint32_t push_len)
+{
+	pkt_state_t before, after;
+	void *data_ptr, *data_ptr_2;
+	uint32_t seg_len, seg_len_2;
+	int rc;
+
+	save_pkt_state(*pkt, &before);
+	rc = odp_packet_extend_tail(pkt, push_len, &data_ptr, &seg_len);
+	CU_ASSERT(rc >= 0);
+	write_pkt_data(*pkt, before.len, push_len);
+	save_pkt_state(*pkt, &after);
+
+	data_ptr_2 = get_data_ptr(&after.seg_info, before.len, &seg_len_2);
+	CU_ASSERT(data_ptr == data_ptr_2);
+	CU_ASSERT(seg_len == seg_len_2);
+
+	check_metadata_equal(&before.metadata, &after.metadata);
+	check_pkt_data(&before, 0, &after, 0, before.len);
+
+	CU_ASSERT(after.len = before.len + push_len);
+
+	if (before.tailroom >= push_len) {
+		CU_ASSERT(rc == 0);
+		CU_ASSERT(after.tail == before.tail + push_len);
+		CU_ASSERT(data_ptr == before.tail);
+		CU_ASSERT(after.headroom == before.headroom);
+		CU_ASSERT(after.tailroom == before.tailroom - push_len);
+	}
+	if (rc == 0) {
+		CU_ASSERT(after.head == before.head);
+		CU_ASSERT(after.data == before.data);
+		CU_ASSERT(after.uarea == before.uarea);
+		check_ptrs_head(&before.seg_info, &after.seg_info, before.len);
+	}
+}
+
+static void pkt_push_tail(odp_packet_t *pkt, uint32_t push_len)
+{
+	pkt_state_t before, after;
+	void *old_tail_ptr;
+
+	save_pkt_state(*pkt, &before);
+	old_tail_ptr = odp_packet_push_tail(*pkt, push_len);
+	save_pkt_state(*pkt, &after);
+
+	if (before.tailroom < push_len) {
+		CU_ASSERT(old_tail_ptr == NULL);
+		check_pkt_state_equal(&before, &after);
+		return;
+	}
+	CU_ASSERT(old_tail_ptr != NULL);
+	CU_ASSERT(old_tail_ptr == before.tail);
+
+	write_pkt_data(*pkt, before.len, push_len);
+
+	check_metadata_equal(&before.metadata, &after.metadata);
+	check_pkt_data(&before, 0, &after, 0, before.len);
+
+	CU_ASSERT(after.len = before.len + push_len);
+	CU_ASSERT(after.head == before.head);
+	CU_ASSERT(after.data == before.data);
+	CU_ASSERT(after.tail  == before.tail + push_len);
+	CU_ASSERT(after.uarea == before.uarea);
+	CU_ASSERT(after.seg_info.num_segs == before.seg_info.num_segs);
+
+	check_ptrs_head(&before.seg_info, &after.seg_info, before.len);
+}
+
+static void pkt_trunc_tail(odp_packet_t *pkt, uint32_t pull_len)
+{
+	pkt_state_t before, after;
+	void *tail;
+	uint32_t tailroom;
+	int rc;
+
+	save_pkt_state(*pkt, &before);
+	rc = odp_packet_trunc_tail(pkt, pull_len, &tail, &tailroom);
+	save_pkt_state(*pkt, &after);
+
+	if (before.len <= pull_len) {
+		CU_ASSERT(rc < 0);
+		check_pkt_state_equal(&before, &after);
+		return;
+	}
+	CU_ASSERT(rc >= 0);
+
+	check_metadata_equal(&before.metadata, &after.metadata);
+	check_pkt_data(&before, 0, &after, 0, after.len);
+
+	CU_ASSERT(tail == after.tail);
+	CU_ASSERT(tailroom  == after.tailroom);
+	CU_ASSERT(after.len = before.len - pull_len);
+
+	if (last_seg(&before.seg_info)->len > pull_len) {
+		bool tail_data_maybe_shared = (odp_packet_is_referencing(*pkt) &&
+					       before.tailroom == 0 &&
+					       after.tailroom == 0);
+		CU_ASSERT(rc == 0);
+		CU_ASSERT(after.tail == before.tail - pull_len);
+		CU_ASSERT(after.headroom == before.headroom);
+		if (!tail_data_maybe_shared)
+			CU_ASSERT(after.tailroom == before.tailroom + pull_len);
+	}
+	if (rc == 0) {
+		CU_ASSERT(after.data == before.data);
+		CU_ASSERT(after.head == before.head);
+		CU_ASSERT(after.uarea == before.uarea);
+		check_ptrs_head(&before.seg_info, &after.seg_info, after.len);
+	}
+}
+
+static void pkt_pull_tail(odp_packet_t *pkt, uint32_t pull_len)
+{
+	pkt_state_t before, after;
+	void *data_ptr;
+
+	save_pkt_state(*pkt, &before);
+	data_ptr = odp_packet_pull_tail(*pkt, pull_len);
+	save_pkt_state(*pkt, &after);
+
+	if (last_seg(&before.seg_info)->len <= pull_len) {
+		CU_ASSERT(data_ptr == NULL);
+		check_pkt_state_equal(&before, &after);
+		return;
+	}
+	CU_ASSERT(data_ptr != NULL);
+	CU_ASSERT(data_ptr == after.tail);
+
+	check_metadata_equal(&before.metadata, &after.metadata);
+	check_pkt_data(&before, 0, &after, 0, after.len);
+
+	CU_ASSERT(after.len = before.len - pull_len);
+	CU_ASSERT(after.head == before.head);
+	CU_ASSERT(after.data == before.data);
+	CU_ASSERT(after.tail  == before.tail - pull_len);
+	CU_ASSERT(after.uarea == before.uarea);
+	CU_ASSERT(after.seg_info.num_segs == before.seg_info.num_segs);
+
+	check_ptrs_head(&before.seg_info, &after.seg_info, after.len);
+}
+
+static void prepare_pkt(odp_packet_t *pkt, uint32_t op, uint32_t op_param)
+{
+	switch (op) {
+	case PRE_OP_NONE:
+	default:
+		return;
+	case PRE_OP_EXTEND_HEAD:
+		pkt_extend_head(pkt, op_param);
+		break;
+	case PRE_OP_EXTEND_TAIL:
+		pkt_extend_tail(pkt, op_param);
+		break;
+	case PRE_OP_TRUNC_HEAD:
+		pkt_trunc_head(pkt, op_param);
+		break;
+	case PRE_OP_TRUNC_TAIL:
+		pkt_trunc_tail(pkt, op_param);
+		break;
+	}
+}
+
+static odp_packet_t make_test_packet(const pkt_param_t *param, test_pkt_state_t *state)
+{
+	odp_packet_t pkt;
+
+	pkt = make_packet(param->base_len, param->base_num_segs);
+
+	switch (param->pkt_type) {
+	case PKT_TYPE_NORMAL:
+		prepare_pkt(&pkt, param->pre_op, param->pre_op_param);
+		state->pkt = ODP_PACKET_INVALID;
+		break;
+	case PKT_TYPE_STATIC_REF:
+		prepare_pkt(&pkt, param->pre_op, param->pre_op_param);
+		state->pkt = pkt;
+		save_pkt_state(state->pkt, &state->pkt_state);
+		pkt = odp_packet_ref_static(pkt);
+		CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+		break;
+	case PKT_TYPE_REFERENCING:
+		state->pkt = pkt;
+		save_pkt_state(state->pkt, &state->pkt_state);
+		pkt = create_ref(pkt, &state->pkt_state, param->ref_offset);
+		prepare_pkt(&pkt, param->pre_op, param->pre_op_param);
+		break;
+	case PKT_TYPE_REFERENCED:
+		save_pkt_state(pkt, &state->pkt_state);
+		state->pkt = create_ref(pkt, &state->pkt_state, param->ref_offset);
+		prepare_pkt(&state->pkt, param->pre_op, param->pre_op_param);
+		save_pkt_state(state->pkt, &state->pkt_state);
+		break;
+	default:
+		CU_FAIL("internal error: invalid packet type");
+		state->pkt = ODP_PACKET_INVALID;
+		break;
+	}
+
+	return pkt;
+}
+
+static void test_packet_done(test_pkt_state_t *state)
+{
+	pkt_state_t after;
+
+	if (state->pkt != ODP_PACKET_INVALID) {
+		save_pkt_state(state->pkt, &after);
+		check_pkt_state_equal(&state->pkt_state, &after);
+		odp_packet_free(state->pkt);
+	}
+}
+
+/* return the length of the test packet corresponding to the parameters */
+static uint32_t test_pkt_len(const pkt_param_t *pkt_param)
+{
+	test_pkt_state_t state;
+	odp_packet_t pkt;
+	uint32_t len;
+
+	if (pkt_param->pre_op == PRE_OP_NONE) {
+		if (pkt_param->pkt_type == PKT_TYPE_REFERENCING)
+			return pkt_param->base_len - pkt_param->ref_offset;
+		else
+			return pkt_param->base_len;
+	}
+	/* let's probe what really happens with pre op applied */
+	pkt = make_test_packet(pkt_param, &state);
+	len = odp_packet_len(pkt);
+	test_packet_done(&state);
+	odp_packet_free(pkt);
+	return len;
+}
+
+static uint32_t ref_shared_offs(const pkt_param_t *param)
+{
+	CU_ASSERT(param->pkt_type == PKT_TYPE_REFERENCING);
+
+	if (param->pre_op == PRE_OP_EXTEND_HEAD)
+		return param->pre_op_param;
+	return 0;
+}
+
+static uint32_t ref_shared_len(const pkt_param_t *param)
+{
+	CU_ASSERT(param->pkt_type == PKT_TYPE_REFERENCING);
+
+	uint32_t len = param->base_len - param->ref_offset;
+
+	if (param->pre_op == PRE_OP_TRUNC_HEAD ||
+	    param->pre_op == PRE_OP_TRUNC_TAIL)
+		len -= param->pre_op_param;
+	return len;
+}
+
+static void for_each_pkt_variant(pkt_type_t pkt_type, pkt_func_t func, const void *ctx)
+{
+	uint32_t iter = 0;
+	pkt_layout_t layout;
+	uint32_t pre_op_params[] = {2, 13};
+
+	while (iterate_pkt_layout(&layout, &iter))
+		for (uint32_t op = 0; op < NUM_PRE_OPS; op++)
+			for (uint32_t opp = 0; opp < ODPH_ARRAY_SIZE(pre_op_params); opp++) {
+				pkt_param_t pkt_param = {
+					.pkt_type = pkt_type,
+					.base_len = layout.len,
+					.base_num_segs = layout.num_segs,
+					.ref_offset = layout.offset,
+					.pre_op = op,
+					.pre_op_param = pre_op_params[opp],
+				};
+
+				func(&pkt_param, ctx);
+			}
+}
+
+static void for_each_mutable_packet_variant(pkt_func_t func, const void *ctx)
+{
+	pkt_type_t pkt_types[] = {PKT_TYPE_NORMAL, PKT_TYPE_REFERENCING};
+
+	for (uint32_t type = 0; type < ODPH_ARRAY_SIZE(pkt_types); type++)
+		for_each_pkt_variant(pkt_types[type], func, ctx);
+}
+
+static void for_each_packet_variant(pkt_func_t func, const void *ctx)
+{
+	pkt_type_t pkt_types[] = {
+		PKT_TYPE_NORMAL,
+		PKT_TYPE_REFERENCING,
+		PKT_TYPE_REFERENCED,
+		PKT_TYPE_STATIC_REF,
+	};
+
+	for (uint32_t type = 0; type < ODPH_ARRAY_SIZE(pkt_types); type++)
+		for_each_pkt_variant(pkt_types[type], func, ctx);
+}
+
+static void do_test_ref(const pkt_param_t *pkt_param, const void *ctx ODP_UNUSED)
+{
+	uint32_t pkt_len = test_pkt_len(pkt_param);
+	test_pkt_state_t state;
+	odp_packet_t pkt, ref;
+	pkt_state_t base_state;
+
+	for (uint32_t offset = 0; offset < pkt_len; offset++) {
+		pkt = make_test_packet(pkt_param, &state);
+		save_pkt_state(pkt, &base_state);
+		ref = create_ref(pkt, &base_state, offset);
+		odp_packet_free(ref);
+		test_packet_done(&state);
+		odp_packet_free(pkt);
+	}
+}
+
+static void test_ref(void)
+{
+	/* pkt types that can be passed to odp_packet_ref() */
+	pkt_type_t pkt_types[] = {PKT_TYPE_NORMAL, PKT_TYPE_REFERENCED};
+
+	for (uint32_t type = 0; type < ODPH_ARRAY_SIZE(pkt_types); type++)
+		for_each_pkt_variant(pkt_types[type], do_test_ref, NULL);
+}
+
+/*
+ * Run the provided function (push/pull/extend/trunc head/tail) with
+ * different len parameters.
+ */
+static void do_test_pkt_adj(const pkt_param_t *pkt_param, const void *ctx)
+{
+	uint32_t pkt_len = test_pkt_len(pkt_param);
+	test_pkt_state_t state;
+	odp_packet_t pkt;
+	const pkt_adj_param_t *param = ctx;
+
+	/*
+	 * We assume ODP implementations check too big values and
+	 * intentionally loop all the way to pkt_len + 1.
+	 */
+	for (uint32_t len = 1; len <= pkt_len + 1; len++) {
+		pkt = make_test_packet(pkt_param, &state);
+		param->func(&pkt, len);
+		test_packet_done(&state);
+		odp_packet_free(pkt);
+	}
+}
+
+static void test_pkt_adj(pkt_adj_func_t func)
+{
+	const pkt_adj_param_t param = {.func = func};
+
+	for_each_mutable_packet_variant(do_test_pkt_adj, &param);
+}
+
+static void test_extend_head(void)
+{
+	test_pkt_adj(pkt_extend_head);
+}
+
+static void test_push_head(void)
+{
+	test_pkt_adj(pkt_push_head);
+}
+
+static void test_trunc_head(void)
+{
+	test_pkt_adj(pkt_trunc_head);
+}
+
+static void test_pull_head(void)
+{
+	test_pkt_adj(pkt_pull_head);
+}
+
+static void test_extend_tail(void)
+{
+	test_pkt_adj(pkt_extend_tail);
+}
+
+static void test_push_tail(void)
+{
+	test_pkt_adj(pkt_push_tail);
+}
+
+static void test_trunc_tail(void)
+{
+	test_pkt_adj(pkt_trunc_tail);
+}
+
+static void test_pull_tail(void)
+{
+	test_pkt_adj(pkt_pull_tail);
+}
+
+static void pkt_reset_meta(odp_packet_t pkt)
+{
+	pkt_state_t before, after;
+	int is_ref, has_ref;
+
+	is_ref = odp_packet_is_referencing(pkt);
+	has_ref = odp_packet_has_ref(pkt);
+
+	save_pkt_state(pkt, &before);
+	odp_packet_reset_meta(pkt);
+	save_pkt_state(pkt, &after);
+
+	CU_ASSERT(before.len        == after.len);
+	CU_ASSERT(before.headroom   == after.headroom);
+	CU_ASSERT(before.tailroom   == after.tailroom);
+	CU_ASSERT(before.head       == after.head);
+	CU_ASSERT(before.data       == after.data);
+	CU_ASSERT(before.tail       == after.tail);
+	/* We assume user area pointer is preserved. API does not say it */
+	CU_ASSERT(before.uarea      == after.uarea);
+
+	check_pkt_data_equal(&before, &after);
+	check_seg_info_equal(&before.seg_info, &after.seg_info);
+	check_metadata_default(pkt);
+
+	CU_ASSERT(before.metadata.user_area_chksum == after.metadata.user_area_chksum);
+
+	CU_ASSERT(odp_packet_is_referencing(pkt) == is_ref);
+	CU_ASSERT(odp_packet_has_ref(pkt) == has_ref);
+}
+
+static void do_test_reset_meta(const pkt_param_t *pkt_param, const void *ctx ODP_UNUSED)
+{
+	test_pkt_state_t state;
+	odp_packet_t pkt;
+
+	if (pkt_param->pkt_type == PKT_TYPE_STATIC_REF)
+		return;
+
+	pkt = make_test_packet(pkt_param, &state);
+	pkt_reset_meta(pkt);
+	test_packet_done(&state);
+	odp_packet_free(pkt);
+}
+
+static void test_reset_meta(void)
+{
+	for_each_packet_variant(do_test_reset_meta, NULL);
+}
+
+static void pkt_copy(odp_packet_t pkt)
+{
+	pkt_state_t before, after, state_copy;
+	odp_packet_t copy;
+
+	save_pkt_state(pkt, &before);
+	copy = odp_packet_copy(pkt, odp_packet_pool(pkt));
+	save_pkt_state(pkt, &after);
+	CU_ASSERT_FATAL(copy != ODP_PACKET_INVALID);
+	save_pkt_state(copy, &state_copy);
+
+	check_pkt_state_equal(&before, &after);
+	check_metadata_equal(&before.metadata, &state_copy.metadata);
+	check_pkt_data_equal(&before, &state_copy);
+	set_random_md(copy);
+	write_uarea(copy);
+	CU_ASSERT(odp_packet_has_ref(copy) == 0);
+	CU_ASSERT(odp_packet_is_referencing(copy) == 0);
+
+	write_pkt_data(copy, 0, state_copy.len);
+	check_pkt_state_equal(&before, &after);
+
+	odp_packet_free(copy);
+}
+
+static void do_test_copy(const pkt_param_t *pkt_param, const void *ctx ODP_UNUSED)
+{
+	test_pkt_state_t state;
+	odp_packet_t pkt;
+
+	pkt = make_test_packet(pkt_param, &state);
+	pkt_copy(pkt);
+	test_packet_done(&state);
+	odp_packet_free(pkt);
+}
+
+static void test_copy(void)
+{
+	for_each_packet_variant(do_test_copy, NULL);
+}
+
+static void pkt_copy_part(odp_packet_t pkt, uint32_t offset, uint32_t len)
+{
+	pkt_state_t before, after, state_copy;
+	odp_packet_t copy;
+
+	save_pkt_state(pkt, &before);
+	copy = odp_packet_copy_part(pkt, offset, len, odp_packet_pool(pkt));
+	save_pkt_state(pkt, &after);
+	CU_ASSERT_FATAL(copy != ODP_PACKET_INVALID);
+	save_pkt_state(copy, &state_copy);
+
+	check_pkt_state_equal(&before, &after);
+	CU_ASSERT(state_copy.len == len);
+	check_metadata_default(copy);
+	check_pkt_data(&before, offset, &state_copy, 0, len);
+	set_random_md(copy);
+	write_uarea(copy);
+	CU_ASSERT(odp_packet_has_ref(copy) == 0);
+	CU_ASSERT(odp_packet_is_referencing(copy) == 0);
+
+	write_pkt_data(copy, 0, state_copy.len);
+	check_pkt_state_equal(&before, &after);
+
+	odp_packet_free(copy);
+}
+
+static void do_test_copy_part(const pkt_param_t *pkt_param, const void *ctx ODP_UNUSED)
+{
+	uint32_t pkt_len = test_pkt_len(pkt_param);
+	test_pkt_state_t state;
+	odp_packet_t pkt;
+
+	for (uint32_t offs = 0; offs < pkt_len; offs++) {
+		for (uint32_t len = 1; len < 20; len++) {
+			if (offs + len > pkt_len)
+				continue;
+			pkt = make_test_packet(pkt_param, &state);
+			pkt_copy_part(pkt, offs, len);
+			test_packet_done(&state);
+			odp_packet_free(pkt);
+		}
+	}
+}
+
+static void test_copy_part(void)
+{
+	for_each_packet_variant(do_test_copy_part, NULL);
+}
+
+static void pkt_concat(odp_packet_t *dst, odp_packet_t src)
+{
+	pkt_state_t dst_before, dst_after, src_before;
+	int rc;
+
+	save_pkt_state(*dst, &dst_before);
+	save_pkt_state(src, &src_before);
+
+	rc = odp_packet_concat(dst, src);
+	CU_ASSERT(rc >= 0);
+	save_pkt_state(*dst, &dst_after);
+
+	check_metadata_equal(&dst_before.metadata, &dst_after.metadata);
+	check_pkt_data(&dst_before, 0, &dst_after, 0, dst_before.len);
+	check_pkt_data(&src_before, 0, &dst_after, dst_before.len, src_before.len);
+	CU_ASSERT(dst_before.len + src_before.len == dst_after.len);
+
+	if (rc == 0) {
+		check_ptrs_head(&dst_after.seg_info, &dst_before.seg_info, dst_before.len);
+		check_ptrs_tail(&dst_after.seg_info, &src_before.seg_info, src_before.len);
+		CU_ASSERT(dst_before.uarea == dst_after.uarea);
+	}
+}
+
+static void do_test_concat(const pkt_param_t *dst_param, const void *ctx)
+{
+	const pkt_param_t *src_param = ctx;
+
+	odp_packet_t dst, src;
+	test_pkt_state_t dst_state, src_state;
+
+	dst = make_test_packet(dst_param, &dst_state);
+	src = make_test_packet(src_param, &src_state);
+
+	pkt_concat(&dst, src);
+
+	test_packet_done(&dst_state);
+	test_packet_done(&src_state);
+	odp_packet_free(dst);
+}
+
+static void test_concat_iterate_dst(const pkt_param_t *src_param, const void *ctx ODP_UNUSED)
+{
+	for_each_mutable_packet_variant(do_test_concat, src_param);
+}
+
+static void test_concat(void)
+{
+	for_each_mutable_packet_variant(test_concat_iterate_dst, NULL);
+}
+
+static void pkt_split(odp_packet_t *pkt, uint32_t len)
+{
+	pkt_state_t before, after_head, after_tail;
+	odp_packet_t tail = ODP_PACKET_INVALID;
+	int rc;
+
+	save_pkt_state(*pkt, &before);
+	rc = odp_packet_split(pkt, len, &tail);
+	save_pkt_state(*pkt, &after_head);
+
+	if (len == 0 || len >= before.len) {
+		CU_ASSERT(rc < 0);
+		check_pkt_state_equal(&before, &after_head);
+		return;
+	}
+
+	CU_ASSERT(rc >= 0);
+	CU_ASSERT_FATAL(tail != ODP_PACKET_INVALID);
+	save_pkt_state(tail, &after_tail);
+
+	check_metadata_equal(&before.metadata, &after_head.metadata);
+	check_metadata_default(tail);
+	CU_ASSERT(after_head.len == len);
+	CU_ASSERT(after_tail.len == before.len - len);
+	check_pkt_data(&after_head, 0, &before, 0, len);
+	check_pkt_data(&after_tail, 0, &before, len, after_tail.len);
+
+	if (rc == 0) {
+		/*
+		 * We do not check tail since the intention, if not the letter,
+		 * of the API may be that the no-ptrs-changed status is only
+		 * about the data that stays in the head part.
+		 */
+		check_ptrs_head(&before.seg_info, &after_head.seg_info, len);
+		CU_ASSERT(before.uarea == after_head.uarea);
+	}
+
+	odp_packet_free(tail);
+}
+
+static void do_test_split(const pkt_param_t *pkt_param, const void *ctx ODP_UNUSED)
+{
+	uint32_t pkt_len = test_pkt_len(pkt_param);
+	test_pkt_state_t state;
+	odp_packet_t pkt;
+
+	for (uint32_t offs = 1 ; offs < pkt_len; offs++) {
+		pkt = make_test_packet(pkt_param, &state);
+		pkt_split(&pkt, offs);
+		test_packet_done(&state);
+		odp_packet_free(pkt);
+	}
+}
+
+static void test_split(void)
+{
+	for_each_mutable_packet_variant(do_test_split, NULL);
+}
+
+static void pkt_add_data(odp_packet_t *pkt, uint32_t offs, uint32_t len)
+{
+	pkt_state_t before, after;
+	int rc;
+
+	save_pkt_state(*pkt, &before);
+	rc = odp_packet_add_data(pkt, offs, len);
+	CU_ASSERT_FATAL(rc >= 0);
+	write_pkt_data(*pkt, offs, len);
+	save_pkt_state(*pkt, &after);
+
+	if (len == 0) {
+		if (rc == 0) {
+			check_pkt_state_equal(&before, &after);
+		} else {
+			check_metadata_equal(&before.metadata, &after.metadata);
+			check_pkt_data_equal(&before, &after);
+		}
+		return;
+	}
+
+	CU_ASSERT(after.len == before.len + len);
+	check_metadata_equal(&before.metadata, &after.metadata);
+	check_pkt_data(&before, 0, &after, 0, offs);
+	check_pkt_data(&before, offs, &after, offs + len, before.len - offs);
+
+	if (rc == 0) {
+		if (offs != 0) {
+			CU_ASSERT(before.data == after.data);
+			CU_ASSERT(before.head == after.head);
+		}
+		CU_ASSERT(before.uarea == after.uarea);
+		check_ptrs_head(&before.seg_info, &after.seg_info, offs);
+		check_ptrs_tail(&before.seg_info, &after.seg_info, before.len - offs);
+	}
+}
+
+static void do_test_add_data(const pkt_param_t *pkt_param, const void *ctx ODP_UNUSED)
+{
+	test_pkt_state_t state;
+	odp_packet_t pkt;
+	uint32_t pkt_len = test_pkt_len(pkt_param);
+
+	for (uint32_t offs = 0; offs < pkt_len; offs++) {
+		for (uint32_t len = 1; len < 20; len++) {
+			pkt = make_test_packet(pkt_param, &state);
+			pkt_add_data(&pkt, offs, len);
+			test_packet_done(&state);
+			odp_packet_free(pkt);
+		}
+	}
+}
+
+static void test_add_data(void)
+{
+	for_each_mutable_packet_variant(do_test_add_data, NULL);
+}
+
+static void pkt_rem_data(odp_packet_t *pkt, uint32_t offs, uint32_t len)
+{
+	pkt_state_t before, after;
+	int rc;
+
+	save_pkt_state(*pkt, &before);
+	rc = odp_packet_rem_data(pkt, offs, len);
+	CU_ASSERT_FATAL(rc >= 0);
+	save_pkt_state(*pkt, &after);
+
+	if (len == 0) {
+		if (rc == 0) {
+			check_pkt_state_equal(&before, &after);
+		} else {
+			check_metadata_equal(&before.metadata, &after.metadata);
+			check_pkt_data_equal(&before, &after);
+		}
+		return;
+	}
+
+	CU_ASSERT(after.len == before.len - len);
+	check_metadata_equal(&before.metadata, &after.metadata);
+	check_pkt_data(&before, 0, &after, 0, offs);
+	check_pkt_data(&before, offs + len, &after, offs, after.len - offs);
+
+	if (rc == 0) {
+		if (offs != 0) {
+			CU_ASSERT(before.data == after.data);
+			CU_ASSERT(before.head == after.head);
+		}
+		CU_ASSERT(before.uarea == after.uarea);
+		check_ptrs_head(&before.seg_info, &after.seg_info, offs);
+		check_ptrs_tail(&before.seg_info, &after.seg_info, after.len - offs);
+	}
+}
+
+static void do_test_rem_data(const pkt_param_t *pkt_param, const void *ctx ODP_UNUSED)
+{
+	uint32_t pkt_len = test_pkt_len(pkt_param);
+	test_pkt_state_t state;
+	odp_packet_t pkt;
+
+	for (uint32_t offs = 0; offs < pkt_len; offs++) {
+		for (uint32_t len = 1; len < 20; len++) {
+			if (offs + len > pkt_len || len >= pkt_len)
+				continue;
+			pkt = make_test_packet(pkt_param, &state);
+			pkt_rem_data(&pkt, offs, len);
+			test_packet_done(&state);
+			odp_packet_free(pkt);
+		}
+	}
+}
+
+static void test_rem_data(void)
+{
+	for_each_mutable_packet_variant(do_test_rem_data, NULL);
+}
+
+static void pkt_align(odp_packet_t *pkt, uint32_t offset, uint32_t len, uint32_t align)
+{
+	pkt_state_t before, after;
+	int rc;
+	uint32_t *ptr;
+	uint32_t seg_len;
+	odp_packet_seg_t seg;
+
+	CU_ASSERT((align & (align - 1)) == 0);
+
+	save_pkt_state(*pkt, &before);
+
+	if (offset >= before.len)
+		offset = before.len == 1 ? 0 : before.len - 2;
+	if (len > before.len - offset)
+		len = before.len - offset;
+
+	rc = odp_packet_align(pkt, offset, len, align);
+	CU_ASSERT_FATAL(rc >= 0);
+	save_pkt_state(*pkt, &after);
+
+	check_metadata_equal(&before.metadata, &after.metadata);
+	check_pkt_data_equal(&before, &after);
+
+	ptr = odp_packet_offset(*pkt, offset, &seg_len, &seg);
+
+	/*
+	 * The linux-gen ODP implementation for regular packets is and has
+	 * always been buggy. When the result is segmented, the requested area
+	 * may not be continuous and properly aligned. We skip the tests
+	 * for regular segmented packets until the bug gets fixed.
+	 */
+	if (odp_packet_is_referencing(*pkt) || !odp_packet_is_segmented(*pkt)) {
+		CU_ASSERT(seg_len >= len);
+		if (align > 1)
+			CU_ASSERT((((uintptr_t)ptr) & (align - 1)) == 0);
+	}
+
+	if (rc == 0) {
+		if (offset > 0) {
+			CU_ASSERT(before.data == after.data);
+			CU_ASSERT(before.head == after.head);
+		}
+		check_ptrs_head(&before.seg_info, &after.seg_info, offset);
+		check_ptrs_tail(&before.seg_info, &after.seg_info, after.len - offset);
+	}
+}
+
+static void do_test_align(const pkt_param_t *pkt_param, const void *ctx ODP_UNUSED)
+{
+	uint32_t offsets[] = {0, 1, 5, 10, 11, 17};
+	uint32_t lengths[] = {0, 1, 2, 5, 15, 100};
+	uint32_t alignments[] = {0, 1, 2, 4, 8};
+
+	for (uint32_t off = 0; off < ODPH_ARRAY_SIZE(offsets); off++) {
+		for (uint32_t len = 0; len < ODPH_ARRAY_SIZE(lengths); len++) {
+			uint32_t offset = offsets[off];
+			uint32_t length = lengths[len];
+
+			if (pkt_param->pkt_type == PKT_TYPE_REFERENCING) {
+				uint32_t shared_offs = ref_shared_offs(pkt_param);
+				uint32_t shared_len = ref_shared_len(pkt_param);
+
+				/* Skip test if we would align shared data */
+				if ((offset >= shared_offs ||
+				     offset + length > shared_offs) &&
+				    (offset < shared_offs + shared_len))
+					continue;
+			}
+
+			for (uint32_t ali = 0; ali < ODPH_ARRAY_SIZE(alignments); ali++) {
+				test_pkt_state_t state;
+				odp_packet_t pkt;
+
+				pkt = make_test_packet(pkt_param, &state);
+				pkt_align(&pkt, offset, length, alignments[ali]);
+				test_packet_done(&state);
+				odp_packet_free(pkt);
+			}
+		}
+	}
+}
+
+static void test_align(void)
+{
+	for_each_mutable_packet_variant(do_test_align, NULL);
+}
+
+odp_testinfo_t packet_ref_suite[] = {
+	ODP_TEST_INFO(test_basic_ref_creation),
+	ODP_TEST_INFO(test_ref),
+	ODP_TEST_INFO(test_extend_head),
+	ODP_TEST_INFO(test_push_head),
+	ODP_TEST_INFO(test_trunc_head),
+	ODP_TEST_INFO(test_pull_head),
+	ODP_TEST_INFO(test_extend_tail),
+	ODP_TEST_INFO(test_push_tail),
+	ODP_TEST_INFO(test_trunc_tail),
+	ODP_TEST_INFO(test_pull_tail),
+	ODP_TEST_INFO(test_reset_meta),
+	ODP_TEST_INFO(test_copy),
+	ODP_TEST_INFO(test_copy_part),
+	ODP_TEST_INFO(test_concat),
+	ODP_TEST_INFO(test_split),
+	ODP_TEST_INFO(test_add_data),
+	ODP_TEST_INFO(test_rem_data),
+	ODP_TEST_INFO(test_align),
+	ODP_TEST_INFO_NULL,
+};
+
+int packet_ref_suite_init(void)
+{
+	odp_pool_capability_t pool_capa;
+	odp_pool_param_t params;
+
+	memset(&pool_capa, 0, sizeof(odp_pool_capability_t));
+
+	if (odp_pool_capability(&pool_capa) < 0) {
+		ODPH_ERR("odp_pool_capability() failed\n");
+		return -1;
+	}
+	if (pool_capa.pkt.max_uarea_size < uarea_size) {
+		printf("Warning: Packet user area too small\n");
+		uarea_size = 0;
+	}
+	if (pool_capa.pkt.max_num != 0 && pool_capa.pkt.max_num < MAX_PKT_NUM) {
+		ODPH_ERR("Max packet pool size is too small\n");
+		return -1;
+	}
+	if (pool_capa.pkt.max_len != 0 && pool_capa.pkt.max_len < MAX_PKT_LEN) {
+		ODPH_ERR("Max packet length is too small\n");
+		return -1;
+	}
+	if (pool_capa.pkt.max_seg_len != 0 && pool_capa.pkt.max_seg_len < MAX_PKT_LEN) {
+		ODPH_ERR("Max packet length is too small\n");
+		return -1;
+	}
+	if (pool_capa.pkt.max_segs_per_pkt < 4)
+		printf("Warning: Max segments per packet is too small\n");
+
+	odp_pool_param_init(&params);
+
+	params.type           = ODP_POOL_PACKET;
+	params.pkt.seg_len    = MAX_PKT_LEN;
+	params.pkt.len        = MAX_PKT_LEN;
+	params.pkt.max_len    = MAX_PKT_LEN;
+	params.pkt.num        = MAX_PKT_NUM;
+	params.pkt.uarea_size = uarea_size;
+
+	packet_pool = odp_pool_create("packet_pool", &params);
+	if (packet_pool == ODP_POOL_INVALID) {
+		ODPH_ERR("Packet pool creation failed\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+int packet_ref_suite_term(void)
+{
+	if (odp_pool_destroy(packet_pool) != 0)
+		return -1;
+
+	return 0;
+}

--- a/test/validation/api/packet/packet_ref.h
+++ b/test/validation/api/packet/packet_ref.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2026 Nokia
+ */
+
+#ifndef _ODP_TEST_PACKET_REF_H_
+#define _ODP_TEST_PACKET_REF_H_
+
+#include <odp_api.h>
+
+int packet_ref_suite_init(void);
+int packet_ref_suite_term(void);
+
+void packet_check_default_meta(odp_packet_t pkt); /* from packet.c */
+
+#endif

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -44,11 +44,15 @@
 /* Optional test flags that can be or'ed */
 typedef enum {
 	TEST_WITH_DEF_POOL = 1,
-	TEST_WITH_REFS = 2,
+	TEST_WITH_STATIC_REFS = 2,
+	TEST_WITH_REFFED_PKTS = 4,
+	TEST_WITH_DYN_REFS = 8,
 } test_flag_values_t;
 
-#define NUM_TEST_FLAGS 2
+#define NUM_TEST_FLAGS 4
 #define NUM_TEST_FLAG_COMBOS (1 << NUM_TEST_FLAGS)
+
+#define TEST_WITH_REFS (TEST_WITH_STATIC_REFS | TEST_WITH_REFFED_PKTS | TEST_WITH_DYN_REFS)
 
 /** local container for pktio attributes */
 typedef struct {
@@ -151,6 +155,39 @@ typedef struct pktio_global_t {
 } pktio_global_t;
 
 static pktio_global_t global;
+
+/*
+ * Some metadata cannot be read from a packet. We encode such metadata also
+ * in user pointer to make it 'readable'.
+ */
+static const uint8_t dummy[5];
+static const uint8_t *l3_chksum_insert_0 = &dummy[0];
+static const uint8_t *l3_chksum_insert_1 = &dummy[1];
+static const uint8_t *l4_chksum_insert_0 = &dummy[2];
+static const uint8_t *l4_chksum_insert_1 = &dummy[3];
+static const uint8_t *ts_request         = &dummy[4];
+
+static void test_flags_next(uint32_t *test_flags)
+{
+	uint32_t ref_flags;
+
+	/* keep looping until ref_flags has at most one bit set */
+	do {
+		*test_flags += 1;
+		ref_flags = *test_flags & TEST_WITH_REFS;
+	} while (ref_flags & (ref_flags - 1));
+}
+
+static int has_packet_ref_capa(const odp_pktio_capability_t *capa, uint32_t test_flags)
+{
+	if ((test_flags & TEST_WITH_STATIC_REFS) && !capa->packet_ref.static_ref)
+		return 0;
+	if ((test_flags & TEST_WITH_DYN_REFS)    && !capa->packet_ref.referencing_pkt)
+		return 0;
+	if ((test_flags & TEST_WITH_REFFED_PKTS) && !capa->packet_ref.referenced_pkt)
+		return 0;
+	return 1;
+}
 
 static odp_pool_t expected_rx_pool(uint32_t test_flags)
 {
@@ -1103,20 +1140,81 @@ static void check_parser_capa(odp_pktio_t pktio, int *l2, int *l3, int *l4)
 	}
 }
 
-static void make_refs(odp_packet_t ref[], odp_packet_t pkt[], uint32_t num)
+/* Return a dynamic reference to a packet, copying relevant metadata. */
+static odp_packet_t make_dyn_ref(odp_packet_t pkt)
+{
+	uint8_t *uptr;
+	odp_packet_t ref;
+
+	ref = odp_packet_ref(pkt, 0);
+	CU_ASSERT_FATAL(ref != ODP_PACKET_INVALID);
+	CU_ASSERT(odp_packet_is_referencing(ref));
+	CU_ASSERT(odp_packet_has_ref(pkt));
+
+	odp_packet_has_ipv4_set(ref,  odp_packet_has_ipv4(pkt));
+	odp_packet_has_udp_set(ref,   odp_packet_has_udp(pkt));
+	odp_packet_has_sctp_set(ref,  odp_packet_has_sctp(pkt));
+	odp_packet_l4_offset_set(ref, odp_packet_l4_offset(pkt));
+	odp_packet_l3_offset_set(ref, odp_packet_l3_offset(pkt));
+	odp_packet_l2_offset_set(ref, odp_packet_l2_offset(pkt));
+	odp_packet_aging_tmo_set(ref, odp_packet_aging_tmo(pkt));
+	odp_packet_free_ctrl_set(ref, odp_packet_free_ctrl(pkt));
+
+	uptr = odp_packet_user_ptr(pkt);
+	odp_packet_user_ptr_set(ref, uptr);
+
+	if (uptr == l3_chksum_insert_0)
+		odp_packet_l3_chksum_insert(ref, 0);
+	else if (uptr == l3_chksum_insert_1)
+		odp_packet_l3_chksum_insert(ref, 1);
+	else if (uptr == l4_chksum_insert_0)
+		odp_packet_l4_chksum_insert(ref, 0);
+	else if (uptr == l4_chksum_insert_1)
+		odp_packet_l4_chksum_insert(ref, 1);
+	else if (uptr == ts_request)
+		odp_packet_ts_request(ref, 1);
+
+	return ref;
+}
+
+static void make_refs(odp_packet_t ref[], odp_packet_t pkt[], uint32_t num, uint32_t test_flags)
 {
 	for (uint32_t i = 0; i < num; i++) {
-		ref[i] = odp_packet_ref_static(pkt[i]);
-		CU_ASSERT_FATAL(ref[i] != ODP_PACKET_INVALID);
-		CU_ASSERT(odp_packet_has_ref(ref[i]));
-		CU_ASSERT(odp_packet_has_ref(pkt[i]));
+		if (test_flags & TEST_WITH_STATIC_REFS) {
+			ref[i] = odp_packet_ref_static(pkt[i]);
+			CU_ASSERT_FATAL(ref[i] != ODP_PACKET_INVALID);
+			CU_ASSERT(odp_packet_has_ref(ref[i]));
+			CU_ASSERT(odp_packet_has_ref(pkt[i]));
+		} else if (test_flags & TEST_WITH_REFFED_PKTS) {
+			ref[i] = odp_packet_ref(pkt[i], 0);
+			CU_ASSERT_FATAL(ref[i] != ODP_PACKET_INVALID);
+			CU_ASSERT(odp_packet_is_referencing(ref[i]));
+			CU_ASSERT(odp_packet_has_ref(pkt[i]));
+		} else if (test_flags & TEST_WITH_DYN_REFS) {
+			/* change pkt to a reference and store original to ref */
+			ref[i] = pkt[i];
+			pkt[i] = make_dyn_ref(pkt[i]);
+		}
 	}
 }
 
-static void free_refs(odp_packet_t ref[], uint32_t num)
+static void free_refs(odp_packet_t ref[], uint32_t num, uint32_t test_flags)
 {
+	if ((test_flags & TEST_WITH_REFS) == 0)
+		return;
+
 	for (uint32_t i = 0; i < num; i++) {
 		CU_ASSERT(odp_packet_has_ref(ref[i]) == 0);
+
+		if (test_flags & TEST_WITH_REFFED_PKTS) {
+			/* We expect a referencing packet still be
+			 * a referencing packet even if the referenced
+			 * packet has been freed or consumed
+			 */
+			CU_ASSERT(odp_packet_is_referencing(ref[i]));
+		} else {
+			CU_ASSERT(!odp_packet_is_referencing(ref[i]));
+		}
 		odp_packet_free(ref[i]);
 	}
 }
@@ -1180,8 +1278,7 @@ static void pktio_txrx_multi(pktio_info_t *pktio_info_a,
 		}
 	}
 
-	if (test_flags & TEST_WITH_REFS)
-		make_refs(ref_tbl, tx_pkt, num_pkts);
+	make_refs(ref_tbl, tx_pkt, num_pkts, test_flags);
 
 	/* send packet(s) out */
 	if (mode == TXRX_MODE_SINGLE) {
@@ -1215,8 +1312,7 @@ static void pktio_txrx_multi(pktio_info_t *pktio_info_a,
 	if (num_rx != num_pkts)
 		ODPH_ERR("received %i, out of %i packets\n", num_rx, num_pkts);
 
-	if (test_flags & TEST_WITH_REFS)
-		free_refs(ref_tbl, num_pkts);
+	free_refs(ref_tbl, num_pkts, test_flags);
 
 	for (i = 0; i < num_rx; ++i) {
 		odp_packet_data_range_t range;
@@ -1280,6 +1376,7 @@ static void do_test_txrx(odp_pktin_mode_t in_mode, int num_pkts,
 		odp_pktout_queue_t pktout;
 		odp_queue_t queue = ODP_QUEUE_INVALID;
 		odp_pktout_mode_t out_mode = ODP_PKTOUT_MODE_DIRECT;
+		odp_pktio_capability_t capa;
 		uint64_t aggr_tmo = 0;
 
 		if (mode == TXRX_MODE_MULTI_EVENT)
@@ -1298,6 +1395,13 @@ static void do_test_txrx(odp_pktin_mode_t in_mode, int num_pkts,
 			CU_FAIL("failed to open iface");
 			return;
 		}
+
+		CU_ASSERT_FATAL(odp_pktio_capability(io->id, &capa) == 0);
+		if (i == 0 && !has_packet_ref_capa(&capa, test_flags)) {
+			CU_ASSERT_FATAL(odp_pktio_close(io->id) == 0);
+			return;
+		}
+
 		io->aggr_tmo = aggr_tmo;
 
 		if (mode == TXRX_MODE_MULTI_EVENT) {
@@ -1344,7 +1448,7 @@ static void test_txrx(odp_pktin_mode_t in_mode, int num_pkts,
 		      txrx_mode_e mode, odp_schedule_sync_t sync_mode,
 		      odp_bool_t vector_mode)
 {
-	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; flags++)
+	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; test_flags_next(&flags))
 		do_test_txrx(in_mode, num_pkts, mode, sync_mode, vector_mode, flags);
 }
 
@@ -3470,6 +3574,11 @@ static void test_pktin_ts(uint32_t test_flags)
 		CU_ASSERT_FATAL(odp_pktio_capability(pktio[i], &capa) == 0);
 		CU_ASSERT_FATAL(capa.config.pktin.bit.ts_all);
 
+		if (i == 0 && !has_packet_ref_capa(&capa, test_flags)) {
+			CU_ASSERT_FATAL(odp_pktio_close(pktio[i]) == 0);
+			return;
+		}
+
 		odp_pktio_config_init(&config);
 		config.pktin.bit.ts_all = 1;
 		CU_ASSERT_FATAL(odp_pktio_config(pktio[i], &config) == 0);
@@ -3507,8 +3616,7 @@ static void test_pktin_ts(uint32_t test_flags)
 	ret = odp_pktout_queue(pktio_tx, &pktout_queue, 1);
 	CU_ASSERT_FATAL(ret > 0);
 
-	if (test_flags & TEST_WITH_REFS)
-		make_refs(ref_tbl, pkt_tbl, TX_BATCH_LEN);
+	make_refs(ref_tbl, pkt_tbl, TX_BATCH_LEN, test_flags);
 
 	/* Send packets one at a time and add delay between the packets */
 	for (i = 0; i < TX_BATCH_LEN;  i++) {
@@ -3537,8 +3645,7 @@ static void test_pktin_ts(uint32_t test_flags)
 	num_rx = i;
 	CU_ASSERT(num_rx == TX_BATCH_LEN);
 
-	if (test_flags & TEST_WITH_REFS)
-		free_refs(ref_tbl, TX_BATCH_LEN);
+	free_refs(ref_tbl, TX_BATCH_LEN, test_flags);
 
 	ts_prev = ODP_TIME_NULL;
 	for (i = 0; i < num_rx; i++) {
@@ -3558,7 +3665,7 @@ static void test_pktin_ts(uint32_t test_flags)
 
 static void pktio_test_pktin_ts(void)
 {
-	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; flags++)
+	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; test_flags_next(&flags))
 		test_pktin_ts(flags);
 }
 
@@ -3596,6 +3703,11 @@ static void test_pktout_ts(uint32_t test_flags)
 		CU_ASSERT_FATAL(odp_pktio_capability(pktio[i], &capa) == 0);
 		CU_ASSERT_FATAL(capa.config.pktin.bit.ts_all);
 
+		if (i == 0 && !has_packet_ref_capa(&capa, test_flags)) {
+			CU_ASSERT_FATAL(odp_pktio_close(pktio[i]) == 0);
+			return;
+		}
+
 		odp_pktio_config_init(&config);
 		config.pktout.bit.ts_ena = 1;
 		CU_ASSERT_FATAL(odp_pktio_config(pktio[i], &config) == 0);
@@ -3630,9 +3742,9 @@ static void test_pktout_ts(uint32_t test_flags)
 
 		/* Enable ts capture on this pkt */
 		odp_packet_ts_request(pkt_tbl[i], 1);
+		odp_packet_user_ptr_set(pkt_tbl[i], ts_request);
 
-		if (test_flags & TEST_WITH_REFS)
-			make_refs(&ref_pkt, &pkt_tbl[i], 1);
+		make_refs(&ref_pkt, &pkt_tbl[i], 1, test_flags);
 
 		CU_ASSERT_FATAL(odp_pktout_send(pktout_queue,
 						&pkt_tbl[i], 1) == 1);
@@ -3640,8 +3752,7 @@ static void test_pktout_ts(uint32_t test_flags)
 				       1, TXRX_MODE_SINGLE, ODP_TIME_SEC_IN_NS,
 				       VECTOR_MODE_DISABLED);
 
-		if (test_flags & TEST_WITH_REFS)
-			free_refs(&ref_pkt, 1);
+		free_refs(&ref_pkt, 1, test_flags);
 
 		if (ret != 1)
 			break;
@@ -3670,8 +3781,31 @@ static void test_pktout_ts(uint32_t test_flags)
 
 static void pktio_test_pktout_ts(void)
 {
-	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; flags++)
+	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; test_flags_next(&flags))
 		test_pktout_ts(flags);
+}
+
+static void request_tx_completion(odp_packet_t pkt_tbl[],
+				  uint32_t pkt_seq[],
+				  odp_packet_tx_compl_mode_t mode,
+				  odp_queue_t compl_queue[])
+{
+	odp_packet_tx_compl_opt_t opt;
+
+	memset(&opt, 0, sizeof(opt));
+
+	for (int i = 0; i < TX_BATCH_LEN;  i++) {
+		CU_ASSERT(odp_packet_has_tx_compl_request(pkt_tbl[i]) == 0);
+		opt.mode = mode;
+		if (mode == ODP_PACKET_TX_COMPL_EVENT)
+			opt.queue = compl_queue[i];
+		else
+			opt.compl_id = i;
+		odp_packet_tx_compl_request(pkt_tbl[i], &opt);
+		CU_ASSERT(odp_packet_has_tx_compl_request(pkt_tbl[i]) != 0);
+		/* Set pkt sequence number as its user ptr */
+		odp_packet_user_ptr_set(pkt_tbl[i], (const void *)&pkt_seq[i]);
+	}
 }
 
 static void pktio_test_pktout_compl_event(bool use_plain_queue, uint32_t test_flags)
@@ -3739,6 +3873,11 @@ static void pktio_test_pktout_compl_event(bool use_plain_queue, uint32_t test_fl
 				CU_ASSERT_FATAL(pktio_capa.tx_compl.queue_type_sched != 0);
 			}
 
+			if (!has_packet_ref_capa(&pktio_capa, test_flags)) {
+				CU_ASSERT_FATAL(odp_pktio_close(pktio[i]) == 0);
+				goto err;
+			}
+
 			odp_pktio_config_init(&config);
 			config.tx_compl.mode_event = 1;
 			CU_ASSERT_FATAL(odp_pktio_config(pktio[i], &config) == 0);
@@ -3784,19 +3923,20 @@ static void pktio_test_pktout_compl_event(bool use_plain_queue, uint32_t test_fl
 	odp_packet_tx_compl_request(pkt_tbl[0], &opt);
 	CU_ASSERT(odp_packet_has_tx_compl_request(pkt_tbl[0]) == 0);
 
-	/* Prepare batch of pkts with different tx completion queues */
-	for (i = 0; i < TX_BATCH_LEN;  i++) {
-		CU_ASSERT(odp_packet_has_tx_compl_request(pkt_tbl[i]) == 0);
-		opt.queue = compl_queue[i];
-		opt.mode = ODP_PACKET_TX_COMPL_EVENT;
-		odp_packet_tx_compl_request(pkt_tbl[i], &opt);
-		CU_ASSERT(odp_packet_has_tx_compl_request(pkt_tbl[i]) != 0);
-		/* Set pkt sequence number as its user ptr */
-		odp_packet_user_ptr_set(pkt_tbl[i], (const void *)&pkt_seq[i]);
-	}
+	/* Prepare batch of pkts with different tx completion queues
+	 *
+	 * Non-static packet references do not share metadata with the original
+	 * packet, so postpone tx completion request after reference creation
+	 * in that case. For static references we have to do it now since we are
+	 * not allowed to alter any metadata after static reference creation.
+	 */
+	if ((test_flags & TEST_WITH_DYN_REFS) == 0)
+		request_tx_completion(pkt_tbl, pkt_seq, ODP_PACKET_TX_COMPL_EVENT, compl_queue);
 
-	if (test_flags & TEST_WITH_REFS)
-		make_refs(ref_tbl, pkt_tbl, TX_BATCH_LEN);
+	make_refs(ref_tbl, pkt_tbl, TX_BATCH_LEN, test_flags);
+
+	if ((test_flags & TEST_WITH_DYN_REFS) != 0)
+		request_tx_completion(pkt_tbl, pkt_seq, ODP_PACKET_TX_COMPL_EVENT, compl_queue);
 
 	CU_ASSERT_FATAL(odp_pktout_send(pktout_queue, pkt_tbl, TX_BATCH_LEN) == TX_BATCH_LEN);
 
@@ -3804,8 +3944,7 @@ static void pktio_test_pktout_compl_event(bool use_plain_queue, uint32_t test_fl
 				  ODP_TIME_SEC_IN_NS, VECTOR_MODE_DISABLED);
 	CU_ASSERT(num_rx == TX_BATCH_LEN);
 
-	if (test_flags & TEST_WITH_REFS)
-		free_refs(ref_tbl, TX_BATCH_LEN);
+	free_refs(ref_tbl, TX_BATCH_LEN, test_flags);
 
 	for (i = 0; i < num_rx; i++) {
 		CU_ASSERT(odp_packet_pool(pkt_tbl[i]) == expected_rx_pool(test_flags));
@@ -3920,6 +4059,7 @@ static void pktio_test_pktout_compl_event(bool use_plain_queue, uint32_t test_fl
 
 	odp_schedule_resume();
 
+err:
 	for (i = 0; i < TX_BATCH_LEN; i++)
 		odp_queue_destroy(compl_queue[i]);
 }
@@ -3953,6 +4093,11 @@ static void test_pktout_compl_poll(uint32_t test_flags)
 		if (i == 0) {
 			CU_ASSERT_FATAL(pktio_capa.tx_compl.mode_poll == 1);
 			CU_ASSERT_FATAL(pktio_capa.tx_compl.max_compl_id >= (TX_BATCH_LEN - 1));
+
+			if (!has_packet_ref_capa(&pktio_capa, test_flags)) {
+				CU_ASSERT_FATAL(odp_pktio_close(pktio[i]) == 0);
+				return;
+			}
 
 			odp_pktio_config_init(&config);
 			config.tx_compl.mode_poll = 1;
@@ -3997,22 +4142,25 @@ static void test_pktout_compl_poll(uint32_t test_flags)
 	odp_packet_tx_compl_request(pkt_tbl[0], &opt);
 	CU_ASSERT(odp_packet_has_tx_compl_request(pkt_tbl[0]) == 0);
 
-	/* Prepare batch of pkts with different tx completion identifiers */
-	for (i = 0; i < TX_BATCH_LEN;  i++) {
-		CU_ASSERT(odp_packet_has_tx_compl_request(pkt_tbl[i]) == 0);
-		opt.compl_id = i;
-		opt.mode = ODP_PACKET_TX_COMPL_POLL;
-		odp_packet_tx_compl_request(pkt_tbl[i], &opt);
-		CU_ASSERT(odp_packet_has_tx_compl_request(pkt_tbl[i]) != 0);
-		/* Set pkt sequence number as its user ptr */
-		odp_packet_user_ptr_set(pkt_tbl[i], (const void *)&pkt_seq[i]);
+	/* Prepare batch of pkts with different tx completion identifiers
+	 *
+	 * Non-static packet references do not share metadata with the original
+	 * packet, so postpone tx completion request after reference creation
+	 * in that case. For static references we have to do it now since we are
+	 * not allowed to alter any metadata after static reference creation.
+	 */
+	if ((test_flags & TEST_WITH_DYN_REFS) == 0)
+		request_tx_completion(pkt_tbl, pkt_seq, ODP_PACKET_TX_COMPL_POLL, NULL);
 
+	make_refs(ref_tbl, pkt_tbl, TX_BATCH_LEN, test_flags);
+
+	if ((test_flags & TEST_WITH_DYN_REFS) != 0)
+		request_tx_completion(pkt_tbl, pkt_seq, ODP_PACKET_TX_COMPL_POLL, NULL);
+
+	for (i = 0; i < TX_BATCH_LEN;  i++) {
 		/* Completion status should be still zero after odp_packet_tx_compl_request() */
 		CU_ASSERT(odp_packet_tx_compl_done(pktio_tx, i) == 0);
 	}
-
-	if (test_flags & TEST_WITH_REFS)
-		make_refs(ref_tbl, pkt_tbl, TX_BATCH_LEN);
 
 	CU_ASSERT_FATAL(odp_pktout_send(pktout_queue, pkt_tbl, TX_BATCH_LEN) == TX_BATCH_LEN);
 
@@ -4020,8 +4168,7 @@ static void test_pktout_compl_poll(uint32_t test_flags)
 				  ODP_TIME_SEC_IN_NS, VECTOR_MODE_DISABLED);
 	CU_ASSERT(num_rx == TX_BATCH_LEN);
 
-	if (test_flags & TEST_WITH_REFS)
-		free_refs(ref_tbl, TX_BATCH_LEN);
+	free_refs(ref_tbl, TX_BATCH_LEN, test_flags);
 
 	for (i = 0; i < num_rx; i++) {
 		CU_ASSERT(odp_packet_pool(pkt_tbl[i]) == expected_rx_pool(test_flags));
@@ -4043,7 +4190,7 @@ static void test_pktout_compl_poll(uint32_t test_flags)
 
 static void pktio_test_pktout_compl_poll(void)
 {
-	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; flags++)
+	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; test_flags_next(&flags))
 		test_pktout_compl_poll(flags);
 }
 
@@ -4082,13 +4229,13 @@ static int pktio_check_pktout_compl_event_sched_queue(void)
 
 static void pktio_test_pktout_compl_event_plain_queue(void)
 {
-	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; flags++)
+	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; test_flags_next(&flags))
 		pktio_test_pktout_compl_event(true, flags);
 }
 
 static void pktio_test_pktout_compl_event_sched_queue(void)
 {
-	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; flags++)
+	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; test_flags_next(&flags))
 		pktio_test_pktout_compl_event(false, flags);
 }
 
@@ -4144,8 +4291,7 @@ static void test_pktout_dont_free(uint32_t test_flags)
 	odp_packet_free_ctrl_set(pkt, ODP_PACKET_FREE_CTRL_DONT_FREE);
 	CU_ASSERT_FATAL(odp_packet_free_ctrl(pkt) == ODP_PACKET_FREE_CTRL_DONT_FREE);
 
-	if (test_flags & TEST_WITH_REFS)
-		make_refs(ref_tbl, &pkt, num_pkt);
+	make_refs(ref_tbl, &pkt, num_pkt, test_flags);
 
 	while (transmits--) {
 		/* Retransmit the same packet after it has been received from the RX interface */
@@ -4166,8 +4312,7 @@ static void test_pktout_dont_free(uint32_t test_flags)
 
 	odp_packet_free(pkt);
 
-	if (test_flags & TEST_WITH_REFS)
-		free_refs(ref_tbl, num_pkt);
+	free_refs(ref_tbl, num_pkt, test_flags);
 
 	for (i = 0; i < global.num_ifaces; i++) {
 		CU_ASSERT_FATAL(odp_pktio_stop(pktio[i]) == 0);
@@ -4177,7 +4322,7 @@ static void test_pktout_dont_free(uint32_t test_flags)
 
 static void pktio_test_pktout_dont_free(void)
 {
-	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; flags++)
+	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; test_flags_next(&flags))
 		test_pktout_dont_free(flags);
 }
 
@@ -4208,10 +4353,18 @@ static void test_chksum(void (*config_fn)(odp_pktio_t, odp_pktio_t),
 
 	/* Open and configure interfaces */
 	for (i = 0; i < global.num_ifaces; ++i) {
+		odp_pktio_capability_t capa;
+
 		pktio[i] = create_pktio_with_flags(i, ODP_PKTIN_MODE_DIRECT,
 						   ODP_PKTOUT_MODE_DIRECT,
 						   test_flags);
 		CU_ASSERT_FATAL(pktio[i] != ODP_PKTIO_INVALID);
+
+		CU_ASSERT_FATAL(odp_pktio_capability(pktio[i], &capa) == 0);
+		if (i == 0 && !has_packet_ref_capa(&capa, test_flags)) {
+			CU_ASSERT_FATAL(odp_pktio_close(pktio[i]) == 0);
+			return;
+		}
 	}
 
 	pktio_tx = pktio[0];
@@ -4251,8 +4404,8 @@ static void test_chksum(void (*config_fn)(odp_pktio_t, odp_pktio_t),
 			prep_fn(pkt_tbl[i]);
 	}
 
-	if (test_flags & TEST_WITH_REFS)
-		make_refs(ref_tbl, pkt_tbl, TX_BATCH_LEN);
+	make_refs(ref_tbl, pkt_tbl, TX_BATCH_LEN, test_flags);
+
 	send_packets(pktout_queue, pkt_tbl, TX_BATCH_LEN);
 
 	num_rx = wait_for_packets_hdr(&pktio_rx_info, pkt_tbl, pkt_seq,
@@ -4260,8 +4413,7 @@ static void test_chksum(void (*config_fn)(odp_pktio_t, odp_pktio_t),
 				      ODP_TIME_SEC_IN_NS, hdr_len,
 				      VECTOR_MODE_DISABLED);
 	CU_ASSERT(num_rx == TX_BATCH_LEN);
-	if (test_flags & TEST_WITH_REFS)
-		free_refs(ref_tbl, TX_BATCH_LEN);
+	free_refs(ref_tbl, TX_BATCH_LEN, test_flags);
 	for (i = 0; i < num_rx; i++) {
 		CU_ASSERT(odp_packet_pool(pkt_tbl[i]) == expected_rx_pool(test_flags));
 		CU_ASSERT(odp_packet_has_ref(pkt_tbl[i]) == 0);
@@ -4279,7 +4431,7 @@ static void pktio_test_chksum(void (*config_fn)(odp_pktio_t, odp_pktio_t),
 			      void (*prep_fn)(odp_packet_t pkt),
 			      void (*test_fn)(odp_packet_t pkt))
 {
-	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; flags++)
+	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; test_flags_next(&flags))
 		test_chksum(config_fn, prep_fn, test_fn, flags, 0);
 }
 
@@ -4287,7 +4439,7 @@ static void pktio_test_chksum_sctp(void (*config_fn)(odp_pktio_t, odp_pktio_t),
 				   void (*prep_fn)(odp_packet_t pkt),
 				   void (*test_fn)(odp_packet_t pkt))
 {
-	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; flags++)
+	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; test_flags_next(&flags))
 		test_chksum(config_fn, prep_fn, test_fn, flags, 1);
 }
 
@@ -4452,6 +4604,7 @@ static void pktio_test_chksum_out_ipv4_test(odp_packet_t pkt)
 static void pktio_test_chksum_out_ipv4_no_ovr_prep(odp_packet_t pkt)
 {
 	odp_packet_l3_chksum_insert(pkt, false);
+	odp_packet_user_ptr_set(pkt, l3_chksum_insert_0);
 }
 
 static void pktio_test_chksum_out_ipv4_no_ovr_test(odp_packet_t pkt)
@@ -4473,6 +4626,7 @@ static void pktio_test_chksum_out_ipv4_no_ovr(void)
 static void pktio_test_chksum_out_ipv4_ovr_prep(odp_packet_t pkt)
 {
 	odp_packet_l3_chksum_insert(pkt, true);
+	odp_packet_user_ptr_set(pkt, l3_chksum_insert_1);
 }
 
 static void pktio_test_chksum_out_ipv4_ovr_test(odp_packet_t pkt)
@@ -4557,6 +4711,7 @@ static void pktio_test_chksum_out_udp_no_ovr_prep(odp_packet_t pkt)
 	odph_ipv4_csum_update(pkt);
 	odp_packet_has_udp_set(pkt, 1);
 	odp_packet_l4_chksum_insert(pkt, false);
+	odp_packet_user_ptr_set(pkt, l4_chksum_insert_0);
 }
 
 static void pktio_test_chksum_out_udp_no_ovr_test(odp_packet_t pkt)
@@ -4579,6 +4734,7 @@ static void pktio_test_chksum_out_udp_ovr_prep(odp_packet_t pkt)
 {
 	odp_packet_has_udp_set(pkt, 1);
 	odp_packet_l4_chksum_insert(pkt, true);
+	odp_packet_user_ptr_set(pkt, l4_chksum_insert_1);
 }
 
 static void pktio_test_chksum_out_udp_ovr_test(odp_packet_t pkt)
@@ -4670,6 +4826,7 @@ static void pktio_test_chksum_out_sctp_no_ovr_prep(odp_packet_t pkt)
 	odph_ipv4_csum_update(pkt);
 	odp_packet_has_sctp_set(pkt, 1);
 	odp_packet_l4_chksum_insert(pkt, false);
+	odp_packet_user_ptr_set(pkt, l4_chksum_insert_0);
 }
 
 static void pktio_test_chksum_out_sctp_no_ovr_test(odp_packet_t pkt)
@@ -4692,6 +4849,7 @@ static void pktio_test_chksum_out_sctp_ovr_prep(odp_packet_t pkt)
 {
 	odp_packet_has_sctp_set(pkt, 1);
 	odp_packet_l4_chksum_insert(pkt, true);
+	odp_packet_user_ptr_set(pkt, l4_chksum_insert_1);
 }
 
 static void pktio_test_chksum_out_sctp_ovr_test(odp_packet_t pkt)
@@ -5207,6 +5365,11 @@ static void test_pktout_aging_tmo(uint32_t test_flags)
 		if (i == 0) {
 			CU_ASSERT_FATAL(pktio_capa.max_tx_aging_tmo_ns > 0);
 
+			if (!has_packet_ref_capa(&pktio_capa, test_flags)) {
+				CU_ASSERT_FATAL(odp_pktio_close(pktio[i]) == 0);
+				return;
+			}
+
 			odp_pktio_config_init(&config);
 			config.pktout.bit.aging_ena = 1;
 			CU_ASSERT_FATAL(odp_pktio_config(pktio[i], &config) == 0);
@@ -5249,16 +5412,14 @@ static void test_pktout_aging_tmo(uint32_t test_flags)
 		CU_ASSERT(odp_packet_aging_tmo(pkt_tbl[i]) != 0);
 	}
 
-	if (test_flags & TEST_WITH_REFS)
-		make_refs(ref_tbl, pkt_tbl, TX_BATCH_LEN);
+	make_refs(ref_tbl, pkt_tbl, TX_BATCH_LEN, test_flags);
 
 	CU_ASSERT_FATAL(odp_pktout_send(pktout_queue, pkt_tbl, TX_BATCH_LEN) == TX_BATCH_LEN);
 
 	num_rx = wait_for_packets(&pktio_rx_info, pkt_tbl, pkt_seq, TX_BATCH_LEN, TXRX_MODE_SINGLE,
 				  ODP_TIME_SEC_IN_NS, VECTOR_MODE_DISABLED);
 	CU_ASSERT(num_rx == TX_BATCH_LEN);
-	if (test_flags & TEST_WITH_REFS)
-		free_refs(ref_tbl, TX_BATCH_LEN);
+	free_refs(ref_tbl, TX_BATCH_LEN, test_flags);
 
 	for (i = 0; i < num_rx; i++) {
 		CU_ASSERT(odp_packet_pool(pkt_tbl[i]) == expected_rx_pool(test_flags));
@@ -5273,7 +5434,7 @@ static void test_pktout_aging_tmo(uint32_t test_flags)
 
 static void pktio_test_pktout_aging_tmo(void)
 {
-	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; flags++)
+	for (uint32_t flags = 0; flags < NUM_TEST_FLAG_COMBOS; test_flags_next(&flags))
 		test_pktout_aging_tmo(flags);
 }
 


### PR DESCRIPTION
Current API regarding dynamic packet references is not easy to efficiently support in some ODP implementations with HW accelerated packet output due to the need to update reference counts after TX completion and based on that conditionally free packet buffers. odp_packet_ref() has been implemented only as a full packet copy in all ODP implementation.

Redefine the semantics of odp_packet_ref() and the packets involved in packet data sharing in a way that hopefully makes it simpler to support packet data sharing with restrictions in packet output and with per-packet reference counting instead of per-segment reference counting. The new semantics also enable use cases that were not previously possible.

Specify better the rules regarding packet data layout manipulation operations, allowing private packet data also in the tail of the packets that reference other packets. Pull and truncate operations may involve shared packet data, in which case they just remove that data from the packet, not affecting the packet owning the data. All extend and truncate operations always produce non-shared packet data.

Change odp_packet_has_ref() to indicate whether a packet is referenced by another packet, not whether the packet shares data with another packet. In partivular, odp_packet_ref() returns a packet that shares data with the given packet but is not itself referenced by other packets. Specify that packet data and layout of packets referenced by other packets can not be modified at all.

Introduce pktio capability bits to indicate whether a pktio supports sending packets with shared data without using the dont_free flag. Sending with the dont_free flag is supported with all types of packets.