### PR TITLE
[PATCH v3] linux-gen: pool: fix pool type reported for external memory pools

### DIFF
--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -2223,6 +2223,7 @@ odp_pool_t odp_pool_ext_create(const char *name, const odp_pool_ext_param_t *par
 
 	pool->ring_mask      = ring_size - 1;
 	pool->type           = param->type;
+	pool->type_2         = param->type;
 	pool->num            = num_buf;
 	pool->headroom       = headroom;
 	pool->tailroom       = 0;

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -2089,6 +2089,8 @@ static void test_packet_pool_ext_info(void)
 	CU_ASSERT_FATAL(odp_pool_info(pool, &info) == 0);
 
 	CU_ASSERT(info.pool_ext);
+	CU_ASSERT(info.type == ODP_POOL_PACKET);
+	CU_ASSERT(info.pool_ext_param.type == ODP_POOL_PACKET);
 	CU_ASSERT(strncmp(name, info.name, strlen(name)) == 0);
 
 	CU_ASSERT(odp_pool_destroy(pool) == 0);


### PR DESCRIPTION
## Problem

`odp_pool_info()` reports the pool type from the internal `pool->type_2` field
(the "pool type from application point of view"), but `odp_pool_ext_create()`
only initialized `pool->type` and left `pool->type_2` at zero. Since zero is not
a valid `odp_pool_type_t` value, every external memory pool reported
`info.type == 0` instead of `ODP_POOL_PACKET`.

The same field is used by `odp_pool_print()` and the pool summary print, so
external memory pools were also printed with pool type "unknown" / "-".

## Fix

Set `pool->type_2` from `param->type` in `odp_pool_ext_create()`, the same way
the regular pool create path does.

## Test

Extend `test_packet_pool_ext_info()` in the pool validation suite to check that
`odp_pool_info()` returns `ODP_POOL_PACKET` in both `info.type` and
`info.pool_ext_param.type` for an external packet pool. The first assertion
fails without the fix.

## Commits

- `linux-gen: pool: set type_2 for external memory pools`
- `validation: pool: check info.type for external memory pools`