### PR TITLE
[PATCH v2] test: packet_gen: fix parsing format

### DIFF
--- a/test/performance/odp_packet_gen.c
+++ b/test/performance/odp_packet_gen.c
@@ -289,8 +289,8 @@ static void print_usage(void)
 	       "                            For ODP_LSO_WRITE_BITS the format is:\n"
 	       "                              mod_op:offset(B):size(B):fm:fv:mm:mv:lm:lv\n"
 	       "                            where size must be 1 and fm/fv, mm/mv, lm/lv are the\n"
-	       "                            mask/value byte pairs (in hex) to write to the first,\n"
-	       "                            middle and last segments respectively. Custom modification\n"
+	       "                            mask/value byte pairs to write to the first, middle\n"
+	       "                            and last segments respectively. Custom modification\n"
 	       "                            options are separated by commas. E.g.:\n"
 	       "                              2,22,1500,0:19:1\n"
 	       "                              2,22,1500,3:19:1:0xff:0x80:0xff:0x00:0xff:0x40\n"
@@ -622,23 +622,26 @@ static odp_bool_t parse_lso_fields(const char *optarg, test_options_t *opts)
 
 		if (mod_op == 3) {
 			/* Parse first/middle/last mask and value byte pairs */
-			uint32_t f_mask, f_val, m_mask, m_val, l_mask, l_val;
+			int32_t f_mask, f_val, m_mask, m_val, l_mask, l_val;
 
 			ret = sscanf(tmp, "%*u" FIELD_DELIMITER "%*u" FIELD_DELIMITER "%*u"
-				     FIELD_DELIMITER "%" SCNu32 FIELD_DELIMITER "%" SCNu32
-				     FIELD_DELIMITER "%" SCNu32 FIELD_DELIMITER "%" SCNu32
-				     FIELD_DELIMITER "%" SCNu32 FIELD_DELIMITER "%" SCNu32,
+				     FIELD_DELIMITER "%" SCNi32 FIELD_DELIMITER "%" SCNi32
+				     FIELD_DELIMITER "%" SCNi32 FIELD_DELIMITER "%" SCNi32
+				     FIELD_DELIMITER "%" SCNi32 FIELD_DELIMITER "%" SCNi32,
 				     &f_mask, &f_val, &m_mask, &m_val, &l_mask, &l_val);
 
 			if (ret != 6) {
-				ODPH_ERR("Error: ODP_LSO_WRITE_BITS requires 6 mask/value bytes\n");
+				ODPH_ERR("Error: ODP_LSO_WRITE_BITS requires 6 mask/value bytes, "
+					 "parsed: %d\n", ret);
 				ret_val = false;
 				goto exit;
 			}
 
-			if (f_mask > UINT8_MAX || f_val > UINT8_MAX || m_mask > UINT8_MAX ||
-			    m_val > UINT8_MAX || l_mask > UINT8_MAX || l_val > UINT8_MAX) {
-				ODPH_ERR("Error: ODP_LSO_WRITE_BITS mask/value byte out of range\n");
+			if (f_mask < 0 || f_mask > UINT8_MAX || f_val < 0 || f_val > UINT8_MAX ||
+			    m_mask < 0 || m_mask > UINT8_MAX || m_val < 0 || m_val > UINT8_MAX ||
+			    l_mask < 0 || l_mask > UINT8_MAX || l_val < 0 || l_val > UINT8_MAX) {
+				ODPH_ERR("Error: ODP_LSO_WRITE_BITS mask/value byte out of "
+					 "range\n");
 				ret_val = false;
 				goto exit;
 			}


### PR DESCRIPTION
Currently, when scanning input for `ODP_LSO_WRITE_BITS` bits and masks, `SCNu32` is used, which doesn't do automatic base detection. Change to use `SCNi32` which does.

v2:
- Added reviewed-by tag