### PR TITLE
[PATCH v6] api: timer: fix freq_hz array with timer pool info

### DIFF
--- a/include/odp/api/spec/timer_types.h
+++ b/include/odp/api/spec/timer_types.h
@@ -500,7 +500,7 @@ typedef struct {
 			 *  exactly compatible (see odp_timer_periodic_capability()) with the
 			 *  'freq_hz' frequencies.
 			 */
-			odp_fract_u64_t *freq_hz;
+			const odp_fract_u64_t *freq_hz;
 
 			/** Number of items in 'freq_hz' array */
 			uint32_t num;
@@ -794,7 +794,15 @@ typedef struct odp_timer_tick_info_t {
  * ODP timer pool information and configuration
  */
 typedef struct {
-	/** Parameters specified at creation */
+	/** Timer pool parameters
+	 *
+	 *  Parameters specified for the pool at creation. Parameter values unused by a particular
+	 *  timer pool type are undefined.
+	 *
+	 *  In case of ODP_TIMER_TYPE_PERIODIC_FREQ, odp_timer_pool_param_t::periodic::freq::freq_hz
+	 *  points to an implementation-specific array containing read-only values that were passed
+	 *  at creation time. The array is accessible until the timer pool is destroyed.
+	 */
 	odp_timer_pool_param_t param;
 
 	/** Number of currently allocated timers */

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1155,7 +1155,7 @@ static odp_timer_pool_t timer_pool_new(const char *name, const odp_timer_pool_pa
 {
 	uint32_t i;
 	int tp_idx;
-	size_t sz0, sz1, sz2;
+	size_t sz0, sz1, sz2, sz3;
 	uint64_t tp_size;
 	uint64_t res_ns, nsec_per_scan;
 	odp_shm_t shm;
@@ -1276,7 +1276,10 @@ static odp_timer_pool_t timer_pool_new(const char *name, const odp_timer_pool_pa
 	sz0 = _ODP_ROUNDUP_CACHE_LINE(sizeof(timer_pool_t));
 	sz1 = _ODP_ROUNDUP_CACHE_LINE(sizeof(tick_buf_t) * param->num_timers);
 	sz2 = _ODP_ROUNDUP_CACHE_LINE(sizeof(_odp_timer_t) * param->num_timers);
-	tp_size = sz0 + sz1 + sz2;
+	sz3 = 0;
+	if (param->timer_type == ODP_TIMER_TYPE_PERIODIC_FREQ)
+		sz3 = _ODP_ROUNDUP_CACHE_LINE(sizeof(odp_fract_u64_t) * param->periodic.freq.num);
+	tp_size = sz0 + sz1 + sz2 + sz3;
 
 	if (periodic) {
 		odp_pool_param_init(&tmo_pool_param);
@@ -1332,6 +1335,13 @@ static odp_timer_pool_t timer_pool_new(const char *name, const odp_timer_pool_pa
 			tp->p.base_freq = base_freq;
 			tp->p.max_multiplier = max_multiplier;
 		} else {
+			odp_fract_u64_t *freq_copy =
+				(void *)((char *)odp_shm_addr(shm) + sz0 + sz1 + sz2);
+
+			memcpy(freq_copy, param->periodic.freq.freq_hz,
+			       sizeof(odp_fract_u64_t) * param->periodic.freq.num);
+			tp->param.periodic.freq.freq_hz = freq_copy;
+
 			tp->p.min_freq = min_freq;
 			tp->p.max_freq = max_freq;
 		}

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1134,7 +1134,7 @@ static void posix_timer_start(timer_pool_t *tp)
 	}
 }
 
-static odp_bool_t check_freq_range(odp_fract_u64_t *freq_hz, uint32_t num, double min_freq,
+static odp_bool_t check_freq_range(const odp_fract_u64_t *freq_hz, uint32_t num, double min_freq,
 				   double max_freq)
 {
 	double prev = -1.0, freq;

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -3555,7 +3555,6 @@ static odp_bool_t fill_periodic_freq_params(periodic_params_t *params)
 	params->pool_param.num_timers = 1;
 	params->pool_param.clk_src = clk_src;
 	params->freq_hz = freq_hz;
-	params->pool_param.periodic.freq.freq_hz = &params->freq_hz;
 	params->pool_param.periodic.freq.num = 1;
 	params->pool_param.periodic.uarea_size =
 					test_global->global_mem.tmo_uarea_support > 0 ? 1 : 0;
@@ -3601,6 +3600,53 @@ static void init_uarea(void *uarea, uint32_t size, void *args, uint32_t index, u
 		 uarea, size, args, index, max_num);
 }
 
+static odp_timer_pool_t create_periodic_timer_pool(periodic_params_t *params)
+{
+	odp_fract_u64_t freq_hz = params->freq_hz;
+	odp_timer_pool_t timer_pool;
+	odp_timer_pool_info_t info;
+	odp_fract_u64_t src_hz = { 0 }, info_hz = { 0 };
+
+	if (params->pool_param.timer_type == ODP_TIMER_TYPE_PERIODIC_FREQ) {
+		params->pool_param.periodic.freq.freq_hz = &freq_hz;
+		timer_pool = odp_timer_pool_create("periodic_timer", &params->pool_param);
+		freq_hz.integer = 0;
+		freq_hz.numer = 0;
+		freq_hz.denom = 0;
+	} else {
+		timer_pool = odp_timer_pool_create("periodic_timer", &params->pool_param);
+	}
+
+	CU_ASSERT_FATAL(timer_pool != ODP_TIMER_POOL_INVALID);
+	CU_ASSERT_FATAL(odp_timer_pool_info(timer_pool, &info) == 0);
+
+	if (params->pool_param.timer_type == ODP_TIMER_TYPE_PERIODIC_FREQ) {
+		CU_ASSERT(info.param.timer_type == ODP_TIMER_TYPE_PERIODIC_FREQ);
+		CU_ASSERT(info.param.periodic.freq.num == params->pool_param.periodic.freq.num);
+		CU_ASSERT_FATAL(info.param.periodic.freq.freq_hz != NULL);
+
+		/* We currently pass a single frequency, so we just check the first one */
+		src_hz = params->freq_hz;
+		info_hz = info.param.periodic.freq.freq_hz[0];
+	} else if (params->pool_param.timer_type == ODP_TIMER_TYPE_PERIODIC_BASE_MUL) {
+		CU_ASSERT(info.param.timer_type == ODP_TIMER_TYPE_PERIODIC_BASE_MUL);
+		CU_ASSERT(info.param.periodic.base_mul.max_multiplier ==
+			  params->pool_param.periodic.base_mul.max_multiplier);
+
+		src_hz = params->pool_param.periodic.base_mul.base_freq_hz;
+		info_hz = info.param.periodic.base_mul.base_freq_hz;
+	}
+
+	CU_ASSERT(info_hz.integer == src_hz.integer);
+	CU_ASSERT(info_hz.numer == src_hz.numer);
+	CU_ASSERT(info_hz.denom == src_hz.denom);
+	CU_ASSERT(info.param.periodic.uarea_size == params->pool_param.periodic.uarea_size);
+	CU_ASSERT(info.param.periodic.max_pending_tmo ==
+		  params->pool_param.periodic.max_pending_tmo);
+
+	return timer_pool;
+}
+
 static void timer_test_periodic(periodic_params_t *params, odp_queue_type_t queue_type,
 				int use_first, int rounds, odp_bool_t max_prio)
 {
@@ -3626,10 +3672,9 @@ static void timer_test_periodic(periodic_params_t *params, odp_queue_type_t queu
 	if (!max_prio)
 		params->pool_param.priority = 0;
 
-	timer_pool = odp_timer_pool_create("periodic_timer", &params->pool_param);
-	CU_ASSERT_FATAL(timer_pool != ODP_TIMER_POOL_INVALID);
-	CU_ASSERT_FATAL(odp_timer_pool_start_multi(&timer_pool, 1) == 1);
+	timer_pool = create_periodic_timer_pool(params);
 
+	CU_ASSERT_FATAL(odp_timer_pool_start_multi(&timer_pool, 1) == 1);
 	odp_queue_param_init(&queue_param);
 
 	if (queue_type == ODP_QUEUE_TYPE_SCHED) {
@@ -3938,8 +3983,7 @@ static void timer_test_periodic_flow_control(periodic_params_t *params, odp_queu
 	max_pending_tmo = ODPH_MAX(timer_capa->periodic.min_pending_tmo, 1U);
 	params->pool_param.periodic.max_pending_tmo = max_pending_tmo;
 
-	timer_pool = odp_timer_pool_create("periodic_timer", &params->pool_param);
-	CU_ASSERT_FATAL(timer_pool != ODP_TIMER_POOL_INVALID);
+	timer_pool = create_periodic_timer_pool(params);
 
 	CU_ASSERT_FATAL(odp_timer_pool_start_multi(&timer_pool, 1) == 1);
 


### PR DESCRIPTION
Clarify the `odp_timer_pool_param_t::periodic::freq::freq_hz` value
delivery via `odp_timer_pool_info()`: the values match what was passed
at timer pool creation time but listed in an implementation-specific
array.

Additionally, change the array to constant values during timer pool
creation where they should remain unchanged.

Alternative to #2356 

v2:
- Matias' comment

v6:
- Rebased 
- Added reviewed-by tags