### PR TITLE
[PATCH v3] api: packet: remove len restriction from odp_packet_{push,pull}_{head,tail}

### DIFF
--- a/include/README
+++ b/include/README
@@ -25,6 +25,11 @@ type odp_packet_t, and packet-related APIs take arguments of this type. What an
 odp_packet_t actually is, is not part of the ODP API specification and
 applications cannot make assumptions about the underlying type.
 
+Most ODP handle types have a special 'invalid' value (e.g. ODP_PACKET_INVALID
+for packet handles) that is typically used for indicating failures of various
+API functions that return handles. Such an invalid handle must not be passed
+to any ODP API function unless explicitly allowed in the API text.
+
 Application gains ODP handle ownership when it receives it from an ODP API call.
 For example, application can receive an odp_event_t handle from `odp_schedule()`
 call. The ownership ends when the handle is passed back to ODP, for example with

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -470,10 +470,10 @@ void odp_packet_prefetch(odp_packet_t pkt, uint32_t offset, uint32_t len);
  * offsets when needed.
  *
  * @param pkt  Packet handle
- * @param len  Number of bytes to push the head (0 ... headroom)
+ * @param len  Number of bytes to push the head
  *
  * @return The new data pointer
- * @retval NULL  Requested offset exceeds available headroom
+ * @retval NULL  len exceeds headroom
  *
  * @see odp_packet_headroom(), odp_packet_pull_head()
  */
@@ -502,10 +502,10 @@ void *odp_packet_push_head(odp_packet_t pkt, uint32_t len);
  * offsets when needed.
  *
  * @param pkt  Packet handle
- * @param len  Number of bytes to pull the head (0 ... seg_len - 1)
+ * @param len  Number of bytes to pull the head
  *
  * @return The new data pointer
- * @retval NULL  Requested offset exceeds packet segment length
+ * @retval NULL  len equals or exceeds first segment length
  *
  * @see odp_packet_seg_len(), odp_packet_push_head()
  */
@@ -531,10 +531,10 @@ void *odp_packet_pull_head(odp_packet_t pkt, uint32_t len);
  * pointers and offsets remain valid.
  *
  * @param pkt  Packet handle
- * @param len  Number of bytes to push the tail (0 ... tailroom)
+ * @param len  Number of bytes to push the tail
  *
  * @return The old tail pointer
- * @retval NULL  Requested offset exceeds available tailroom
+ * @retval NULL  len exceeds tailroom
  *
  * @see odp_packet_tailroom(), odp_packet_pull_tail()
  */
@@ -565,10 +565,10 @@ void *odp_packet_push_tail(odp_packet_t pkt, uint32_t len);
  * offsets when needed.
  *
  * @param pkt  Packet handle
- * @param len  Number of bytes to pull the tail (0 ... last_seg:data_len - 1)
+ * @param len  Number of bytes to pull the tail
  *
  * @return The new tail pointer
- * @retval NULL  The specified offset exceeds allowable data length
+ * @retval NULL  len equals or exceeds last segment length
  */
 void *odp_packet_pull_tail(odp_packet_t pkt, uint32_t len);
 

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -459,11 +459,13 @@ void odp_packet_prefetch(odp_packet_t pkt, uint32_t offset, uint32_t len);
  * pushed out up to 'headroom' bytes. Packet is not modified if there's not
  * enough headroom space.
  *
- * odp_packet_xxx:
- * seg_len  += len
- * len      += len
- * headroom -= len
- * data     -= len
+ * @code{.unparsed}
+ *     odp_packet_xxx:
+ *         seg_len  += len
+ *         len      += len
+ *         headroom -= len
+ *         data     -= len
+ * @endcode
  *
  * Operation does not modify packet segmentation or move data. Handles and
  * pointers remain valid. User is responsible to update packet metadata
@@ -487,11 +489,13 @@ void *odp_packet_push_head(odp_packet_t pkt, uint32_t len);
  * pointer must stay in the first segment). Packet is not modified if there's
  * not enough data in the first segment.
  *
- * odp_packet_xxx:
- * seg_len  -= len
- * len      -= len
- * data     += len
- * headroom += len, if the packet is not a referencing packet
+ * @code{.unparsed}
+ *     odp_packet_xxx:
+ *         seg_len  -= len
+ *         len      -= len
+ *         data     += len
+ *         headroom += len, if the packet is not a referencing packet
+ * @endcode
  *
  * If the packet is a referencing packet and the first segment shares data
  * with another packet, headroom does not increase. Otherwise headroom
@@ -519,13 +523,15 @@ void *odp_packet_pull_head(odp_packet_t pkt, uint32_t len);
  * pushed out up to 'tailroom' bytes. Packet is not modified if there's not
  * enough tailroom.
  *
- * last_seg:
- * data_len += len
+ * @code{.unparsed}
+ *     last_seg:
+ *         data_len += len
  *
- * odp_packet_xxx:
- * len      += len
- * tail     += len
- * tailroom -= len
+ *     odp_packet_xxx:
+ *         len      += len
+ *         tail     += len
+ *         tailroom -= len
+ * @endcode
  *
  * Operation does not modify packet segmentation or move data. Handles,
  * pointers and offsets remain valid.
@@ -548,13 +554,15 @@ void *odp_packet_push_tail(odp_packet_t pkt, uint32_t len);
  * in up to last segment data_len - 1 bytes. (i.e. packet tail must stay in the
  * last segment). Packet is not modified if there's not enough data.
  *
- * last_seg:
- * data_len -= len
+ * @code{.unparsed}
+ *     last_seg:
+ *         data_len -= len
  *
- * odp_packet_xxx:
- * len      -= len
- * tail     -= len
- * tailroom += len, if the packet is not a referencing packet
+ *     odp_packet_xxx:
+ *         len      -= len
+ *         tail     -= len
+ *         tailroom += len, if the packet is not a referencing packet
+ * @endcode
  *
  * If the packet is a referencing packet and the last segment shares data
  * with another packet, tailroom does not increase. Otherwise tailroom


### PR DESCRIPTION
- Remove value range from the len parameter descriptions as it is intended that an application may pass any len value and that too large len values cause the function to fail. 

- Add a paragraph in the API principles section in the API README explaining that invalid handles must not  be passed to any ODP API function unless explicitly allowed.
