### PR TITLE
[PATCH v2] linux-gen: packet: fix and optimise packet metadata copying

### DIFF
--- a/platform/linux-generic/include/odp_macros_internal.h
+++ b/platform/linux-generic/include/odp_macros_internal.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
- * Copyright (c) 2022-2025 Nokia
+ * Copyright (c) 2022-2026 Nokia
  */
 
 /**
@@ -13,10 +13,12 @@
 #define ODP_MACROS_INTERNAL_H_
 
 #include <odp/api/align.h>
+#include <odp/api/debug.h>
 
 #include <odp_config_internal.h>
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -108,6 +110,15 @@ __extension__ ({			\
 #else
 #define _ODP_CACHE_PAD
 #endif
+
+/*
+ * Check that the offset of 'field' in struct 'type' falls within the 'block':th
+ * 64 byte block of the struct. Only do the check in 64-bit compilations.
+ */
+#define _ODP_STATIC_ASSERT_64B_BLOCK(block, type, field)				\
+	ODP_STATIC_ASSERT((sizeof(void *) != 8) ||					\
+			  (offsetof(type, field) / 64 + 1 == (block)),	\
+			  #type "::" #field " not in 64B block " #block)
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -144,15 +144,18 @@ typedef struct ODP_ALIGNED_CACHE odp_packet_hdr_t {
 	/* Max payload size in a LSO segment */
 	uint16_t lso_max_payload;
 
+	/* LSO profile index */
+	uint8_t lso_profile_idx;
+
+	/* Unused field. Used only for optimizing metadata copying */
+	uint8_t unused;
+
 	/* Packet aging drop timeout before enqueue. Once enqueued holds the maximum age (time of
 	 * request + requested drop timeout). */
 	uint64_t tx_aging_ns;
 
 	/* Tx completion poll completion identifier */
 	uint32_t tx_compl_id;
-
-	/* LSO profile index */
-	uint8_t lso_profile_idx;
 
 	/* Pktio where packet is used as a memory source */
 	uint8_t ms_pktio_idx;
@@ -311,8 +314,8 @@ static inline int _odp_packet_copy_md_possible(odp_pool_t dst_pool,
  *                         are swapped between the packet headers (allowed
  *                         only when packets are from the same pool).
  */
-static inline void _odp_packet_copy_md(odp_packet_hdr_t *dst_hdr,
-				       odp_packet_hdr_t *src_hdr,
+static inline void _odp_packet_copy_md(odp_packet_hdr_t *restrict dst_hdr,
+				       odp_packet_hdr_t *restrict src_hdr,
 				       odp_bool_t uarea_copy)
 {
 	int8_t subtype = src_hdr->event_hdr.subtype;
@@ -328,6 +331,8 @@ static inline void _odp_packet_copy_md(odp_packet_hdr_t *dst_hdr,
 	 *   .seg_indirect
 	 *   .seg_referenced
 	 */
+
+	_ODP_ASSERT(dst_hdr != src_hdr);
 
 	_ODP_STATIC_ASSERT_64B_BLOCK(2, odp_packet_hdr_t, input);
 	_ODP_STATIC_ASSERT_64B_BLOCK(1, odp_packet_hdr_t, event_hdr.subtype);
@@ -364,6 +369,7 @@ static inline void _odp_packet_copy_md(odp_packet_hdr_t *dst_hdr,
 		dst_hdr->tx_aging_ns     = src_hdr->tx_aging_ns;
 		dst_hdr->tx_compl_id     = src_hdr->tx_compl_id;
 		dst_hdr->lso_profile_idx = src_hdr->lso_profile_idx;
+		dst_hdr->unused          = src_hdr->unused; /* not copying this is slower */
 	}
 
 	dst_hdr->p = src_hdr->p;

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -328,32 +328,43 @@ static inline void _odp_packet_copy_md(odp_packet_hdr_t *dst_hdr,
 	 *   .seg_indirect
 	 *   .seg_referenced
 	 */
+
+	_ODP_STATIC_ASSERT_64B_BLOCK(2, odp_packet_hdr_t, input);
+	_ODP_STATIC_ASSERT_64B_BLOCK(1, odp_packet_hdr_t, event_hdr.subtype);
+	_ODP_STATIC_ASSERT_64B_BLOCK(2, odp_packet_hdr_t, dst_queue);
+	_ODP_STATIC_ASSERT_64B_BLOCK(2, odp_packet_hdr_t, cos);
+	_ODP_STATIC_ASSERT_64B_BLOCK(2, odp_packet_hdr_t, flow_hash);
+	_ODP_STATIC_ASSERT_64B_BLOCK(2, odp_packet_hdr_t, user_ptr);
+
 	dst_hdr->input = src_hdr->input;
 	dst_hdr->event_hdr.subtype = subtype;
 	dst_hdr->dst_queue = src_hdr->dst_queue;
 	dst_hdr->cos = src_hdr->cos;
-	dst_hdr->cls_mark = src_hdr->cls_mark;
+	dst_hdr->flow_hash = src_hdr->flow_hash;
 	dst_hdr->user_ptr = src_hdr->user_ptr;
 
-	if (src_hdr->p.input_flags.flow_hash)
-		dst_hdr->flow_hash = src_hdr->flow_hash;
+	/* Avoid accessing the third 64 B block of the headers if not necessary */
+	if (src_hdr->p.input_flags.timestamp ||
+	    src_hdr->p.input_flags.cls_mark ||
+	    src_hdr->p.flags.payload_off ||
+	    src_hdr->p.flags.lso ||
+	    src_hdr->p.flags.tx_aging ||
+	    src_hdr->p.flags.tx_compl_poll) {
+		_ODP_STATIC_ASSERT_64B_BLOCK(3, odp_packet_hdr_t, cls_mark);
+		_ODP_STATIC_ASSERT_64B_BLOCK(3, odp_packet_hdr_t, payload_offset);
+		_ODP_STATIC_ASSERT_64B_BLOCK(3, odp_packet_hdr_t, lso_max_payload);
+		_ODP_STATIC_ASSERT_64B_BLOCK(3, odp_packet_hdr_t, tx_aging_ns);
+		_ODP_STATIC_ASSERT_64B_BLOCK(3, odp_packet_hdr_t, tx_compl_id);
+		_ODP_STATIC_ASSERT_64B_BLOCK(3, odp_packet_hdr_t, lso_profile_idx);
 
-	if (src_hdr->p.input_flags.timestamp)
-		dst_hdr->timestamp = src_hdr->timestamp;
-
-	if (src_hdr->p.flags.lso) {
+		dst_hdr->timestamp       = src_hdr->timestamp;
+		dst_hdr->cls_mark        = src_hdr->cls_mark;
+		dst_hdr->payload_offset  = src_hdr->payload_offset;
 		dst_hdr->lso_max_payload = src_hdr->lso_max_payload;
+		dst_hdr->tx_aging_ns     = src_hdr->tx_aging_ns;
+		dst_hdr->tx_compl_id     = src_hdr->tx_compl_id;
 		dst_hdr->lso_profile_idx = src_hdr->lso_profile_idx;
 	}
-
-	if (src_hdr->p.flags.payload_off)
-		dst_hdr->payload_offset = src_hdr->payload_offset;
-
-	if (src_hdr->p.flags.tx_aging)
-		dst_hdr->tx_aging_ns = src_hdr->tx_aging_ns;
-
-	if (src_hdr->p.flags.tx_compl_poll)
-		dst_hdr->tx_compl_id = src_hdr->tx_compl_id;
 
 	dst_hdr->p = src_hdr->p;
 

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2019-2022 Nokia
+ * Copyright (c) 2019-2026 Nokia
  */
 
 /**
@@ -348,6 +348,12 @@ static inline void _odp_packet_copy_md(odp_packet_hdr_t *dst_hdr,
 
 	if (src_hdr->p.flags.payload_off)
 		dst_hdr->payload_offset = src_hdr->payload_offset;
+
+	if (src_hdr->p.flags.tx_aging)
+		dst_hdr->tx_aging_ns = src_hdr->tx_aging_ns;
+
+	if (src_hdr->p.flags.tx_compl_poll)
+		dst_hdr->tx_compl_id = src_hdr->tx_compl_id;
 
 	dst_hdr->p = src_hdr->p;
 

--- a/test/common/odp_cunit_common.c
+++ b/test/common/odp_cunit_common.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
- * Copyright (c) 2019-2024 Nokia
+ * Copyright (c) 2019-2026 Nokia
  * Copyright (c) 2021 Marvell
  */
 
@@ -52,7 +52,8 @@ static struct {
 static odp_suiteinfo_t *global_testsuites;
 
 #define MAX_STR_LEN 256
-#define MAX_FAILURES 10
+#define MAX_POSTPONED_FAILURES 10
+#define MAX_FAILURES_BEFORE_FATAL 100
 
 /* Recorded assertion failure for later CUnit call in the initial thread */
 typedef struct assertion_failure_t {
@@ -63,7 +64,7 @@ typedef struct assertion_failure_t {
 } assertion_failure_t;
 
 typedef struct thr_global_t {
-	assertion_failure_t failure[MAX_FAILURES];
+	assertion_failure_t failure[MAX_POSTPONED_FAILURES];
 	unsigned long num_failures;
 } thr_global_t;
 
@@ -78,6 +79,17 @@ void odp_cu_assert(CU_BOOL value, unsigned int line,
 	unsigned long idx;
 
 	if (initial_thread) {
+		static uint64_t num_failures;
+
+		/* CUnit does not scale well to a big number of failed assertions. */
+		if (!value && ++num_failures > MAX_FAILURES_BEFORE_FATAL) {
+			if (num_failures == MAX_FAILURES_BEFORE_FATAL + 1)
+				CU_assertImplementation(value, line,
+					"All subsequent assertions are treated as fatal.",
+					file, "", 0);
+			fatal = true;
+		}
+
 		CU_assertImplementation(value, line, condition, file, "", fatal);
 		return;
 	}
@@ -102,7 +114,7 @@ void odp_cu_assert(CU_BOOL value, unsigned int line,
 
 	idx = __atomic_fetch_add(&thr_global->num_failures, 1, __ATOMIC_RELAXED);
 
-	if (idx < MAX_FAILURES) {
+	if (idx < MAX_POSTPONED_FAILURES) {
 		assertion_failure_t *a = &thr_global->failure[idx];
 
 		odph_strcpy(a->cond, condition, sizeof(a->cond));
@@ -119,8 +131,8 @@ static void handle_postponed_asserts(void)
 {
 	unsigned long num = thr_global->num_failures;
 
-	if (num > MAX_FAILURES)
-		num = MAX_FAILURES;
+	if (num > MAX_POSTPONED_FAILURES)
+		num = MAX_POSTPONED_FAILURES;
 
 	for (unsigned long n = 0; n < num; n++) {
 		assertion_failure_t *a = &thr_global->failure[n];

--- a/test/common/packet_common.c
+++ b/test/common/packet_common.c
@@ -1,19 +1,63 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2023 Nokia
+ * Copyright (c) 2023-2026 Nokia
  */
 
 #include <packet_common.h>
 #include <string.h>
 
+static uint32_t minstd_rand(void)
+{
+	static __thread uint64_t s = 1;
+	uint64_t prime = 0x7fffffff;
+
+	s = (48271 * s) % prime;
+	return s;
+}
+
+static uint32_t random_u32(void)
+{
+	return minstd_rand();
+}
+
+static uint8_t random_u8(void)
+{
+	return minstd_rand();
+}
+
+int test_packet_write_data(odp_packet_t pkt, uint32_t offset, uint32_t len)
+{
+	uint8_t w_data[len + 1]; /* +1 to avoid zero length array */
+	uint8_t r_data[len + 1];
+
+	if (len == 0)
+		return 0;
+	if (offset + len > odp_packet_len(pkt))
+		return 1;
+
+	for (uint32_t n = 0; n < len; n++)
+		w_data[n] = random_u8();
+	if (odp_packet_copy_from_mem(pkt, offset, len, w_data) != 0 ||
+	    odp_packet_copy_to_mem(pkt, offset, len, r_data) != 0 ||
+	    memcmp(w_data, r_data, len) != 0)
+		return 2;
+
+	return 0;
+}
+
 void test_packet_set_md(odp_packet_t pkt)
 {
 	const int binary_flag = 1;
-	const uint32_t offset = 1;
+	const int varying_flag = random_u8() % 2;
 	uint8_t *uarea = odp_packet_user_area(pkt);
-	uint32_t uarea_size = odp_packet_user_area_size(pkt);
+	const uint32_t uarea_size = odp_packet_user_area_size(pkt);
+	const uint32_t len = odp_packet_len(pkt);
+	const odp_packet_tx_compl_opt_t tx_compl_opt = {
+		.mode = ODP_PACKET_TX_COMPL_POLL,
+		.compl_id = random_u32(),
+	};
 
 	for (uint32_t n = 0; n < uarea_size; n++)
-		uarea[n] = n;
+		uarea[n] = random_u8();
 
 	/*
 	 * Some of these flags cannot be set simultaneously, but we do not
@@ -23,35 +67,37 @@ void test_packet_set_md(odp_packet_t pkt)
 	odp_packet_has_l3_set(pkt, binary_flag);
 	odp_packet_has_l4_set(pkt, binary_flag);
 	odp_packet_has_eth_set(pkt, binary_flag);
-	odp_packet_has_eth_bcast_set(pkt, binary_flag);
-	odp_packet_has_eth_mcast_set(pkt, !binary_flag);
+	odp_packet_has_eth_bcast_set(pkt, varying_flag);
+	odp_packet_has_eth_mcast_set(pkt, !varying_flag);
 	odp_packet_has_jumbo_set(pkt, binary_flag);
 	odp_packet_has_vlan_set(pkt, binary_flag);
 	odp_packet_has_vlan_qinq_set(pkt, binary_flag);
 	odp_packet_has_arp_set(pkt, binary_flag);
-	odp_packet_has_ipv4_set(pkt, binary_flag);
-	odp_packet_has_ipv6_set(pkt, !binary_flag);
+	odp_packet_has_ipv4_set(pkt, varying_flag);
+	odp_packet_has_ipv6_set(pkt, !varying_flag);
 	odp_packet_has_ip_bcast_set(pkt, binary_flag);
 	odp_packet_has_ip_mcast_set(pkt, binary_flag);
 	odp_packet_has_ipfrag_set(pkt, binary_flag);
 	odp_packet_has_ipopt_set(pkt, binary_flag);
 	odp_packet_has_ipsec_set(pkt, binary_flag);
-	odp_packet_has_udp_set(pkt, binary_flag);
-	odp_packet_has_tcp_set(pkt, !binary_flag);
+	odp_packet_has_udp_set(pkt, varying_flag);
+	odp_packet_has_tcp_set(pkt, !varying_flag);
 	odp_packet_has_sctp_set(pkt, binary_flag);
 	odp_packet_has_icmp_set(pkt, binary_flag);
 
-	odp_packet_user_ptr_set(pkt, &pkt);
+	odp_packet_user_ptr_set(pkt, (void *)(uintptr_t)random_u32());
 	odp_packet_user_flag_set(pkt, binary_flag);
-	(void)odp_packet_l2_offset_set(pkt, offset);
-	(void)odp_packet_l3_offset_set(pkt, offset);
-	(void)odp_packet_l4_offset_set(pkt, offset);
-	odp_packet_flow_hash_set(pkt, 0x12345678);
+	(void)odp_packet_l2_offset_set(pkt, random_u32() % len);
+	(void)odp_packet_l3_offset_set(pkt, random_u32() % len);
+	(void)odp_packet_l4_offset_set(pkt, random_u32() % len);
+	odp_packet_flow_hash_set(pkt, random_u32());
 	odp_packet_ts_set(pkt, odp_time_local_from_ns(ODP_TIME_SEC_IN_NS));
-	odp_packet_color_set(pkt, ODP_PACKET_YELLOW);
+	odp_packet_color_set(pkt, varying_flag ? ODP_PACKET_YELLOW : ODP_PACKET_RED);
 	odp_packet_drop_eligible_set(pkt, binary_flag);
-	odp_packet_shaper_len_adjust_set(pkt, -42);
-	(void)odp_packet_payload_offset_set(pkt, offset);
+	odp_packet_shaper_len_adjust_set(pkt, random_u8() - 128);
+	(void)odp_packet_payload_offset_set(pkt, random_u32() % len);
+	odp_packet_aging_tmo_set(pkt, random_u32());
+	(void)odp_packet_tx_compl_request(pkt, &tx_compl_opt);
 	odp_packet_free_ctrl_set(pkt, binary_flag);
 }
 

--- a/test/common/packet_common.h
+++ b/test/common/packet_common.h
@@ -62,6 +62,7 @@ typedef struct test_packet_md_t {
 	odp_proto_stats_t proto_stats;
 } test_packet_md_t;
 
+int test_packet_write_data(odp_packet_t pkt, uint32_t offset, uint32_t len);
 void test_packet_set_md(odp_packet_t pkt);
 void test_packet_get_md(odp_packet_t pkt, test_packet_md_t *md);
 int test_packet_is_md_equal(const test_packet_md_t *md_1,

--- a/test/validation/api/packet/packet_ref.c
+++ b/test/validation/api/packet/packet_ref.c
@@ -101,25 +101,6 @@ typedef struct pkt_adj_param_t {
 	pkt_adj_func_t func;
 } pkt_adj_param_t;
 
-static uint32_t minstd_rand(void)
-{
-	static uint64_t s = 1;
-	uint64_t prime = 0x7fffffff;
-
-	s = (48271 * s) % prime;
-	return s;
-}
-
-static uint32_t random_u32(void)
-{
-	return minstd_rand();
-}
-
-static uint8_t random_u8(void)
-{
-	return minstd_rand();
-}
-
 static void check_metadata_equal(const test_packet_md_t *md_1,
 				 const test_packet_md_t *md_2)
 {
@@ -279,6 +260,7 @@ static void save_pkt_state(odp_packet_t pkt, pkt_state_t *state)
 	state->uarea    = odp_packet_user_area(pkt);
 
 	test_packet_get_md(pkt, &state->metadata);
+	CU_ASSERT(odp_packet_user_area_size(pkt) == uarea_size);
 
 	save_seg_info(pkt, &state->seg_info);
 	CU_ASSERT(state->seg_info.num_segs == (uint32_t)odp_packet_num_segs(pkt));
@@ -397,51 +379,17 @@ static odp_packet_t alloc_packet(uint32_t len, uint32_t num_segs)
 	return pkt;
 }
 
-static void write_uarea(odp_packet_t pkt)
-{
-	uint8_t *uarea = odp_packet_user_area(pkt);
-
-	CU_ASSERT(uarea_size == odp_packet_user_area_size(pkt));
-	if (uarea_size == 0) {
-		CU_ASSERT(uarea == NULL);
-		return;
-	}
-	CU_ASSERT_FATAL(uarea != NULL);
-
-	for (uint32_t n = 0; n < uarea_size; n++)
-		uarea[n] = random_u8();
-}
-
-/* set some metadata to random values to better see changes and equality */
-static void set_random_md(odp_packet_t pkt)
-{
-	uint32_t len = odp_packet_len(pkt);
-	uintptr_t addr = random_u32();
-
-	odp_packet_user_ptr_set(pkt, (const void *)addr);
-	odp_packet_flow_hash_set(pkt, random_u32());
-	CU_ASSERT(odp_packet_l2_offset_set(pkt, random_u8() % len) == 0);
-	CU_ASSERT(odp_packet_l3_offset_set(pkt, random_u8() % len) == 0);
-	CU_ASSERT(odp_packet_l4_offset_set(pkt, random_u8() % len) == 0);
-	CU_ASSERT(odp_packet_payload_offset_set(pkt, random_u8() % len) == 0);
-}
-
 static odp_packet_t make_packet(uint32_t len, uint32_t num_segs)
 {
 	odp_packet_t pkt;
-	uint8_t data[len];
 	int rc;
 
 	pkt = alloc_packet(len, num_segs);
 
-	for (uint32_t n = 0; n < len; n++)
-		data[n] = random_u8();
-	rc = odp_packet_copy_from_mem(pkt, 0, len, data);
+	rc = test_packet_write_data(pkt, 0, len);
 	CU_ASSERT(rc == 0);
 
 	test_packet_set_md(pkt);
-	set_random_md(pkt);
-	write_uarea(pkt);
 
 	return pkt;
 }
@@ -465,20 +413,10 @@ static void check_packet_data(odp_packet_t ref, const pkt_state_t *base_state, u
 
 static void write_pkt_data(odp_packet_t pkt, uint32_t offset, uint32_t len)
 {
-	uint8_t w_data[len + 1]; /* +1 to avoid zero length array */
-	uint8_t r_data[len + 1];
 	int rc;
 
-	if (len == 0)
-		return;
-
-	for (uint32_t n = 0; n < len; n++)
-		w_data[n] = random_u8();
-	rc = odp_packet_copy_from_mem(pkt, offset, len, w_data);
+	rc = test_packet_write_data(pkt, offset, len);
 	CU_ASSERT(rc == 0);
-	rc = odp_packet_copy_to_mem(pkt, offset, len, r_data);
-	CU_ASSERT(rc == 0);
-	CU_ASSERT(memcmp(w_data, r_data, len) == 0);
 }
 
 static uint32_t iterate_pkt_layout(pkt_layout_t *layout, uint32_t *iterator)
@@ -532,8 +470,7 @@ static odp_packet_t create_ref(odp_packet_t base, const pkt_state_t *base_state,
 	CU_ASSERT(odp_packet_tailroom(ref) == 0);
 
 	check_metadata_default(ref);
-	set_random_md(ref);
-	write_uarea(ref);
+	test_packet_set_md(ref);
 
 	save_pkt_state(base, &after);
 	check_pkt_state_equal(base_state, &after);
@@ -1158,8 +1095,7 @@ static void pkt_copy(odp_packet_t pkt)
 	check_pkt_state_equal(&before, &after);
 	check_metadata_equal(&before.metadata, &state_copy.metadata);
 	check_pkt_data_equal(&before, &state_copy);
-	set_random_md(copy);
-	write_uarea(copy);
+	test_packet_set_md(copy);
 	CU_ASSERT(odp_packet_has_ref(copy) == 0);
 	CU_ASSERT(odp_packet_is_referencing(copy) == 0);
 
@@ -1200,8 +1136,7 @@ static void pkt_copy_part(odp_packet_t pkt, uint32_t offset, uint32_t len)
 	CU_ASSERT(state_copy.len == len);
 	check_metadata_default(copy);
 	check_pkt_data(&before, offset, &state_copy, 0, len);
-	set_random_md(copy);
-	write_uarea(copy);
+	test_packet_set_md(copy);
 	CU_ASSERT(odp_packet_has_ref(copy) == 0);
 	CU_ASSERT(odp_packet_is_referencing(copy) == 0);
 


### PR DESCRIPTION
Fix packet metadata copying by adding copying of missing fields and optimise the copying code a little bit.