### PR TITLE
[PATCH v4] api: ipsec: add capabilities for outbound options

### DIFF
--- a/example/sysinfo/odp_sysinfo.c
+++ b/example/sysinfo/odp_sysinfo.c
@@ -1360,6 +1360,15 @@ int main(int argc, char **argv)
 		       support_level(ipsec_capa.pipeline_cls));
 		printf("    retaining outer headers:      %s\n",
 		       support_level(ipsec_capa.retain_header));
+		printf("    outbound operation options:\n");
+		printf("      frag_mode:                  %i\n",
+		       ipsec_capa.out_op.opt.frag_mode);
+		printf("      tfc_pad:                    %i\n",
+		       ipsec_capa.out_op.opt.tfc_pad);
+		printf("      tfc_dummy:                  %i\n",
+		       ipsec_capa.out_op.opt.tfc_dummy);
+		printf("      ip_param:                   %i\n",
+		       ipsec_capa.out_op.opt.ip_param);
 		printf("    inbound checksum offload support:\n");
 		printf("      IPv4 header checksum:       %s\n",
 		       support_level(ipsec_capa.chksums_in.chksum.ipv4));

--- a/include/odp/api/spec/ipsec_types.h
+++ b/include/odp/api/spec/ipsec_types.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2016-2018 Linaro Limited
- * Copyright (c) 2022-2025 Nokia
+ * Copyright (c) 2022-2026 Nokia
  */
 
 /**
@@ -33,7 +33,7 @@ extern "C" {
  * IPSEC Security Association (SA)
  */
 
- /**
+/**
  * @def ODP_IPSEC_SA_INVALID
  * Invalid IPSEC SA
  */
@@ -255,6 +255,34 @@ typedef struct odp_ipsec_outbound_config_t {
 } odp_ipsec_outbound_config_t;
 
 /**
+ * Capabilities regarding IPsec outbound operation parameters
+ */
+typedef struct odp_ipsec_out_op_capability_t {
+	/** Supported outbound operation option flags.
+	 *
+	 *  If a flag is set, the corresponding option in odp_ipsec_out_opt_t
+	 *  is supported in outbound IPsec processing. If a flag is clear,
+	 *  the corresponding flag and parameter fields of odp_ipsec_out_opt_t
+	 *  are ignored by the IPsec outbound processing functions.
+	 */
+	struct {
+		/** fragmentation mode option supported */
+		uint8_t frag_mode :1;
+
+		/** TFC padding length option supported */
+		uint8_t tfc_pad   :1;
+
+		/** TFC dummy packet option supported */
+		uint8_t tfc_dummy :1;
+
+		/** IP parameters option supported */
+		uint8_t ip_param  :1;
+
+	} opt;
+
+} odp_ipsec_out_op_capability_t;
+
+/**
  * IPSEC TEST capability
  */
 typedef struct odp_ipsec_test_capability_t {
@@ -323,6 +351,9 @@ typedef struct odp_ipsec_capability_t {
 	 * processed packets
 	 */
 	odp_support_t retain_header;
+
+	/** Outbound operation specific capabilities */
+	odp_ipsec_out_op_capability_t out_op;
 
 	/**
 	 * Inner packet checksum check offload support in inbound direction.
@@ -1213,7 +1244,11 @@ typedef struct odp_ipsec_op_flag_t {
 /**
  * IPSEC outbound operation options
  *
- * These may be used to override some SA level options
+ * These may be used to override some SA level options. Supported options are
+ * listed in odp_ipsec_capability_t::out_op returned by odp_ipsec_capability().
+ * Options that are not supported are ignored.
+ *
+ * @see odp_ipsec_out_op_capability_t
  */
 typedef struct odp_ipsec_out_opt_t {
 	/** Union of all flag bits */

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -236,6 +236,11 @@ int odp_ipsec_capability(odp_ipsec_capability_t *capa)
 
 	capa->max_num_sa = _odp_ipsec_max_num_sa();
 
+	capa->out_op.opt.frag_mode = 1;
+	capa->out_op.opt.tfc_pad = 1;
+	capa->out_op.opt.tfc_dummy = 1;
+	capa->out_op.opt.ip_param = 1;
+
 	capa->max_antireplay_ws = IPSEC_AR_WIN_SIZE_MAX;
 
 	rc = set_ipsec_crypto_capa(capa);

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2017-2018 Linaro Limited
- * Copyright (c) 2018-2025 Nokia
+ * Copyright (c) 2018-2026 Nokia
  * Copyright (c) 2020-2021 Marvell
  */
 
@@ -376,6 +376,30 @@ int ipsec_check_esp_null_aes_xcbc(void)
 {
 	return  ipsec_check_esp(ODP_CIPHER_ALG_NULL, 0,
 				ODP_AUTH_ALG_AES_XCBC_MAC, 128);
+}
+
+int ipsec_check_out_ipv4_ah_sha256_frag_check(void)
+{
+	if (!capa.out_op.opt.frag_mode || ipsec_check_ah_sha256() == ODP_TEST_INACTIVE)
+		return ODP_TEST_INACTIVE;
+
+	return ODP_TEST_ACTIVE;
+}
+
+int ipsec_check_out_ipv4_esp_null_sha256_frag_check(void)
+{
+	if (!capa.out_op.opt.frag_mode || ipsec_check_esp_null_sha256() == ODP_TEST_INACTIVE)
+		return ODP_TEST_INACTIVE;
+
+	return ODP_TEST_ACTIVE;
+}
+
+int ipsec_check_out_dummy_esp_null_sha256(void)
+{
+	if (!capa.out_op.opt.tfc_dummy || ipsec_check_esp_null_sha256() == ODP_TEST_INACTIVE)
+		return ODP_TEST_INACTIVE;
+
+	return ODP_TEST_ACTIVE;
 }
 
 void ipsec_sa_param_fill(odp_ipsec_sa_param_t *param,

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2017-2018 Linaro Limited
  * Copyright (c) 2020 Marvell
- * Copyright (c) 2020 Nokia
+ * Copyright (c) 2020-2026 Nokia
  */
 
 #ifndef _ODP_TEST_IPSEC_H_
@@ -161,6 +161,9 @@ int ipsec_check_test_sa_update_seq_num(void);
 int ipsec_check_esp_aes_gcm_128_reass_ipv4(void);
 int ipsec_check_esp_aes_gcm_128_reass_ipv6(void);
 int ipsec_check_esp_null_aes_xcbc(void);
+int ipsec_check_out_ipv4_ah_sha256_frag_check(void);
+int ipsec_check_out_ipv4_esp_null_sha256_frag_check(void);
+int ipsec_check_out_dummy_esp_null_sha256(void);
 void ipsec_status_event_get(odp_ipsec_sa_t sa,
 			    enum ipsec_test_sa_expiry sa_expiry);
 

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2017-2018 Linaro Limited
  * Copyright (c) 2020 Marvell
- * Copyright (c) 2020-2025 Nokia
+ * Copyright (c) 2020-2026 Nokia
  */
 
 #include <stddef.h>
@@ -2152,11 +2152,11 @@ odp_testinfo_t ipsec_out_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(test_out_ipv4_esp_udp_null_sha256,
 				  ipsec_check_esp_null_sha256),
 	ODP_TEST_INFO_CONDITIONAL(test_out_ipv4_ah_sha256_frag_check,
-				  ipsec_check_ah_sha256),
+				  ipsec_check_out_ipv4_ah_sha256_frag_check),
 	ODP_TEST_INFO_CONDITIONAL(test_out_ipv4_ah_sha256_frag_check_2,
 				  ipsec_check_ah_sha256),
 	ODP_TEST_INFO_CONDITIONAL(test_out_ipv4_esp_null_sha256_frag_check,
-				  ipsec_check_esp_null_sha256),
+				  ipsec_check_out_ipv4_esp_null_sha256_frag_check),
 	ODP_TEST_INFO_CONDITIONAL(test_out_ipv4_esp_null_sha256_frag_check_2,
 				  ipsec_check_esp_null_sha256),
 	ODP_TEST_INFO_CONDITIONAL(test_out_ipv6_ah_sha256,
@@ -2174,9 +2174,9 @@ odp_testinfo_t ipsec_out_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(test_out_ipv6_esp_udp_null_sha256,
 				  ipsec_check_esp_null_sha256),
 	ODP_TEST_INFO_CONDITIONAL(test_out_dummy_esp_null_sha256_tun_ipv4,
-				  ipsec_check_esp_null_sha256),
+				  ipsec_check_out_dummy_esp_null_sha256),
 	ODP_TEST_INFO_CONDITIONAL(test_out_dummy_esp_null_sha256_tun_ipv6,
-				  ipsec_check_esp_null_sha256),
+				  ipsec_check_out_dummy_esp_null_sha256),
 	ODP_TEST_INFO_CONDITIONAL(test_out_ipv4_udp_esp_null_sha256,
 				  ipsec_check_esp_null_sha256),
 	ODP_TEST_INFO_CONDITIONAL(test_out_ipv4_null_aes_xcbc,


### PR DESCRIPTION
Make per-packet outbound options optional by introducing capability bits that show which options are supported. Currently not all ODP implementations actually implement the options. The new capability bits let an implementation advertise which options it supports, allowing it to stay API-compliant.