### PR TITLE
[PATCH v2] test: pipeline: fix coverity warnings

### DIFF
--- a/test/performance/pipeline/cls_parser.c
+++ b/test/performance/pipeline/cls_parser.c
@@ -1075,6 +1075,7 @@ static odp_bool_t classifier_parser_init(config_t *config)
 
 			if (ret == -1) {
 				ODPH_ERR("Invalid \"" CONF_STR_COS "\" entry (%d)\n", i);
+				free_cos_template(&cos_templ);
 				return false;
 			}
 
@@ -1128,6 +1129,7 @@ static odp_bool_t classifier_parser_init(config_t *config)
 
 			if (ret == -1) {
 				ODPH_ERR("Invalid \"" CONF_STR_PMR "\" entry (%d)\n", i);
+				free_pmr_template(&pmr_templ);
 				return false;
 			}
 

--- a/test/performance/pipeline/flow.c
+++ b/test/performance/pipeline/flow.c
@@ -31,6 +31,11 @@ flow_t flow_create_flow(char *queue)
 	return (flow_t)flow;
 }
 
+uint32_t flow_get_data_size(void)
+{
+	return sizeof(flow_priv_t);
+}
+
 odp_bool_t flow_add_input(flow_t flow,  work_t *work, uint32_t num)
 {
 	flow_sub_t *sub = &((flow_priv_t *)flow)->sub[F_IN];

--- a/test/performance/pipeline/flow.h
+++ b/test/performance/pipeline/flow.h
@@ -22,6 +22,8 @@ typedef enum {
 
 flow_t flow_create_flow(char *queue);
 
+uint32_t flow_get_data_size(void);
+
 odp_bool_t flow_add_input(flow_t flow,  work_t *work, uint32_t num);
 
 odp_bool_t flow_add_output(flow_t flow,  work_t *work, uint32_t num);

--- a/test/performance/pipeline/flow_parser.c
+++ b/test/performance/pipeline/flow_parser.c
@@ -466,6 +466,7 @@ static odp_bool_t flow_parser_init(config_t *config)
 
 			if (ret == -1) {
 				ODPH_ERR("Invalid \"" FLOW_DOMAIN "\" entry (%d)\n", i);
+				free_flow_template(&templ);
 				return false;
 			}
 
@@ -529,29 +530,27 @@ static odp_bool_t flow_parser_deploy(void)
 			else
 				(void)flow_add_output(parse->flow, work, parse->num);
 
-			if (odp_queue_context_set(queue, parse->flow, sizeof(parse->flow)) < 0) {
+			if (odp_queue_context_set(queue, (void *)parse->flow, flow_get_data_size())
+			    < 0) {
 				ODPH_ERR("Error setting queue context\n");
 				return false;
 			}
 		} else {
-			if (parse->input != NULL &&
-			    !flow_add_input(flow, work, parse->num)) {
+			if (parse->input != NULL && !flow_add_input(flow, work, parse->num)) {
 				ODPH_ERR("Error setting input flow\n");
 
-				for (uint32_t j = 0U; j < parse->num; ++j) {
+				for (uint32_t j = 0U; j < parse->num; ++j)
 					work_destroy_work(work[j]);
-					free(work);
-				}
 
+				free(work);
 				return false;
 			} else if (!flow_add_output(flow, work, parse->num)) {
 				ODPH_ERR("Error setting output flow\n");
 
-				for (uint32_t j = 0U; j < parse->num; ++j) {
+				for (uint32_t j = 0U; j < parse->num; ++j)
 					work_destroy_work(work[j]);
-					free(work);
-				}
 
+				free(work);
 				return false;
 			}
 		}

--- a/test/performance/pipeline/queue_parser.c
+++ b/test/performance/pipeline/queue_parser.c
@@ -337,6 +337,7 @@ static odp_bool_t queue_parser_init(config_t *config)
 
 			if (ret == -1) {
 				ODPH_ERR("Invalid \"" QUEUE_DOMAIN "\" entry (%d)\n", i);
+				free_queue_template(&templ);
 				return false;
 			}
 


### PR DESCRIPTION
Fix a few potential memory leaks and double frees. Additionally, use correct size when utilizing `odp_queue_context_set()` in flow deployment.

v2:
- Added reviewed-by tag