### PR TITLE
[PATCH v2] linux-gen: ipsec: fix handling of outbound operation options

### DIFF
--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -1460,10 +1460,8 @@ static int ipsec_out_tunnel_ipv4(odp_packet_t *pkt,
 	out_ip.ttl = ipv4_param->ttl;
 	/* Will be filled later by packet checksum update */
 	out_ip.chksum = 0;
-	memcpy(&out_ip.src_addr, ipv4_param->src_addr,
-	       _ODP_IPV4ADDR_LEN);
-	memcpy(&out_ip.dst_addr, ipv4_param->dst_addr,
-	       _ODP_IPV4ADDR_LEN);
+	out_ip.src_addr = ipsec_sa->out.tun_ipv4.src_ip;
+	out_ip.dst_addr = ipsec_sa->out.tun_ipv4.dst_ip;
 
 	if (odp_packet_extend_head(pkt, _ODP_IPV4HDR_LEN,
 				   NULL, NULL) < 0)
@@ -1519,10 +1517,8 @@ static int ipsec_out_tunnel_ipv6(odp_packet_t *pkt,
 	state->ip_tot_len += _ODP_IPV6HDR_LEN;
 
 	out_ip.hop_limit = ipv6_param->hlimit;
-	memcpy(&out_ip.src_addr, ipv6_param->src_addr,
-	       _ODP_IPV6ADDR_LEN);
-	memcpy(&out_ip.dst_addr, ipv6_param->dst_addr,
-	       _ODP_IPV6ADDR_LEN);
+	memcpy(&out_ip.src_addr, ipsec_sa->out.tun_ipv6.src_ip, _ODP_IPV6ADDR_LEN);
+	memcpy(&out_ip.dst_addr, ipsec_sa->out.tun_ipv6.dst_ip, _ODP_IPV6ADDR_LEN);
 
 	if (odp_packet_extend_head(pkt, _ODP_IPV6HDR_LEN,
 				   NULL, NULL) < 0)

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -592,10 +592,8 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 			memcpy(&ipsec_sa->out.tun_ipv4.dst_ip,
 			       param->outbound.tunnel.ipv4.dst_addr,
 			       sizeof(ipsec_sa->out.tun_ipv4.dst_ip));
-			ipsec_sa->out.tun_ipv4.param.src_addr =
-				&ipsec_sa->out.tun_ipv4.src_ip;
-			ipsec_sa->out.tun_ipv4.param.dst_addr =
-				&ipsec_sa->out.tun_ipv4.dst_ip;
+			ipsec_sa->out.tun_ipv4.param.src_addr = NULL; /* unused */
+			ipsec_sa->out.tun_ipv4.param.dst_addr = NULL; /* unused */
 			ipsec_sa->out.tun_ipv4.param.ttl =
 				param->outbound.tunnel.ipv4.ttl;
 			ipsec_sa->out.tun_ipv4.param.dscp =
@@ -610,10 +608,8 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 			memcpy(&ipsec_sa->out.tun_ipv6.dst_ip,
 			       param->outbound.tunnel.ipv6.dst_addr,
 			       sizeof(ipsec_sa->out.tun_ipv6.dst_ip));
-			ipsec_sa->out.tun_ipv4.param.src_addr =
-				&ipsec_sa->out.tun_ipv6.src_ip;
-			ipsec_sa->out.tun_ipv4.param.dst_addr =
-				&ipsec_sa->out.tun_ipv6.dst_ip;
+			ipsec_sa->out.tun_ipv6.param.src_addr = NULL; /* unused */
+			ipsec_sa->out.tun_ipv6.param.dst_addr = NULL; /* unused */
 			ipsec_sa->out.tun_ipv6.param.hlimit =
 				param->outbound.tunnel.ipv6.hlimit;
 			ipsec_sa->out.tun_ipv6.param.dscp =


### PR DESCRIPTION
Ignore IP addresses in optional options to IPsec outbound operations.

ODP API says that the IP addresses contained in odp_ipsec_out_opt_t are ignored, i.e. the outer IP addresses in tunnel mode always come from the SA configuration and cannot be overridden on a per-packet basis. Fix the current implementation that erroneously copies also IP addresses in addition to the other IP parameters passed in odp_ipsec_out_opt_t.

Since ipsec_sa_t::out.tun_ipv4.param.src_addr and .dst_addr pointers and the analogous IPv6 address pointers are no longer needed for anything (but cannot easily be removed since they come from an API-defined type), initialize them to NULL. Fix also the bug where the IPv6 address pointers were written through the IPv4 side of the containing union, which works just because the pointers happen to be located in the same offsets.