### PR TITLE
[PATCH v2] linux-gen: small rst ring and stash improvements

### DIFF
--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -36,8 +36,6 @@ typedef struct ODP_ALIGNED_CACHE pool_cache_t {
 
 } pool_cache_t;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
 /* Event header ring */
 typedef struct ODP_ALIGNED_CACHE {
 	/* Ring header */
@@ -50,7 +48,6 @@ typedef struct ODP_ALIGNED_CACHE {
 	_odp_event_hdr_t *event_hdr_by_index[];
 
 } pool_ring_t;
-#pragma GCC diagnostic pop
 
 struct _odp_pool_mem_src_ops_t;
 

--- a/platform/linux-generic/include/ring/odp_ring_mpmc_rst_internal.h
+++ b/platform/linux-generic/include/ring/odp_ring_mpmc_rst_internal.h
@@ -53,47 +53,38 @@ struct ring_xpxc_rst_common {
 
 typedef struct ODP_ALIGNED_CACHE {
 	struct ring_xpxc_rst_common r;
-	uint32_t data[];
 } ring_mpmc_rst_u32_t;
 
 typedef struct ODP_ALIGNED_CACHE {
 	struct ring_xpxc_rst_common r;
-	uint64_t data[];
 } ring_mpmc_rst_u64_t;
 
 typedef struct ODP_ALIGNED_CACHE {
 	struct ring_xpxc_rst_common r;
-	void *data[];
 } ring_mpmc_rst_ptr_t;
 
 typedef struct ODP_ALIGNED_CACHE {
 	struct ring_xpxc_rst_common r;
-	uint32_t data[];
 } ring_mpsc_rst_u32_t;
 
 typedef struct ODP_ALIGNED_CACHE {
 	struct ring_xpxc_rst_common r;
-	uint64_t data[];
 } ring_mpsc_rst_u64_t;
 
 typedef struct ODP_ALIGNED_CACHE {
 	struct ring_xpxc_rst_common r;
-	void *data[];
 } ring_mpsc_rst_ptr_t;
 
 typedef struct ODP_ALIGNED_CACHE {
 	struct ring_xpxc_rst_common r;
-	uint32_t data[];
 } ring_spmc_rst_u32_t;
 
 typedef struct ODP_ALIGNED_CACHE {
 	struct ring_xpxc_rst_common r;
-	uint64_t data[];
 } ring_spmc_rst_u64_t;
 
 typedef struct ODP_ALIGNED_CACHE {
 	struct ring_xpxc_rst_common r;
-	void *data[];
 } ring_spmc_rst_ptr_t;
 
 /* 32-bit CAS with memory order selection */
@@ -240,7 +231,9 @@ static inline void _RING_XPXC_RST_INIT(_ring_xpxc_rst_gen_t *ring)
 
 #ifdef _RING_MPMC_RST_DEQ
 /* Dequeue data from the ring head */
-static inline uint32_t _RING_MPMC_RST_DEQ(_ring_xpxc_rst_gen_t *ring, uint32_t mask,
+static inline uint32_t _RING_MPMC_RST_DEQ(_ring_xpxc_rst_gen_t *ring,
+					  _ring_xpxc_rst_data_t *ring_data,
+					  uint32_t ring_mask,
 					  _ring_xpxc_rst_data_t *data)
 {
 	uint32_t head, tail, new_head;
@@ -264,7 +257,7 @@ static inline uint32_t _RING_MPMC_RST_DEQ(_ring_xpxc_rst_gen_t *ring, uint32_t m
 					 __ATOMIC_ACQUIRE) == 0));
 
 	/* Read data. */
-	*data = ring->data[new_head & mask];
+	*data = ring_data[new_head & ring_mask];
 
 	/* Wait until other readers have updated the tail */
 	while (odp_unlikely(odp_atomic_load_u32(&ring->r.r_tail) != head))
@@ -279,7 +272,9 @@ static inline uint32_t _RING_MPMC_RST_DEQ(_ring_xpxc_rst_gen_t *ring, uint32_t m
 
 #ifdef _RING_MPMC_RST_DEQ_MULTI
 /* Dequeue multiple data from the ring head. Num is smaller than ring size. */
-static inline uint32_t _RING_MPMC_RST_DEQ_MULTI(_ring_xpxc_rst_gen_t *ring, uint32_t mask,
+static inline uint32_t _RING_MPMC_RST_DEQ_MULTI(_ring_xpxc_rst_gen_t *ring,
+						_ring_xpxc_rst_data_t *ring_data,
+						uint32_t ring_mask,
 						_ring_xpxc_rst_data_t data[], uint32_t num)
 {
 	uint32_t head, tail, new_head, i;
@@ -309,7 +304,7 @@ static inline uint32_t _RING_MPMC_RST_DEQ_MULTI(_ring_xpxc_rst_gen_t *ring, uint
 
 	/* Read data. */
 	for (i = 0; i < num; i++)
-		data[i] = ring->data[(head + 1 + i) & mask];
+		data[i] = ring_data[(head + 1 + i) & ring_mask];
 
 	/* Wait until other readers have updated the tail */
 	while (odp_unlikely(odp_atomic_load_u32(&ring->r.r_tail) != head))
@@ -325,7 +320,9 @@ static inline uint32_t _RING_MPMC_RST_DEQ_MULTI(_ring_xpxc_rst_gen_t *ring, uint
 #ifdef _RING_MPSC_RST_DEQ_MULTI
 /* Single-consumer dequeue of multiple data items from the ring head. Num is
  * smaller than ring size. */
-static inline uint32_t _RING_MPSC_RST_DEQ_MULTI(_ring_xpxc_rst_gen_t *ring, uint32_t mask,
+static inline uint32_t _RING_MPSC_RST_DEQ_MULTI(_ring_xpxc_rst_gen_t *ring,
+						_ring_xpxc_rst_data_t *ring_data,
+						uint32_t ring_mask,
 						_ring_xpxc_rst_data_t data[], uint32_t num)
 {
 	uint32_t head, tail, new_head, i;
@@ -350,7 +347,7 @@ static inline uint32_t _RING_MPSC_RST_DEQ_MULTI(_ring_xpxc_rst_gen_t *ring, uint
 
 	/* Read data. */
 	for (i = 0; i < num; i++)
-		data[i] = ring->data[(head + 1 + i) & mask];
+		data[i] = ring_data[(head + 1 + i) & ring_mask];
 
 	/* Update the tail. Writers acquire it. */
 	odp_atomic_store_rel_u32(&ring->r.r_tail, new_head);
@@ -361,7 +358,9 @@ static inline uint32_t _RING_MPSC_RST_DEQ_MULTI(_ring_xpxc_rst_gen_t *ring, uint
 
 #ifdef _RING_MPMC_RST_DEQ_BATCH
 /* Dequeue batch of data (0 or num) from the ring head. Num is smaller than ring size. */
-static inline uint32_t _RING_MPMC_RST_DEQ_BATCH(_ring_xpxc_rst_gen_t *ring, uint32_t mask,
+static inline uint32_t _RING_MPMC_RST_DEQ_BATCH(_ring_xpxc_rst_gen_t *ring,
+						_ring_xpxc_rst_data_t *ring_data,
+						uint32_t ring_mask,
 						_ring_xpxc_rst_data_t data[], uint32_t num)
 {
 	uint32_t head, tail, new_head, i;
@@ -387,7 +386,7 @@ static inline uint32_t _RING_MPMC_RST_DEQ_BATCH(_ring_xpxc_rst_gen_t *ring, uint
 
 	/* Read data. */
 	for (i = 0; i < num; i++)
-		data[i] = ring->data[(head + 1 + i) & mask];
+		data[i] = ring_data[(head + 1 + i) & ring_mask];
 
 	/* Wait until other readers have updated the tail */
 	while (odp_unlikely(odp_atomic_load_u32(&ring->r.r_tail) != head))
@@ -403,7 +402,9 @@ static inline uint32_t _RING_MPMC_RST_DEQ_BATCH(_ring_xpxc_rst_gen_t *ring, uint
 #ifdef _RING_MPSC_RST_DEQ_BATCH
 /* Single-consumer batch dequeue of data items from the ring head. Num is
  * smaller than ring size. */
-static inline uint32_t _RING_MPSC_RST_DEQ_BATCH(_ring_xpxc_rst_gen_t *ring, uint32_t mask,
+static inline uint32_t _RING_MPSC_RST_DEQ_BATCH(_ring_xpxc_rst_gen_t *ring,
+						_ring_xpxc_rst_data_t *ring_data,
+						uint32_t ring_mask,
 						_ring_xpxc_rst_data_t data[], uint32_t num)
 {
 	uint32_t head, tail, new_head, i;
@@ -422,7 +423,7 @@ static inline uint32_t _RING_MPSC_RST_DEQ_BATCH(_ring_xpxc_rst_gen_t *ring, uint
 
 	/* Read data. */
 	for (i = 0; i < num; i++)
-		data[i] = ring->data[(head + 1 + i) & mask];
+		data[i] = ring_data[(head + 1 + i) & ring_mask];
 
 	/* Update the tail. Writers acquire it. */
 	odp_atomic_store_rel_u32(&ring->r.r_tail, new_head);
@@ -433,11 +434,13 @@ static inline uint32_t _RING_MPSC_RST_DEQ_BATCH(_ring_xpxc_rst_gen_t *ring, uint
 
 #ifdef _RING_MPMC_RST_ENQ
 /* Enqueue data into the ring tail */
-static inline void _RING_MPMC_RST_ENQ(_ring_xpxc_rst_gen_t *ring, uint32_t mask,
+static inline void _RING_MPMC_RST_ENQ(_ring_xpxc_rst_gen_t *ring,
+				      _ring_xpxc_rst_data_t *ring_data,
+				      uint32_t ring_mask,
 				      _ring_xpxc_rst_data_t data)
 {
 	uint32_t old_head, new_head;
-	uint32_t size = mask + 1;
+	uint32_t size = ring_mask + 1;
 
 	/* Reserve a slot in the ring for writing */
 	old_head = odp_atomic_fetch_inc_u32(&ring->r.w_head);
@@ -451,7 +454,7 @@ static inline void _RING_MPMC_RST_ENQ(_ring_xpxc_rst_gen_t *ring, uint32_t mask,
 		odp_cpu_pause();
 
 	/* Write data */
-	ring->data[new_head & mask] = data;
+	ring_data[new_head & ring_mask] = data;
 
 	/* Wait until other writers have updated the tail */
 	while (odp_unlikely(odp_atomic_load_u32(&ring->r.w_tail) != old_head))
@@ -464,11 +467,13 @@ static inline void _RING_MPMC_RST_ENQ(_ring_xpxc_rst_gen_t *ring, uint32_t mask,
 
 #ifdef _RING_MPMC_RST_ENQ_MULTI
 /* Enqueue multiple data into the ring tail. Num is smaller than ring size. */
-static inline void _RING_MPMC_RST_ENQ_MULTI(_ring_xpxc_rst_gen_t *ring, uint32_t mask,
+static inline void _RING_MPMC_RST_ENQ_MULTI(_ring_xpxc_rst_gen_t *ring,
+					    _ring_xpxc_rst_data_t *ring_data,
+					    uint32_t ring_mask,
 					    _ring_xpxc_rst_data_t data[], uint32_t num)
 {
 	uint32_t old_head, new_head, i;
-	uint32_t size = mask + 1;
+	uint32_t size = ring_mask + 1;
 
 	/* Reserve a slot in the ring for writing */
 	old_head = odp_atomic_fetch_add_u32(&ring->r.w_head, num);
@@ -483,7 +488,7 @@ static inline void _RING_MPMC_RST_ENQ_MULTI(_ring_xpxc_rst_gen_t *ring, uint32_t
 
 	/* Write data */
 	for (i = 0; i < num; i++)
-		ring->data[(new_head + i) & mask] = data[i];
+		ring_data[(new_head + i) & ring_mask] = data[i];
 
 	/* Wait until other writers have updated the tail */
 	while (odp_unlikely(odp_atomic_load_u32(&ring->r.w_tail) != old_head))
@@ -497,11 +502,13 @@ static inline void _RING_MPMC_RST_ENQ_MULTI(_ring_xpxc_rst_gen_t *ring, uint32_t
 #ifdef _RING_SPMC_RST_ENQ_MULTI
 /* Single-producer enqueue of multiple data items into the ring tail. Num is
  * smaller than ring size. */
-static inline void _RING_SPMC_RST_ENQ_MULTI(_ring_xpxc_rst_gen_t *ring, uint32_t mask,
+static inline void _RING_SPMC_RST_ENQ_MULTI(_ring_xpxc_rst_gen_t *ring,
+					    _ring_xpxc_rst_data_t *ring_data,
+					    uint32_t ring_mask,
 					    _ring_xpxc_rst_data_t data[], uint32_t num)
 {
 	uint32_t old_head, new_head, i;
-	uint32_t size = mask + 1;
+	uint32_t size = ring_mask + 1;
 
 	/* Reserve the slots for writing. Relaxed load and store are enough as
 	 * there are no other writers. */
@@ -518,7 +525,7 @@ static inline void _RING_SPMC_RST_ENQ_MULTI(_ring_xpxc_rst_gen_t *ring, uint32_t
 
 	/* Write data */
 	for (i = 0; i < num; i++)
-		ring->data[(new_head + i) & mask] = data[i];
+		ring_data[(new_head + i) & ring_mask] = data[i];
 
 	/* Release the new writer tail, readers acquire it. */
 	odp_atomic_store_rel_u32(&ring->r.w_tail, old_head + num);

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -132,14 +132,16 @@ static inline _odp_event_hdr_t *cache_pop_single(pool_cache_t *cache)
 }
 
 static inline void cache_pop_to_ring(pool_cache_t *cache,
-				     ring_mpmc_rst_ptr_t *ring, uint32_t mask,
+				     ring_mpmc_rst_ptr_t *ring,
+				     _odp_event_hdr_t **ring_data, uint32_t mask,
 				     uint32_t cache_num, uint32_t num)
 {
 	const uint32_t cache_begin = cache_num - num;
 
 	_ODP_ASSERT(num <= cache_num);
 
-	ring_mpmc_rst_ptr_enq_multi(ring, mask, (void **)&cache->event_hdr[cache_begin], num);
+	ring_mpmc_rst_ptr_enq_multi(ring, (void **)ring_data, mask,
+				    (void **)&cache->event_hdr[cache_begin], num);
 	odp_atomic_store_u32(&cache->cache_num, cache_begin);
 }
 
@@ -163,14 +165,15 @@ static inline void cache_push_single(pool_cache_t *cache, _odp_event_hdr_t *even
 }
 
 static inline uint32_t cache_push_from_ring(pool_cache_t *cache,
-					    ring_mpmc_rst_ptr_t *ring, uint32_t mask,
+					    ring_mpmc_rst_ptr_t *ring,
+					    _odp_event_hdr_t **ring_data, uint32_t mask,
 					    uint32_t cache_num, uint32_t num)
 {
 	uint32_t cached;
 
 	_ODP_ASSERT(cache_num + num <= CONFIG_POOL_CACHE_MAX_SIZE);
 
-	cached = ring_mpmc_rst_ptr_deq_multi(ring, mask,
+	cached = ring_mpmc_rst_ptr_deq_multi(ring, (void **)ring_data, mask,
 					     (void **)&cache->event_hdr[cache_num], num);
 
 	odp_atomic_store_u32(&cache->cache_num, cache_num + cached);
@@ -182,16 +185,18 @@ static void cache_flush(pool_cache_t *cache, pool_t *pool)
 {
 	_odp_event_hdr_t *event_hdr;
 	ring_mpmc_rst_ptr_t *ring;
+	_odp_event_hdr_t **ring_data;
 	uint32_t mask;
 
 	if (!pool->ring)
 		return;
 
 	ring = &pool->ring->hdr;
+	ring_data = pool->ring->event_hdr;
 	mask = pool->ring_mask;
 
 	while (cache_pop(cache, &event_hdr, 1))
-		ring_mpmc_rst_ptr_enq(ring, mask, event_hdr);
+		ring_mpmc_rst_ptr_enq(ring, (void **)ring_data, mask, event_hdr);
 }
 
 static inline int cache_available(pool_t *pool, odp_pool_stats_t *stats)
@@ -614,6 +619,7 @@ static void init_buffers(pool_t *pool)
 	uint8_t *data_ptr = NULL;
 	uint32_t offset;
 	ring_mpmc_rst_ptr_t *ring;
+	_odp_event_hdr_t **ring_data;
 	uint32_t mask;
 	odp_pool_type_t type;
 	uint64_t page_size;
@@ -624,6 +630,7 @@ static void init_buffers(pool_t *pool)
 
 	page_size = shm_info.page_size;
 	ring = &pool->ring->hdr;
+	ring_data = pool->ring->event_hdr;
 	mask = pool->ring_mask;
 	type = pool->type;
 
@@ -675,7 +682,7 @@ static void init_buffers(pool_t *pool)
 		init_event_hdr(pool, event_hdr, i, data_ptr, uarea);
 
 		/* Store buffer into the global pool */
-		ring_mpmc_rst_ptr_enq(ring, mask, event_hdr);
+		ring_mpmc_rst_ptr_enq(ring, (void **)ring_data, mask, event_hdr);
 	}
 	pool->skipped_blocks = skipped_blocks;
 
@@ -1392,8 +1399,8 @@ odp_event_t _odp_event_alloc(pool_t *pool)
 	}
 
 	/* Cache is empty. Refill from the global pool directly into the local cache. */
-	cached = cache_push_from_ring(cache, &pool->ring->hdr, pool->ring_mask, 0,
-				      pool->burst_size);
+	cached = cache_push_from_ring(cache, &pool->ring->hdr, pool->ring->event_hdr,
+				      pool->ring_mask, 0, pool->burst_size);
 
 	if (CONFIG_POOL_STATISTICS) {
 		if (pool->params.stats.bit.alloc_ops)
@@ -1416,6 +1423,7 @@ int _odp_event_alloc_multi(pool_t *pool, _odp_event_hdr_t *event_hdr[], int max_
 	uint32_t pool_idx = pool->pool_idx;
 	pool_cache_t *cache = local.cache[pool_idx];
 	ring_mpmc_rst_ptr_t *ring;
+	_odp_event_hdr_t **ring_data;
 	_odp_event_hdr_t *hdr;
 	uint32_t mask, num_ch, num_alloc, i;
 	uint32_t num_deq = 0;
@@ -1439,8 +1447,10 @@ int _odp_event_alloc_multi(pool_t *pool, _odp_event_hdr_t *event_hdr[], int max_
 		_odp_event_hdr_t *hdr_tmp[burst];
 
 		ring      = &pool->ring->hdr;
+		ring_data = pool->ring->event_hdr;
 		mask      = pool->ring_mask;
-		burst     = ring_mpmc_rst_ptr_deq_multi(ring, mask, (void **)hdr_tmp, burst);
+		burst     = ring_mpmc_rst_ptr_deq_multi(ring, (void **)ring_data, mask,
+							(void **)hdr_tmp, burst);
 		cache_num = burst - num_deq;
 
 		if (CONFIG_POOL_STATISTICS) {
@@ -1479,6 +1489,7 @@ static inline void event_free_to_pool(pool_t *pool,
 	uint32_t pool_idx = pool->pool_idx;
 	pool_cache_t *cache = local.cache[pool_idx];
 	ring_mpmc_rst_ptr_t *ring;
+	_odp_event_hdr_t **ring_data;
 	uint32_t cache_num, mask;
 	uint32_t cache_size = pool->cache_size;
 
@@ -1486,9 +1497,11 @@ static inline void event_free_to_pool(pool_t *pool,
 	 * the global pool. */
 	if (odp_unlikely(num > (int)cache_size)) {
 		ring  = &pool->ring->hdr;
+		ring_data = pool->ring->event_hdr;
 		mask  = pool->ring_mask;
 
-		ring_mpmc_rst_ptr_enq_multi(ring, mask, (void **)event_hdr, num);
+		ring_mpmc_rst_ptr_enq_multi(ring, (void **)ring_data, mask,
+					    (void **)event_hdr, num);
 
 		if (CONFIG_POOL_STATISTICS && pool->params.stats.bit.free_ops)
 			odp_atomic_inc_u64(&pool->stats.free_ops);
@@ -1504,6 +1517,7 @@ static inline void event_free_to_pool(pool_t *pool,
 		int burst = pool->burst_size;
 
 		ring  = &pool->ring->hdr;
+		ring_data = pool->ring->event_hdr;
 		mask  = pool->ring_mask;
 
 		if (odp_unlikely(num > burst))
@@ -1511,7 +1525,7 @@ static inline void event_free_to_pool(pool_t *pool,
 		if (odp_unlikely((uint32_t)num > cache_num))
 			burst = cache_num;
 
-		cache_pop_to_ring(cache, ring, mask, cache_num, burst);
+		cache_pop_to_ring(cache, ring, ring_data, mask, cache_num, burst);
 
 		if (CONFIG_POOL_STATISTICS && pool->params.stats.bit.free_ops)
 			odp_atomic_inc_u64(&pool->stats.free_ops);
@@ -1532,9 +1546,10 @@ void _odp_event_free(odp_event_t event)
 
 	if (odp_unlikely(cache_size == 0)) {
 		ring_mpmc_rst_ptr_t *ring = &pool->ring->hdr;
+		_odp_event_hdr_t **ring_data = pool->ring->event_hdr;
 		uint32_t mask = pool->ring_mask;
 
-		ring_mpmc_rst_ptr_enq(ring, mask, (void *)event_hdr);
+		ring_mpmc_rst_ptr_enq(ring, (void **)ring_data, mask, (void *)event_hdr);
 
 		if (CONFIG_POOL_STATISTICS && pool->params.stats.bit.free_ops)
 			odp_atomic_inc_u64(&pool->stats.free_ops);
@@ -1546,9 +1561,10 @@ void _odp_event_free(odp_event_t event)
 	if (odp_unlikely(cache_size == cache_num)) {
 		const uint32_t burst = pool->burst_size;
 		ring_mpmc_rst_ptr_t *ring = &pool->ring->hdr;
+		_odp_event_hdr_t **ring_data = pool->ring->event_hdr;
 		uint32_t mask = pool->ring_mask;
 
-		cache_pop_to_ring(cache, ring, mask, cache_num, burst);
+		cache_pop_to_ring(cache, ring, ring_data, mask, cache_num, burst);
 
 		if (CONFIG_POOL_STATISTICS && pool->params.stats.bit.free_ops)
 			odp_atomic_inc_u64(&pool->stats.free_ops);
@@ -2242,6 +2258,7 @@ int odp_pool_ext_populate(odp_pool_t pool_hdl, void *buf[], uint32_t buf_size, u
 	pool_t *pool;
 	_odp_event_hdr_t *event_hdr;
 	ring_mpmc_rst_ptr_t *ring;
+	_odp_event_hdr_t **ring_data;
 	uint32_t i, ring_mask, buf_index, head_offset;
 	uint32_t num_populated;
 	uint8_t *data_ptr, *min_addr, *max_addr;
@@ -2285,6 +2302,7 @@ int odp_pool_ext_populate(odp_pool_t pool_hdl, void *buf[], uint32_t buf_size, u
 	}
 
 	ring = &pool->ring->hdr;
+	ring_data = pool->ring->event_hdr;
 	ring_mask = pool->ring_mask;
 	buf_index = pool->num_populated;
 	head_offset = pool->ext_head_offset;
@@ -2316,7 +2334,7 @@ int odp_pool_ext_populate(odp_pool_t pool_hdl, void *buf[], uint32_t buf_size, u
 		pool->ring->event_hdr_by_index[buf_index] = event_hdr;
 		buf_index++;
 
-		ring_mpmc_rst_ptr_enq(ring, ring_mask, event_hdr);
+		ring_mpmc_rst_ptr_enq(ring, (void **)ring_data, ring_mask, event_hdr);
 	}
 
 	pool->num_populated += num;

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -187,6 +187,7 @@ typedef struct ODP_ALIGNED_CACHE {
 		uint32_t    qi;
 		odp_queue_t queue;
 		ring_mpmc_rst_u32_t   *ring;
+		uint32_t    *ring_data;
 		odp_event_t ev[STASH_SIZE];
 	} stash;
 
@@ -210,18 +211,15 @@ typedef struct ODP_ALIGNED_CACHE {
 
 } sched_local_t;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
 /* Priority queue */
 typedef struct ODP_ALIGNED_CACHE {
 	/* Ring header */
 	ring_mpmc_rst_u32_t ring;
 
 	/* Ring data: queue indexes */
-	uint32_t queue_index[MAX_RING_SIZE]; /* overlaps with ring.data[] */
+	uint32_t queue_index[MAX_RING_SIZE];
 
 } prio_queue_t;
-#pragma GCC diagnostic pop
 
 /* Order context of a queue */
 typedef struct ODP_ALIGNED_CACHE {
@@ -724,11 +722,13 @@ static int schedule_term_global(void)
 		for (i = 0; i < NUM_PRIO; i++) {
 			for (j = 0; j < MAX_SPREAD; j++) {
 				ring_mpmc_rst_u32_t *ring;
+				uint32_t *ring_data;
 				uint32_t qi;
 
 				ring = &sched->prio_q[grp][i][j].ring;
+				ring_data = sched->prio_q[grp][i][j].queue_index;
 
-				while (ring_mpmc_rst_u32_deq(ring, ring_mask, &qi)) {
+				while (ring_mpmc_rst_u32_deq(ring, ring_data, ring_mask, &qi)) {
 					odp_event_t events[1];
 					int num;
 
@@ -1001,8 +1001,9 @@ static int schedule_sched_queue(uint32_t queue_index)
 	int prio     = sched->queue[queue_index].prio;
 	int spread   = sched->queue[queue_index].spread;
 	ring_mpmc_rst_u32_t *ring = &sched->prio_q[grp][prio][spread].ring;
+	uint32_t *ring_data = sched->prio_q[grp][prio][spread].queue_index;
 
-	ring_mpmc_rst_u32_enq(ring, sched->ring_mask, queue_index);
+	ring_mpmc_rst_u32_enq(ring, ring_data, sched->ring_mask, queue_index);
 	return 0;
 }
 
@@ -1032,9 +1033,10 @@ static inline void release_atomic(void)
 {
 	uint32_t qi  = sched_local.stash.qi;
 	ring_mpmc_rst_u32_t *ring = sched_local.stash.ring;
+	uint32_t *ring_data = sched_local.stash.ring_data;
 
 	/* Release current atomic queue */
-	ring_mpmc_rst_u32_enq(ring, sched->ring_mask, qi);
+	ring_mpmc_rst_u32_enq(ring, ring_data, sched->ring_mask, qi);
 
 	/* We don't hold sync context anymore */
 	sched_local.sync_ctx = NO_SYNC_CONTEXT;
@@ -1582,6 +1584,7 @@ static inline int schedule_grp_prio(odp_queue_t *out_queue, odp_event_t out_ev[]
 		uint8_t sync_ctx, ordered;
 		odp_queue_t handle;
 		ring_mpmc_rst_u32_t *ring;
+		uint32_t *ring_data;
 		int pktin;
 		uint32_t max_deq;
 		int stashed = 1;
@@ -1598,9 +1601,10 @@ static inline int schedule_grp_prio(odp_queue_t *out_queue, odp_event_t out_ev[]
 		}
 
 		ring = &sched->prio_q[grp][prio][spr].ring;
+		ring_data = sched->prio_q[grp][prio][spr].queue_index;
 
 		/* Get queue index from the spread queue */
-		if (ring_mpmc_rst_u32_deq(ring, ring_mask, &qi) == 0) {
+		if (ring_mpmc_rst_u32_deq(ring, ring_data, ring_mask, &qi) == 0) {
 			/* Spread queue is empty */
 			i++;
 			spr++;
@@ -1637,6 +1641,7 @@ static inline int schedule_grp_prio(odp_queue_t *out_queue, odp_event_t out_ev[]
 			if (new_spr != spr) {
 				sched->queue[qi].spread = new_spr;
 				ring = &sched->prio_q[grp][prio][new_spr].ring;
+				ring_data = sched->prio_q[grp][prio][new_spr].queue_index;
 				update_queue_count(grp, prio, spr, new_spr);
 			}
 		}
@@ -1670,7 +1675,7 @@ static inline int schedule_grp_prio(odp_queue_t *out_queue, odp_event_t out_ev[]
 			if (num_pkt == 0 || !direct_recv) {
 				/* No packets to be returned. Continue scheduling
 				 * packet input queue even when it is empty. */
-				ring_mpmc_rst_u32_enq(ring, ring_mask, qi);
+				ring_mpmc_rst_u32_enq(ring, ring_data, ring_mask, qi);
 
 				/* Continue scheduling from the next spread */
 				i++;
@@ -1693,17 +1698,18 @@ static inline int schedule_grp_prio(odp_queue_t *out_queue, odp_event_t out_ev[]
 			sched_local.ordered.src_queue = qi;
 
 			/* Continue scheduling ordered queues */
-			ring_mpmc_rst_u32_enq(ring, ring_mask, qi);
+			ring_mpmc_rst_u32_enq(ring, ring_data, ring_mask, qi);
 			sched_local.sync_ctx = sync_ctx;
 
 		} else if (sync_ctx == ODP_SCHED_SYNC_ATOMIC) {
 			/* Hold queue during atomic access */
-			sched_local.stash.qi   = qi;
-			sched_local.stash.ring = ring;
-			sched_local.sync_ctx   = sync_ctx;
+			sched_local.stash.qi        = qi;
+			sched_local.stash.ring      = ring;
+			sched_local.stash.ring_data = ring_data;
+			sched_local.sync_ctx        = sync_ctx;
 		} else {
 			/* Continue scheduling parallel queues */
-			ring_mpmc_rst_u32_enq(ring, ring_mask, qi);
+			ring_mpmc_rst_u32_enq(ring, ring_data, ring_mask, qi);
 		}
 
 		handle = queue_from_index(qi);

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -3,14 +3,6 @@
  * Copyright (c) 2019-2025 Nokia
  */
 
-/*
- * Suppress bounds warnings about interior zero length arrays. Such an array
- * is used intentionally in prio_queue_t.
- */
-#if __GNUC__ >= 10
-#pragma GCC diagnostic ignored "-Wzero-length-bounds"
-#endif
-
 #include <odp/api/packet.h>
 #include <odp/api/ticketlock.h>
 #include <odp/api/thread.h>
@@ -77,17 +69,14 @@ typedef struct ODP_ALIGNED_CACHE {
 	odp_queue_t        queue[NUM_PKTIN];
 } sched_cmd_t;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
 typedef struct ODP_ALIGNED_CACHE {
 	/* Ring header */
 	ring_mpmc_rst_u32_t ring;
 
 	/* Ring data: queue indexes */
-	uint32_t ring_idx[RING_SIZE]; /* overlaps with ring.data[] */
+	uint32_t ring_idx[RING_SIZE];
 
 } prio_queue_t;
-#pragma GCC diagnostic pop
 
 typedef struct thr_group_t {
 	/* A generation counter for fast comparison if groups have changed */
@@ -125,10 +114,7 @@ typedef struct {
 	sched_cmd_t   queue_cmd[NUM_QUEUE];
 	sched_cmd_t   pktio_cmd[NUM_PKTIO];
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
 	prio_queue_t  prio_queue[NUM_GROUP][NUM_PRIO];
-#pragma GCC diagnostic pop
 	sched_group_t sched_group;
 	odp_shm_t     shm;
 	/* Scheduler interface config options (not used in fast path) */
@@ -648,7 +634,7 @@ static inline void add_tail(sched_cmd_t *cmd)
 	uint32_t idx = cmd->ring_idx;
 
 	prio_queue = &sched_global->prio_queue[group][prio];
-	ring_mpmc_rst_u32_enq(&prio_queue->ring, RING_MASK, idx);
+	ring_mpmc_rst_u32_enq(&prio_queue->ring, prio_queue->ring_idx, RING_MASK, idx);
 }
 
 static inline sched_cmd_t *rem_head(int group, int prio)
@@ -659,7 +645,8 @@ static inline sched_cmd_t *rem_head(int group, int prio)
 
 	prio_queue = &sched_global->prio_queue[group][prio];
 
-	if (ring_mpmc_rst_u32_deq(&prio_queue->ring, RING_MASK, &ring_idx) == 0)
+	if (ring_mpmc_rst_u32_deq(&prio_queue->ring, prio_queue->ring_idx, RING_MASK,
+				  &ring_idx) == 0)
 		return NULL;
 
 	pktio = index_from_ring_idx(&index, ring_idx);

--- a/platform/linux-generic/odp_stash.c
+++ b/platform/linux-generic/odp_stash.c
@@ -1112,8 +1112,7 @@ static inline int32_t stash_put(odp_stash_t st, const void *obj, int32_t num, od
 	uint32_t obj_size;
 	int32_t i;
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 
 	if (is_batch) {
 		ring_u32_enq = stash->ring_fn.u32.enq_batch;
@@ -1168,9 +1167,7 @@ int32_t odp_stash_put_u32(odp_stash_t st, const uint32_t val[], int32_t num)
 {
 	stash_t *stash = stash_entry(st);
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
-
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 	_ODP_ASSERT(stash->obj_size == sizeof(uint32_t));
 
 	return stash->ring_fn.u32.enq_multi(stash, val, num);
@@ -1180,9 +1177,7 @@ int32_t odp_stash_put_u32_batch(odp_stash_t st, const uint32_t val[], int32_t nu
 {
 	stash_t *stash = stash_entry(st);
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
-
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 	_ODP_ASSERT(stash->obj_size == sizeof(uint32_t));
 
 	return stash->ring_fn.u32.enq_batch(stash, val, num);
@@ -1192,9 +1187,7 @@ int32_t odp_stash_put_u64(odp_stash_t st, const uint64_t val[], int32_t num)
 {
 	stash_t *stash = stash_entry(st);
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
-
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 	_ODP_ASSERT(stash->obj_size == sizeof(uint64_t));
 
 	return stash->ring_fn.u64.enq_multi(stash, (uint64_t *)(uintptr_t)val, num);
@@ -1205,9 +1198,7 @@ int32_t odp_stash_put_u64_batch(odp_stash_t st, const uint64_t val[],
 {
 	stash_t *stash = stash_entry(st);
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
-
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 	_ODP_ASSERT(stash->obj_size == sizeof(uint64_t));
 
 	return stash->ring_fn.u64.enq_batch(stash, (uint64_t *)(uintptr_t)val, num);
@@ -1217,9 +1208,7 @@ int32_t odp_stash_put_ptr(odp_stash_t st, const uintptr_t ptr[], int32_t num)
 {
 	stash_t *stash = stash_entry(st);
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
-
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 	_ODP_ASSERT(stash->obj_size == sizeof(uintptr_t));
 
 	if (sizeof(uintptr_t) == sizeof(uint32_t))
@@ -1236,9 +1225,7 @@ int32_t odp_stash_put_ptr_batch(odp_stash_t st,	const uintptr_t ptr[],
 {
 	stash_t *stash = stash_entry(st);
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
-
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 	_ODP_ASSERT(stash->obj_size == sizeof(uintptr_t));
 
 	if (sizeof(uintptr_t) == sizeof(uint32_t))
@@ -1258,8 +1245,7 @@ static inline int32_t stash_get(odp_stash_t st, void *obj, int32_t num, odp_bool
 	uint32_t obj_size;
 	uint32_t i, num_deq;
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 
 	if (is_batch) {
 		ring_u32_deq = stash->ring_fn.u32.deq_batch;
@@ -1318,9 +1304,7 @@ int32_t odp_stash_get_u32(odp_stash_t st, uint32_t val[], int32_t num)
 {
 	stash_t *stash = stash_entry(st);
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
-
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 	_ODP_ASSERT(stash->obj_size == sizeof(uint32_t));
 
 	return stash->ring_fn.u32.deq_multi(stash, val, num);
@@ -1330,9 +1314,7 @@ int32_t odp_stash_get_u32_batch(odp_stash_t st, uint32_t val[], int32_t num)
 {
 	stash_t *stash = stash_entry(st);
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
-
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 	_ODP_ASSERT(stash->obj_size == sizeof(uint32_t));
 
 	return stash->ring_fn.u32.deq_batch(stash, val, num);
@@ -1342,9 +1324,7 @@ int32_t odp_stash_get_u64(odp_stash_t st, uint64_t val[], int32_t num)
 {
 	stash_t *stash = stash_entry(st);
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
-
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 	_ODP_ASSERT(stash->obj_size == sizeof(uint64_t));
 
 	return stash->ring_fn.u64.deq_multi(stash, val, num);
@@ -1354,9 +1334,7 @@ int32_t odp_stash_get_u64_batch(odp_stash_t st, uint64_t val[], int32_t num)
 {
 	stash_t *stash = stash_entry(st);
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
-
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 	_ODP_ASSERT(stash->obj_size == sizeof(uint64_t));
 
 	return stash->ring_fn.u64.deq_batch(stash, val, num);
@@ -1366,9 +1344,7 @@ int32_t odp_stash_get_ptr(odp_stash_t st, uintptr_t ptr[], int32_t num)
 {
 	stash_t *stash = stash_entry(st);
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
-
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 	_ODP_ASSERT(stash->obj_size == sizeof(uintptr_t));
 
 	if (sizeof(uintptr_t) == sizeof(uint32_t))
@@ -1384,9 +1360,7 @@ int32_t odp_stash_get_ptr_batch(odp_stash_t st, uintptr_t ptr[], int32_t num)
 {
 	stash_t *stash = stash_entry(st);
 
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
-
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 	_ODP_ASSERT(stash->obj_size == sizeof(uintptr_t));
 
 	if (sizeof(uintptr_t) == sizeof(uint32_t))
@@ -1400,8 +1374,7 @@ int32_t odp_stash_get_ptr_batch(odp_stash_t st, uintptr_t ptr[], int32_t num)
 
 int odp_stash_flush_cache(odp_stash_t st)
 {
-	if (odp_unlikely(st == ODP_STASH_INVALID))
-		return -1;
+	_ODP_ASSERT(st != ODP_STASH_INVALID);
 
 	return 0;
 }

--- a/platform/linux-generic/odp_stash.c
+++ b/platform/linux-generic/odp_stash.c
@@ -400,8 +400,8 @@ static void mpmc_rst_ring_u64_init(stash_t *stash)
 static int32_t mpmc_rst_ring_u32_enq_multi(stash_t *stash, const uint32_t val[], int32_t num)
 {
 	/* Success always */
-	ring_mpmc_rst_u32_enq_multi(&stash->ring_mpmc_rst_u32.hdr, stash->ring_mask,
-				    (uint32_t *)(uintptr_t)val, num);
+	ring_mpmc_rst_u32_enq_multi(&stash->ring_mpmc_rst_u32.hdr, stash->ring_mpmc_rst_u32.data,
+				    stash->ring_mask, (uint32_t *)(uintptr_t)val, num);
 
 	return num;
 }
@@ -409,33 +409,37 @@ static int32_t mpmc_rst_ring_u32_enq_multi(stash_t *stash, const uint32_t val[],
 static int32_t mpmc_rst_ring_u64_enq_multi(stash_t *stash, const uint64_t val[], int32_t num)
 {
 	/* Success always */
-	ring_mpmc_rst_u64_enq_multi(&stash->ring_mpmc_rst_u64.hdr, stash->ring_mask,
-				    (uint64_t *)(uintptr_t)val, num);
+	ring_mpmc_rst_u64_enq_multi(&stash->ring_mpmc_rst_u64.hdr, stash->ring_mpmc_rst_u64.data,
+				    stash->ring_mask, (uint64_t *)(uintptr_t)val, num);
 
 	return num;
 }
 
 static int32_t mpmc_rst_ring_u32_deq_multi(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_mpmc_rst_u32_deq_multi(&stash->ring_mpmc_rst_u32.hdr, stash->ring_mask, val,
+	return ring_mpmc_rst_u32_deq_multi(&stash->ring_mpmc_rst_u32.hdr,
+					   stash->ring_mpmc_rst_u32.data, stash->ring_mask, val,
 					   num);
 }
 
 static int32_t mpmc_rst_ring_u64_deq_multi(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_mpmc_rst_u64_deq_multi(&stash->ring_mpmc_rst_u64.hdr, stash->ring_mask, val,
+	return ring_mpmc_rst_u64_deq_multi(&stash->ring_mpmc_rst_u64.hdr,
+					   stash->ring_mpmc_rst_u64.data, stash->ring_mask, val,
 					   num);
 }
 
 static int32_t mpmc_rst_ring_u32_deq_batch(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_mpmc_rst_u32_deq_batch(&stash->ring_mpmc_rst_u32.hdr, stash->ring_mask, val,
+	return ring_mpmc_rst_u32_deq_batch(&stash->ring_mpmc_rst_u32.hdr,
+					   stash->ring_mpmc_rst_u32.data, stash->ring_mask, val,
 					   num);
 }
 
 static int32_t mpmc_rst_ring_u64_deq_batch(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_mpmc_rst_u64_deq_batch(&stash->ring_mpmc_rst_u64.hdr, stash->ring_mask, val,
+	return ring_mpmc_rst_u64_deq_batch(&stash->ring_mpmc_rst_u64.hdr,
+					   stash->ring_mpmc_rst_u64.data, stash->ring_mask, val,
 					   num);
 }
 
@@ -452,40 +456,44 @@ static int32_t mpmc_rst_ring_u64_len(stash_t *stash)
 static int32_t spmc_rst_ring_u32_enq_multi(stash_t *stash, const uint32_t val[], int32_t num)
 {
 	/* Success always */
-	ring_spmc_rst_u32_enq_multi(&stash->ring_spmc_rst_u32.hdr, stash->ring_mask,
-				    (uint32_t *)(uintptr_t)val, num);
+	ring_spmc_rst_u32_enq_multi(&stash->ring_spmc_rst_u32.hdr, stash->ring_spmc_rst_u32.data,
+				    stash->ring_mask, (uint32_t *)(uintptr_t)val, num);
 	return num;
 }
 
 static int32_t spmc_rst_ring_u64_enq_multi(stash_t *stash, const uint64_t val[], int32_t num)
 {
 	/* Success always */
-	ring_spmc_rst_u64_enq_multi(&stash->ring_spmc_rst_u64.hdr, stash->ring_mask,
-				    (uint64_t *)(uintptr_t)val, num);
+	ring_spmc_rst_u64_enq_multi(&stash->ring_spmc_rst_u64.hdr, stash->ring_spmc_rst_u64.data,
+				    stash->ring_mask, (uint64_t *)(uintptr_t)val, num);
 	return num;
 }
 
 static int32_t mpsc_rst_ring_u32_deq_multi(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_mpsc_rst_u32_deq_multi(&stash->ring_mpsc_rst_u32.hdr, stash->ring_mask,
+	return ring_mpsc_rst_u32_deq_multi(&stash->ring_mpsc_rst_u32.hdr,
+					   stash->ring_mpsc_rst_u32.data, stash->ring_mask,
 					   val, num);
 }
 
 static int32_t mpsc_rst_ring_u64_deq_multi(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_mpsc_rst_u64_deq_multi(&stash->ring_mpsc_rst_u64.hdr, stash->ring_mask,
+	return ring_mpsc_rst_u64_deq_multi(&stash->ring_mpsc_rst_u64.hdr,
+					   stash->ring_mpsc_rst_u64.data, stash->ring_mask,
 					   val, num);
 }
 
 static int32_t mpsc_rst_ring_u32_deq_batch(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_mpsc_rst_u32_deq_batch(&stash->ring_mpsc_rst_u32.hdr, stash->ring_mask,
+	return ring_mpsc_rst_u32_deq_batch(&stash->ring_mpsc_rst_u32.hdr,
+					   stash->ring_mpsc_rst_u32.data, stash->ring_mask,
 					   val, num);
 }
 
 static int32_t mpsc_rst_ring_u64_deq_batch(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_mpsc_rst_u64_deq_batch(&stash->ring_mpsc_rst_u64.hdr, stash->ring_mask,
+	return ring_mpsc_rst_u64_deq_batch(&stash->ring_mpsc_rst_u64.hdr,
+					   stash->ring_mpsc_rst_u64.data, stash->ring_mask,
 					   val, num);
 }
 
@@ -507,25 +515,29 @@ static void spmc_rst_ring_u64_init(stash_t *stash)
 
 static int32_t spmc_rst_ring_u32_deq_multi(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_spmc_rst_u32_deq_multi(&stash->ring_spmc_rst_u32.hdr, stash->ring_mask,
+	return ring_spmc_rst_u32_deq_multi(&stash->ring_spmc_rst_u32.hdr,
+					   stash->ring_spmc_rst_u32.data, stash->ring_mask,
 					   val, num);
 }
 
 static int32_t spmc_rst_ring_u64_deq_multi(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_spmc_rst_u64_deq_multi(&stash->ring_spmc_rst_u64.hdr, stash->ring_mask,
+	return ring_spmc_rst_u64_deq_multi(&stash->ring_spmc_rst_u64.hdr,
+					   stash->ring_spmc_rst_u64.data, stash->ring_mask,
 					   val, num);
 }
 
 static int32_t spmc_rst_ring_u32_deq_batch(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_spmc_rst_u32_deq_batch(&stash->ring_spmc_rst_u32.hdr, stash->ring_mask,
+	return ring_spmc_rst_u32_deq_batch(&stash->ring_spmc_rst_u32.hdr,
+					   stash->ring_spmc_rst_u32.data, stash->ring_mask,
 					   val, num);
 }
 
 static int32_t spmc_rst_ring_u64_deq_batch(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_spmc_rst_u64_deq_batch(&stash->ring_spmc_rst_u64.hdr, stash->ring_mask,
+	return ring_spmc_rst_u64_deq_batch(&stash->ring_spmc_rst_u64.hdr,
+					   stash->ring_spmc_rst_u64.data, stash->ring_mask,
 					   val, num);
 }
 
@@ -558,16 +570,16 @@ static void mpsc_rst_ring_u64_init(stash_t *stash)
 static int32_t mpsc_rst_ring_u32_enq_multi(stash_t *stash, const uint32_t val[], int32_t num)
 {
 	/* Success always */
-	ring_mpsc_rst_u32_enq_multi(&stash->ring_mpsc_rst_u32.hdr, stash->ring_mask,
-				    (uint32_t *)(uintptr_t)val, num);
+	ring_mpsc_rst_u32_enq_multi(&stash->ring_mpsc_rst_u32.hdr, stash->ring_mpsc_rst_u32.data,
+				    stash->ring_mask, (uint32_t *)(uintptr_t)val, num);
 	return num;
 }
 
 static int32_t mpsc_rst_ring_u64_enq_multi(stash_t *stash, const uint64_t val[], int32_t num)
 {
 	/* Success always */
-	ring_mpsc_rst_u64_enq_multi(&stash->ring_mpsc_rst_u64.hdr, stash->ring_mask,
-				    (uint64_t *)(uintptr_t)val, num);
+	ring_mpsc_rst_u64_enq_multi(&stash->ring_mpsc_rst_u64.hdr, stash->ring_mpsc_rst_u64.data,
+				    stash->ring_mask, (uint64_t *)(uintptr_t)val, num);
 	return num;
 }
 

--- a/platform/linux-generic/odp_stash.c
+++ b/platform/linux-generic/odp_stash.c
@@ -51,22 +51,20 @@ enum {
 
 typedef struct stash_t stash_t;
 
-typedef void (*ring_u32_init_fn_t)(stash_t *stash);
+typedef void (*ring_init_fn_t)(stash_t *stash);
+
 typedef int32_t (*ring_u32_enq_multi_fn_t)(stash_t *stash, const uint32_t val[], int32_t num);
 typedef int32_t (*ring_u32_enq_batch_fn_t)(stash_t *stash, const uint32_t val[], int32_t num);
 typedef int32_t (*ring_u32_deq_multi_fn_t)(stash_t *stash, uint32_t val[], int32_t num);
 typedef int32_t (*ring_u32_deq_batch_fn_t)(stash_t *stash, uint32_t val[], int32_t num);
 typedef int32_t (*ring_u32_len_fn_t)(stash_t *stash);
 
-typedef void (*ring_u64_init_fn_t)(stash_t *stash);
 typedef int32_t (*ring_u64_enq_multi_fn_t)(stash_t *stash, const uint64_t val[], int32_t num);
 typedef int32_t (*ring_u64_enq_batch_fn_t)(stash_t *stash, const uint64_t val[], int32_t num);
 typedef int32_t (*ring_u64_deq_multi_fn_t)(stash_t *stash, uint64_t val[], int32_t num);
 typedef int32_t (*ring_u64_deq_batch_fn_t)(stash_t *stash, uint64_t val[], int32_t num);
 typedef int32_t (*ring_u64_len_fn_t)(stash_t *stash);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
 typedef struct ODP_ALIGNED_CACHE stash_t {
 	/* Ring functions */
 	union {
@@ -75,7 +73,6 @@ typedef struct ODP_ALIGNED_CACHE stash_t {
 			ring_u32_enq_batch_fn_t enq_batch;
 			ring_u32_deq_multi_fn_t deq_multi;
 			ring_u32_deq_batch_fn_t deq_batch;
-			ring_u32_init_fn_t      init;
 			ring_u32_len_fn_t       len;
 		} u32;
 
@@ -84,7 +81,6 @@ typedef struct ODP_ALIGNED_CACHE stash_t {
 			ring_u64_enq_batch_fn_t enq_batch;
 			ring_u64_deq_multi_fn_t deq_multi;
 			ring_u64_deq_batch_fn_t deq_batch;
-			ring_u64_init_fn_t      init;
 			ring_u64_len_fn_t       len;
 		} u64;
 	} ring_fn;
@@ -97,91 +93,28 @@ typedef struct ODP_ALIGNED_CACHE stash_t {
 	int       index;
 	uint8_t   strict_size;
 
-	/* Ring header followed by variable sized data (object handles) */
-	union {
-		struct ODP_ALIGNED_CACHE {
-			ring_mpmc_rst_u32_t hdr;
-			uint32_t   data[];
-		} ring_mpmc_rst_u32;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_mpmc_rst_u64_t hdr;
-			uint64_t   data[];
-		} ring_mpmc_rst_u64;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_mpsc_rst_u32_t hdr;
-			uint32_t   data[];
-		} ring_mpsc_rst_u32;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_mpsc_rst_u64_t hdr;
-			uint64_t   data[];
-		} ring_mpsc_rst_u64;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_spmc_rst_u32_t hdr;
-			uint32_t   data[];
-		} ring_spmc_rst_u32;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_spmc_rst_u64_t hdr;
-			uint64_t   data[];
-		} ring_spmc_rst_u64;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_mpmc_u32_t hdr;
-			uint32_t   data[];
-		} ring_mpmc_u32;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_mpmc_u64_t hdr;
-			uint64_t   data[];
-		} ring_mpmc_u64;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_mpsc_u32_t hdr;
-			uint32_t   data[];
-		} ring_mpsc_u32;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_mpsc_u64_t hdr;
-			uint64_t   data[];
-		} ring_mpsc_u64;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_spmc_u32_t hdr;
-			uint32_t   data[];
-		} ring_spmc_u32;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_spmc_u64_t hdr;
-			uint64_t   data[];
-		} ring_spmc_u64;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_st_u32_t hdr;
-			uint32_t   data[];
-		} ring_st_u32;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_st_u64_t hdr;
-			uint64_t   data[];
-		} ring_st_u64;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_spsc_u32_t hdr;
-			uint32_t   data[];
-		} ring_spsc_u32;
-
-		struct ODP_ALIGNED_CACHE {
-			ring_spsc_u64_t hdr;
-			uint64_t   data[];
-		} ring_spsc_u64;
+	union ODP_ALIGNED_CACHE {
+		ring_mpmc_rst_u32_t ring_mpmc_rst_u32;
+		ring_mpmc_rst_u64_t ring_mpmc_rst_u64;
+		ring_mpsc_rst_u32_t ring_mpsc_rst_u32;
+		ring_mpsc_rst_u64_t ring_mpsc_rst_u64;
+		ring_spmc_rst_u32_t ring_spmc_rst_u32;
+		ring_spmc_rst_u64_t ring_spmc_rst_u64;
+		ring_mpmc_u32_t     ring_mpmc_u32;
+		ring_mpmc_u64_t     ring_mpmc_u64;
+		ring_mpsc_u32_t     ring_mpsc_u32;
+		ring_mpsc_u64_t     ring_mpsc_u64;
+		ring_spmc_u32_t     ring_spmc_u32;
+		ring_spmc_u64_t     ring_spmc_u64;
+		ring_st_u32_t       ring_st_u32;
+		ring_st_u64_t       ring_st_u64;
+		ring_spsc_u32_t     ring_spsc_u32;
+		ring_spsc_u64_t     ring_spsc_u64;
 	};
 
+	uint64_t ring_data[];
+
 } stash_t;
-#pragma GCC diagnostic pop
 
 typedef struct stash_global_t {
 	odp_ticketlock_t  lock;
@@ -372,6 +305,11 @@ static int reserve_index(void)
 	return index;
 }
 
+static inline void *ring_data(stash_t *stash)
+{
+	return stash->ring_data;
+}
+
 static void free_index(int i)
 {
 	odp_ticketlock_lock(&stash_global->lock);
@@ -383,24 +321,18 @@ static void free_index(int i)
 
 static void mpmc_rst_ring_u32_init(stash_t *stash)
 {
-	ring_mpmc_rst_u32_init(&stash->ring_mpmc_rst_u32.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_mpmc_rst_u32.data[i] = 0;
+	ring_mpmc_rst_u32_init(&stash->ring_mpmc_rst_u32);
 }
 
 static void mpmc_rst_ring_u64_init(stash_t *stash)
 {
-	ring_mpmc_rst_u64_init(&stash->ring_mpmc_rst_u64.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_mpmc_rst_u64.data[i] = 0;
+	ring_mpmc_rst_u64_init(&stash->ring_mpmc_rst_u64);
 }
 
 static int32_t mpmc_rst_ring_u32_enq_multi(stash_t *stash, const uint32_t val[], int32_t num)
 {
 	/* Success always */
-	ring_mpmc_rst_u32_enq_multi(&stash->ring_mpmc_rst_u32.hdr, stash->ring_mpmc_rst_u32.data,
+	ring_mpmc_rst_u32_enq_multi(&stash->ring_mpmc_rst_u32, ring_data(stash),
 				    stash->ring_mask, (uint32_t *)(uintptr_t)val, num);
 
 	return num;
@@ -409,7 +341,7 @@ static int32_t mpmc_rst_ring_u32_enq_multi(stash_t *stash, const uint32_t val[],
 static int32_t mpmc_rst_ring_u64_enq_multi(stash_t *stash, const uint64_t val[], int32_t num)
 {
 	/* Success always */
-	ring_mpmc_rst_u64_enq_multi(&stash->ring_mpmc_rst_u64.hdr, stash->ring_mpmc_rst_u64.data,
+	ring_mpmc_rst_u64_enq_multi(&stash->ring_mpmc_rst_u64, ring_data(stash),
 				    stash->ring_mask, (uint64_t *)(uintptr_t)val, num);
 
 	return num;
@@ -417,46 +349,46 @@ static int32_t mpmc_rst_ring_u64_enq_multi(stash_t *stash, const uint64_t val[],
 
 static int32_t mpmc_rst_ring_u32_deq_multi(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_mpmc_rst_u32_deq_multi(&stash->ring_mpmc_rst_u32.hdr,
-					   stash->ring_mpmc_rst_u32.data, stash->ring_mask, val,
+	return ring_mpmc_rst_u32_deq_multi(&stash->ring_mpmc_rst_u32,
+					   ring_data(stash), stash->ring_mask, val,
 					   num);
 }
 
 static int32_t mpmc_rst_ring_u64_deq_multi(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_mpmc_rst_u64_deq_multi(&stash->ring_mpmc_rst_u64.hdr,
-					   stash->ring_mpmc_rst_u64.data, stash->ring_mask, val,
+	return ring_mpmc_rst_u64_deq_multi(&stash->ring_mpmc_rst_u64,
+					   ring_data(stash), stash->ring_mask, val,
 					   num);
 }
 
 static int32_t mpmc_rst_ring_u32_deq_batch(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_mpmc_rst_u32_deq_batch(&stash->ring_mpmc_rst_u32.hdr,
-					   stash->ring_mpmc_rst_u32.data, stash->ring_mask, val,
+	return ring_mpmc_rst_u32_deq_batch(&stash->ring_mpmc_rst_u32,
+					   ring_data(stash), stash->ring_mask, val,
 					   num);
 }
 
 static int32_t mpmc_rst_ring_u64_deq_batch(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_mpmc_rst_u64_deq_batch(&stash->ring_mpmc_rst_u64.hdr,
-					   stash->ring_mpmc_rst_u64.data, stash->ring_mask, val,
+	return ring_mpmc_rst_u64_deq_batch(&stash->ring_mpmc_rst_u64,
+					   ring_data(stash), stash->ring_mask, val,
 					   num);
 }
 
 static int32_t mpmc_rst_ring_u32_len(stash_t *stash)
 {
-	return ring_mpmc_rst_u32_len(&stash->ring_mpmc_rst_u32.hdr);
+	return ring_mpmc_rst_u32_len(&stash->ring_mpmc_rst_u32);
 }
 
 static int32_t mpmc_rst_ring_u64_len(stash_t *stash)
 {
-	return ring_mpmc_rst_u64_len(&stash->ring_mpmc_rst_u64.hdr);
+	return ring_mpmc_rst_u64_len(&stash->ring_mpmc_rst_u64);
 }
 
 static int32_t spmc_rst_ring_u32_enq_multi(stash_t *stash, const uint32_t val[], int32_t num)
 {
 	/* Success always */
-	ring_spmc_rst_u32_enq_multi(&stash->ring_spmc_rst_u32.hdr, stash->ring_spmc_rst_u32.data,
+	ring_spmc_rst_u32_enq_multi(&stash->ring_spmc_rst_u32, ring_data(stash),
 				    stash->ring_mask, (uint32_t *)(uintptr_t)val, num);
 	return num;
 }
@@ -464,113 +396,101 @@ static int32_t spmc_rst_ring_u32_enq_multi(stash_t *stash, const uint32_t val[],
 static int32_t spmc_rst_ring_u64_enq_multi(stash_t *stash, const uint64_t val[], int32_t num)
 {
 	/* Success always */
-	ring_spmc_rst_u64_enq_multi(&stash->ring_spmc_rst_u64.hdr, stash->ring_spmc_rst_u64.data,
+	ring_spmc_rst_u64_enq_multi(&stash->ring_spmc_rst_u64, ring_data(stash),
 				    stash->ring_mask, (uint64_t *)(uintptr_t)val, num);
 	return num;
 }
 
 static int32_t mpsc_rst_ring_u32_deq_multi(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_mpsc_rst_u32_deq_multi(&stash->ring_mpsc_rst_u32.hdr,
-					   stash->ring_mpsc_rst_u32.data, stash->ring_mask,
+	return ring_mpsc_rst_u32_deq_multi(&stash->ring_mpsc_rst_u32,
+					   ring_data(stash), stash->ring_mask,
 					   val, num);
 }
 
 static int32_t mpsc_rst_ring_u64_deq_multi(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_mpsc_rst_u64_deq_multi(&stash->ring_mpsc_rst_u64.hdr,
-					   stash->ring_mpsc_rst_u64.data, stash->ring_mask,
+	return ring_mpsc_rst_u64_deq_multi(&stash->ring_mpsc_rst_u64,
+					   ring_data(stash), stash->ring_mask,
 					   val, num);
 }
 
 static int32_t mpsc_rst_ring_u32_deq_batch(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_mpsc_rst_u32_deq_batch(&stash->ring_mpsc_rst_u32.hdr,
-					   stash->ring_mpsc_rst_u32.data, stash->ring_mask,
+	return ring_mpsc_rst_u32_deq_batch(&stash->ring_mpsc_rst_u32,
+					   ring_data(stash), stash->ring_mask,
 					   val, num);
 }
 
 static int32_t mpsc_rst_ring_u64_deq_batch(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_mpsc_rst_u64_deq_batch(&stash->ring_mpsc_rst_u64.hdr,
-					   stash->ring_mpsc_rst_u64.data, stash->ring_mask,
+	return ring_mpsc_rst_u64_deq_batch(&stash->ring_mpsc_rst_u64,
+					   ring_data(stash), stash->ring_mask,
 					   val, num);
 }
 
 static void spmc_rst_ring_u32_init(stash_t *stash)
 {
-	ring_spmc_rst_u32_init(&stash->ring_spmc_rst_u32.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_spmc_rst_u32.data[i] = 0;
+	ring_spmc_rst_u32_init(&stash->ring_spmc_rst_u32);
 }
 
 static void spmc_rst_ring_u64_init(stash_t *stash)
 {
-	ring_spmc_rst_u64_init(&stash->ring_spmc_rst_u64.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_spmc_rst_u64.data[i] = 0;
+	ring_spmc_rst_u64_init(&stash->ring_spmc_rst_u64);
 }
 
 static int32_t spmc_rst_ring_u32_deq_multi(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_spmc_rst_u32_deq_multi(&stash->ring_spmc_rst_u32.hdr,
-					   stash->ring_spmc_rst_u32.data, stash->ring_mask,
+	return ring_spmc_rst_u32_deq_multi(&stash->ring_spmc_rst_u32,
+					   ring_data(stash), stash->ring_mask,
 					   val, num);
 }
 
 static int32_t spmc_rst_ring_u64_deq_multi(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_spmc_rst_u64_deq_multi(&stash->ring_spmc_rst_u64.hdr,
-					   stash->ring_spmc_rst_u64.data, stash->ring_mask,
+	return ring_spmc_rst_u64_deq_multi(&stash->ring_spmc_rst_u64,
+					   ring_data(stash), stash->ring_mask,
 					   val, num);
 }
 
 static int32_t spmc_rst_ring_u32_deq_batch(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_spmc_rst_u32_deq_batch(&stash->ring_spmc_rst_u32.hdr,
-					   stash->ring_spmc_rst_u32.data, stash->ring_mask,
+	return ring_spmc_rst_u32_deq_batch(&stash->ring_spmc_rst_u32,
+					   ring_data(stash), stash->ring_mask,
 					   val, num);
 }
 
 static int32_t spmc_rst_ring_u64_deq_batch(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_spmc_rst_u64_deq_batch(&stash->ring_spmc_rst_u64.hdr,
-					   stash->ring_spmc_rst_u64.data, stash->ring_mask,
+	return ring_spmc_rst_u64_deq_batch(&stash->ring_spmc_rst_u64,
+					   ring_data(stash), stash->ring_mask,
 					   val, num);
 }
 
 static int32_t spmc_rst_ring_u32_len(stash_t *stash)
 {
-	return ring_spmc_rst_u32_len(&stash->ring_spmc_rst_u32.hdr);
+	return ring_spmc_rst_u32_len(&stash->ring_spmc_rst_u32);
 }
 
 static int32_t spmc_rst_ring_u64_len(stash_t *stash)
 {
-	return ring_spmc_rst_u64_len(&stash->ring_spmc_rst_u64.hdr);
+	return ring_spmc_rst_u64_len(&stash->ring_spmc_rst_u64);
 }
 
 static void mpsc_rst_ring_u32_init(stash_t *stash)
 {
-	ring_mpsc_rst_u32_init(&stash->ring_mpsc_rst_u32.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_mpsc_rst_u32.data[i] = 0;
+	ring_mpsc_rst_u32_init(&stash->ring_mpsc_rst_u32);
 }
 
 static void mpsc_rst_ring_u64_init(stash_t *stash)
 {
-	ring_mpsc_rst_u64_init(&stash->ring_mpsc_rst_u64.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_mpsc_rst_u64.data[i] = 0;
+	ring_mpsc_rst_u64_init(&stash->ring_mpsc_rst_u64);
 }
 
 static int32_t mpsc_rst_ring_u32_enq_multi(stash_t *stash, const uint32_t val[], int32_t num)
 {
 	/* Success always */
-	ring_mpsc_rst_u32_enq_multi(&stash->ring_mpsc_rst_u32.hdr, stash->ring_mpsc_rst_u32.data,
+	ring_mpsc_rst_u32_enq_multi(&stash->ring_mpsc_rst_u32, ring_data(stash),
 				    stash->ring_mask, (uint32_t *)(uintptr_t)val, num);
 	return num;
 }
@@ -578,389 +498,359 @@ static int32_t mpsc_rst_ring_u32_enq_multi(stash_t *stash, const uint32_t val[],
 static int32_t mpsc_rst_ring_u64_enq_multi(stash_t *stash, const uint64_t val[], int32_t num)
 {
 	/* Success always */
-	ring_mpsc_rst_u64_enq_multi(&stash->ring_mpsc_rst_u64.hdr, stash->ring_mpsc_rst_u64.data,
+	ring_mpsc_rst_u64_enq_multi(&stash->ring_mpsc_rst_u64, ring_data(stash),
 				    stash->ring_mask, (uint64_t *)(uintptr_t)val, num);
 	return num;
 }
 
 static int32_t mpsc_rst_ring_u32_len(stash_t *stash)
 {
-	return ring_mpsc_rst_u32_len(&stash->ring_mpsc_rst_u32.hdr);
+	return ring_mpsc_rst_u32_len(&stash->ring_mpsc_rst_u32);
 }
 
 static int32_t mpsc_rst_ring_u64_len(stash_t *stash)
 {
-	return ring_mpsc_rst_u64_len(&stash->ring_mpsc_rst_u64.hdr);
+	return ring_mpsc_rst_u64_len(&stash->ring_mpsc_rst_u64);
 }
 
 static void mpmc_ring_u32_init(stash_t *stash)
 {
-	ring_mpmc_u32_init(&stash->ring_mpmc_u32.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_mpmc_u32.data[i] = 0;
+	ring_mpmc_u32_init(&stash->ring_mpmc_u32);
 }
 
 static void mpmc_ring_u64_init(stash_t *stash)
 {
-	ring_mpmc_u64_init(&stash->ring_mpmc_u64.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_mpmc_u64.data[i] = 0;
+	ring_mpmc_u64_init(&stash->ring_mpmc_u64);
 }
 
 static int32_t mpmc_ring_u32_enq_multi(stash_t *stash, const uint32_t val[], int32_t num)
 {
-	return ring_mpmc_u32_enq_multi(&stash->ring_mpmc_u32.hdr, stash->ring_mpmc_u32.data,
+	return ring_mpmc_u32_enq_multi(&stash->ring_mpmc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpmc_ring_u64_enq_multi(stash_t *stash, const uint64_t val[], int32_t num)
 {
-	return ring_mpmc_u64_enq_multi(&stash->ring_mpmc_u64.hdr, stash->ring_mpmc_u64.data,
+	return ring_mpmc_u64_enq_multi(&stash->ring_mpmc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpmc_ring_u32_enq_batch(stash_t *stash, const uint32_t val[], int32_t num)
 {
-	return ring_mpmc_u32_enq_batch(&stash->ring_mpmc_u32.hdr, stash->ring_mpmc_u32.data,
+	return ring_mpmc_u32_enq_batch(&stash->ring_mpmc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpmc_ring_u64_enq_batch(stash_t *stash, const uint64_t val[], int32_t num)
 {
-	return ring_mpmc_u64_enq_batch(&stash->ring_mpmc_u64.hdr, stash->ring_mpmc_u64.data,
+	return ring_mpmc_u64_enq_batch(&stash->ring_mpmc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpmc_ring_u32_deq_multi(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_mpmc_u32_deq_multi(&stash->ring_mpmc_u32.hdr, stash->ring_mpmc_u32.data,
+	return ring_mpmc_u32_deq_multi(&stash->ring_mpmc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpmc_ring_u64_deq_multi(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_mpmc_u64_deq_multi(&stash->ring_mpmc_u64.hdr, stash->ring_mpmc_u64.data,
+	return ring_mpmc_u64_deq_multi(&stash->ring_mpmc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpmc_ring_u32_deq_batch(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_mpmc_u32_deq_batch(&stash->ring_mpmc_u32.hdr, stash->ring_mpmc_u32.data,
+	return ring_mpmc_u32_deq_batch(&stash->ring_mpmc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpmc_ring_u64_deq_batch(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_mpmc_u64_deq_batch(&stash->ring_mpmc_u64.hdr, stash->ring_mpmc_u64.data,
+	return ring_mpmc_u64_deq_batch(&stash->ring_mpmc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpmc_ring_u32_len(stash_t *stash)
 {
-	return ring_mpmc_u32_len(&stash->ring_mpmc_u32.hdr);
+	return ring_mpmc_u32_len(&stash->ring_mpmc_u32);
 }
 
 static int32_t mpmc_ring_u64_len(stash_t *stash)
 {
-	return ring_mpmc_u64_len(&stash->ring_mpmc_u64.hdr);
+	return ring_mpmc_u64_len(&stash->ring_mpmc_u64);
 }
 
 static void st_ring_u32_init(stash_t *stash)
 {
-	ring_st_u32_init(&stash->ring_st_u32.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_st_u32.data[i] = 0;
+	ring_st_u32_init(&stash->ring_st_u32);
 }
 
 static void st_ring_u64_init(stash_t *stash)
 {
-	ring_st_u64_init(&stash->ring_st_u64.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_st_u64.data[i] = 0;
+	ring_st_u64_init(&stash->ring_st_u64);
 }
 
 static int32_t st_ring_u32_enq_multi(stash_t *stash, const uint32_t val[], int32_t num)
 {
-	return ring_st_u32_enq_multi(&stash->ring_st_u32.hdr, stash->ring_st_u32.data,
+	return ring_st_u32_enq_multi(&stash->ring_st_u32, ring_data(stash),
 				     stash->ring_mask, val, num);
 }
 
 static int32_t st_ring_u32_enq_batch(stash_t *stash, const uint32_t val[], int32_t num)
 {
-	return ring_st_u32_enq_batch(&stash->ring_st_u32.hdr, stash->ring_st_u32.data,
+	return ring_st_u32_enq_batch(&stash->ring_st_u32, ring_data(stash),
 				     stash->ring_mask, val, num);
 }
 
 static int32_t st_ring_u64_enq_multi(stash_t *stash, const uint64_t val[], int32_t num)
 {
-	return ring_st_u64_enq_multi(&stash->ring_st_u64.hdr, stash->ring_st_u64.data,
+	return ring_st_u64_enq_multi(&stash->ring_st_u64, ring_data(stash),
 				     stash->ring_mask, val, num);
 }
 
 static int32_t st_ring_u64_enq_batch(stash_t *stash, const uint64_t val[], int32_t num)
 {
-	return ring_st_u64_enq_batch(&stash->ring_st_u64.hdr, stash->ring_st_u64.data,
+	return ring_st_u64_enq_batch(&stash->ring_st_u64, ring_data(stash),
 				     stash->ring_mask, val, num);
 }
 
 static int32_t st_ring_u32_deq_multi(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_st_u32_deq_multi(&stash->ring_st_u32.hdr, stash->ring_st_u32.data,
+	return ring_st_u32_deq_multi(&stash->ring_st_u32, ring_data(stash),
 				     stash->ring_mask, val, num);
 }
 
 static int32_t st_ring_u64_deq_multi(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_st_u64_deq_multi(&stash->ring_st_u64.hdr, stash->ring_st_u64.data,
+	return ring_st_u64_deq_multi(&stash->ring_st_u64, ring_data(stash),
 				     stash->ring_mask, val, num);
 }
 
 static int32_t st_ring_u32_deq_batch(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_st_u32_deq_batch(&stash->ring_st_u32.hdr, stash->ring_st_u32.data,
+	return ring_st_u32_deq_batch(&stash->ring_st_u32, ring_data(stash),
 				     stash->ring_mask, val, num);
 }
 
 static int32_t st_ring_u64_deq_batch(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_st_u64_deq_batch(&stash->ring_st_u64.hdr, stash->ring_st_u64.data,
+	return ring_st_u64_deq_batch(&stash->ring_st_u64, ring_data(stash),
 				     stash->ring_mask, val, num);
 }
 
 static int32_t st_ring_u32_len(stash_t *stash)
 {
-	return ring_st_u32_len(&stash->ring_st_u32.hdr);
+	return ring_st_u32_len(&stash->ring_st_u32);
 }
 
 static int32_t st_ring_u64_len(stash_t *stash)
 {
-	return ring_st_u64_len(&stash->ring_st_u64.hdr);
+	return ring_st_u64_len(&stash->ring_st_u64);
 }
 
 static void spsc_ring_u32_init(stash_t *stash)
 {
-	ring_spsc_u32_init(&stash->ring_spsc_u32.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_spsc_u32.data[i] = 0;
+	ring_spsc_u32_init(&stash->ring_spsc_u32);
 }
 
 static void spsc_ring_u64_init(stash_t *stash)
 {
-	ring_spsc_u64_init(&stash->ring_spsc_u64.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_spsc_u64.data[i] = 0;
+	ring_spsc_u64_init(&stash->ring_spsc_u64);
 }
 
 static int32_t spsc_ring_u32_enq_multi(stash_t *stash, const uint32_t val[], int32_t num)
 {
-	return ring_spsc_u32_enq_multi(&stash->ring_spsc_u32.hdr, stash->ring_spsc_u32.data,
+	return ring_spsc_u32_enq_multi(&stash->ring_spsc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spsc_ring_u64_enq_multi(stash_t *stash, const uint64_t val[], int32_t num)
 {
-	return ring_spsc_u64_enq_multi(&stash->ring_spsc_u64.hdr, stash->ring_spsc_u64.data,
+	return ring_spsc_u64_enq_multi(&stash->ring_spsc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spsc_ring_u32_enq_batch(stash_t *stash, const uint32_t val[], int32_t num)
 {
-	return ring_spsc_u32_enq_batch(&stash->ring_spsc_u32.hdr, stash->ring_spsc_u32.data,
+	return ring_spsc_u32_enq_batch(&stash->ring_spsc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spsc_ring_u64_enq_batch(stash_t *stash, const uint64_t val[], int32_t num)
 {
-	return ring_spsc_u64_enq_batch(&stash->ring_spsc_u64.hdr, stash->ring_spsc_u64.data,
+	return ring_spsc_u64_enq_batch(&stash->ring_spsc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spsc_ring_u32_deq_multi(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_spsc_u32_deq_multi(&stash->ring_spsc_u32.hdr, stash->ring_spsc_u32.data,
+	return ring_spsc_u32_deq_multi(&stash->ring_spsc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spsc_ring_u64_deq_multi(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_spsc_u64_deq_multi(&stash->ring_spsc_u64.hdr, stash->ring_spsc_u64.data,
+	return ring_spsc_u64_deq_multi(&stash->ring_spsc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spsc_ring_u32_deq_batch(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_spsc_u32_deq_batch(&stash->ring_spsc_u32.hdr, stash->ring_spsc_u32.data,
+	return ring_spsc_u32_deq_batch(&stash->ring_spsc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spsc_ring_u64_deq_batch(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_spsc_u64_deq_batch(&stash->ring_spsc_u64.hdr, stash->ring_spsc_u64.data,
+	return ring_spsc_u64_deq_batch(&stash->ring_spsc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spsc_ring_u32_len(stash_t *stash)
 {
-	return ring_spsc_u32_len(&stash->ring_spsc_u32.hdr);
+	return ring_spsc_u32_len(&stash->ring_spsc_u32);
 }
 
 static int32_t spsc_ring_u64_len(stash_t *stash)
 {
-	return ring_spsc_u64_len(&stash->ring_spsc_u64.hdr);
+	return ring_spsc_u64_len(&stash->ring_spsc_u64);
 }
 
 static void spmc_ring_u32_init(stash_t *stash)
 {
-	ring_spmc_u32_init(&stash->ring_spmc_u32.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_spmc_u32.data[i] = 0;
+	ring_spmc_u32_init(&stash->ring_spmc_u32);
 }
 
 static void spmc_ring_u64_init(stash_t *stash)
 {
-	ring_spmc_u64_init(&stash->ring_spmc_u64.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_spmc_u64.data[i] = 0;
+	ring_spmc_u64_init(&stash->ring_spmc_u64);
 }
 
 static int32_t spmc_ring_u32_enq_multi(stash_t *stash, const uint32_t val[], int32_t num)
 {
-	return ring_spmc_u32_enq_multi(&stash->ring_spmc_u32.hdr, stash->ring_spmc_u32.data,
+	return ring_spmc_u32_enq_multi(&stash->ring_spmc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spmc_ring_u64_enq_multi(stash_t *stash, const uint64_t val[], int32_t num)
 {
-	return ring_spmc_u64_enq_multi(&stash->ring_spmc_u64.hdr, stash->ring_spmc_u64.data,
+	return ring_spmc_u64_enq_multi(&stash->ring_spmc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spmc_ring_u32_enq_batch(stash_t *stash, const uint32_t val[], int32_t num)
 {
-	return ring_spmc_u32_enq_batch(&stash->ring_spmc_u32.hdr, stash->ring_spmc_u32.data,
+	return ring_spmc_u32_enq_batch(&stash->ring_spmc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spmc_ring_u64_enq_batch(stash_t *stash, const uint64_t val[], int32_t num)
 {
-	return ring_spmc_u64_enq_batch(&stash->ring_spmc_u64.hdr, stash->ring_spmc_u64.data,
+	return ring_spmc_u64_enq_batch(&stash->ring_spmc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spmc_ring_u32_deq_multi(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_spmc_u32_deq_multi(&stash->ring_spmc_u32.hdr, stash->ring_spmc_u32.data,
+	return ring_spmc_u32_deq_multi(&stash->ring_spmc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spmc_ring_u64_deq_multi(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_spmc_u64_deq_multi(&stash->ring_spmc_u64.hdr, stash->ring_spmc_u64.data,
+	return ring_spmc_u64_deq_multi(&stash->ring_spmc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spmc_ring_u32_deq_batch(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_spmc_u32_deq_batch(&stash->ring_spmc_u32.hdr, stash->ring_spmc_u32.data,
+	return ring_spmc_u32_deq_batch(&stash->ring_spmc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spmc_ring_u64_deq_batch(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_spmc_u64_deq_batch(&stash->ring_spmc_u64.hdr, stash->ring_spmc_u64.data,
+	return ring_spmc_u64_deq_batch(&stash->ring_spmc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t spmc_ring_u32_len(stash_t *stash)
 {
-	return ring_spmc_u32_len(&stash->ring_spmc_u32.hdr);
+	return ring_spmc_u32_len(&stash->ring_spmc_u32);
 }
 
 static int32_t spmc_ring_u64_len(stash_t *stash)
 {
-	return ring_spmc_u64_len(&stash->ring_spmc_u64.hdr);
+	return ring_spmc_u64_len(&stash->ring_spmc_u64);
 }
 
 static void mpsc_ring_u32_init(stash_t *stash)
 {
-	ring_mpsc_u32_init(&stash->ring_mpsc_u32.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_mpsc_u32.data[i] = 0;
+	ring_mpsc_u32_init(&stash->ring_mpsc_u32);
 }
 
 static void mpsc_ring_u64_init(stash_t *stash)
 {
-	ring_mpsc_u64_init(&stash->ring_mpsc_u64.hdr);
-
-	for (uint32_t i = 0; i < stash->ring_size; i++)
-		stash->ring_mpsc_u64.data[i] = 0;
+	ring_mpsc_u64_init(&stash->ring_mpsc_u64);
 }
 
 static int32_t mpsc_ring_u32_enq_multi(stash_t *stash, const uint32_t val[], int32_t num)
 {
-	return ring_mpsc_u32_enq_multi(&stash->ring_mpsc_u32.hdr, stash->ring_mpsc_u32.data,
+	return ring_mpsc_u32_enq_multi(&stash->ring_mpsc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpsc_ring_u64_enq_multi(stash_t *stash, const uint64_t val[], int32_t num)
 {
-	return ring_mpsc_u64_enq_multi(&stash->ring_mpsc_u64.hdr, stash->ring_mpsc_u64.data,
+	return ring_mpsc_u64_enq_multi(&stash->ring_mpsc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpsc_ring_u32_enq_batch(stash_t *stash, const uint32_t val[], int32_t num)
 {
-	return ring_mpsc_u32_enq_batch(&stash->ring_mpsc_u32.hdr, stash->ring_mpsc_u32.data,
+	return ring_mpsc_u32_enq_batch(&stash->ring_mpsc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpsc_ring_u64_enq_batch(stash_t *stash, const uint64_t val[], int32_t num)
 {
-	return ring_mpsc_u64_enq_batch(&stash->ring_mpsc_u64.hdr, stash->ring_mpsc_u64.data,
+	return ring_mpsc_u64_enq_batch(&stash->ring_mpsc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpsc_ring_u32_deq_multi(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_mpsc_u32_deq_multi(&stash->ring_mpsc_u32.hdr, stash->ring_mpsc_u32.data,
+	return ring_mpsc_u32_deq_multi(&stash->ring_mpsc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpsc_ring_u64_deq_multi(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_mpsc_u64_deq_multi(&stash->ring_mpsc_u64.hdr, stash->ring_mpsc_u64.data,
+	return ring_mpsc_u64_deq_multi(&stash->ring_mpsc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpsc_ring_u32_deq_batch(stash_t *stash, uint32_t val[], int32_t num)
 {
-	return ring_mpsc_u32_deq_batch(&stash->ring_mpsc_u32.hdr, stash->ring_mpsc_u32.data,
+	return ring_mpsc_u32_deq_batch(&stash->ring_mpsc_u32, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static int32_t mpsc_ring_u64_deq_batch(stash_t *stash, uint64_t val[], int32_t num)
 {
-	return ring_mpsc_u64_deq_batch(&stash->ring_mpsc_u64.hdr, stash->ring_mpsc_u64.data,
+	return ring_mpsc_u64_deq_batch(&stash->ring_mpsc_u64, ring_data(stash),
 				       stash->ring_mask, val, num);
 }
 
 static inline int32_t mpsc_ring_u32_len(stash_t *stash)
 {
-	return ring_mpsc_u32_len(&stash->ring_mpsc_u32.hdr);
+	return ring_mpsc_u32_len(&stash->ring_mpsc_u32);
 }
 
 static inline int32_t mpsc_ring_u64_len(stash_t *stash)
 {
-	return ring_mpsc_u64_len(&stash->ring_mpsc_u64.hdr);
+	return ring_mpsc_u64_len(&stash->ring_mpsc_u64);
 }
 
 odp_stash_t odp_stash_create(const char *name, const odp_stash_param_t *param)
@@ -969,6 +859,7 @@ odp_stash_t odp_stash_create(const char *name, const odp_stash_param_t *param)
 	stash_t *stash;
 	uint64_t ring_size;
 	int ring_u64, index;
+	ring_init_fn_t init_fn;
 
 	if (odp_global_ro.disable.stash) {
 		_ODP_ERR("Stash is disabled\n");
@@ -1024,14 +915,14 @@ odp_stash_t odp_stash_create(const char *name, const odp_stash_param_t *param)
 
 	if (param->get_mode == ODP_STASH_OP_LOCAL && param->put_mode == ODP_STASH_OP_LOCAL) {
 		if (ring_u64) {
-			stash->ring_fn.u64.init      = st_ring_u64_init;
+			init_fn                      = st_ring_u64_init;
 			stash->ring_fn.u64.enq_multi = st_ring_u64_enq_multi;
 			stash->ring_fn.u64.enq_batch = st_ring_u64_enq_batch;
 			stash->ring_fn.u64.deq_multi = st_ring_u64_deq_multi;
 			stash->ring_fn.u64.deq_batch = st_ring_u64_deq_batch;
 			stash->ring_fn.u64.len       = st_ring_u64_len;
 		} else {
-			stash->ring_fn.u32.init      = st_ring_u32_init;
+			init_fn                      = st_ring_u32_init;
 			stash->ring_fn.u32.enq_multi = st_ring_u32_enq_multi;
 			stash->ring_fn.u32.enq_batch = st_ring_u32_enq_batch;
 			stash->ring_fn.u32.deq_multi = st_ring_u32_deq_multi;
@@ -1040,14 +931,14 @@ odp_stash_t odp_stash_create(const char *name, const odp_stash_param_t *param)
 		}
 	} else if (single_producer && single_consumer) {
 		if (ring_u64) {
-			stash->ring_fn.u64.init      = spsc_ring_u64_init;
+			init_fn                      = spsc_ring_u64_init;
 			stash->ring_fn.u64.enq_multi = spsc_ring_u64_enq_multi;
 			stash->ring_fn.u64.enq_batch = spsc_ring_u64_enq_batch;
 			stash->ring_fn.u64.deq_multi = spsc_ring_u64_deq_multi;
 			stash->ring_fn.u64.deq_batch = spsc_ring_u64_deq_batch;
 			stash->ring_fn.u64.len       = spsc_ring_u64_len;
 		} else {
-			stash->ring_fn.u32.init      = spsc_ring_u32_init;
+			init_fn                      = spsc_ring_u32_init;
 			stash->ring_fn.u32.enq_multi = spsc_ring_u32_enq_multi;
 			stash->ring_fn.u32.enq_batch = spsc_ring_u32_enq_batch;
 			stash->ring_fn.u32.deq_multi = spsc_ring_u32_deq_multi;
@@ -1057,21 +948,21 @@ odp_stash_t odp_stash_create(const char *name, const odp_stash_param_t *param)
 	} else if (stash->strict_size) {
 		if (ring_u64) {
 			if (single_producer) {
-				stash->ring_fn.u64.init      = spmc_rst_ring_u64_init;
+				init_fn                      = spmc_rst_ring_u64_init;
 				stash->ring_fn.u64.enq_multi = spmc_rst_ring_u64_enq_multi;
 				stash->ring_fn.u64.enq_batch = spmc_rst_ring_u64_enq_multi;
 				stash->ring_fn.u64.deq_multi = spmc_rst_ring_u64_deq_multi;
 				stash->ring_fn.u64.deq_batch = spmc_rst_ring_u64_deq_batch;
 				stash->ring_fn.u64.len       = spmc_rst_ring_u64_len;
 			} else if (single_consumer) {
-				stash->ring_fn.u64.init      = mpsc_rst_ring_u64_init;
+				init_fn                      = mpsc_rst_ring_u64_init;
 				stash->ring_fn.u64.enq_multi = mpsc_rst_ring_u64_enq_multi;
 				stash->ring_fn.u64.enq_batch = mpsc_rst_ring_u64_enq_multi;
 				stash->ring_fn.u64.deq_multi = mpsc_rst_ring_u64_deq_multi;
 				stash->ring_fn.u64.deq_batch = mpsc_rst_ring_u64_deq_batch;
 				stash->ring_fn.u64.len       = mpsc_rst_ring_u64_len;
 			} else {
-				stash->ring_fn.u64.init      = mpmc_rst_ring_u64_init;
+				init_fn                      = mpmc_rst_ring_u64_init;
 				stash->ring_fn.u64.enq_multi = mpmc_rst_ring_u64_enq_multi;
 				stash->ring_fn.u64.enq_batch = mpmc_rst_ring_u64_enq_multi;
 				stash->ring_fn.u64.deq_multi = mpmc_rst_ring_u64_deq_multi;
@@ -1080,21 +971,21 @@ odp_stash_t odp_stash_create(const char *name, const odp_stash_param_t *param)
 			}
 		} else {
 			if (single_producer) {
-				stash->ring_fn.u32.init      = spmc_rst_ring_u32_init;
+				init_fn                      = spmc_rst_ring_u32_init;
 				stash->ring_fn.u32.enq_multi = spmc_rst_ring_u32_enq_multi;
 				stash->ring_fn.u32.enq_batch = spmc_rst_ring_u32_enq_multi;
 				stash->ring_fn.u32.deq_multi = spmc_rst_ring_u32_deq_multi;
 				stash->ring_fn.u32.deq_batch = spmc_rst_ring_u32_deq_batch;
 				stash->ring_fn.u32.len       = spmc_rst_ring_u32_len;
 			} else if (single_consumer) {
-				stash->ring_fn.u32.init      = mpsc_rst_ring_u32_init;
+				init_fn                      = mpsc_rst_ring_u32_init;
 				stash->ring_fn.u32.enq_multi = mpsc_rst_ring_u32_enq_multi;
 				stash->ring_fn.u32.enq_batch = mpsc_rst_ring_u32_enq_multi;
 				stash->ring_fn.u32.deq_multi = mpsc_rst_ring_u32_deq_multi;
 				stash->ring_fn.u32.deq_batch = mpsc_rst_ring_u32_deq_batch;
 				stash->ring_fn.u32.len       = mpsc_rst_ring_u32_len;
 			} else {
-				stash->ring_fn.u32.init      = mpmc_rst_ring_u32_init;
+				init_fn                      = mpmc_rst_ring_u32_init;
 				stash->ring_fn.u32.enq_multi = mpmc_rst_ring_u32_enq_multi;
 				stash->ring_fn.u32.enq_batch = mpmc_rst_ring_u32_enq_multi;
 				stash->ring_fn.u32.deq_multi = mpmc_rst_ring_u32_deq_multi;
@@ -1105,21 +996,21 @@ odp_stash_t odp_stash_create(const char *name, const odp_stash_param_t *param)
 	} else {
 		if (ring_u64) {
 			if (single_producer) {
-				stash->ring_fn.u64.init      = spmc_ring_u64_init;
+				init_fn                      = spmc_ring_u64_init;
 				stash->ring_fn.u64.enq_multi = spmc_ring_u64_enq_multi;
 				stash->ring_fn.u64.enq_batch = spmc_ring_u64_enq_batch;
 				stash->ring_fn.u64.deq_multi = spmc_ring_u64_deq_multi;
 				stash->ring_fn.u64.deq_batch = spmc_ring_u64_deq_batch;
 				stash->ring_fn.u64.len       = spmc_ring_u64_len;
 			} else if (single_consumer) {
-				stash->ring_fn.u64.init      = mpsc_ring_u64_init;
+				init_fn                      = mpsc_ring_u64_init;
 				stash->ring_fn.u64.enq_multi = mpsc_ring_u64_enq_multi;
 				stash->ring_fn.u64.enq_batch = mpsc_ring_u64_enq_batch;
 				stash->ring_fn.u64.deq_multi = mpsc_ring_u64_deq_multi;
 				stash->ring_fn.u64.deq_batch = mpsc_ring_u64_deq_batch;
 				stash->ring_fn.u64.len       = mpsc_ring_u64_len;
 			} else {
-				stash->ring_fn.u64.init      = mpmc_ring_u64_init;
+				init_fn                      = mpmc_ring_u64_init;
 				stash->ring_fn.u64.enq_multi = mpmc_ring_u64_enq_multi;
 				stash->ring_fn.u64.enq_batch = mpmc_ring_u64_enq_batch;
 				stash->ring_fn.u64.deq_multi = mpmc_ring_u64_deq_multi;
@@ -1128,21 +1019,21 @@ odp_stash_t odp_stash_create(const char *name, const odp_stash_param_t *param)
 			}
 		} else {
 			if (single_producer) {
-				stash->ring_fn.u32.init      = spmc_ring_u32_init;
+				init_fn                      = spmc_ring_u32_init;
 				stash->ring_fn.u32.enq_multi = spmc_ring_u32_enq_multi;
 				stash->ring_fn.u32.enq_batch = spmc_ring_u32_enq_batch;
 				stash->ring_fn.u32.deq_multi = spmc_ring_u32_deq_multi;
 				stash->ring_fn.u32.deq_batch = spmc_ring_u32_deq_batch;
 				stash->ring_fn.u32.len       = spmc_ring_u32_len;
 			} else if (single_consumer) {
-				stash->ring_fn.u32.init      = mpsc_ring_u32_init;
+				init_fn                      = mpsc_ring_u32_init;
 				stash->ring_fn.u32.enq_multi = mpsc_ring_u32_enq_multi;
 				stash->ring_fn.u32.enq_batch = mpsc_ring_u32_enq_batch;
 				stash->ring_fn.u32.deq_multi = mpsc_ring_u32_deq_multi;
 				stash->ring_fn.u32.deq_batch = mpsc_ring_u32_deq_batch;
 				stash->ring_fn.u32.len       = mpsc_ring_u32_len;
 			} else {
-				stash->ring_fn.u32.init      = mpmc_ring_u32_init;
+				init_fn                      = mpmc_ring_u32_init;
 				stash->ring_fn.u32.enq_multi = mpmc_ring_u32_enq_multi;
 				stash->ring_fn.u32.enq_batch = mpmc_ring_u32_enq_batch;
 				stash->ring_fn.u32.deq_multi = mpmc_ring_u32_deq_multi;
@@ -1160,10 +1051,11 @@ odp_stash_t odp_stash_create(const char *name, const odp_stash_param_t *param)
 	stash->ring_mask    = ring_size - 1;
 	stash->ring_size    = ring_size;
 
-	if (ring_u64)
-		stash->ring_fn.u64.init(stash);
-	else
-		stash->ring_fn.u32.init(stash);
+	init_fn(stash);
+
+	/* Not required but may help debugging */
+	for (uint32_t i = 0; i < stash->ring_size; i++)
+		stash->ring_data[i] = 0;
 
 	/* This makes stash visible to lookups */
 	odp_ticketlock_lock(&stash_global->lock);

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -156,6 +156,11 @@ static int _ring_destroy(const char *name)
 	return 0;
 }
 
+static inline void **_ring_data(ring_mpmc_rst_ptr_t *r)
+{
+	return (void **)(r + 1);
+}
+
 /**
  * Return the number of entries in a ring.
  */
@@ -595,7 +600,7 @@ static void _ipc_free_ring_packets(pktio_entry_t *pktio_entry, ring_mpmc_rst_ptr
 	rbuf_p = (void *)&offsets;
 
 	while (1) {
-		ret = ring_mpmc_rst_ptr_deq_multi(r, r_mask, rbuf_p, IPC_BURST_SIZE);
+		ret = ring_mpmc_rst_ptr_deq_multi(r, _ring_data(r), r_mask, rbuf_p, IPC_BURST_SIZE);
 		if (ret <= 0)
 			break;
 		for (i = 0; i < ret; i++) {
@@ -633,7 +638,7 @@ static int ipc_pktio_recv_lockless(pktio_entry_t *pktio_entry,
 
 	/* rx from cache */
 	r = pktio_ipc->rx.cache;
-	pkts = ring_mpmc_rst_ptr_deq_multi(r, ring_mask, ipcbufs_p, len);
+	pkts = ring_mpmc_rst_ptr_deq_multi(r, _ring_data(r), ring_mask, ipcbufs_p, len);
 	if (odp_unlikely(pkts < 0))
 		_ODP_ABORT("internal error dequeue\n");
 
@@ -641,7 +646,7 @@ static int ipc_pktio_recv_lockless(pktio_entry_t *pktio_entry,
 	if (pkts == 0) {
 		ipcbufs_p = (void *)&offsets[0];
 		r = pktio_ipc->rx.recv;
-		pkts = ring_mpmc_rst_ptr_deq_multi(r, ring_mask, ipcbufs_p, len);
+		pkts = ring_mpmc_rst_ptr_deq_multi(r, _ring_data(r), ring_mask, ipcbufs_p, len);
 		if (odp_unlikely(pkts < 0))
 			_ODP_ABORT("internal error dequeue\n");
 	}
@@ -710,7 +715,7 @@ static int ipc_pktio_recv_lockless(pktio_entry_t *pktio_entry,
 	if (pkts != i) {
 		ipcbufs_p = (void *)&offsets[i];
 		r_p = pktio_ipc->rx.cache;
-		ring_mpmc_rst_ptr_enq_multi(r_p, ring_mask, ipcbufs_p, pkts - i);
+		ring_mpmc_rst_ptr_enq_multi(r_p, _ring_data(r_p), ring_mask, ipcbufs_p, pkts - i);
 
 		if (i == 0)
 			return 0;
@@ -723,7 +728,7 @@ static int ipc_pktio_recv_lockless(pktio_entry_t *pktio_entry,
 	r_p = pktio_ipc->rx.free;
 
 	ipcbufs_p = (void *)&offsets[0];
-	ring_mpmc_rst_ptr_enq_multi(r_p, ring_mask, ipcbufs_p, pkts);
+	ring_mpmc_rst_ptr_enq_multi(r_p, _ring_data(r_p), ring_mask, ipcbufs_p, pkts);
 
 	for (i = 0; i < pkts; i++) {
 		ODP_DBG_LVL(IPC_DBG, "%d/%d send to be free packet offset %" PRIuPTR "\n",
@@ -817,7 +822,7 @@ static int ipc_pktio_send_lockless(pktio_entry_t *pktio_entry,
 	/* Put packets to ring to be processed by other process. */
 	rbuf_p = (void *)&offsets[0];
 	r = pktio_ipc->tx.send;
-	ring_mpmc_rst_ptr_enq_multi(r, ring_mask, rbuf_p, num);
+	ring_mpmc_rst_ptr_enq_multi(r, _ring_data(r), ring_mask, rbuf_p, num);
 
 	return num;
 }


### PR DESCRIPTION
Avoid using flexible array members in structs in a way that is not allowed by the C standard and get rid of the pragmas that have been used for suppressing related warnings.

- Make rst rings similar to other ring flavors by removing the data array from the rst ring header structs and by adding a ring data pointer parameter to the rst ring functions. Update all rst ring users accordingly.
- Move ring data array to the end of stash_t

Also remove unneeded ring init function pointer from stash_t and change checks for invalid stash handles to assertions in fast path stash functions.