### PR TITLE
[PATCH v1] linux-gen: cpu_flags: use correct print macro for a warning

### DIFF
--- a/platform/linux-generic/arch/x86/cpu_flags.c
+++ b/platform/linux-generic/arch/x86/cpu_flags.c
@@ -362,8 +362,8 @@ int _odp_time_cpu_global_freq_is_const(void)
 	    cpu_get_flag_enabled(RTE_CPUFLAG_INVTSC) > 0)
 		return 1;
 
-	_ODP_ERR("WARN: assuming constant TSC based on CPU arch, but could not confirm from CPU "
-		 "flags\n");
+	_ODP_WARN("Assuming constant TSC based on CPU arch, but could not confirm from CPU "
+		  "flags\n");
 
 	return 1;
 }


### PR DESCRIPTION
Use correct print macro for missing INVTSC flag warning.


Reviewed-by: Janne Peltonen <janne.peltonen@nokia.com>