### PR TITLE
[PATCH v2] linux-gen: sched: remove unnecessary warning suppression pragmas

### DIFF
--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -1,15 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2019-2025 Nokia
+ * Copyright (c) 2019-2026 Nokia
  */
-
-/*
- * Suppress bounds warnings about interior zero length arrays. Such an array
- * is used intentionally in prio_queue_t.
- */
-#if __GNUC__ >= 10
-#pragma GCC diagnostic ignored "-Wzero-length-bounds"
-#endif
 
 #include <odp_posix_extensions.h>
 
@@ -266,10 +258,7 @@ typedef struct {
 	} queue[CONFIG_MAX_SCHED_QUEUES];
 
 	/* Scheduler priority queues */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
 	prio_queue_t prio_q[NUM_SCHED_GRPS][NUM_PRIO][MAX_SPREAD];
-#pragma GCC diagnostic pop
 	uint32_t prio_q_count[NUM_SCHED_GRPS][NUM_PRIO][MAX_SPREAD];
 
 	/* Number of queues per group and priority  */


### PR DESCRIPTION
Remove pragma that disables -Wzero-length-bounds warning. The warning was originally caused by a zero length array (e.g. array[0]) that was changed to a flexible array member (e.g. array[]) in 8fafdb1af, at which point the warning would not have come. Now even the flexible array member is gone.

Remove also the pragma that disables -Wpedantic around the prio_q struct field declaration. The type no longer contains flexible array members, but it is not clear if the pragma was really needed in this location in the first place.