### PR TITLE
[PATCH v2] github_ci: update coverity test container

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,7 +7,7 @@ env:
   CC: gcc
   ARCH: x86_64
   CONTAINER_NAMESPACE: ghcr.io/opendataplane/odp-docker-images
-  OS: ubuntu_20.04
+  OS: ubuntu_24.04
   COVERITY_EMAIL: dummy@opendataplane.org
   COVERITY_PROJECT: ODP
 


### PR DESCRIPTION
Upgrade to Ubuntu 24.04 Coverity container.