### PR TITLE
[PATCH v5] linux-gen: add configure option for passing target system

### DIFF
--- a/.github/workflows/ci-pipeline-arm64.yml
+++ b/.github/workflows/ci-pipeline-arm64.yml
@@ -198,7 +198,7 @@ jobs:
                '--disable-host-optimization --enable-abi-compat',
                '--enable-lto',
                '--without-openssl --without-pcap',
-               '--enable-wfe-locks']
+               '--with-target=neoverse-v1 --enable-wfe-locks']
     steps:
       - uses: OpenDataPlane/action-clean-up@main
       - uses: actions/checkout@v6

--- a/include/odp/autoheader_external.h.in
+++ b/include/odp/autoheader_external.h.in
@@ -14,6 +14,9 @@
 /* Define to 1 or 2 to enable event validation */
 #undef _ODP_EVENT_VALIDATION
 
+/* Define to 1 when target has 1 GHz time counter frequency */
+#undef _ODP_TIME_FREQ_1GHZ
+
 /* Define to 1 to enable WFE based lock implementation on aarch64 */
 #undef _ODP_WFE_LOCKS
 

--- a/include/odp/autoheader_external.h.in
+++ b/include/odp/autoheader_external.h.in
@@ -14,6 +14,9 @@
 /* Define to 1 or 2 to enable event validation */
 #undef _ODP_EVENT_VALIDATION
 
+/* Define to 1 when FEAT_ECV is available */
+#undef _ODP_FEAT_ECV
+
 /* Define to 1 when target has 1 GHz time counter frequency */
 #undef _ODP_TIME_FREQ_1GHZ
 

--- a/platform/linux-generic/arch/aarch64/odp/api/abi/time_cpu.h
+++ b/platform/linux-generic/arch/aarch64/odp/api/abi/time_cpu.h
@@ -1,9 +1,11 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2021 Nokia
+ * Copyright (c) 2021-2026 Nokia
  */
 
 #ifndef ODP_API_ABI_TIME_CPU_H_
 #define ODP_API_ABI_TIME_CPU_H_
+
+#include <odp/autoheader_external.h>
 
 #include <stdint.h>
 
@@ -24,8 +26,12 @@ static inline uint64_t _odp_time_cpu_global_strict(void)
 {
 	uint64_t cntvct;
 
+#ifdef _ODP_FEAT_ECV
+	__asm__ volatile("mrs %0, cntvctss_el0" : "=r"(cntvct) : : "memory");
+#else
 	__asm__ volatile("isb" ::: "memory");
 	__asm__ volatile("mrs %0, cntvct_el0" : "=r"(cntvct) : : "memory");
+#endif
 
 	return cntvct;
 }

--- a/platform/linux-generic/arch/common/odp/api/abi/time_cpu_inlines.h
+++ b/platform/linux-generic/arch/common/odp/api/abi/time_cpu_inlines.h
@@ -1,10 +1,12 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2020-2023 Nokia
+ * Copyright (c) 2020-2026 Nokia
  */
 
 #ifndef ODP_ARCH_TIME_CPU_INLINES_H_
 #define ODP_ARCH_TIME_CPU_INLINES_H_
+
+#include <odp/autoheader_external.h>
 
 #include <odp/api/time_types.h>
 
@@ -51,7 +53,9 @@ static inline uint64_t _odp_time_to_ns(odp_time_t time)
 {
 	uint64_t count = time.count;
 
-#ifdef __SIZEOF_INT128__
+#ifdef _ODP_TIME_FREQ_1GHZ
+	return count;
+#elif defined(__SIZEOF_INT128__)
 	return (uint64_t)(((__uint128_t)count * _odp_time_glob.mult_to_ns) >>
 			  _odp_time_glob.shift_to_ns);
 #else
@@ -75,7 +79,9 @@ static inline odp_time_t _odp_time_from_ns(uint64_t ns)
 	odp_time_t time;
 	uint64_t count;
 
-#ifdef __SIZEOF_INT128__
+#ifdef _ODP_TIME_FREQ_1GHZ
+	count = ns;
+#elif defined(__SIZEOF_INT128__)
 	count = (uint64_t)(((__uint128_t)ns * _odp_time_glob.mult_from_ns) >>
 			   _odp_time_glob.shift_from_ns);
 #else

--- a/platform/linux-generic/arch/common/odp_time_cpu.c
+++ b/platform/linux-generic/arch/common/odp_time_cpu.c
@@ -1,7 +1,9 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2020-2023 Nokia
+ * Copyright (c) 2020-2026 Nokia
  */
+
+#include <odp/autoheader_external.h>
 
 #include <odp/api/time_types.h>
 
@@ -40,7 +42,13 @@ int _odp_time_init_global(void)
 
 	_ODP_PRINT("HW time counter freq: %" PRIu64 " hz\n\n", global->freq_hz);
 
-#ifdef __SIZEOF_INT128__
+#ifdef _ODP_TIME_FREQ_1GHZ
+	if (global->freq_hz != _ODP_TIME_GIGA_HZ) {
+		_ODP_ERR("_ODP_TIME_FREQ_1GHZ defined, but actual frequency is %" PRIu64 " Hz\n",
+			 global->freq_hz);
+		return -1;
+	}
+#elif defined(__SIZEOF_INT128__)
 	/* Find the maximum shift for which the multiplier fits into 64 bits */
 	for (global->shift_to_ns = 63; global->shift_to_ns > 0; global->shift_to_ns--) {
 		__uint128_t cur = ((__uint128_t)_ODP_TIME_GIGA_HZ << global->shift_to_ns) /

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -14,6 +14,7 @@ m4_include([platform/linux-generic/m4/odp_cpu.m4])
 m4_include([platform/linux-generic/m4/odp_event_validation.m4])
 m4_include([platform/linux-generic/m4/odp_pcap.m4])
 m4_include([platform/linux-generic/m4/odp_scheduler.m4])
+m4_include([platform/linux-generic/m4/odp_target.m4])
 
 AC_ARG_WITH([pcap],
 	    [AS_HELP_STRING([--without-pcap],
@@ -36,6 +37,7 @@ m4_include([platform/linux-generic/m4/odp_dpdk.m4])
 m4_include([platform/linux-generic/m4/odp_wfe.m4])
 m4_include([platform/linux-generic/m4/odp_xdp.m4])
 m4_include([platform/linux-generic/m4/odp_ml.m4])
+ODP_TARGET_OPTIONS
 ODP_EVENT_VALIDATION
 ODP_SCHEDULER
 
@@ -44,6 +46,7 @@ AS_VAR_APPEND([PLAT_DEP_LIBS], ["${ATOMIC_LIBS} ${AARCH64CRYPTO_LIBS} ${LIBCONFI
 # Add text to the end of configure with platform specific settings.
 # Make sure it's aligned same as other lines in configure.ac.
 AS_VAR_APPEND([PLAT_CFG_TEXT], ["
+	with_target:            ${with_target}
 	event_validation:       ${enable_event_validation}
 	openssl:                ${with_openssl}
 	openssl_rand:           ${openssl_rand}

--- a/platform/linux-generic/m4/odp_target.m4
+++ b/platform/linux-generic/m4/odp_target.m4
@@ -51,6 +51,7 @@ AC_ARG_WITH([target],
 	     with_target=default])
 
 # Set safe default values for all feature flags
+feat_ecv=no
 time_freq_1ghz=no
 
 AS_CASE([$ODP_TARGET],
@@ -58,6 +59,10 @@ AS_CASE([$ODP_TARGET],
 	[AC_MSG_ERROR([unsupported --with-target value '$ODP_TARGET'. Supported values: ]m4_defn([_ODP_TARGET_NAMES]))]
 )
 
+if test "x$feat_ecv" = "xyes"; then
+	AC_DEFINE([_ODP_FEAT_ECV], [1],
+		  [Define to 1 when FEAT_ECV is available])
+fi
 if test "x$time_freq_1ghz" = "xyes"; then
 	AC_DEFINE([_ODP_TIME_FREQ_1GHZ], [1],
 		  [Define to 1 when target has 1 GHz time counter frequency])

--- a/platform/linux-generic/m4/odp_target.m4
+++ b/platform/linux-generic/m4/odp_target.m4
@@ -50,9 +50,17 @@ AC_ARG_WITH([target],
 	    [ODP_TARGET=default
 	     with_target=default])
 
+# Set safe default values for all feature flags
+time_freq_1ghz=no
+
 AS_CASE([$ODP_TARGET],
 	_ODP_TARGET_CASES,
 	[AC_MSG_ERROR([unsupported --with-target value '$ODP_TARGET'. Supported values: ]m4_defn([_ODP_TARGET_NAMES]))]
 )
+
+if test "x$time_freq_1ghz" = "xyes"; then
+	AC_DEFINE([_ODP_TIME_FREQ_1GHZ], [1],
+		  [Define to 1 when target has 1 GHz time counter frequency])
+fi
 
 ])

--- a/platform/linux-generic/m4/odp_target.m4
+++ b/platform/linux-generic/m4/odp_target.m4
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Nokia
+#
+
+# Target registry, grown by ODP_TARGET_REGISTER. The "default" target is always
+# available and carries no per-target flags.
+m4_define([_ODP_TARGET_NAMES], [default])
+m4_define([_ODP_TARGET_CASES], [[default], []])
+
+# ODP_TARGET_REGISTER(name, features)
+# -------------------------------
+# Register new target for '--with-target' configure option.
+#
+# Adding new target
+# -----------------
+# 1. Create (or edit) a *.m4 file under platform/linux-generic/m4/targets/. Any
+#    *.m4 file in that directory is picked up automatically.
+#
+# 2. Call ODP_TARGET_REGISTER once per target. The first argument is the value
+#    the user passes to --with-target; the second is a list of feature flags
+#    that should be enabled when that target is selected, for example:
+#
+#        ODP_TARGET_REGISTER([my-cpu], [feature_1=yes
+#                                       feature_2=yes])
+#
+# 3. Re-run ./bootstrap so the new target appears in configure.
+#
+m4_define([ODP_TARGET_REGISTER], [dnl
+m4_define([_ODP_TARGET_NAMES],
+	  m4_defn([_ODP_TARGET_NAMES])[, ]$1)dnl
+m4_define([_ODP_TARGET_CASES],
+	  m4_defn([_ODP_TARGET_CASES])[,
+	  []$1[], [$2]])dnl
+])
+
+# Auto-include every targets/*.m4 file found at autoreconf time
+m4_esyscmd_s([for f in platform/linux-generic/m4/targets/*.m4; do
+	test -f "$f" && echo "m4_sinclude([$f])"
+done])
+
+# ODP_TARGET_OPTIONS
+# ------------------
+# Configure target-specific options
+AC_DEFUN([ODP_TARGET_OPTIONS],
+[
+AC_ARG_WITH([target],
+	    [AS_HELP_STRING([--with-target=TARGET],
+		    [select target system [default=default]. Supported values: ]m4_defn([_ODP_TARGET_NAMES]))],
+	    [ODP_TARGET=$with_target],
+	    [ODP_TARGET=default
+	     with_target=default])
+
+AS_CASE([$ODP_TARGET],
+	_ODP_TARGET_CASES,
+	[AC_MSG_ERROR([unsupported --with-target value '$ODP_TARGET'. Supported values: ]m4_defn([_ODP_TARGET_NAMES]))]
+)
+
+])

--- a/platform/linux-generic/m4/targets/neoverse.m4
+++ b/platform/linux-generic/m4/targets/neoverse.m4
@@ -2,7 +2,9 @@
 # Copyright (c) 2026 Nokia
 
 ODP_TARGET_REGISTER([neoverse-n2], [time_freq_1ghz=yes])
-ODP_TARGET_REGISTER([neoverse-n3], [time_freq_1ghz=yes])
+ODP_TARGET_REGISTER([neoverse-n3], [feat_ecv=yes
+				    time_freq_1ghz=yes])
 ODP_TARGET_REGISTER([neoverse-v1], [])
 ODP_TARGET_REGISTER([neoverse-v2], [time_freq_1ghz=yes])
-ODP_TARGET_REGISTER([neoverse-v3], [time_freq_1ghz=yes])
+ODP_TARGET_REGISTER([neoverse-v3], [feat_ecv=yes
+				    time_freq_1ghz=yes])

--- a/platform/linux-generic/m4/targets/neoverse.m4
+++ b/platform/linux-generic/m4/targets/neoverse.m4
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Nokia
+
+ODP_TARGET_REGISTER([neoverse-n2], [])
+ODP_TARGET_REGISTER([neoverse-n3], [])
+ODP_TARGET_REGISTER([neoverse-v1], [])
+ODP_TARGET_REGISTER([neoverse-v2], [])
+ODP_TARGET_REGISTER([neoverse-v3], [])

--- a/platform/linux-generic/m4/targets/neoverse.m4
+++ b/platform/linux-generic/m4/targets/neoverse.m4
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2026 Nokia
 
-ODP_TARGET_REGISTER([neoverse-n2], [])
-ODP_TARGET_REGISTER([neoverse-n3], [])
+ODP_TARGET_REGISTER([neoverse-n2], [time_freq_1ghz=yes])
+ODP_TARGET_REGISTER([neoverse-n3], [time_freq_1ghz=yes])
 ODP_TARGET_REGISTER([neoverse-v1], [])
-ODP_TARGET_REGISTER([neoverse-v2], [])
-ODP_TARGET_REGISTER([neoverse-v3], [])
+ODP_TARGET_REGISTER([neoverse-v2], [time_freq_1ghz=yes])
+ODP_TARGET_REGISTER([neoverse-v3], [time_freq_1ghz=yes])


### PR DESCRIPTION
V2:
* New targets can be added by creating or editing a *.m4 file under
`platform/linux-generic/m4/targets/` and calling `ODP_TARGET_REGISTER()`.