### PR TITLE
[PATCH v2] test: pipeline: load work from shared libraries at runtime

### DIFF
--- a/test/m4/configure.m4
+++ b/test/m4/configure.m4
@@ -17,6 +17,7 @@ AC_CONFIG_FILES([test/common/Makefile
 		 test/miscellaneous/Makefile
 		 test/performance/Makefile
 		 test/performance/pipeline/Makefile
+		 test/performance/pipeline/libodp_pipeline.pc
 		 test/validation/Makefile
 		 test/validation/api/align/Makefile
 		 test/validation/api/atomic/Makefile

--- a/test/performance/pipeline/.gitignore
+++ b/test/performance/pipeline/.gitignore
@@ -1,1 +1,2 @@
+libodp_pipeline.pc
 odp_pipeline

--- a/test/performance/pipeline/Makefile.am
+++ b/test/performance/pipeline/Makefile.am
@@ -5,6 +5,11 @@ AM_CFLAGS += \
 	$(LIBCONFIG_CFLAGS) \
 	-I$(top_srcdir)/test/performance/pipeline
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libodp_pipeline.pc
+
+include_HEADERS = odp_pipeline_work.h
+
 bin_PROGRAMS = odp_pipeline
 
 odp_pipeline_SOURCES = \
@@ -29,6 +34,7 @@ odp_pipeline_SOURCES = \
 	sched_parser.c \
 	stash_parser.c \
 	timer_parser.c \
+	odp_pipeline_work.h \
 	work.h \
 	work.c \
 	work_forward.c \

--- a/test/performance/pipeline/Makefile.am
+++ b/test/performance/pipeline/Makefile.am
@@ -12,6 +12,11 @@ include_HEADERS = odp_pipeline_work.h
 
 bin_PROGRAMS = odp_pipeline
 
+# Export the executable's dynamic symbols so runtime-loaded work libraries can resolve
+# work_register_work() and link libdl for dlopen().
+odp_pipeline_LDFLAGS = $(AM_LDFLAGS) -Wl,--export-dynamic
+odp_pipeline_LDADD = $(LDADD) -ldl
+
 odp_pipeline_SOURCES = \
 	cls_parser.c \
 	common.h \

--- a/test/performance/pipeline/Makefile.am
+++ b/test/performance/pipeline/Makefile.am
@@ -11,12 +11,13 @@ pkgconfig_DATA = libodp_pipeline.pc
 include_HEADERS = \
 	odp_pipeline_config.h \
 	odp_pipeline_domains.h \
+	odp_pipeline_orchestrator.h \
 	odp_pipeline_work.h
 
 bin_PROGRAMS = odp_pipeline
 
 # Export the executable's dynamic symbols so runtime-loaded work libraries can resolve
-# odp_pl_work_register_work() and link libdl for dlopen().
+# the public odp_pl_*() functions and link libdl for dlopen().
 odp_pipeline_LDFLAGS = $(AM_LDFLAGS) -Wl,--export-dynamic
 odp_pipeline_LDADD = $(LDADD) -ldl
 
@@ -36,6 +37,7 @@ odp_pipeline_SOURCES = \
 	flow_parser.c \
 	helpers.h \
 	main.c \
+	odp_pipeline_orchestrator.h \
 	orchestrator.h \
 	orchestrator.c \
 	pktio_parser.c \

--- a/test/performance/pipeline/Makefile.am
+++ b/test/performance/pipeline/Makefile.am
@@ -16,7 +16,7 @@ include_HEADERS = \
 bin_PROGRAMS = odp_pipeline
 
 # Export the executable's dynamic symbols so runtime-loaded work libraries can resolve
-# work_register_work() and link libdl for dlopen().
+# odp_pl_work_register_work() and link libdl for dlopen().
 odp_pipeline_LDFLAGS = $(AM_LDFLAGS) -Wl,--export-dynamic
 odp_pipeline_LDADD = $(LDADD) -ldl
 

--- a/test/performance/pipeline/Makefile.am
+++ b/test/performance/pipeline/Makefile.am
@@ -8,7 +8,10 @@ AM_CFLAGS += \
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libodp_pipeline.pc
 
-include_HEADERS = odp_pipeline_work.h
+include_HEADERS = \
+	odp_pipeline_config.h \
+	odp_pipeline_domains.h \
+	odp_pipeline_work.h
 
 bin_PROGRAMS = odp_pipeline
 
@@ -20,6 +23,8 @@ odp_pipeline_LDADD = $(LDADD) -ldl
 odp_pipeline_SOURCES = \
 	cls_parser.c \
 	common.h \
+	odp_pipeline_config.h \
+	odp_pipeline_domains.h \
 	config_parser.h \
 	config_parser.c \
 	cpumap.h \

--- a/test/performance/pipeline/README.md
+++ b/test/performance/pipeline/README.md
@@ -595,6 +595,11 @@ queue is marked as "output" flow, where again a set of events is passed to flow 
 instead of consuming the events, they are produced to the passed event set. Output flows are
 executed once per poll/scheduling round and after input flows have been handled.
 
+Work elements can assume that they are operating in a properly initialized ODP instance and must
+not initialize or create ODP instances themselves. Additionally, work elements must only use the
+explicitly configured ODP resources (configured via the configuration file) and must not create ODP
+resources themselves.
+
 ### Forward
 
 - name in configuration file: `work_forward`
@@ -660,3 +665,13 @@ executed once per poll/scheduling round and after input flows have been handled.
 - info: waits a given amount, no events consumed
 - parameter list:
   - index 0: time to wait in nanoseconds
+
+### External work libraries
+
+In addition to the baseline work compiled into the tester, work can be provided at runtime through
+shared libraries loaded with the `-l`, `--lib` command line option (the option may be repeated to
+load several libraries). Such a library is built against the installed, pkg-config discoverable
+`libodp_pipeline` package and registers its work with the `WORK_AUTOREGISTER()` macro from the
+public `odp_pipeline_work.h` header. Work registered from a loaded library overrides baseline work
+or work from a previously loaded library (order matters) of the same name, allowing work behavior
+to be replaced.

--- a/test/performance/pipeline/README.md
+++ b/test/performance/pipeline/README.md
@@ -687,3 +687,7 @@ to be replaced.
 
 Libraries can query resources parsed from the configuration file, such as queues or pools, with the
 `odp_pl_config_parser_get()` function from the public `odp_pipeline_config.h` header.
+
+Work can request the tester to stop with the `odp_pl_request_termination()` function from the public
+`odp_pipeline_orchestrator.h` header. The passed source and cause strings are printed and the
+pipeline is then torn down as if a termination signal had been received.

--- a/test/performance/pipeline/README.md
+++ b/test/performance/pipeline/README.md
@@ -675,3 +675,6 @@ load several libraries). Such a library is built against the installed, pkg-conf
 public `odp_pipeline_work.h` header. Work registered from a loaded library overrides baseline work
 or work from a previously loaded library (order matters) of the same name, allowing work behavior
 to be replaced.
+
+Libraries can query resources parsed from the configuration file, such as queues or pools, with the
+`config_parser_get()` function from the public `odp_pipeline_config.h` header.

--- a/test/performance/pipeline/README.md
+++ b/test/performance/pipeline/README.md
@@ -256,6 +256,15 @@ A few examples showcasing how one could configure the pipeline:
   - element: `name`
     - necessity: required
     - type: string, max `ODP_DMA_NAME_LEN`
+  - element: `compl_mode_mask`
+    - necessity: optional
+    - type: string, hexadecimal `odp_dma_compl_mode_t` mask
+    - default: `ODP_DMA_COMPL_EVENT`
+  - element: `order`
+    - necessity: optional
+    - type: string
+    - values: `"none"`, `"compl"`, `"all"`, mapping to `odp_dma_transfer_order_t`
+    - default: `odp_dma_param_init()`
 
 ### Flows
 

--- a/test/performance/pipeline/README.md
+++ b/test/performance/pipeline/README.md
@@ -671,10 +671,10 @@ resources themselves.
 In addition to the baseline work compiled into the tester, work can be provided at runtime through
 shared libraries loaded with the `-l`, `--lib` command line option (the option may be repeated to
 load several libraries). Such a library is built against the installed, pkg-config discoverable
-`libodp_pipeline` package and registers its work with the `WORK_AUTOREGISTER()` macro from the
+`libodp_pipeline` package and registers its work with the `ODP_PL_WORK_AUTOREGISTER()` macro from the
 public `odp_pipeline_work.h` header. Work registered from a loaded library overrides baseline work
 or work from a previously loaded library (order matters) of the same name, allowing work behavior
 to be replaced.
 
 Libraries can query resources parsed from the configuration file, such as queues or pools, with the
-`config_parser_get()` function from the public `odp_pipeline_config.h` header.
+`odp_pl_config_parser_get()` function from the public `odp_pipeline_config.h` header.

--- a/test/performance/pipeline/cls_parser.c
+++ b/test/performance/pipeline/cls_parser.c
@@ -1015,10 +1015,10 @@ static odp_bool_t classifier_parser_init(config_t *config)
 	pmr_parse_t *pmr;
 	pmr_parse_template_t pmr_templ;
 
-	cs = config_lookup(config, CLASSIFICATION_DOMAIN);
+	cs = config_lookup(config, ODP_PL_CLASSIFICATION_DOMAIN);
 
 	if (cs == NULL)	{
-		printf("Nothing to parse for \"" CLASSIFICATION_DOMAIN "\" domain\n");
+		printf("Nothing to parse for \"" ODP_PL_CLASSIFICATION_DOMAIN "\" domain\n");
 		return true;
 	}
 
@@ -1168,18 +1168,18 @@ static odp_bool_t classifier_parser_deploy(void)
 	pmr_parse_t *pmr;
 	odp_cos_t src, dst;
 
-	printf("\n*** " CLASSIFICATION_DOMAIN " resources ***\n");
+	printf("\n*** " ODP_PL_CLASSIFICATION_DOMAIN " resources ***\n");
 
 	for (uint32_t i = 0U; i < cls.num_cos; ++i) {
 		cos = &cls.coss[i];
 
 		if (cos->queue != NULL)
-			cos->cos_param.queue = (odp_queue_t)config_parser_get(QUEUE_DOMAIN,
-									      cos->queue);
+			cos->cos_param.queue =
+			(odp_queue_t)odp_pl_config_parser_get(ODP_PL_QUEUE_DOMAIN, cos->queue);
 
 		if (cos->pool != NULL)
-			cos->cos_param.pool = (odp_pool_t)config_parser_get(POOL_DOMAIN,
-									    cos->pool);
+			cos->cos_param.pool =
+			(odp_pool_t)odp_pl_config_parser_get(ODP_PL_POOL_DOMAIN, cos->pool);
 
 		cos->cos = odp_cls_cos_create(cos->name, &cos->cos_param);
 
@@ -1189,7 +1189,8 @@ static odp_bool_t classifier_parser_deploy(void)
 		}
 
 		if (cos->def != NULL) {
-			pktio = (odp_pktio_t)config_parser_get(PKTIO_DOMAIN, cos->def);
+			pktio =
+			(odp_pktio_t)odp_pl_config_parser_get(ODP_PL_PKTIO_DOMAIN, cos->def);
 
 			if (odp_pktio_default_cos_set(pktio, cos->cos) < 0) {
 				ODPH_ERR("Error setting default CoS (%s)\n", cos->name);
@@ -1204,8 +1205,8 @@ static odp_bool_t classifier_parser_deploy(void)
 
 	for (uint32_t i = 0U; i < cls.num_pmr; ++i) {
 		pmr = &cls.pmrs[i];
-		src = (odp_cos_t)config_parser_get(CLASSIFICATION_DOMAIN, pmr->src);
-		dst = (odp_cos_t)config_parser_get(CLASSIFICATION_DOMAIN, pmr->dst);
+		src = (odp_cos_t)odp_pl_config_parser_get(ODP_PL_CLASSIFICATION_DOMAIN, pmr->src);
+		dst = (odp_cos_t)odp_pl_config_parser_get(ODP_PL_CLASSIFICATION_DOMAIN, pmr->dst);
 		pmr->pmr = odp_cls_pmr_create(&pmr->param, 1, src, dst);
 
 		if (pmr->pmr == ODP_PMR_INVALID) {
@@ -1254,6 +1255,6 @@ static uintptr_t classifier_parser_get_resource(const char *resource)
 	return (uintptr_t)cos;
 }
 
-CONFIG_PARSER_AUTOREGISTER(LOW_PRIO, CLASSIFICATION_DOMAIN, classifier_parser_init,
+CONFIG_PARSER_AUTOREGISTER(LOW_PRIO, ODP_PL_CLASSIFICATION_DOMAIN, classifier_parser_init,
 			   classifier_parser_deploy, NULL, classifier_parser_destroy,
 			   classifier_parser_get_resource)

--- a/test/performance/pipeline/common.h
+++ b/test/performance/pipeline/common.h
@@ -7,19 +7,6 @@
 #ifndef COMMON_H_
 #define COMMON_H_
 
-#define CLASSIFICATION_DOMAIN "classification"
-#define CPUMAP_DOMAIN "cpumap"
-#define CRYPTO_DOMAIN "crypto"
-#define DMA_DOMAIN "dma"
-#define FLOW_DOMAIN "flows"
-#define	PKTIO_DOMAIN "pktios"
-#define	POOL_DOMAIN "pools"
-#define	QUEUE_DOMAIN "queues"
-#define SCHED_DOMAIN "scheduler"
-#define STASH_DOMAIN "stash"
-#define TIMER_DOMAIN "timers"
-#define	WORKER_DOMAIN "workers"
-
 #define CRIT_PRIO 101
 #define HIGH_PRIO (CRIT_PRIO + 1)
 #define MED_PRIO (HIGH_PRIO + 1)

--- a/test/performance/pipeline/config_parser.c
+++ b/test/performance/pipeline/config_parser.c
@@ -4,6 +4,7 @@
 
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
+#include <dlfcn.h>
 #include <stdlib.h>
 
 #include <odp/helper/odph_api.h>
@@ -26,23 +27,67 @@ typedef struct {
 	TAILQ_HEAD(, parser_s) p;
 
 	config_t config;
-	char *path;
+	const opts_t *opts;
+	void **handles;
 	odp_bool_t init_done;
 	odp_bool_t config_done;
 } parsers_t;
 
 static parsers_t parsers;
 
-odp_bool_t config_parser_init(char *path)
+/* Loaded after baseline work is registered so library work of the same name takes precedence. */
+static odp_bool_t load_libs(void)
+{
+	if (parsers.opts->num_libs == 0U)
+		return true;
+
+	parsers.handles = calloc(parsers.opts->num_libs, sizeof(*parsers.handles));
+
+	if (parsers.handles == NULL) {
+		ODPH_ERR("Error allocating memory\n");
+		return false;
+	}
+
+	for (uint32_t i = 0U; i < parsers.opts->num_libs; ++i) {
+		parsers.handles[i] = dlopen(parsers.opts->libs[i], RTLD_NOW);
+
+		if (parsers.handles[i] == NULL) {
+			ODPH_ERR("Error loading library %s: %s\n", parsers.opts->libs[i],
+				 dlerror());
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static void unload_libs(void)
+{
+	if (parsers.handles == NULL)
+		return;
+
+	for (uint32_t i = 0U; i < parsers.opts->num_libs; ++i) {
+		if (parsers.handles[i] != NULL)
+			dlclose(parsers.handles[i]);
+	}
+
+	free(parsers.handles);
+}
+
+odp_bool_t config_parser_init(const opts_t *opts)
 {
 	int ret;
 	parser_t *parser;
 	odp_bool_t p_ret = true;
 
-	parsers.path = path;
+	parsers.opts = opts;
+
+	if (!load_libs())
+		return false;
+
 	config_init(&parsers.config);
 	parsers.config_done = true;
-	ret = config_read_file(&parsers.config, parsers.path);
+	ret = config_read_file(&parsers.config, parsers.opts->path);
 
 	if (ret == CONFIG_FALSE) {
 		ODPH_ERR("Error opening configuration file, line %d: %s\n",
@@ -136,4 +181,6 @@ void config_parser_destroy(void)
 
 	if (parsers.config_done)
 		config_destroy(&parsers.config);
+
+	unload_libs();
 }

--- a/test/performance/pipeline/config_parser.c
+++ b/test/performance/pipeline/config_parser.c
@@ -25,9 +25,10 @@ typedef struct parser_s {
 typedef struct {
 	TAILQ_HEAD(, parser_s) p;
 
-	odp_bool_t init_done;
 	config_t config;
 	char *path;
+	odp_bool_t init_done;
+	odp_bool_t config_done;
 } parsers_t;
 
 static parsers_t parsers;
@@ -40,12 +41,12 @@ odp_bool_t config_parser_init(char *path)
 
 	parsers.path = path;
 	config_init(&parsers.config);
+	parsers.config_done = true;
 	ret = config_read_file(&parsers.config, parsers.path);
 
 	if (ret == CONFIG_FALSE) {
 		ODPH_ERR("Error opening configuration file, line %d: %s\n",
 			 config_error_line(&parsers.config), config_error_text(&parsers.config));
-		config_destroy(&parsers.config);
 		return false;
 	}
 
@@ -133,6 +134,6 @@ void config_parser_destroy(void)
 		free(drop);
 	}
 
-	config_destroy(&parsers.config);
-	free(parsers.path);
+	if (parsers.config_done)
+		config_destroy(&parsers.config);
 }

--- a/test/performance/pipeline/config_parser.c
+++ b/test/performance/pipeline/config_parser.c
@@ -117,7 +117,7 @@ odp_bool_t config_parser_deploy(void)
 	return true;
 }
 
-uintptr_t config_parser_get(const char *domain, const char *resource)
+uintptr_t odp_pl_config_parser_get(const char *domain, const char *resource)
 {
 	parser_t *parser;
 

--- a/test/performance/pipeline/config_parser.h
+++ b/test/performance/pipeline/config_parser.h
@@ -18,7 +18,13 @@ typedef void (*conf_undeploy_fn_t)(void);
 typedef void (*conf_destroy_fn_t)(void);
 typedef uintptr_t (*conf_resource_fn_t)(const char *resource);
 
-odp_bool_t config_parser_init(char *path);
+typedef struct {
+	char **libs;
+	char *path;
+	uint32_t num_libs;
+} opts_t;
+
+odp_bool_t config_parser_init(const opts_t *opts);
 
 odp_bool_t config_parser_deploy(void);
 

--- a/test/performance/pipeline/config_parser.h
+++ b/test/performance/pipeline/config_parser.h
@@ -11,6 +11,7 @@
 #include <odp_api.h>
 
 #include "helpers.h"
+#include "odp_pipeline_config.h"
 
 typedef odp_bool_t (*conf_init_fn_t)(config_t *config);
 typedef odp_bool_t (*conf_deploy_fn_t)(void);
@@ -27,8 +28,6 @@ typedef struct {
 odp_bool_t config_parser_init(const opts_t *opts);
 
 odp_bool_t config_parser_deploy(void);
-
-uintptr_t config_parser_get(const char *domain, const char *resource);
 
 void config_parser_register_parser(const char *domain, conf_init_fn_t init_fn,
 				   conf_deploy_fn_t deploy_fn, conf_undeploy_fn_t undeploy_fn,

--- a/test/performance/pipeline/cpumap_parser.c
+++ b/test/performance/pipeline/cpumap_parser.c
@@ -31,10 +31,10 @@ static odp_bool_t cpumap_parser_init(config_t *config)
 	const char *val_str;
 	int num;
 
-	cs = config_lookup(config, CPUMAP_DOMAIN);
+	cs = config_lookup(config, ODP_PL_CPUMAP_DOMAIN);
 
 	if (cs == NULL)	{
-		printf("Nothing to parse for \"" CPUMAP_DOMAIN "\" domain\n");
+		printf("Nothing to parse for \"" ODP_PL_CPUMAP_DOMAIN "\" domain\n");
 		return true;
 	}
 
@@ -88,7 +88,7 @@ static odp_bool_t cpumap_parser_deploy(void)
 
 	(void)odp_cpumask_to_str(&cpumap.cpumask, str, ODP_CPUMASK_STR_SIZE);
 
-	printf("\n*** " CPUMAP_DOMAIN " resources ***\n\n"
+	printf("\n*** " ODP_PL_CPUMAP_DOMAIN " resources ***\n\n"
 	       "name: N/A\n"
 	       "info:\n"
 	       "  cpumask: %s\n"
@@ -113,5 +113,6 @@ static uintptr_t cpumap_parser_get_resource(const char *resource ODP_UNUSED)
 	return (uintptr_t)&cpumap;
 }
 
-CONFIG_PARSER_AUTOREGISTER(HIGH_PRIO, CPUMAP_DOMAIN, cpumap_parser_init, cpumap_parser_deploy,
-			   NULL, cpumap_parser_destroy, cpumap_parser_get_resource)
+CONFIG_PARSER_AUTOREGISTER(HIGH_PRIO, ODP_PL_CPUMAP_DOMAIN, cpumap_parser_init,
+			   cpumap_parser_deploy, NULL, cpumap_parser_destroy,
+			   cpumap_parser_get_resource)

--- a/test/performance/pipeline/crypto_parser.c
+++ b/test/performance/pipeline/crypto_parser.c
@@ -343,17 +343,17 @@ static odp_bool_t crypto_parser_init(config_t *config)
 	int num;
 	crypto_parse_t *crypto;
 
-	cs = config_lookup(config, CRYPTO_DOMAIN);
+	cs = config_lookup(config, ODP_PL_CRYPTO_DOMAIN);
 
 	if (cs == NULL)	{
-		printf("Nothing to parse for \"" CRYPTO_DOMAIN "\" domain\n");
+		printf("Nothing to parse for \"" ODP_PL_CRYPTO_DOMAIN "\" domain\n");
 		return true;
 	}
 
 	num = config_setting_length(cs);
 
 	if (num == 0) {
-		ODPH_ERR("No valid \"" CRYPTO_DOMAIN "\" entries found\n");
+		ODPH_ERR("No valid \"" ODP_PL_CRYPTO_DOMAIN "\" entries found\n");
 		return false;
 	}
 
@@ -366,14 +366,14 @@ static odp_bool_t crypto_parser_init(config_t *config)
 		elem = config_setting_get_elem(cs, i);
 
 		if (elem == NULL) {
-			ODPH_ERR("Unparsable \"" CRYPTO_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Unparsable \"" ODP_PL_CRYPTO_DOMAIN "\" entry (%d)\n", i);
 			return false;
 		}
 
 		crypto = &cryptos.cryptos[cryptos.num];
 
 		if (!parse_crypto_entry(elem, crypto)) {
-			ODPH_ERR("Invalid \"" CRYPTO_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Invalid \"" ODP_PL_CRYPTO_DOMAIN "\" entry (%d)\n", i);
 			free_crypto_entry(crypto);
 			return false;
 		}
@@ -390,11 +390,11 @@ static odp_bool_t crypto_parser_deploy(void)
 	odp_queue_t queue;
 	odp_crypto_ses_create_err_t status;
 
-	printf("\n*** " CRYPTO_DOMAIN " resources ***\n");
+	printf("\n*** " ODP_PL_CRYPTO_DOMAIN " resources ***\n");
 
 	for (uint32_t i = 0U; i < cryptos.num; ++i) {
 		crypto = &cryptos.cryptos[i];
-		queue = (odp_queue_t)config_parser_get(QUEUE_DOMAIN, crypto->queue);
+		queue = (odp_queue_t)odp_pl_config_parser_get(ODP_PL_QUEUE_DOMAIN, crypto->queue);
 		crypto->param.compl_queue = queue;
 		(void)odp_crypto_session_create(&crypto->param, &crypto->crypto, &status);
 
@@ -439,5 +439,6 @@ static uintptr_t crypto_parser_get_resource(const char *resource)
 	return (uintptr_t)crypto;
 }
 
-CONFIG_PARSER_AUTOREGISTER(LOW_PRIO, CRYPTO_DOMAIN, crypto_parser_init, crypto_parser_deploy, NULL,
-			   crypto_parser_destroy, crypto_parser_get_resource)
+CONFIG_PARSER_AUTOREGISTER(LOW_PRIO, ODP_PL_CRYPTO_DOMAIN, crypto_parser_init,
+			   crypto_parser_deploy, NULL, crypto_parser_destroy,
+			   crypto_parser_get_resource)

--- a/test/performance/pipeline/dma_parser.c
+++ b/test/performance/pipeline/dma_parser.c
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <libconfig.h>
@@ -20,6 +21,12 @@
 #include "config_parser.h"
 
 #define CONF_STR_NAME "name"
+#define CONF_STR_COMPL_MODE_MASK "compl_mode_mask"
+#define CONF_STR_ORDER "order"
+
+#define ORDER_NONE "none"
+#define ORDER_COMPL "compl"
+#define ORDER_ALL "all"
 
 typedef struct {
 	char *name;
@@ -51,6 +58,22 @@ static odp_bool_t parse_dma_entry(config_setting_t *cs, dma_parse_t *dma)
 
 	if (dma->name == NULL)
 		ODPH_ABORT("Error allocating memory, aborting\n");
+
+	if (config_setting_lookup_string(cs, CONF_STR_COMPL_MODE_MASK, &val_str) == CONFIG_TRUE)
+		dma->param.compl_mode_mask = (odp_dma_compl_mode_t)strtoul(val_str, NULL, 0);
+
+	if (config_setting_lookup_string(cs, CONF_STR_ORDER, &val_str) == CONFIG_TRUE) {
+		if (strcmp(val_str, ORDER_NONE) == 0) {
+			dma->param.order = ODP_DMA_ORDER_NONE;
+		} else if (strcmp(val_str, ORDER_COMPL) == 0) {
+			dma->param.order = ODP_DMA_ORDER_COMPL;
+		} else if (strcmp(val_str, ORDER_ALL) == 0) {
+			dma->param.order = ODP_DMA_ORDER_ALL;
+		} else {
+			ODPH_ERR("No valid \"" CONF_STR_ORDER "\" found\n");
+			return false;
+		}
+	}
 
 	return true;
 }

--- a/test/performance/pipeline/dma_parser.c
+++ b/test/performance/pipeline/dma_parser.c
@@ -69,17 +69,17 @@ static odp_bool_t dma_parser_init(config_t *config)
 	int num;
 	dma_parse_t *dma;
 
-	cs = config_lookup(config, DMA_DOMAIN);
+	cs = config_lookup(config, ODP_PL_DMA_DOMAIN);
 
 	if (cs == NULL)	{
-		printf("Nothing to parse for \"" DMA_DOMAIN "\" domain\n");
+		printf("Nothing to parse for \"" ODP_PL_DMA_DOMAIN "\" domain\n");
 		return true;
 	}
 
 	num = config_setting_length(cs);
 
 	if (num == 0) {
-		ODPH_ERR("No valid \"" DMA_DOMAIN "\" entries found\n");
+		ODPH_ERR("No valid \"" ODP_PL_DMA_DOMAIN "\" entries found\n");
 		return false;
 	}
 
@@ -92,14 +92,14 @@ static odp_bool_t dma_parser_init(config_t *config)
 		elem = config_setting_get_elem(cs, i);
 
 		if (elem == NULL) {
-			ODPH_ERR("Unparsable \"" DMA_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Unparsable \"" ODP_PL_DMA_DOMAIN "\" entry (%d)\n", i);
 			return false;
 		}
 
 		dma = &dmas.dmas[dmas.num];
 
 		if (!parse_dma_entry(elem, dma)) {
-			ODPH_ERR("Invalid \"" DMA_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Invalid \"" ODP_PL_DMA_DOMAIN "\" entry (%d)\n", i);
 			free_dma_entry(dma);
 			return false;
 		}
@@ -114,7 +114,7 @@ static odp_bool_t dma_parser_deploy(void)
 {
 	dma_parse_t *dma;
 
-	printf("\n*** " DMA_DOMAIN " resources ***\n");
+	printf("\n*** " ODP_PL_DMA_DOMAIN " resources ***\n");
 
 	for (uint32_t i = 0U; i < dmas.num; ++i) {
 		dma = &dmas.dmas[i];
@@ -162,5 +162,5 @@ static uintptr_t dma_parser_get_resource(const char *resource)
 	return (uintptr_t)dma;
 }
 
-CONFIG_PARSER_AUTOREGISTER(MED_PRIO, DMA_DOMAIN, dma_parser_init, dma_parser_deploy, NULL,
+CONFIG_PARSER_AUTOREGISTER(MED_PRIO, ODP_PL_DMA_DOMAIN, dma_parser_init, dma_parser_deploy, NULL,
 			   dma_parser_destroy, dma_parser_get_resource)

--- a/test/performance/pipeline/flow_parser.c
+++ b/test/performance/pipeline/flow_parser.c
@@ -39,7 +39,7 @@ typedef struct {
 	char *input;
 	char *output;
 	flow_t flow;
-	work_param_t *work;
+	odp_pl_work_param_t *work;
 	uint32_t num;
 } flow_parse_t;
 
@@ -52,7 +52,7 @@ typedef struct {
 	char *name_prefix;
 	char *input_prefix;
 	char *output_prefix;
-	work_param_t *work;
+	odp_pl_work_param_t *work;
 	uint32_t name_idx;
 	uint32_t name_inc;
 	uint32_t input_idx;
@@ -70,7 +70,7 @@ typedef enum {
 
 static flow_parses_t flows;
 
-static odp_bool_t parse_work_entry(config_setting_t *cs, work_param_t *work)
+static odp_bool_t parse_work_entry(config_setting_t *cs, odp_pl_work_param_t *work)
 {
 	const char *val_str;
 
@@ -89,7 +89,7 @@ static odp_bool_t parse_work_entry(config_setting_t *cs, work_param_t *work)
 	return true;
 }
 
-static void free_work_entry(work_param_t *work)
+static void free_work_entry(odp_pl_work_param_t *work)
 {
 	free(work->type);
 }
@@ -99,7 +99,7 @@ static res_t parse_flow_entry(config_setting_t *cs, flow_parse_t *flow)
 	const char *val_str;
 	int num;
 	config_setting_t *elem;
-	work_param_t *work;
+	odp_pl_work_param_t *work;
 
 	memset(flow, 0, sizeof(*flow));
 
@@ -179,7 +179,7 @@ static int parse_flow_entry_template(config_setting_t *cs, flow_parse_template_t
 	uint32_t num;
 	config_setting_t *elem;
 	const char *val_str;
-	work_param_t *work;
+	odp_pl_work_param_t *work;
 
 	memset(templ, 0, sizeof(*templ));
 
@@ -344,7 +344,7 @@ static odp_bool_t parse_flow_entry_from_template(flow_parse_template_t *templ, f
 {
 	char flow_name[FLOW_NAME_LEN];
 	char queue_name[ODP_QUEUE_NAME_LEN];
-	work_param_t *work_templ, *work;
+	odp_pl_work_param_t *work_templ, *work;
 
 	memset(flow, 0, sizeof(*flow));
 	memset(flow_name, 0, sizeof(flow_name));
@@ -427,17 +427,17 @@ static odp_bool_t flow_parser_init(config_t *config)
 	res_t res;
 	flow_parse_template_t templ;
 
-	cs = config_lookup(config, FLOW_DOMAIN);
+	cs = config_lookup(config, ODP_PL_FLOW_DOMAIN);
 
 	if (cs == NULL)	{
-		printf("Nothing to parse for \"" FLOW_DOMAIN "\" domain\n");
+		printf("Nothing to parse for \"" ODP_PL_FLOW_DOMAIN "\" domain\n");
 		return true;
 	}
 
 	num = config_setting_length(cs);
 
 	if (num == 0) {
-		ODPH_ERR("No valid \"" FLOW_DOMAIN "\" entries found\n");
+		ODPH_ERR("No valid \"" ODP_PL_FLOW_DOMAIN "\" entries found\n");
 		return false;
 	}
 
@@ -450,7 +450,7 @@ static odp_bool_t flow_parser_init(config_t *config)
 		elem = config_setting_get_elem(cs, i);
 
 		if (elem == NULL) {
-			ODPH_ERR("Unparsable \"" FLOW_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Unparsable \"" ODP_PL_FLOW_DOMAIN "\" entry (%d)\n", i);
 			return false;
 		}
 
@@ -458,14 +458,14 @@ static odp_bool_t flow_parser_init(config_t *config)
 		res = parse_flow_entry(elem, flow);
 
 		if (res == PARSE_NOK) {
-			ODPH_ERR("Invalid \"" FLOW_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Invalid \"" ODP_PL_FLOW_DOMAIN "\" entry (%d)\n", i);
 			free_flow_entry(flow);
 			return false;
 		} else if (res == PARSE_TEMPL) {
 			ret = parse_flow_entry_template(elem, &templ);
 
 			if (ret == -1) {
-				ODPH_ERR("Invalid \"" FLOW_DOMAIN "\" entry (%d)\n", i);
+				ODPH_ERR("Invalid \"" ODP_PL_FLOW_DOMAIN "\" entry (%d)\n", i);
 				free_flow_template(&templ);
 				return false;
 			}
@@ -480,7 +480,8 @@ static odp_bool_t flow_parser_init(config_t *config)
 				flow = &flows.flows[flows.num];
 
 				if (!parse_flow_entry_from_template(&templ, flow)) {
-					ODPH_ERR("Invalid \"" FLOW_DOMAIN "\" entry (%d)\n", i);
+					ODPH_ERR("Invalid \"" ODP_PL_FLOW_DOMAIN "\" entry (%d)\n",
+						 i);
 					free_flow_template(&templ);
 					free_flow_entry(flow);
 					return false;
@@ -506,7 +507,7 @@ static odp_bool_t flow_parser_deploy(void)
 	flow_t flow;
 	work_t *work;
 
-	printf("\n*** " FLOW_DOMAIN " resources ***\n");
+	printf("\n*** " ODP_PL_FLOW_DOMAIN " resources ***\n");
 
 	for (uint32_t i = 0U; i < flows.num; ++i) {
 		parse = &flows.flows[i];
@@ -519,7 +520,7 @@ static odp_bool_t flow_parser_deploy(void)
 			work[j] = work_create_work(&parse->work[j]);
 
 		name = parse->input != NULL ? parse->input : parse->output;
-		queue = (odp_queue_t)config_parser_get(QUEUE_DOMAIN, name);
+		queue = (odp_queue_t)odp_pl_config_parser_get(ODP_PL_QUEUE_DOMAIN, name);
 		flow = odp_queue_context(queue);
 
 		if (flow == NULL) {
@@ -610,5 +611,5 @@ static uintptr_t flow_parser_get_resource(const char *resource)
 	return (uintptr_t)flow;
 }
 
-CONFIG_PARSER_AUTOREGISTER(LOW_PRIO, FLOW_DOMAIN, flow_parser_init, flow_parser_deploy, NULL,
+CONFIG_PARSER_AUTOREGISTER(LOW_PRIO, ODP_PL_FLOW_DOMAIN, flow_parser_init, flow_parser_deploy, NULL,
 			   flow_parser_destroy, flow_parser_get_resource)

--- a/test/performance/pipeline/libodp_pipeline.pc.in
+++ b/test/performance/pipeline/libodp_pipeline.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libodp_pipeline
+Description: ODP pipeline tester work registration interface
+Version: @PKGCONFIG_VERSION@
+Requires: lib@ODP_LIB_NAME@ libconfig
+Cflags: -I${includedir}

--- a/test/performance/pipeline/libodp_pipeline.pc.in
+++ b/test/performance/pipeline/libodp_pipeline.pc.in
@@ -4,7 +4,7 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: libodp_pipeline
-Description: ODP pipeline tester work registration and config parsing interface
+Description: ODP pipeline tester work registration, config parsing and orchestrator control interface
 Version: @PKGCONFIG_VERSION@
 Requires: lib@ODP_LIB_NAME@ libconfig
 Cflags: -I${includedir}

--- a/test/performance/pipeline/libodp_pipeline.pc.in
+++ b/test/performance/pipeline/libodp_pipeline.pc.in
@@ -4,7 +4,7 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: libodp_pipeline
-Description: ODP pipeline tester work registration interface
+Description: ODP pipeline tester work registration and config parsing interface
 Version: @PKGCONFIG_VERSION@
 Requires: lib@ODP_LIB_NAME@ libconfig
 Cflags: -I${includedir}

--- a/test/performance/pipeline/main.c
+++ b/test/performance/pipeline/main.c
@@ -99,11 +99,11 @@ int main(int argc, char **argv)
 	/* No support for process mode so no helper argument parsing */
 	parse_res = parse_options(argc, argv);
 
-	if (parse_res == PRS_NOK)
-		return EXIT_FAILURE;
+	if (parse_res != PRS_OK) {
+		free(opts.path);
 
-	if (parse_res == PRS_TERM)
-		return EXIT_SUCCESS;
+		return parse_res == PRS_NOK ? EXIT_FAILURE : EXIT_SUCCESS;
+	}
 
 	if (orchestrator_init() && config_parser_init(opts.path) && config_parser_deploy()) {
 		orchestrator_deploy();
@@ -114,6 +114,7 @@ int main(int argc, char **argv)
 
 	config_parser_destroy();
 	orchestrator_destroy();
+	free(opts.path);
 
 	return ret;
 }

--- a/test/performance/pipeline/main.c
+++ b/test/performance/pipeline/main.c
@@ -25,10 +25,6 @@ typedef enum {
 	PRS_TERM
 } parse_result_t;
 
-static struct {
-	char *path;
-} opts;
-
 static void print_usage(void)
 {
 	printf("\n"
@@ -44,23 +40,27 @@ static void print_usage(void)
 	       "\n"
 	       "Optional OPTIONS:\n"
 	       "\n"
+	       "  -l, --lib         Path to a shared library providing additional work. May be\n"
+	       "                    given multiple times. Work registered by a library overrides\n"
+	       "                    baseline work of the same name.\n"
 	       "  -h, --help        This help.\n"
 	       "\n");
 }
 
-static parse_result_t parse_options(int argc, char **argv)
+static parse_result_t parse_options(int argc, char **argv, opts_t *opts)
 {
 	int opt;
 
 	static const struct option longopts[] = {
 		{ "config_file", required_argument, NULL, 'f' },
+		{ "lib", required_argument, NULL, 'l' },
 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
 
-	static const char *shortopts = "f:h";
+	static const char *shortopts = "f:l:h";
 
-	memset(&opts, 0, sizeof(opts));
+	memset(opts, 0, sizeof(*opts));
 
 	while (true) {
 		opt = getopt_long(argc, argv, shortopts, longopts, NULL);
@@ -70,15 +70,34 @@ static parse_result_t parse_options(int argc, char **argv)
 
 		switch (opt) {
 		case 'f':
-			free(opts.path);
-			opts.path = strdup(optarg);
+			free(opts->path);
+			opts->path = strdup(optarg);
 
-			if (opts.path == NULL) {
+			if (opts->path == NULL) {
 				ODPH_ERR("Error allocating memory\n");
 				return PRS_NOK;
 			}
 
 			break;
+		case 'l': {
+			char **libs = realloc(opts->libs, (opts->num_libs + 1U) * sizeof(*libs));
+
+			if (libs == NULL) {
+				ODPH_ERR("Error allocating memory\n");
+				return PRS_NOK;
+			}
+
+			opts->libs = libs;
+			opts->libs[opts->num_libs] = strdup(optarg);
+
+			if (opts->libs[opts->num_libs] == NULL) {
+				ODPH_ERR("Error allocating memory\n");
+				return PRS_NOK;
+			}
+
+			++opts->num_libs;
+			break;
+		}
 		case 'h':
 			print_usage();
 			return PRS_TERM;
@@ -92,20 +111,30 @@ static parse_result_t parse_options(int argc, char **argv)
 	return PRS_OK;
 }
 
+static void free_options(opts_t *opts)
+{
+	for (uint32_t i = 0U; i < opts->num_libs; ++i)
+		free(opts->libs[i]);
+
+	free(opts->libs);
+	free(opts->path);
+}
+
 int main(int argc, char **argv)
 {
+	opts_t opts;
 	parse_result_t parse_res;
 	int ret = EXIT_SUCCESS;
 	/* No support for process mode so no helper argument parsing */
-	parse_res = parse_options(argc, argv);
+	parse_res = parse_options(argc, argv, &opts);
 
 	if (parse_res != PRS_OK) {
-		free(opts.path);
+		free_options(&opts);
 
 		return parse_res == PRS_NOK ? EXIT_FAILURE : EXIT_SUCCESS;
 	}
 
-	if (orchestrator_init() && config_parser_init(opts.path) && config_parser_deploy()) {
+	if (orchestrator_init() && config_parser_init(&opts) && config_parser_deploy()) {
 		orchestrator_deploy();
 	} else {
 		ODPH_ERR("Error initializing pipeline\n");
@@ -114,7 +143,7 @@ int main(int argc, char **argv)
 
 	config_parser_destroy();
 	orchestrator_destroy();
-	free(opts.path);
+	free_options(&opts);
 
 	return ret;
 }

--- a/test/performance/pipeline/odp_pipeline_config.h
+++ b/test/performance/pipeline/odp_pipeline_config.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef ODP_PIPELINE_CONFIG_H_
+#define ODP_PIPELINE_CONFIG_H_
+
+#include <stdint.h>
+
+#include "odp_pipeline_domains.h"
+
+uintptr_t config_parser_get(const char *domain, const char *resource);
+
+#endif

--- a/test/performance/pipeline/odp_pipeline_config.h
+++ b/test/performance/pipeline/odp_pipeline_config.h
@@ -11,6 +11,6 @@
 
 #include "odp_pipeline_domains.h"
 
-uintptr_t config_parser_get(const char *domain, const char *resource);
+uintptr_t odp_pl_config_parser_get(const char *domain, const char *resource);
 
 #endif

--- a/test/performance/pipeline/odp_pipeline_domains.h
+++ b/test/performance/pipeline/odp_pipeline_domains.h
@@ -7,17 +7,17 @@
 #ifndef ODP_PIPELINE_DOMAINS_H_
 #define ODP_PIPELINE_DOMAINS_H_
 
-#define CLASSIFICATION_DOMAIN "classification"
-#define CPUMAP_DOMAIN "cpumap"
-#define CRYPTO_DOMAIN "crypto"
-#define DMA_DOMAIN "dma"
-#define FLOW_DOMAIN "flows"
-#define PKTIO_DOMAIN "pktios"
-#define POOL_DOMAIN "pools"
-#define QUEUE_DOMAIN "queues"
-#define SCHED_DOMAIN "scheduler"
-#define STASH_DOMAIN "stash"
-#define TIMER_DOMAIN "timers"
-#define WORKER_DOMAIN "workers"
+#define ODP_PL_CLASSIFICATION_DOMAIN "classification"
+#define ODP_PL_CPUMAP_DOMAIN "cpumap"
+#define ODP_PL_CRYPTO_DOMAIN "crypto"
+#define ODP_PL_DMA_DOMAIN "dma"
+#define ODP_PL_FLOW_DOMAIN "flows"
+#define ODP_PL_PKTIO_DOMAIN "pktios"
+#define ODP_PL_POOL_DOMAIN "pools"
+#define ODP_PL_QUEUE_DOMAIN "queues"
+#define ODP_PL_SCHED_DOMAIN "scheduler"
+#define ODP_PL_STASH_DOMAIN "stash"
+#define ODP_PL_TIMER_DOMAIN "timers"
+#define ODP_PL_WORKER_DOMAIN "workers"
 
 #endif

--- a/test/performance/pipeline/odp_pipeline_domains.h
+++ b/test/performance/pipeline/odp_pipeline_domains.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef ODP_PIPELINE_DOMAINS_H_
+#define ODP_PIPELINE_DOMAINS_H_
+
+#define CLASSIFICATION_DOMAIN "classification"
+#define CPUMAP_DOMAIN "cpumap"
+#define CRYPTO_DOMAIN "crypto"
+#define DMA_DOMAIN "dma"
+#define FLOW_DOMAIN "flows"
+#define PKTIO_DOMAIN "pktios"
+#define POOL_DOMAIN "pools"
+#define QUEUE_DOMAIN "queues"
+#define SCHED_DOMAIN "scheduler"
+#define STASH_DOMAIN "stash"
+#define TIMER_DOMAIN "timers"
+#define WORKER_DOMAIN "workers"
+
+#endif

--- a/test/performance/pipeline/odp_pipeline_orchestrator.h
+++ b/test/performance/pipeline/odp_pipeline_orchestrator.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef ODP_PIPELINE_ORCHESTRATOR_H_
+#define ODP_PIPELINE_ORCHESTRATOR_H_
+
+void odp_pl_request_termination(const char *source, const char *cause);
+
+#endif

--- a/test/performance/pipeline/odp_pipeline_work.h
+++ b/test/performance/pipeline/odp_pipeline_work.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Nokia
+ */
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+#ifndef ODP_PIPELINE_WORK_H_
+#define ODP_PIPELINE_WORK_H_
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <libconfig.h>
+#include <odp_api.h>
+
+#define WORK_CONCAT_HELPER(a, b) a##b
+#define WORK_CONCAT(a, b) WORK_CONCAT_HELPER(a, b)
+
+typedef struct {
+	char *queue;
+	char *type;
+	config_setting_t *param;
+} work_param_t;
+
+typedef struct {
+	uint64_t data1;
+	uint64_t data2;
+	uint64_t data3;
+	uint64_t data4;
+} work_stats_t;
+
+typedef int (*work_fn_t)(uintptr_t data, odp_event_t ev[], int num, work_stats_t *stats);
+
+typedef struct {
+	work_fn_t fn;
+	uintptr_t data;
+} work_init_t;
+
+typedef void (*work_init_fn_t)(const work_param_t *param, work_init_t *init);
+typedef void (*work_print_fn_t)(const char *queue, const work_stats_t *stats);
+typedef void (*work_destroy_fn_t)(uintptr_t data);
+
+void work_register_work(const char *name, work_init_fn_t init_fn, work_print_fn_t print_fn,
+			work_destroy_fn_t destroy_fn);
+
+#define WORK_AUTOREGISTER(name, init, print, destroy)			\
+	__attribute__((constructor))					\
+	static void WORK_CONCAT(autoregister, __LINE__)(void) {		\
+		work_register_work(name, init, print, destroy);		\
+	}
+
+#endif

--- a/test/performance/pipeline/odp_pipeline_work.h
+++ b/test/performance/pipeline/odp_pipeline_work.h
@@ -14,40 +14,42 @@
 #include <libconfig.h>
 #include <odp_api.h>
 
-#define WORK_CONCAT_HELPER(a, b) a##b
-#define WORK_CONCAT(a, b) WORK_CONCAT_HELPER(a, b)
+#define ODP_PL_WORK_CONCAT_HELPER(a, b) a##b
+#define ODP_PL_WORK_CONCAT(a, b) ODP_PL_WORK_CONCAT_HELPER(a, b)
 
 typedef struct {
 	char *queue;
 	char *type;
 	config_setting_t *param;
-} work_param_t;
+} odp_pl_work_param_t;
 
 typedef struct {
 	uint64_t data1;
 	uint64_t data2;
 	uint64_t data3;
 	uint64_t data4;
-} work_stats_t;
+} odp_pl_work_stats_t;
 
-typedef int (*work_fn_t)(uintptr_t data, odp_event_t ev[], int num, work_stats_t *stats);
+typedef int (*odp_pl_work_fn_t)(uintptr_t data, odp_event_t ev[], int num,
+				odp_pl_work_stats_t *stats);
 
 typedef struct {
-	work_fn_t fn;
+	odp_pl_work_fn_t fn;
 	uintptr_t data;
-} work_init_t;
+} odp_pl_work_init_t;
 
-typedef void (*work_init_fn_t)(const work_param_t *param, work_init_t *init);
-typedef void (*work_print_fn_t)(const char *queue, const work_stats_t *stats);
-typedef void (*work_destroy_fn_t)(uintptr_t data);
+typedef void (*odp_pl_work_init_fn_t)(const odp_pl_work_param_t *param, odp_pl_work_init_t *init);
+typedef void (*odp_pl_work_print_fn_t)(const char *queue, const odp_pl_work_stats_t *stats);
+typedef void (*odp_pl_work_destroy_fn_t)(uintptr_t data);
 
-void work_register_work(const char *name, work_init_fn_t init_fn, work_print_fn_t print_fn,
-			work_destroy_fn_t destroy_fn);
+void odp_pl_work_register_work(const char *name, odp_pl_work_init_fn_t init_fn,
+			       odp_pl_work_print_fn_t print_fn,
+			       odp_pl_work_destroy_fn_t destroy_fn);
 
-#define WORK_AUTOREGISTER(name, init, print, destroy)			\
+#define ODP_PL_WORK_AUTOREGISTER(name, init, print, destroy)		\
 	__attribute__((constructor))					\
-	static void WORK_CONCAT(autoregister, __LINE__)(void) {		\
-		work_register_work(name, init, print, destroy);		\
+	static void ODP_PL_WORK_CONCAT(autoregister, __LINE__)(void) {	\
+		odp_pl_work_register_work(name, init, print, destroy);	\
 	}
 
 #endif

--- a/test/performance/pipeline/orchestrator.c
+++ b/test/performance/pipeline/orchestrator.c
@@ -49,7 +49,6 @@ typedef struct orchestrator_s {
 	odph_thread_t thrs[MAX_WORKERS];
 	orchestrator_worker_t worker[MAX_WORKERS];
 	odp_instance_t instance;
-	odp_shm_t shm;
 	odp_atomic_u32_t is_running;
 	odp_barrier_t init_barrier;
 	odp_barrier_t term_barrier;
@@ -58,7 +57,14 @@ typedef struct orchestrator_s {
 
 typedef int (*worker_fn_t)(void *);
 
-static orchestrator_t *config;
+typedef struct {
+	orchestrator_t *config;
+	odp_instance_t instance;
+	odp_shm_t shm;
+	odp_bool_t odp_ready;
+} orchestrator_global_t;
+
+static orchestrator_global_t orchestrator = { .shm = ODP_SHM_INVALID };
 
 static odp_instance_t init_odp(void)
 {
@@ -84,7 +90,7 @@ static void term_odp(odp_instance_t instance)
 
 static void terminate(int signal ODP_UNUSED)
 {
-	odp_atomic_store_u32(&config->is_running, 0U);
+	odp_atomic_store_u32(&orchestrator.config->is_running, 0U);
 }
 
 static void setup_signals(void)
@@ -100,36 +106,35 @@ static void setup_signals(void)
 
 odp_bool_t orchestrator_init(void)
 {
-	odp_instance_t instance = init_odp();
 	odp_shm_t shm;
+
+	orchestrator.instance = init_odp();
+	orchestrator.odp_ready = true;
 
 	shm = odp_shm_reserve("orchestrator", sizeof(orchestrator_t), ODP_CACHE_LINE_SIZE, 0U);
 
 	if (shm == ODP_SHM_INVALID) {
 		ODPH_ERR("Error reserving shared memory\n");
-		term_odp(instance);
 		return false;
 	}
 
-	config = odp_shm_addr(shm);
+	orchestrator.shm = shm;
+	orchestrator.config = odp_shm_addr(shm);
 
-	if (config == NULL) {
+	if (orchestrator.config == NULL) {
 		ODPH_ERR("Error resolving shared memory address\n");
-		odp_shm_free(shm);
-		term_odp(instance);
 		return false;
 	}
+
+	orchestrator.config->num_workers = 0U;
 
 	if (odp_schedule_config(NULL) < 0) {
 		ODPH_ERR("Error configuring scheduler\n");
-		odp_shm_free(shm);
-		term_odp(instance);
 		return false;
 	}
 
-	config->instance = instance;
-	config->shm = shm;
-	odp_atomic_init_u32(&config->is_running, 1U);
+	orchestrator.config->instance = orchestrator.instance;
+	odp_atomic_init_u32(&orchestrator.config->is_running, 1U);
 	setup_signals();
 
 	return true;
@@ -351,8 +356,8 @@ static void print_stats(void)
 
 	printf("\n*** pipeline finished ***\n");
 
-	for (uint32_t i = 0U; i < config->num_workers; ++i) {
-		worker = &config->worker[i];
+	for (uint32_t i = 0U; i < orchestrator.config->num_workers; ++i) {
+		worker = &orchestrator.config->worker[i];
 		printf("\n%s:\n"
 		       "  unhandled input events:  %" PRIu64 "\n"
 		       "  unhandled output events: %" PRIu64 "\n", worker->worker->name,
@@ -368,15 +373,15 @@ void orchestrator_deploy(void)
 	odph_thread_param_t params[num], *param;
 	orchestrator_worker_t *worker;
 
-	odp_barrier_init(&config->init_barrier, num + 1);
-	odp_barrier_init(&config->term_barrier, num + 1);
+	odp_barrier_init(&orchestrator.config->init_barrier, num + 1);
+	odp_barrier_init(&orchestrator.config->term_barrier, num + 1);
 	odph_thread_common_param_init(&common);
-	common.instance = config->instance;
+	common.instance = orchestrator.config->instance;
 	common.cpumask = &map->cpumask;
 
 	for (int i = 0; i < num; ++i) {
-		worker = &config->worker[i];
-		worker->prog_config = config;
+		worker = &orchestrator.config->worker[i];
+		worker->prog_config = orchestrator.config;
 		worker->worker = (worker_t *)config_parser_get(WORKER_DOMAIN, map->workers[i]);
 		param = &params[i];
 		odph_thread_param_init(param);
@@ -385,38 +390,42 @@ void orchestrator_deploy(void)
 		param->arg = worker;
 	}
 
-	if (odph_thread_create(config->thrs, &common, params, num) != num)
+	if (odph_thread_create(orchestrator.config->thrs, &common, params, num) != num)
 		ODPH_ABORT("Error launching worker threads, aborting\n");
 
-	config->num_workers = num;
-	odp_barrier_wait(&config->init_barrier);
+	orchestrator.config->num_workers = num;
+	odp_barrier_wait(&orchestrator.config->init_barrier);
 
-	while (odp_atomic_load_u32(&config->is_running))
+	while (odp_atomic_load_u32(&orchestrator.config->is_running))
 		sleep(1U);
 
 	config_parser_undeploy();
-	odp_barrier_wait(&config->term_barrier);
+	odp_barrier_wait(&orchestrator.config->term_barrier);
 	printf("\n*** flushing queues and freeing inflight events ***\n");
-	(void)odph_thread_join(config->thrs, config->num_workers);
+	(void)odph_thread_join(orchestrator.config->thrs, orchestrator.config->num_workers);
 	print_stats();
 }
 
 void orchestrator_destroy(void)
 {
-	odp_instance_t instance = config->instance;
 	orchestrator_worker_t *worker;
 
-	for (uint32_t i = 0U; i < config->num_workers; ++i) {
-		worker = &config->worker[i];
+	if (orchestrator.config != NULL) {
+		for (uint32_t i = 0U; i < orchestrator.config->num_workers; ++i) {
+			worker = &orchestrator.config->worker[i];
 
-		if (worker->worker->type == WT_SCHED)
-			free(worker->inputs.g);
-		else
-			free(worker->inputs.q);
+			if (worker->worker->type == WT_SCHED)
+				free(worker->inputs.g);
+			else
+				free(worker->inputs.q);
 
-		free(config->worker[i].outputs);
+			free(orchestrator.config->worker[i].outputs);
+		}
 	}
 
-	odp_shm_free(config->shm);
-	term_odp(instance);
+	if (orchestrator.shm != ODP_SHM_INVALID)
+		odp_shm_free(orchestrator.shm);
+
+	if (orchestrator.odp_ready)
+		term_odp(orchestrator.instance);
 }

--- a/test/performance/pipeline/orchestrator.c
+++ b/test/performance/pipeline/orchestrator.c
@@ -304,8 +304,8 @@ static worker_fn_t get_worker(orchestrator_worker_t *orch)
 			ODPH_ABORT("Error allocating memory, aborting\n");
 
 		for (uint32_t i = 0U; i < worker->num_out; ++i)
-			outputs[i] = (odp_queue_t)config_parser_get(QUEUE_DOMAIN,
-								    worker->outputs[i]);
+			outputs[i] = (odp_queue_t)odp_pl_config_parser_get(ODP_PL_QUEUE_DOMAIN,
+									   worker->outputs[i]);
 
 		orch->outputs = outputs;
 	}
@@ -318,8 +318,9 @@ static worker_fn_t get_worker(orchestrator_worker_t *orch)
 				ODPH_ABORT("Error allocating memory, aborting\n");
 
 			for (uint32_t i = 0U; i < worker->num_in; ++i)
-				grps[i] = (odp_schedule_group_t)config_parser_get(SCHED_DOMAIN,
-										worker->inputs[i]);
+				grps[i] = (odp_schedule_group_t)
+					odp_pl_config_parser_get(ODP_PL_SCHED_DOMAIN,
+								 worker->inputs[i]);
 
 			orch->inputs.g = grps;
 		} else {
@@ -329,8 +330,8 @@ static worker_fn_t get_worker(orchestrator_worker_t *orch)
 				ODPH_ABORT("Error allocating memory, aborting\n");
 
 			for (uint32_t i = 0U; i < worker->num_in; ++i)
-				qs[i] = (odp_queue_t)config_parser_get(QUEUE_DOMAIN,
-								       worker->inputs[i]);
+				qs[i] = (odp_queue_t)odp_pl_config_parser_get(ODP_PL_QUEUE_DOMAIN,
+									      worker->inputs[i]);
 
 			orch->inputs.q = qs;
 		}
@@ -367,7 +368,7 @@ static void print_stats(void)
 
 void orchestrator_deploy(void)
 {
-	cpumap_t *map = (cpumap_t *)config_parser_get(CPUMAP_DOMAIN, NULL);
+	cpumap_t *map = (cpumap_t *)odp_pl_config_parser_get(ODP_PL_CPUMAP_DOMAIN, NULL);
 	odph_thread_common_param_t common;
 	const int num = map->num;
 	odph_thread_param_t params[num], *param;
@@ -382,7 +383,8 @@ void orchestrator_deploy(void)
 	for (int i = 0; i < num; ++i) {
 		worker = &orchestrator.config->worker[i];
 		worker->prog_config = orchestrator.config;
-		worker->worker = (worker_t *)config_parser_get(WORKER_DOMAIN, map->workers[i]);
+		worker->worker = (worker_t *)
+			odp_pl_config_parser_get(ODP_PL_WORKER_DOMAIN, map->workers[i]);
 		param = &params[i];
 		odph_thread_param_init(param);
 		param->start = get_worker(worker);

--- a/test/performance/pipeline/orchestrator.c
+++ b/test/performance/pipeline/orchestrator.c
@@ -93,6 +93,12 @@ static void terminate(int signal ODP_UNUSED)
 	odp_atomic_store_u32(&orchestrator.config->is_running, 0U);
 }
 
+void odp_pl_request_termination(const char *source, const char *cause)
+{
+	printf("\n*** termination requested by %s: %s ***\n", source, cause);
+	odp_atomic_store_u32(&orchestrator.config->is_running, 0U);
+}
+
 static void setup_signals(void)
 {
 	struct sigaction action = { .sa_handler = terminate };

--- a/test/performance/pipeline/orchestrator.h
+++ b/test/performance/pipeline/orchestrator.h
@@ -9,6 +9,8 @@
 
 #include <odp_api.h>
 
+#include "odp_pipeline_orchestrator.h"
+
 odp_bool_t orchestrator_init(void);
 
 void orchestrator_deploy(void);

--- a/test/performance/pipeline/pktio_parser.c
+++ b/test/performance/pipeline/pktio_parser.c
@@ -274,17 +274,17 @@ static odp_bool_t pktio_parser_init(config_t *config)
 	int num;
 	pktio_parse_t *pktio;
 
-	cs = config_lookup(config, PKTIO_DOMAIN);
+	cs = config_lookup(config, ODP_PL_PKTIO_DOMAIN);
 
 	if (cs == NULL)	{
-		printf("Nothing to parse for \"" PKTIO_DOMAIN "\" domain\n");
+		printf("Nothing to parse for \"" ODP_PL_PKTIO_DOMAIN "\" domain\n");
 		return true;
 	}
 
 	num = config_setting_length(cs);
 
 	if (num == 0) {
-		ODPH_ERR("No valid \"" PKTIO_DOMAIN "\" entries found\n");
+		ODPH_ERR("No valid \"" ODP_PL_PKTIO_DOMAIN "\" entries found\n");
 		return false;
 	}
 
@@ -297,14 +297,14 @@ static odp_bool_t pktio_parser_init(config_t *config)
 		elem = config_setting_get_elem(cs, i);
 
 		if (elem == NULL) {
-			ODPH_ERR("Unparsable \"" PKTIO_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Unparsable \"" ODP_PL_PKTIO_DOMAIN "\" entry (%d)\n", i);
 			return false;
 		}
 
 		pktio = &pktios.pktios[pktios.num];
 
 		if (!parse_pktio_entry(elem, pktio)) {
-			ODPH_ERR("Invalid \"" PKTIO_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Invalid \"" ODP_PL_PKTIO_DOMAIN "\" entry (%d)\n", i);
 			free_pktio_entry(pktio);
 			return false;
 		}
@@ -319,18 +319,19 @@ static odp_bool_t pktio_parser_deploy(void)
 {
 	pktio_parse_t *pktio;
 
-	printf("\n*** " PKTIO_DOMAIN " resources ***\n");
+	printf("\n*** " ODP_PL_PKTIO_DOMAIN " resources ***\n");
 
 	for (uint32_t i = 0U; i < pktios.num; ++i) {
 		pktio = &pktios.pktios[i];
 
 		if (pktio->group != NULL)
-			pktio->in_param.queue_param.sched.group =
-			       (odp_schedule_group_t)config_parser_get(SCHED_DOMAIN, pktio->group);
+			pktio->in_param.queue_param.sched.group = (odp_schedule_group_t)
+				odp_pl_config_parser_get(ODP_PL_SCHED_DOMAIN, pktio->group);
 
-		pktio->pktio = odp_pktio_open(pktio->iface,
-					      (odp_pool_t)config_parser_get(POOL_DOMAIN,
-									    pktio->pool),
+		pktio->pktio =
+		odp_pktio_open(pktio->iface,
+			       (odp_pool_t)odp_pl_config_parser_get(ODP_PL_POOL_DOMAIN,
+								    pktio->pool),
 					      &pktio->param);
 
 		if (pktio->pktio == ODP_PKTIO_INVALID) {
@@ -468,5 +469,5 @@ static uintptr_t pktio_parser_get_resource(const char *resource)
 	ODPH_ABORT("No resource found (%s), aborting\n", resource);
 }
 
-CONFIG_PARSER_AUTOREGISTER(MED_PRIO, PKTIO_DOMAIN, pktio_parser_init, pktio_parser_deploy,
+CONFIG_PARSER_AUTOREGISTER(MED_PRIO, ODP_PL_PKTIO_DOMAIN, pktio_parser_init, pktio_parser_deploy,
 			   pktio_parser_undeploy, pktio_parser_destroy, pktio_parser_get_resource)

--- a/test/performance/pipeline/pool_parser.c
+++ b/test/performance/pipeline/pool_parser.c
@@ -138,17 +138,17 @@ static odp_bool_t pool_parser_init(config_t *config)
 	int num;
 	pool_parse_t *pool;
 
-	cs = config_lookup(config, POOL_DOMAIN);
+	cs = config_lookup(config, ODP_PL_POOL_DOMAIN);
 
 	if (cs == NULL)	{
-		printf("Nothing to parse for \"" POOL_DOMAIN "\" domain\n");
+		printf("Nothing to parse for \"" ODP_PL_POOL_DOMAIN "\" domain\n");
 		return true;
 	}
 
 	num = config_setting_length(cs);
 
 	if (num == 0) {
-		ODPH_ERR("No valid \"" POOL_DOMAIN "\" entries found\n");
+		ODPH_ERR("No valid \"" ODP_PL_POOL_DOMAIN "\" entries found\n");
 		return false;
 	}
 
@@ -161,14 +161,14 @@ static odp_bool_t pool_parser_init(config_t *config)
 		elem = config_setting_get_elem(cs, i);
 
 		if (elem == NULL) {
-			ODPH_ERR("Unparsable \"" POOL_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Unparsable \"" ODP_PL_POOL_DOMAIN "\" entry (%d)\n", i);
 			return false;
 		}
 
 		pool = &pools.pools[pools.num];
 
 		if (!parse_pool_entry(elem, pool)) {
-			ODPH_ERR("Invalid \"" POOL_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Invalid \"" ODP_PL_POOL_DOMAIN "\" entry (%d)\n", i);
 			free_pool_entry(pool);
 			return false;
 		}
@@ -183,7 +183,7 @@ static odp_bool_t pool_parser_deploy(void)
 {
 	pool_parse_t *pool;
 
-	printf("\n*** " POOL_DOMAIN " resources ***\n");
+	printf("\n*** " ODP_PL_POOL_DOMAIN " resources ***\n");
 
 	for (uint32_t i = 0U; i < pools.num; ++i) {
 		pool = &pools.pools[i];
@@ -235,5 +235,5 @@ static uintptr_t pool_parser_get_resource(const char *resource)
 	return (uintptr_t)pool;
 }
 
-CONFIG_PARSER_AUTOREGISTER(HIGH_PRIO, POOL_DOMAIN, pool_parser_init, pool_parser_deploy, NULL,
-			   pool_parser_destroy, pool_parser_get_resource)
+CONFIG_PARSER_AUTOREGISTER(HIGH_PRIO, ODP_PL_POOL_DOMAIN, pool_parser_init, pool_parser_deploy,
+			   NULL, pool_parser_destroy, pool_parser_get_resource)

--- a/test/performance/pipeline/queue_parser.c
+++ b/test/performance/pipeline/queue_parser.c
@@ -298,17 +298,17 @@ static odp_bool_t queue_parser_init(config_t *config)
 	res_t res;
 	queue_parse_template_t templ;
 
-	cs = config_lookup(config, QUEUE_DOMAIN);
+	cs = config_lookup(config, ODP_PL_QUEUE_DOMAIN);
 
 	if (cs == NULL)	{
-		printf("Nothing to parse for \"" QUEUE_DOMAIN "\" domain\n");
+		printf("Nothing to parse for \"" ODP_PL_QUEUE_DOMAIN "\" domain\n");
 		return true;
 	}
 
 	num = config_setting_length(cs);
 
 	if (num == 0) {
-		ODPH_ERR("No valid \"" QUEUE_DOMAIN "\" entries found\n");
+		ODPH_ERR("No valid \"" ODP_PL_QUEUE_DOMAIN "\" entries found\n");
 		return false;
 	}
 
@@ -321,7 +321,7 @@ static odp_bool_t queue_parser_init(config_t *config)
 		elem = config_setting_get_elem(cs, i);
 
 		if (elem == NULL) {
-			ODPH_ERR("Unparsable \"" QUEUE_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Unparsable \"" ODP_PL_QUEUE_DOMAIN "\" entry (%d)\n", i);
 			return false;
 		}
 
@@ -329,14 +329,14 @@ static odp_bool_t queue_parser_init(config_t *config)
 		res = parse_queue_entry(elem, queue);
 
 		if (res == PARSE_NOK) {
-			ODPH_ERR("Invalid \"" QUEUE_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Invalid \"" ODP_PL_QUEUE_DOMAIN "\" entry (%d)\n", i);
 			free_queue_entry(queue);
 			return false;
 		} else if (res == PARSE_TEMPL) {
 			ret = parse_queue_entry_template(elem, &templ);
 
 			if (ret == -1) {
-				ODPH_ERR("Invalid \"" QUEUE_DOMAIN "\" entry (%d)\n", i);
+				ODPH_ERR("Invalid \"" ODP_PL_QUEUE_DOMAIN "\" entry (%d)\n", i);
 				free_queue_template(&templ);
 				return false;
 			}
@@ -351,7 +351,8 @@ static odp_bool_t queue_parser_init(config_t *config)
 				queue = &queues.queues[queues.num];
 
 				if (!parse_queue_entry_from_template(&templ, queue)) {
-					ODPH_ERR("Invalid \"" QUEUE_DOMAIN "\" entry (%d)\n", i);
+					ODPH_ERR("Invalid \"" ODP_PL_QUEUE_DOMAIN "\" entry "
+						 "(%d)\n", i);
 					free_queue_template(&templ);
 					free_queue_entry(queue);
 					return false;
@@ -373,7 +374,7 @@ static odp_bool_t queue_parser_deploy(void)
 {
 	queue_parse_t *queue;
 
-	printf("\n*** " QUEUE_DOMAIN " resources ***\n");
+	printf("\n*** " ODP_PL_QUEUE_DOMAIN " resources ***\n");
 
 	for (uint32_t i = 0U; i < queues.num; ++i) {
 		queue = &queues.queues[i];
@@ -382,8 +383,8 @@ static odp_bool_t queue_parser_deploy(void)
 			continue;
 
 		if (queue->group != NULL)
-			queue->param.sched.group =
-			       (odp_schedule_group_t)config_parser_get(SCHED_DOMAIN, queue->group);
+			queue->param.sched.group = (odp_schedule_group_t)
+				odp_pl_config_parser_get(ODP_PL_SCHED_DOMAIN, queue->group);
 
 		queue->queue = odp_queue_create(queue->name, &queue->param);
 
@@ -420,7 +421,7 @@ static uintptr_t queue_parser_get_resource(const char *resource)
 			continue;
 
 		if (parse->ext != NULL)
-			queue = (odp_queue_t)config_parser_get(parse->ext, resource);
+			queue = (odp_queue_t)odp_pl_config_parser_get(parse->ext, resource);
 		else
 			queue = parse->queue;
 
@@ -433,5 +434,5 @@ static uintptr_t queue_parser_get_resource(const char *resource)
 	return (uintptr_t)queue;
 }
 
-CONFIG_PARSER_AUTOREGISTER(HIGH_PRIO, QUEUE_DOMAIN, queue_parser_init, queue_parser_deploy, NULL,
-			   queue_parser_destroy, queue_parser_get_resource)
+CONFIG_PARSER_AUTOREGISTER(HIGH_PRIO, ODP_PL_QUEUE_DOMAIN, queue_parser_init, queue_parser_deploy,
+			   NULL, queue_parser_destroy, queue_parser_get_resource)

--- a/test/performance/pipeline/sched_parser.c
+++ b/test/performance/pipeline/sched_parser.c
@@ -67,10 +67,10 @@ static odp_bool_t sched_parser_init(config_t *config)
 	int num;
 	grp_parse_t *grp;
 
-	cs = config_lookup(config, SCHED_DOMAIN);
+	cs = config_lookup(config, ODP_PL_SCHED_DOMAIN);
 
 	if (cs == NULL)	{
-		printf("Nothing to parse for \"" SCHED_DOMAIN "\" domain\n");
+		printf("Nothing to parse for \"" ODP_PL_SCHED_DOMAIN "\" domain\n");
 		return true;
 	}
 
@@ -122,7 +122,7 @@ static odp_bool_t sched_parser_deploy(void)
 	grp_parse_t *grp;
 	odp_thrmask_t mask;
 
-	printf("\n*** " SCHED_DOMAIN " resources ***\n");
+	printf("\n*** " ODP_PL_SCHED_DOMAIN " resources ***\n");
 
 	for (uint32_t i = 0U; i < scd.num; ++i) {
 		grp = &scd.grps[i];
@@ -171,5 +171,5 @@ static uintptr_t sched_parser_get_resource(const char *resource)
 	return (uintptr_t)grp;
 }
 
-CONFIG_PARSER_AUTOREGISTER(CRIT_PRIO, SCHED_DOMAIN, sched_parser_init, sched_parser_deploy, NULL,
-			   sched_parser_destroy, sched_parser_get_resource)
+CONFIG_PARSER_AUTOREGISTER(CRIT_PRIO, ODP_PL_SCHED_DOMAIN, sched_parser_init, sched_parser_deploy,
+			   NULL, sched_parser_destroy, sched_parser_get_resource)

--- a/test/performance/pipeline/stash_parser.c
+++ b/test/performance/pipeline/stash_parser.c
@@ -136,17 +136,17 @@ static odp_bool_t stash_parser_init(config_t *config)
 	int num;
 	stash_parse_t *stash;
 
-	cs = config_lookup(config, STASH_DOMAIN);
+	cs = config_lookup(config, ODP_PL_STASH_DOMAIN);
 
 	if (cs == NULL)	{
-		printf("Nothing to parse for \"" STASH_DOMAIN "\" domain\n");
+		printf("Nothing to parse for \"" ODP_PL_STASH_DOMAIN "\" domain\n");
 		return true;
 	}
 
 	num = config_setting_length(cs);
 
 	if (num == 0) {
-		ODPH_ERR("No valid \"" STASH_DOMAIN "\" entries found\n");
+		ODPH_ERR("No valid \"" ODP_PL_STASH_DOMAIN "\" entries found\n");
 		return false;
 	}
 
@@ -159,14 +159,14 @@ static odp_bool_t stash_parser_init(config_t *config)
 		elem = config_setting_get_elem(cs, i);
 
 		if (elem == NULL) {
-			ODPH_ERR("Unparsable \"" STASH_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Unparsable \"" ODP_PL_STASH_DOMAIN "\" entry (%d)\n", i);
 			return false;
 		}
 
 		stash = &stashes.stashes[stashes.num];
 
 		if (!parse_stash_entry(elem, stash)) {
-			ODPH_ERR("Invalid \"" STASH_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Invalid \"" ODP_PL_STASH_DOMAIN "\" entry (%d)\n", i);
 			free_stash_entry(stash);
 			return false;
 		}
@@ -181,7 +181,7 @@ static odp_bool_t stash_parser_deploy(void)
 {
 	stash_parse_t *stash;
 
-	printf("\n*** " STASH_DOMAIN " resources ***\n");
+	printf("\n*** " ODP_PL_STASH_DOMAIN " resources ***\n");
 
 	for (uint32_t i = 0U; i < stashes.num; ++i) {
 		stash = &stashes.stashes[i];
@@ -229,5 +229,5 @@ static uintptr_t stash_parser_get_resource(const char *resource)
 	return (uintptr_t)stash;
 }
 
-CONFIG_PARSER_AUTOREGISTER(MED_PRIO, STASH_DOMAIN, stash_parser_init, stash_parser_deploy, NULL,
-			   stash_parser_destroy, stash_parser_get_resource)
+CONFIG_PARSER_AUTOREGISTER(MED_PRIO, ODP_PL_STASH_DOMAIN, stash_parser_init, stash_parser_deploy,
+			   NULL, stash_parser_destroy, stash_parser_get_resource)

--- a/test/performance/pipeline/timer_parser.c
+++ b/test/performance/pipeline/timer_parser.c
@@ -130,17 +130,17 @@ static odp_bool_t timer_parser_init(config_t *config)
 	int num;
 	timer_parse_t *timer;
 
-	cs = config_lookup(config, TIMER_DOMAIN);
+	cs = config_lookup(config, ODP_PL_TIMER_DOMAIN);
 
 	if (cs == NULL)	{
-		printf("Nothing to parse for \"" TIMER_DOMAIN "\" domain\n");
+		printf("Nothing to parse for \"" ODP_PL_TIMER_DOMAIN "\" domain\n");
 		return true;
 	}
 
 	num = config_setting_length(cs);
 
 	if (num == 0) {
-		ODPH_ERR("No valid \"" TIMER_DOMAIN "\" entries found\n");
+		ODPH_ERR("No valid \"" ODP_PL_TIMER_DOMAIN "\" entries found\n");
 		return false;
 	}
 
@@ -153,14 +153,14 @@ static odp_bool_t timer_parser_init(config_t *config)
 		elem = config_setting_get_elem(cs, i);
 
 		if (elem == NULL) {
-			ODPH_ERR("Unparsable \"" TIMER_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Unparsable \"" ODP_PL_TIMER_DOMAIN "\" entry (%d)\n", i);
 			return false;
 		}
 
 		timer = &timers.timers[timers.num];
 
 		if (!parse_timer_entry(elem, timer)) {
-			ODPH_ERR("Invalid \"" TIMER_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Invalid \"" ODP_PL_TIMER_DOMAIN "\" entry (%d)\n", i);
 			free_timer_entry(timer);
 			return false;
 		}
@@ -175,7 +175,7 @@ static odp_bool_t timer_parser_deploy(void)
 {
 	timer_parse_t *timer;
 
-	printf("\n*** " TIMER_DOMAIN " resources ***\n");
+	printf("\n*** " ODP_PL_TIMER_DOMAIN " resources ***\n");
 
 	for (uint32_t i = 0U; i < timers.num; ++i) {
 		timer = &timers.timers[i];
@@ -228,5 +228,5 @@ static uintptr_t timer_parser_get_resource(const char *resource)
 	return (uintptr_t)pool;
 }
 
-CONFIG_PARSER_AUTOREGISTER(MED_PRIO, TIMER_DOMAIN, timer_parser_init, timer_parser_deploy, NULL,
-			   timer_parser_destroy, timer_parser_get_resource)
+CONFIG_PARSER_AUTOREGISTER(MED_PRIO, ODP_PL_TIMER_DOMAIN, timer_parser_init, timer_parser_deploy,
+			   NULL, timer_parser_destroy, timer_parser_get_resource)

--- a/test/performance/pipeline/work.c
+++ b/test/performance/pipeline/work.c
@@ -86,7 +86,9 @@ void work_register_work(const char *name, work_init_fn_t init_fn, work_print_fn_
 		entries.init_done = true;
 	}
 
-	TAILQ_INSERT_TAIL(&entries.w, entry, w);
+	/* Insert at head so later registrations, e.g. from runtime-loaded libraries, take
+	 * precedence over earlier baseline work of the same name. */
+	TAILQ_INSERT_HEAD(&entries.w, entry, w);
 }
 
 void work_print_work(work_t work, const char *queue)

--- a/test/performance/pipeline/work.c
+++ b/test/performance/pipeline/work.c
@@ -18,9 +18,9 @@ typedef struct work_entry_s {
 	TAILQ_ENTRY(work_entry_s) w;
 
 	const char *name;
-	work_init_fn_t init_fn;
-	work_print_fn_t print_fn;
-	work_destroy_fn_t destroy_fn;
+	odp_pl_work_init_fn_t init_fn;
+	odp_pl_work_print_fn_t print_fn;
+	odp_pl_work_destroy_fn_t destroy_fn;
 } work_entry_t;
 
 typedef struct {
@@ -30,19 +30,19 @@ typedef struct {
 } work_entries_t;
 
 typedef struct ODP_ALIGNED_CACHE {
-	work_fn_t fn;
+	odp_pl_work_fn_t fn;
 	uintptr_t data;
 	work_entry_t *entry;
-	work_stats_t stats;
+	odp_pl_work_stats_t stats;
 } work_priv_t;
 
 static work_entries_t entries;
 
-work_t work_create_work(const work_param_t *param)
+work_t work_create_work(const odp_pl_work_param_t *param)
 {
 	work_priv_t *work = calloc(1U, sizeof(*work));
 	work_entry_t *entry;
-	work_init_t init;
+	odp_pl_work_init_t init;
 
 	if (work == NULL)
 		ODPH_ABORT("Error allocating memory, aborting\n");
@@ -68,8 +68,9 @@ int work_issue(work_t work, odp_event_t ev[], int num)
 	return priv->fn(priv->data, ev, num, &priv->stats);
 }
 
-void work_register_work(const char *name, work_init_fn_t init_fn, work_print_fn_t print_fn,
-			work_destroy_fn_t destroy_fn)
+void odp_pl_work_register_work(const char *name, odp_pl_work_init_fn_t init_fn,
+			       odp_pl_work_print_fn_t print_fn,
+			       odp_pl_work_destroy_fn_t destroy_fn)
 {
 	work_entry_t *entry = calloc(1U, sizeof(*entry));
 

--- a/test/performance/pipeline/work.h
+++ b/test/performance/pipeline/work.h
@@ -7,56 +7,18 @@
 #ifndef WORK_H_
 #define WORK_H_
 
-#include <inttypes.h>
-#include <stdint.h>
-#include <stdio.h>
-
-#include <libconfig.h>
 #include <odp_api.h>
 
-#include "helpers.h"
+#include "odp_pipeline_work.h"
 
 typedef void *work_t;
-
-typedef struct {
-	char *queue;
-	char *type;
-	config_setting_t *param;
-} work_param_t;
-
-typedef struct {
-	uint64_t data1;
-	uint64_t data2;
-	uint64_t data3;
-	uint64_t data4;
-} work_stats_t;
-
-typedef int (*work_fn_t)(uintptr_t data, odp_event_t ev[], int num, work_stats_t *stats);
-
-typedef struct {
-	work_fn_t fn;
-	uintptr_t data;
-} work_init_t;
-
-typedef void (*work_init_fn_t)(const work_param_t *param, work_init_t *init);
-typedef void (*work_print_fn_t)(const char *queue, const work_stats_t *stats);
-typedef void (*work_destroy_fn_t)(uintptr_t data);
 
 work_t work_create_work(const work_param_t *param);
 
 int work_issue(work_t work, odp_event_t ev[], int num);
 
-void work_register_work(const char *name, work_init_fn_t init_fn, work_print_fn_t print_fn,
-			work_destroy_fn_t destroy_fn);
-
 void work_print_work(work_t work, const char *queue);
 
 void work_destroy_work(work_t work);
-
-#define WORK_AUTOREGISTER(name, init, print, destroy)		\
-	__attribute__((constructor))				\
-	static void CONCAT(autoregister, __LINE__)(void) {	\
-		work_register_work(name, init, print, destroy);	\
-	}
 
 #endif

--- a/test/performance/pipeline/work.h
+++ b/test/performance/pipeline/work.h
@@ -13,7 +13,7 @@
 
 typedef void *work_t;
 
-work_t work_create_work(const work_param_t *param);
+work_t work_create_work(const odp_pl_work_param_t *param);
 
 int work_issue(work_t work, odp_event_t ev[], int num);
 

--- a/test/performance/pipeline/work_forward.c
+++ b/test/performance/pipeline/work_forward.c
@@ -15,7 +15,7 @@
 
 #define WORK_FORWARD "forward"
 
-static int work_forward(uintptr_t data, odp_event_t ev[], int num, work_stats_t *stats)
+static int work_forward(uintptr_t data, odp_event_t ev[], int num, odp_pl_work_stats_t *stats)
 {
 	int ret;
 
@@ -26,7 +26,7 @@ static int work_forward(uintptr_t data, odp_event_t ev[], int num, work_stats_t 
 	return ret;
 }
 
-static void work_forward_init(const work_param_t *param, work_init_t *init)
+static void work_forward_init(const odp_pl_work_param_t *param, odp_pl_work_init_t *init)
 {
 	const char *val_str;
 
@@ -42,10 +42,10 @@ static void work_forward_init(const work_param_t *param, work_init_t *init)
 		ODPH_ABORT("No \"" CONF_STR_OUTPUT "\" found\n");
 
 	init->fn = work_forward;
-	init->data = config_parser_get(QUEUE_DOMAIN, val_str);
+	init->data = odp_pl_config_parser_get(ODP_PL_QUEUE_DOMAIN, val_str);
 }
 
-static void work_forward_print(const char *queue, const work_stats_t *stats)
+static void work_forward_print(const char *queue, const odp_pl_work_stats_t *stats)
 {
 	printf("\n%s:\n"
 	       "  work:             %s\n"
@@ -56,4 +56,4 @@ static void work_forward_destroy(uintptr_t data ODP_UNUSED)
 {
 }
 
-WORK_AUTOREGISTER(WORK_FORWARD, work_forward_init, work_forward_print, work_forward_destroy)
+ODP_PL_WORK_AUTOREGISTER(WORK_FORWARD, work_forward_init, work_forward_print, work_forward_destroy)

--- a/test/performance/pipeline/work_global_forward.c
+++ b/test/performance/pipeline/work_global_forward.c
@@ -25,7 +25,8 @@ typedef struct {
 
 static work_global_forward_data_t common;
 
-static int work_global_forward(uintptr_t data, odp_event_t ev[], int num, work_stats_t *stats)
+static int work_global_forward(uintptr_t data, odp_event_t ev[], int num,
+			       odp_pl_work_stats_t *stats)
 {
 	work_global_forward_data_t *priv = (work_global_forward_data_t *)data;
 	int ret;
@@ -38,7 +39,7 @@ static int work_global_forward(uintptr_t data, odp_event_t ev[], int num, work_s
 	return ret;
 }
 
-static void work_global_forward_init(const work_param_t *param, work_init_t *init)
+static void work_global_forward_init(const odp_pl_work_param_t *param, odp_pl_work_init_t *init)
 {
 	const char *val_str;
 	config_setting_t *elem;
@@ -68,7 +69,8 @@ static void work_global_forward_init(const work_param_t *param, work_init_t *ini
 
 		for (int i = 0; i < num; ++i) {
 			val_str = config_setting_get_string_elem(elem, i);
-			common.out[i] = (odp_queue_t)config_parser_get(QUEUE_DOMAIN, val_str);
+			common.out[i] = (odp_queue_t)
+				odp_pl_config_parser_get(ODP_PL_QUEUE_DOMAIN, val_str);
 		}
 
 		common.num = num;
@@ -78,7 +80,7 @@ static void work_global_forward_init(const work_param_t *param, work_init_t *ini
 	init->data = (uintptr_t)&common;
 }
 
-static void work_global_forward_print(const char *queue, const work_stats_t *stats)
+static void work_global_forward_print(const char *queue, const odp_pl_work_stats_t *stats)
 {
 	printf("\n%s:\n"
 	       "  work:      %s\n"
@@ -94,5 +96,5 @@ static void work_global_forward_destroy(uintptr_t data ODP_UNUSED)
 	common.out = NULL;
 }
 
-WORK_AUTOREGISTER(WORK_GLOBAL_FORWARD, work_global_forward_init, work_global_forward_print,
-		  work_global_forward_destroy)
+ODP_PL_WORK_AUTOREGISTER(WORK_GLOBAL_FORWARD, work_global_forward_init, work_global_forward_print,
+			 work_global_forward_destroy)

--- a/test/performance/pipeline/work_packet_copy.c
+++ b/test/performance/pipeline/work_packet_copy.c
@@ -15,7 +15,7 @@
 
 #define WORK_PACKET_COPY "packet_copy"
 
-static int work_packet_copy(uintptr_t data, odp_event_t ev[], int num, work_stats_t *stats)
+static int work_packet_copy(uintptr_t data, odp_event_t ev[], int num, odp_pl_work_stats_t *stats)
 {
 	odp_pool_t pool = (odp_pool_t)data;
 	odp_packet_t dst, src;
@@ -38,7 +38,7 @@ static int work_packet_copy(uintptr_t data, odp_event_t ev[], int num, work_stat
 	return 0;
 }
 
-static void work_packet_copy_init(const work_param_t *param, work_init_t *init)
+static void work_packet_copy_init(const odp_pl_work_param_t *param, odp_pl_work_init_t *init)
 {
 	const char *val_str;
 
@@ -54,10 +54,10 @@ static void work_packet_copy_init(const work_param_t *param, work_init_t *init)
 		ODPH_ABORT("No \"" CONF_STR_POOL "\" found\n");
 
 	init->fn = work_packet_copy;
-	init->data = config_parser_get(POOL_DOMAIN, val_str);
+	init->data = odp_pl_config_parser_get(ODP_PL_POOL_DOMAIN, val_str);
 }
 
-static void work_packet_copy_print(const char *queue, const work_stats_t *stats)
+static void work_packet_copy_print(const char *queue, const odp_pl_work_stats_t *stats)
 {
 	printf("\n%s:\n"
 	       "  work:   %s\n"
@@ -68,5 +68,5 @@ static void work_packet_copy_destroy(uintptr_t data ODP_UNUSED)
 {
 }
 
-WORK_AUTOREGISTER(WORK_PACKET_COPY, work_packet_copy_init, work_packet_copy_print,
-		  work_packet_copy_destroy)
+ODP_PL_WORK_AUTOREGISTER(WORK_PACKET_COPY, work_packet_copy_init, work_packet_copy_print,
+			 work_packet_copy_destroy)

--- a/test/performance/pipeline/work_packet_source.c
+++ b/test/performance/pipeline/work_packet_source.c
@@ -24,7 +24,7 @@ typedef struct {
 	uint32_t len;
 } work_packet_source_data_t;
 
-static int work_packet_source(uintptr_t data, odp_event_t ev[], int num, work_stats_t *stats)
+static int work_packet_source(uintptr_t data, odp_event_t ev[], int num, odp_pl_work_stats_t *stats)
 {
 	work_packet_source_data_t *priv = (work_packet_source_data_t *)data;
 	int num_allocd = odp_packet_alloc_multi(priv->pool, priv->len, (odp_packet_t *)ev, num);
@@ -35,7 +35,7 @@ static int work_packet_source(uintptr_t data, odp_event_t ev[], int num, work_st
 	return num_allocd;
 }
 
-static void work_packet_source_init(const work_param_t *param, work_init_t *init)
+static void work_packet_source_init(const odp_pl_work_param_t *param, odp_pl_work_init_t *init)
 {
 	work_packet_source_data_t *data = calloc(1U, sizeof(*data));
 	const char *val_str;
@@ -55,7 +55,7 @@ static void work_packet_source_init(const work_param_t *param, work_init_t *init
 	if (val_str == NULL)
 		ODPH_ABORT("No \"" CONF_STR_POOL "\" found\n");
 
-	data->pool = (odp_pool_t)config_parser_get(POOL_DOMAIN, val_str);
+	data->pool = (odp_pool_t)odp_pl_config_parser_get(ODP_PL_POOL_DOMAIN, val_str);
 	val_i = config_setting_get_int_elem(param->param, 1);
 
 	if (val_i == 0)
@@ -66,7 +66,7 @@ static void work_packet_source_init(const work_param_t *param, work_init_t *init
 	init->data = (uintptr_t)data;
 }
 
-static void work_packet_source_print(const char *queue, const work_stats_t *stats)
+static void work_packet_source_print(const char *queue, const odp_pl_work_stats_t *stats)
 {
 	printf("\n%s:\n"
 	       "  work:         %s\n"
@@ -78,5 +78,5 @@ static void work_packet_source_destroy(uintptr_t data)
 	free((void *)data);
 }
 
-WORK_AUTOREGISTER(WORK_PACKET_SOURCE, work_packet_source_init, work_packet_source_print,
-		  work_packet_source_destroy)
+ODP_PL_WORK_AUTOREGISTER(WORK_PACKET_SOURCE, work_packet_source_init, work_packet_source_print,
+			 work_packet_source_destroy)

--- a/test/performance/pipeline/work_sink.c
+++ b/test/performance/pipeline/work_sink.c
@@ -11,7 +11,8 @@
 
 #define WORK_SINK "sink"
 
-static int work_sink(uintptr_t data ODP_UNUSED, odp_event_t ev[], int num, work_stats_t *stats)
+static int work_sink(uintptr_t data ODP_UNUSED, odp_event_t ev[], int num,
+		     odp_pl_work_stats_t *stats)
 {
 	odp_event_free_multi(ev, num);
 	stats->data1 += num;
@@ -19,12 +20,12 @@ static int work_sink(uintptr_t data ODP_UNUSED, odp_event_t ev[], int num, work_
 	return num;
 }
 
-static void work_sink_init(const work_param_t *param ODP_UNUSED, work_init_t *init)
+static void work_sink_init(const odp_pl_work_param_t *param ODP_UNUSED, odp_pl_work_init_t *init)
 {
 	init->fn = work_sink;
 }
 
-static void work_sink_print(const char *queue, const work_stats_t *stats)
+static void work_sink_print(const char *queue, const odp_pl_work_stats_t *stats)
 {
 	printf("\n%s:\n"
 	       "  work:         %s\n"
@@ -35,4 +36,4 @@ static void work_sink_destroy(uintptr_t data ODP_UNUSED)
 {
 }
 
-WORK_AUTOREGISTER(WORK_SINK, work_sink_init, work_sink_print, work_sink_destroy)
+ODP_PL_WORK_AUTOREGISTER(WORK_SINK, work_sink_init, work_sink_print, work_sink_destroy)

--- a/test/performance/pipeline/work_timeout_source.c
+++ b/test/performance/pipeline/work_timeout_source.c
@@ -29,7 +29,7 @@ typedef struct {
 } work_timeout_source_data_t;
 
 static int work_timeout_source(uintptr_t data, odp_event_t ev[] ODP_UNUSED, int num ODP_UNUSED,
-			       work_stats_t *stats)
+			       odp_pl_work_stats_t *stats)
 {
 	work_timeout_source_data_t *priv = (work_timeout_source_data_t *)data;
 	odp_timeout_t tmo;
@@ -72,7 +72,7 @@ static int work_timeout_source(uintptr_t data, odp_event_t ev[] ODP_UNUSED, int 
 	return 0;
 }
 
-static void work_timeout_source_init(const work_param_t *param, work_init_t *init)
+static void work_timeout_source_init(const odp_pl_work_param_t *param, odp_pl_work_init_t *init)
 {
 	work_timeout_source_data_t *data = calloc(1U, sizeof(*data));
 	const char *val_str;
@@ -92,13 +92,13 @@ static void work_timeout_source_init(const work_param_t *param, work_init_t *ini
 	if (val_str == NULL)
 		ODPH_ABORT("No \"" CONF_STR_TIMER "\" found\n");
 
-	data->tmr_pool = (odp_timer_pool_t)config_parser_get(TIMER_DOMAIN, val_str);
+	data->tmr_pool = (odp_timer_pool_t)odp_pl_config_parser_get(ODP_PL_TIMER_DOMAIN, val_str);
 	val_str = config_setting_get_string_elem(param->param, 1);
 
 	if (val_str == NULL)
 		ODPH_ABORT("No \"" CONF_STR_POOL "\" found\n");
 
-	data->tmo_pool = (odp_pool_t)config_parser_get(POOL_DOMAIN, val_str);
+	data->tmo_pool = (odp_pool_t)odp_pl_config_parser_get(ODP_PL_POOL_DOMAIN, val_str);
 	val_ll = config_setting_get_int64_elem(param->param, 2);
 
 	if (val_ll == 0)
@@ -106,12 +106,12 @@ static void work_timeout_source_init(const work_param_t *param, work_init_t *ini
 
 	data->timeout_ns = val_ll;
 	init->fn = work_timeout_source;
-	data->queue = (odp_queue_t)config_parser_get(QUEUE_DOMAIN, param->queue);
+	data->queue = (odp_queue_t)odp_pl_config_parser_get(ODP_PL_QUEUE_DOMAIN, param->queue);
 	data->tmr = ODP_TIMER_INVALID;
 	init->data = (uintptr_t)data;
 }
 
-static void work_timeout_source_print(const char *queue, const work_stats_t *stats)
+static void work_timeout_source_print(const char *queue, const odp_pl_work_stats_t *stats)
 {
 	printf("\n%s:\n"
 	       "  work:           %s\n"
@@ -137,5 +137,5 @@ static void work_timeout_source_destroy(uintptr_t data)
 	free(priv);
 }
 
-WORK_AUTOREGISTER(WORK_TIMEOUT_SOURCE, work_timeout_source_init, work_timeout_source_print,
-		  work_timeout_source_destroy)
+ODP_PL_WORK_AUTOREGISTER(WORK_TIMEOUT_SOURCE, work_timeout_source_init, work_timeout_source_print,
+			 work_timeout_source_destroy)

--- a/test/performance/pipeline/work_wait.c
+++ b/test/performance/pipeline/work_wait.c
@@ -16,7 +16,7 @@
 #define WORK_WAIT "wait"
 
 static int work_wait(uintptr_t data, odp_event_t ev[] ODP_UNUSED, int num ODP_UNUSED,
-		     work_stats_t *stats)
+		     odp_pl_work_stats_t *stats)
 {
 	odp_time_wait_ns((uint64_t)data);
 	stats->data1 = (uint64_t)data;
@@ -24,7 +24,7 @@ static int work_wait(uintptr_t data, odp_event_t ev[] ODP_UNUSED, int num ODP_UN
 	return 0;
 }
 
-static void work_wait_init(const work_param_t *param, work_init_t *init)
+static void work_wait_init(const odp_pl_work_param_t *param, odp_pl_work_init_t *init)
 {
 	long long val_ll;
 
@@ -43,7 +43,7 @@ static void work_wait_init(const work_param_t *param, work_init_t *init)
 	init->data = (uintptr_t)val_ll;
 }
 
-static void work_wait_print(const char *queue, const work_stats_t *stats)
+static void work_wait_print(const char *queue, const odp_pl_work_stats_t *stats)
 {
 	printf("\n%s:\n"
 	       "  work:        %s\n"
@@ -54,4 +54,4 @@ static void work_wait_destroy(uintptr_t data ODP_UNUSED)
 {
 }
 
-WORK_AUTOREGISTER(WORK_WAIT, work_wait_init, work_wait_print, work_wait_destroy)
+ODP_PL_WORK_AUTOREGISTER(WORK_WAIT, work_wait_init, work_wait_print, work_wait_destroy)

--- a/test/performance/pipeline/worker_parser.c
+++ b/test/performance/pipeline/worker_parser.c
@@ -174,17 +174,17 @@ static odp_bool_t worker_parser_init(config_t *config)
 	int num;
 	worker_t *worker;
 
-	cs = config_lookup(config, WORKER_DOMAIN);
+	cs = config_lookup(config, ODP_PL_WORKER_DOMAIN);
 
 	if (cs == NULL)	{
-		printf("Nothing to parse for \"" WORKER_DOMAIN "\" domain\n");
+		printf("Nothing to parse for \"" ODP_PL_WORKER_DOMAIN "\" domain\n");
 		return true;
 	}
 
 	num = config_setting_length(cs);
 
 	if (num == 0) {
-		ODPH_ERR("No valid \"" WORKER_DOMAIN "\" entries found\n");
+		ODPH_ERR("No valid \"" ODP_PL_WORKER_DOMAIN "\" entries found\n");
 		return false;
 	}
 
@@ -197,14 +197,14 @@ static odp_bool_t worker_parser_init(config_t *config)
 		elem = config_setting_get_elem(cs, i);
 
 		if (elem == NULL) {
-			ODPH_ERR("Unparsable \"" WORKER_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Unparsable \"" ODP_PL_WORKER_DOMAIN "\" entry (%d)\n", i);
 			return false;
 		}
 
 		worker = &workers.workers[workers.num];
 
 		if (!parse_worker_entry(elem, worker)) {
-			ODPH_ERR("Invalid \"" WORKER_DOMAIN "\" entry (%d)\n", i);
+			ODPH_ERR("Invalid \"" ODP_PL_WORKER_DOMAIN "\" entry (%d)\n", i);
 			free_worker_entry(worker);
 			return false;
 		}
@@ -219,7 +219,7 @@ static odp_bool_t worker_parser_deploy(void)
 {
 	worker_t *worker;
 
-	printf("\n*** " WORKER_DOMAIN " resources ***\n");
+	printf("\n*** " ODP_PL_WORKER_DOMAIN " resources ***\n");
 
 	for (uint32_t i = 0U; i < workers.num; ++i) {
 		worker = &workers.workers[i];
@@ -274,5 +274,6 @@ static uintptr_t worker_parser_get_resource(const char *resource)
 	return (uintptr_t)worker;
 }
 
-CONFIG_PARSER_AUTOREGISTER(LOW_PRIO, WORKER_DOMAIN, worker_parser_init, worker_parser_deploy, NULL,
-			   worker_parser_destroy, worker_parser_get_resource)
+CONFIG_PARSER_AUTOREGISTER(LOW_PRIO, ODP_PL_WORKER_DOMAIN, worker_parser_init,
+			   worker_parser_deploy, NULL, worker_parser_destroy,
+			   worker_parser_get_resource)


### PR DESCRIPTION
Add a repeatable `-l`, `--lib` command line option that loads shared libraries providing additional work.

The libraries are loaded after the baseline work has been registered, so loaded work takes precedence over baseline work of the same name and overrides it.

Additionally, patchset includes a few bug fixes and enabling changes related to library loading such as new public APIs.

v2:
- Added reviewed-by tags