### PR TITLE
[PATCH v1] abi: time: change odp_time_t abi type to uint64_t

### DIFF
--- a/include/odp/api/abi-default/time_types.h
+++ b/include/odp/api/abi-default/time_types.h
@@ -11,32 +11,13 @@
 extern "C" {
 #endif
 
-/**
- * @internal Time structure used for both POSIX timespec and HW counter
- * implementations.
- */
-struct odp_time_s {
-	/** @internal Variant mappings for time type */
-	union {
-		/** @internal Used with generic 64 bit operations */
-		uint64_t u64;
-
-		/** @internal Nanoseconds */
-		uint64_t nsec;
-
-		/** @internal HW timer counter value */
-		uint64_t count;
-
-	};
-};
-
 /** @addtogroup odp_time
  *  @{
  **/
 
-typedef struct odp_time_s odp_time_t;
+typedef uint64_t odp_time_t;
 
-#define ODP_TIME_NULL ((odp_time_t){.u64 = 0})
+#define ODP_TIME_NULL ((odp_time_t)0)
 
 /**
  * @}

--- a/platform/linux-generic/arch/common/odp/api/abi/time_cpu_inlines.h
+++ b/platform/linux-generic/arch/common/odp/api/abi/time_cpu_inlines.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2020-2023 Nokia
+ * Copyright (c) 2020-2026 Nokia
  */
 
 #ifndef ODP_ARCH_TIME_CPU_INLINES_H_
@@ -20,34 +20,38 @@ extern "C" {
 
 typedef struct _odp_time_global_t {
 	uint64_t freq_hz;
-	uint64_t start_time;
+	odp_time_t start_time;
 	uint64_t start_time_ns;
 
 } _odp_time_global_t;
 
 extern _odp_time_global_t _odp_time_glob;
 
+static inline uint64_t _odp_time_to_u64(odp_time_t time)
+{
+	return (uint64_t)time;
+}
+
+static inline odp_time_t _odp_time_from_u64(uint64_t val)
+{
+	return (odp_time_t)val;
+}
+
 static inline odp_time_t _odp_time_cur(void)
 {
-	odp_time_t time;
-
-	time.count = _odp_time_cpu_global();
-	return time;
+	return _odp_time_from_u64(_odp_time_cpu_global());
 }
 
 static inline odp_time_t _odp_time_cur_strict(void)
 {
-	odp_time_t time;
-
-	time.count = _odp_time_cpu_global_strict();
-	return time;
+	return _odp_time_from_u64(_odp_time_cpu_global_strict());
 }
 
 static inline uint64_t _odp_time_to_ns(odp_time_t time)
 {
 	uint64_t nsec;
 	uint64_t freq_hz = _odp_time_glob.freq_hz;
-	uint64_t count = time.count;
+	uint64_t count = _odp_time_to_u64(time);
 	uint64_t sec = 0;
 
 	if (count >= freq_hz) {
@@ -62,7 +66,6 @@ static inline uint64_t _odp_time_to_ns(odp_time_t time)
 
 static inline odp_time_t _odp_time_from_ns(uint64_t ns)
 {
-	odp_time_t time;
 	uint64_t count;
 	uint64_t freq_hz = _odp_time_glob.freq_hz;
 	uint64_t sec = 0;
@@ -75,9 +78,7 @@ static inline odp_time_t _odp_time_from_ns(uint64_t ns)
 	count  = sec * freq_hz;
 	count += (ns * freq_hz) / ODP_TIME_SEC_IN_NS;
 
-	time.count = count;
-
-	return time;
+	return _odp_time_from_u64(count);
 }
 
 static inline uint64_t _odp_time_res(void)
@@ -87,8 +88,8 @@ static inline uint64_t _odp_time_res(void)
 
 static inline void _odp_time_startup(odp_time_startup_t *startup)
 {
-	startup->global.count = _odp_time_glob.start_time;
-	startup->global_ns    = _odp_time_glob.start_time_ns;
+	startup->global    = _odp_time_glob.start_time;
+	startup->global_ns = _odp_time_glob.start_time_ns;
 }
 
 #ifdef __cplusplus

--- a/platform/linux-generic/arch/common/odp_time_cpu.c
+++ b/platform/linux-generic/arch/common/odp_time_cpu.c
@@ -26,7 +26,6 @@ _odp_time_global_t _odp_time_glob;
 int _odp_time_init_global(void)
 {
 	uint64_t count, diff, years;
-	odp_time_t time;
 	_odp_time_global_t *global = &_odp_time_glob;
 
 	memset(global, 0, sizeof(_odp_time_global_t));
@@ -41,9 +40,8 @@ int _odp_time_init_global(void)
 	_ODP_PRINT("HW time counter freq: %" PRIu64 " hz\n\n", global->freq_hz);
 
 	count = _odp_time_cpu_global();
-	time.count = count;
-	global->start_time = count;
-	global->start_time_ns = _odp_time_to_ns(time);
+	global->start_time = _odp_time_from_u64(count);
+	global->start_time_ns = _odp_time_to_ns(global->start_time);
 
 	/* Make sure that counters will not wrap */
 	diff = UINT64_MAX - count;

--- a/platform/linux-generic/arch/default/odp/api/abi/time_inlines.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/time_inlines.h
@@ -27,16 +27,22 @@ static inline odp_time_t _odp_time_cur_strict(void)
 
 static inline uint64_t _odp_time_to_ns(odp_time_t time)
 {
-	return time.nsec;
+	return (uint64_t)time;
 }
 
 static inline odp_time_t _odp_time_from_ns(uint64_t ns)
 {
-	odp_time_t time;
+	return (odp_time_t)ns;
+}
 
-	time.nsec = ns;
+static inline uint64_t _odp_time_to_u64(odp_time_t time)
+{
+	return (uint64_t)time;
+}
 
-	return time;
+static inline odp_time_t _odp_time_from_u64(uint64_t val)
+{
+	return (odp_time_t)val;
 }
 
 #ifdef __cplusplus

--- a/platform/linux-generic/arch/default/odp_time.c
+++ b/platform/linux-generic/arch/default/odp_time.c
@@ -41,16 +41,13 @@ static inline uint64_t time_nsec(struct timespec *t)
 odp_time_t _odp_time_cur(void)
 {
 	int ret;
-	odp_time_t time;
 	struct timespec sys_time;
 
 	ret = clock_gettime(CLOCK_MONOTONIC_RAW, &sys_time);
 	if (odp_unlikely(ret != 0))
 		_ODP_ABORT("clock_gettime() failed\n");
 
-	time.nsec = time_nsec(&sys_time);
-
-	return time;
+	return _odp_time_from_u64(time_nsec(&sys_time));
 }
 
 uint64_t _odp_time_res(void)
@@ -67,8 +64,8 @@ uint64_t _odp_time_res(void)
 
 void _odp_time_startup(odp_time_startup_t *startup)
 {
-	startup->global.nsec = _odp_time_glob.start_time_ns;
-	startup->global_ns   = _odp_time_glob.start_time_ns;
+	startup->global = _odp_time_from_u64(_odp_time_glob.start_time_ns);
+	startup->global_ns = _odp_time_glob.start_time_ns;
 }
 
 #include <odp/visibility_end.h>

--- a/platform/linux-generic/include/odp/api/plat/time_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/time_inlines.h
@@ -100,10 +100,10 @@ _ODP_INLINE uint64_t odp_time_to_ns(odp_time_t time)
 
 _ODP_INLINE int odp_time_cmp(odp_time_t t2, odp_time_t t1)
 {
-	if (odp_likely(t2.u64 > t1.u64))
+	if (odp_likely(t2 > t1))
 		return 1;
 
-	if (t2.u64 < t1.u64)
+	if (t2 < t1)
 		return -1;
 
 	return 0;
@@ -111,38 +111,22 @@ _ODP_INLINE int odp_time_cmp(odp_time_t t2, odp_time_t t1)
 
 _ODP_INLINE odp_time_t odp_time_diff(odp_time_t t2, odp_time_t t1)
 {
-	odp_time_t time;
-
-	time.u64 = t2.u64 - t1.u64;
-
-	return time;
+	return t2 - t1;
 }
 
 _ODP_INLINE uint64_t odp_time_diff_ns(odp_time_t t2, odp_time_t t1)
 {
-	odp_time_t time;
-
-	time.u64 = t2.u64 - t1.u64;
-
-	return odp_time_to_ns(time);
+	return odp_time_to_ns(t2 - t1);
 }
 
 _ODP_INLINE odp_time_t odp_time_add_ns(odp_time_t time, uint64_t ns)
 {
-	odp_time_t t = _odp_time_from_ns(ns);
-
-	t.u64 += time.u64;
-
-	return t;
+	return time + _odp_time_from_ns(ns);
 }
 
 _ODP_INLINE odp_time_t odp_time_sum(odp_time_t t1, odp_time_t t2)
 {
-	odp_time_t time;
-
-	time.u64 = t1.u64 + t2.u64;
-
-	return time;
+	return t1 + t2;
 }
 
 _ODP_INLINE odp_time_t odp_time_local_from_ns(uint64_t ns)

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -24,6 +24,7 @@ extern "C" {
 #include <odp/api/time.h>
 
 #include <odp/api/plat/packet_io_inlines.h>
+#include <odp/api/plat/time_inlines.h>
 
 #include <odp/autoheader_internal.h>
 #include <odp_classification_datamodel.h>
@@ -294,9 +295,7 @@ static inline int _odp_pktio_tx_aging_enabled(pktio_entry_t *entry)
 
 static inline void _odp_pktio_tx_ts_set(pktio_entry_t *entry)
 {
-	odp_time_t ts_val = odp_time_global();
-
-	odp_atomic_store_u64(&entry->tx_ts, ts_val.u64);
+	odp_atomic_store_u64(&entry->tx_ts, _odp_time_to_u64(odp_time_global()));
 }
 
 extern const pktio_if_ops_t _odp_dpdk_pktio_ops;

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -2604,7 +2604,7 @@ int odp_pktin_recv_mq_tmo(const odp_pktin_queue_t queues[], uint32_t num_q, uint
 {
 	uint32_t i;
 	int ret;
-	odp_time_t t1, t2;
+	odp_time_t t1 = ODP_TIME_NULL, t2;
 	struct timespec ts;
 	int started = 0;
 	uint64_t sleep_round = 0;
@@ -2833,7 +2833,7 @@ int odp_pktout_ts_read(odp_pktio_t hdl, odp_time_t *ts)
 	if (odp_unlikely(ts_val == 0))
 		return 1;
 
-	ts->u64 = ts_val;
+	*ts = _odp_time_from_u64(ts_val);
 	return 0;
 }
 

--- a/platform/linux-generic/odp_pcapng.c
+++ b/platform/linux-generic/odp_pcapng.c
@@ -15,6 +15,7 @@
 
 #include <odp/api/plat/packet_inlines.h>
 #include <odp/api/plat/packet_io_inlines.h>
+#include <odp/api/plat/time_inlines.h>
 
 #include <odp_config_internal.h>
 #include <odp_global_data.h>
@@ -564,9 +565,8 @@ int _odp_pcapng_dump_pkts(pktio_entry_t *entry, int qidx,
 			_ODP_ROUNDUP_ALIGN(seg_len, PCAPNG_DATA_ALIGN) +
 			PCAPNG_DATA_ALIGN;
 		epb[i].interface_idx = 0;
-		epb[i].timestamp_high =
-			(uint32_t)(pkt_hdr->timestamp.u64 >> 32);
-		epb[i].timestamp_low = (uint32_t)(pkt_hdr->timestamp.u64);
+		epb[i].timestamp_high = (uint32_t)(_odp_time_to_u64(pkt_hdr->timestamp) >> 32);
+		epb[i].timestamp_low = (uint32_t)_odp_time_to_u64(pkt_hdr->timestamp);
 		epb[i].captured_len = seg_len;
 		epb[i].packet_len = seg_len;
 

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -1884,7 +1884,7 @@ static inline int schedule_loop_sleep(odp_queue_t *out_queue, uint64_t wait,
 				      odp_event_t out_ev[], uint32_t max_num)
 {
 	int ret;
-	odp_time_t start, end, current, start_sleep;
+	odp_time_t start, end = ODP_TIME_NULL, current = ODP_TIME_NULL, start_sleep = ODP_TIME_NULL;
 	int first = 1, sleep = 0;
 
 	while (1) {

--- a/test/performance/odp_packet_gen.c
+++ b/test/performance/odp_packet_gen.c
@@ -1794,7 +1794,7 @@ static int rx_thread(void *arg)
 	int i, thr, num;
 	uint32_t exit_test;
 	uint64_t bytes;
-	odp_time_t t1, t2, exit_time;
+	odp_time_t t1, t2 = ODP_TIME_NULL, exit_time;
 	thread_arg_t *thread_arg = arg;
 	test_global_t *global = thread_arg->global;
 	int direct_rx = global->test_options.direct_rx;


### PR DESCRIPTION
Change odp_time_t ABI type from struct to uint64_t, which makes the time API implementation simpler. The change triggered a couple false positive 'maybe-uninitialized' warnings.