### PR TITLE
[PATCH v2] test: sched_pktio: decrease pool size to reduce memory usage

### DIFF
--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -30,7 +30,7 @@
 #define MAX_PIPE_STAGES   64
 #define MAX_PIPE_QUEUES   1024
 #define MAX_PKT_LEN       1514
-#define MAX_PKT_NUM       (128 * 1024)
+#define MAX_PKT_NUM       (16 * 1024)
 #define MIN_PKT_SEG_LEN   64
 #define CHECK_PERIOD      10000
 #define TEST_PASSED_LIMIT 5000


### PR DESCRIPTION
Decrease odp_sched_pktio example packet pool size to reduce memory usage. Fixes out of memory failures in CI process mode test.