### PR TITLE
[PATCH v2] api: timer: fix freq_hz array with timer pool info

### DIFF
--- a/include/odp/api/spec/timer_types.h
+++ b/include/odp/api/spec/timer_types.h
@@ -794,8 +794,24 @@ typedef struct odp_timer_tick_info_t {
  * ODP timer pool information and configuration
  */
 typedef struct {
-	/** Parameters specified at creation */
+	/** Timer pool parameters
+	 *
+	 *  Parameters specified at creation with the exception of
+	 *  odp_timer_pool_param_t::periodic::freq::freq_hz and
+	 *  odp_timer_pool_param_t::periodic::freq::num which are set to NULL and 0 respectively.
+	 *  The creation-time values for these are provided via 'freq_hz' and 'num_freq_hz' fields
+	 *  in case of ODP_TIMER_TYPE_PERIODIC_FREQ pools.
+	 */
 	odp_timer_pool_param_t param;
+
+	/** Array of constraining periodic timer frequencies for timer pool specified at
+	 *  creation. Must not be modified after population by odp_timer_pool_info(). Accessible
+	 *  until the timer pool is destroyed.
+	 */
+	const odp_fract_u64_t *freq_hz;
+
+	/** Number of items in 'freq_hz' array */
+	uint32_t num_freq_hz;
 
 	/** Number of currently allocated timers */
 	uint32_t cur_timers;

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1155,7 +1155,7 @@ static odp_timer_pool_t timer_pool_new(const char *name, const odp_timer_pool_pa
 {
 	uint32_t i;
 	int tp_idx;
-	size_t sz0, sz1, sz2;
+	size_t sz0, sz1, sz2, sz3;
 	uint64_t tp_size;
 	uint64_t res_ns, nsec_per_scan;
 	odp_shm_t shm;
@@ -1276,7 +1276,10 @@ static odp_timer_pool_t timer_pool_new(const char *name, const odp_timer_pool_pa
 	sz0 = _ODP_ROUNDUP_CACHE_LINE(sizeof(timer_pool_t));
 	sz1 = _ODP_ROUNDUP_CACHE_LINE(sizeof(tick_buf_t) * param->num_timers);
 	sz2 = _ODP_ROUNDUP_CACHE_LINE(sizeof(_odp_timer_t) * param->num_timers);
-	tp_size = sz0 + sz1 + sz2;
+	sz3 = 0;
+	if (param->timer_type == ODP_TIMER_TYPE_PERIODIC_FREQ)
+		sz3 = _ODP_ROUNDUP_CACHE_LINE(sizeof(odp_fract_u64_t) * param->periodic.freq.num);
+	tp_size = sz0 + sz1 + sz2 + sz3;
 
 	if (periodic) {
 		odp_pool_param_init(&tmo_pool_param);
@@ -1332,6 +1335,14 @@ static odp_timer_pool_t timer_pool_new(const char *name, const odp_timer_pool_pa
 			tp->p.base_freq = base_freq;
 			tp->p.max_multiplier = max_multiplier;
 		} else {
+			odp_fract_u64_t *freq_copy =
+				(void *)((char *)odp_shm_addr(shm) + sz0 + sz1 + sz2);
+			const uint32_t num = param->periodic.freq.num;
+
+			memcpy(freq_copy, param->periodic.freq.freq_hz,
+			       sizeof(odp_fract_u64_t) * num);
+			tp->param.periodic.freq.freq_hz = freq_copy;
+
 			tp->p.min_freq = min_freq;
 			tp->p.max_freq = max_freq;
 		}
@@ -1644,6 +1655,14 @@ int odp_timer_pool_info(odp_timer_pool_t tpid, odp_timer_pool_info_t *tp_info)
 
 	memset(tp_info, 0, sizeof(odp_timer_pool_info_t));
 	tp_info->param = tp->param;
+
+	if (tp->p.type == ODP_TIMER_TYPE_PERIODIC_FREQ) {
+		tp_info->freq_hz = tp->param.periodic.freq.freq_hz;
+		tp_info->num_freq_hz = tp->param.periodic.freq.num;
+	}
+
+	tp_info->param.periodic.freq.freq_hz = NULL;
+	tp_info->param.periodic.freq.num = 0;
 	tp_info->cur_timers = tp->num_alloc;
 	tp_info->hwm_timers = odp_atomic_load_u32(&tp->high_wm);
 	tp_info->name = tp->name;

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -3606,6 +3606,7 @@ static void timer_test_periodic(periodic_params_t *params, odp_queue_type_t queu
 {
 	odp_queue_param_t queue_param;
 	odp_timer_pool_t timer_pool;
+	odp_timer_pool_info_t info;
 	odp_timer_periodic_start_t start_param;
 	odp_queue_t queue;
 	odp_event_t ev = ODP_EVENT_INVALID;
@@ -3616,6 +3617,8 @@ static void timer_test_periodic(periodic_params_t *params, odp_queue_type_t queu
 	const char *user_ctx = "User context";
 	uarea_data_t data;
 	uint8_t *uarea;
+	uint32_t num_freq;
+	const odp_fract_u64_t *src;
 	int num_tmo;
 	int done;
 	const int num = 200;
@@ -3627,9 +3630,31 @@ static void timer_test_periodic(periodic_params_t *params, odp_queue_type_t queu
 		params->pool_param.priority = 0;
 
 	timer_pool = odp_timer_pool_create("periodic_timer", &params->pool_param);
-	CU_ASSERT_FATAL(timer_pool != ODP_TIMER_POOL_INVALID);
-	CU_ASSERT_FATAL(odp_timer_pool_start_multi(&timer_pool, 1) == 1);
 
+	CU_ASSERT_FATAL(timer_pool != ODP_TIMER_POOL_INVALID);
+	CU_ASSERT_FATAL(odp_timer_pool_info(timer_pool, &info) == 0);
+	CU_ASSERT(info.param.periodic.freq.freq_hz == NULL);
+	CU_ASSERT(info.param.periodic.freq.num == 0);
+
+	if (params->pool_param.timer_type == ODP_TIMER_TYPE_PERIODIC_FREQ) {
+		num_freq = params->pool_param.periodic.freq.num;
+		src = params->pool_param.periodic.freq.freq_hz;
+
+		CU_ASSERT(info.param.timer_type == ODP_TIMER_TYPE_PERIODIC_FREQ);
+		CU_ASSERT_FATAL(info.freq_hz != NULL);
+		CU_ASSERT(info.num_freq_hz == num_freq);
+
+		for (uint32_t i = 0; i < num_freq; i++) {
+			CU_ASSERT(info.freq_hz[i].integer == src[i].integer);
+			CU_ASSERT(info.freq_hz[i].numer == src[i].numer);
+			CU_ASSERT(info.freq_hz[i].denom == src[i].denom);
+		}
+	} else {
+		CU_ASSERT(info.freq_hz == NULL);
+		CU_ASSERT(info.num_freq_hz == 0);
+	}
+
+	CU_ASSERT_FATAL(odp_timer_pool_start_multi(&timer_pool, 1) == 1);
 	odp_queue_param_init(&queue_param);
 
 	if (queue_type == ODP_QUEUE_TYPE_SCHED) {


### PR DESCRIPTION
Amend `odp_timer_pool_info_t` with new 'freq_hz' and 'num' fields that are used to return the constraining frequencies used to configure the timer pool in case of a `ODP_TIMER_TYPE_PERIODIC_FREQ` pool. The data is constant and should not be modified by the application once populated.

v2:
- Rebased
- Matias' comments