### PR TITLE
[PATCH v2] linux-gen: check actual api pool type in alloc calls

### DIFF
--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2019-2025 Nokia
+ * Copyright (c) 2019-2026 Nokia
  */
 
 /**
@@ -189,8 +189,18 @@ static inline _odp_event_hdr_t *event_hdr_from_index(pool_t *pool,
 	return event_hdr;
 }
 
-odp_event_t _odp_event_alloc(pool_t *pool);
 int _odp_event_alloc_multi(pool_t *pool, _odp_event_hdr_t *event_hdr[], int num);
+
+static inline odp_event_t _odp_event_alloc(pool_t *pool)
+{
+	odp_event_t event;
+
+	if (odp_likely(_odp_event_alloc_multi(pool, (_odp_event_hdr_t **)&event, 1) == 1))
+		return event;
+
+	return ODP_EVENT_INVALID;
+}
+
 void _odp_event_free_multi(_odp_event_hdr_t *event_hdr[], int num_free);
 void _odp_event_free_sp(_odp_event_hdr_t *event_hdr[], int num);
 int _odp_event_is_valid(odp_event_t event);

--- a/platform/linux-generic/odp_ml.c
+++ b/platform/linux-generic/odp_ml.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2023-2024 Nokia
+ * Copyright (c) 2023-2026 Nokia
  */
 
 #include <odp/autoheader_external.h>
@@ -1347,23 +1347,25 @@ odp_pool_t odp_ml_compl_pool_create(const char *name, const odp_ml_compl_pool_pa
 	return _odp_pool_create(name, &ml_pool_param, ODP_POOL_ML_COMPL);
 }
 
-odp_ml_compl_t odp_ml_compl_alloc(odp_pool_t pool)
+odp_ml_compl_t odp_ml_compl_alloc(odp_pool_t pool_hdl)
 {
 	odp_buffer_t buf;
 	odp_event_t ev;
 	odp_ml_run_result_t *result;
+	pool_t *pool = _odp_pool_entry(pool_hdl);
 	uint32_t buf_size = _ODP_MAX(sizeof(odp_ml_run_result_t),
 				     sizeof(odp_ml_load_result_t));
 
-	buf = odp_buffer_alloc(pool);
+	_ODP_ASSERT(pool->type_2 == ODP_POOL_ML_COMPL);
 
-	if (odp_unlikely(buf == ODP_BUFFER_INVALID))
+	ev = _odp_event_alloc(pool);
+	if (odp_unlikely(ev == ODP_EVENT_INVALID))
 		return ODP_ML_COMPL_INVALID;
 
+	buf = odp_buffer_from_event(ev);
 	result = odp_buffer_addr(buf);
 	memset(result, 0, buf_size);
 
-	ev = odp_buffer_to_event(buf);
 	_odp_event_type_set(ev, ODP_EVENT_ML_COMPL);
 
 	return (odp_ml_compl_t)(uintptr_t)buf;

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -1488,7 +1488,8 @@ odp_buffer_t odp_buffer_alloc(odp_pool_t pool_hdl)
 
 	pool = _odp_pool_entry(pool_hdl);
 
-	_ODP_ASSERT(pool->type == ODP_POOL_BUFFER);
+	/* Buffer pools are also used by other pool implementations so check both types */
+	_ODP_ASSERT(pool->type == ODP_POOL_BUFFER && pool->type_2 == ODP_POOL_BUFFER);
 
 	ret  = _odp_event_alloc_multi(pool, (_odp_event_hdr_t **)&buf, 1);
 
@@ -1496,19 +1497,6 @@ odp_buffer_t odp_buffer_alloc(odp_pool_t pool_hdl)
 		return buf;
 
 	return ODP_BUFFER_INVALID;
-}
-
-odp_event_t _odp_event_alloc(pool_t *pool)
-{
-	odp_event_t event;
-	int ret;
-
-	ret  = _odp_event_alloc_multi(pool, (_odp_event_hdr_t **)&event, 1);
-
-	if (odp_likely(ret == 1))
-		return event;
-
-	return ODP_EVENT_INVALID;
 }
 
 int odp_buffer_alloc_multi(odp_pool_t pool_hdl, odp_buffer_t buf[], int num)
@@ -1519,7 +1507,8 @@ int odp_buffer_alloc_multi(odp_pool_t pool_hdl, odp_buffer_t buf[], int num)
 
 	pool = _odp_pool_entry(pool_hdl);
 
-	_ODP_ASSERT(pool->type == ODP_POOL_BUFFER);
+	/* Buffer pools are also used by other pool implementations so check both types */
+	_ODP_ASSERT(pool->type == ODP_POOL_BUFFER && pool->type_2 == ODP_POOL_BUFFER);
 
 	return _odp_event_alloc_multi(pool, (_odp_event_hdr_t **)buf, num);
 }


### PR DESCRIPTION
Check that correct pool type is used with odp_buffer_alloc() and odp_buffer_alloc_multi() functions also from application PoV. odp_dma_compl_alloc() and odp_ml_compl_alloc() functions now use implementation internal _odp_event_alloc() function for allocating their events and check the used pool type. Also, make _odp_event_alloc() function inlined.