### PR TITLE
[PATCH v2] linux-gen: time: remove memory clobber from aarch64 cntvct_el0 read

### DIFF
--- a/platform/linux-generic/arch/aarch64/odp/api/abi/time_cpu.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/time_cpu.h
@@ -15,7 +15,7 @@ static inline uint64_t _odp_time_cpu_global(void)
 {
 	uint64_t cntvct;
 
-	__asm__ volatile("mrs %0, cntvct_el0" : "=r"(cntvct) : : "memory");
+	__asm__ volatile("mrs %0, cntvct_el0" : "=r"(cntvct));
 
 	return cntvct;
 }


### PR DESCRIPTION
Remove unnecessary compiler memory barrier from aarch64 cntvct_el0 read in _odp_time_cpu_global() function, which is used to implement non-strict odp_cpu_cycles(), odp_time_local(), and odp_time_global() API functions. It's enough to have the memory clobber in _odp_time_cpu_global_strict(), which is used to implement the strict functions variants.