### PR TITLE
[PATCH v1] api: pool: add buffer support for external pools

### DIFF
--- a/include/odp/api/spec/buffer.h
+++ b/include/odp/api/spec/buffer.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2013-2018 Linaro Limited
- * Copyright (c) 2022-2023 Nokia
+ * Copyright (c) 2022-2026 Nokia
  */
 
 /**
@@ -77,6 +77,23 @@ void odp_buffer_to_event_multi(const odp_buffer_t buf[], odp_event_t ev[], int n
  * @return Buffer start address
  */
 void *odp_buffer_addr(odp_buffer_t buf);
+
+/**
+ * Convert buffer start address to handle
+ *
+ * Converts a buffer start address (from a previous odp_buffer_addr() call) to a buffer handle.
+ * This allows an application to save memory as it can store only buffer addresses (instead of
+ * addresses and handles) and convert those to handles when needed.
+ *
+ * This call can be used only for buffers of an external memory pool (see odp_pool_ext_create()).
+ *
+ * @param      pool     Pool the buffer originates from
+ * @param      addr     Buffer start address
+ *
+ * @return Buffer handle on success
+ * @retval ODP_BUFFER_INVALID on failure
+ */
+odp_buffer_t odp_buffer_from_addr(odp_pool_t pool, void *addr);
 
 /**
  * Buffer maximum data size

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2015-2018 Linaro Limited
- * Copyright (c) 2020-2023 Nokia
+ * Copyright (c) 2020-2026 Nokia
  */
 
 /**
@@ -292,6 +292,33 @@ odp_pool_t odp_pool_ext_create(const char *name, const odp_pool_ext_param_t *par
  * odp_packet_head()--> |                               |                            |
  *                      | Packet data                   |                            |
  *                      |  (headroom, data, tailroom)   |                            |
+ *                      |                               |                            |
+ *                      |                               |                            |
+ *                      +-------------------------------+    --                      |
+ *                      |                               |     |                      |
+ *                      | ODP trailer (optional)        |      > odp_trailer_size    |
+ *                      |                               |     |                      |
+ *                      +-------------------------------+    --                     --
+ *
+ * @endcode
+ *
+ * For buffer pools, buffer layout is shown below. The buffer data (odp_buffer_addr())
+ * starts immediately after the application header. Buffer size includes all headers,
+ * data and trailer.
+ *
+ * @code{.unparsed}
+ *
+ *                      +-------------------------------+    --                     --
+ *          buf[N] ---> |                               |     |                      |
+ *                      | ODP header (optional)         |      > odp_header_size     |
+ *                      |                               |     |                      |
+ *                      +-------------------------------+    --                      |
+ *                      |                               |     |                      |
+ *                      | Application header (optional) |      > app_header_size     |
+ *                      |                               |     |                       > buf_size
+ *                      +-------------------------------+    --                      |
+ * odp_buffer_addr()--> |                               |                            |
+ *                      | Buffer data                   |                            |
  *                      |                               |                            |
  *                      |                               |                            |
  *                      +-------------------------------+    --                      |

--- a/include/odp/api/spec/pool_types.h
+++ b/include/odp/api/spec/pool_types.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2021-2025 Nokia
+ * Copyright (c) 2021-2026 Nokia
  */
 
 /**
@@ -738,6 +738,77 @@ typedef struct odp_pool_ext_capability_t {
 	/** Supported statistics counters */
 	odp_pool_stats_opt_t stats;
 
+	/** Buffer pool capabilities  */
+	struct {
+		/** Maximum number of buffers */
+		uint32_t max_num_buf;
+
+		/** Maximum buffer size in bytes */
+		uint32_t max_buf_size;
+
+		/** ODP header size in bytes
+		 *
+		 *  Application must reserve this many bytes from the start of a buffer
+		 *  for ODP implementation usage. When the value is zero, ODP implementation does
+		 *  not need header space to be reserved for it. Application will not modify this
+		 *  memory area (after buffer populate call).
+		 */
+		uint32_t odp_header_size;
+
+		/** ODP trailer size in bytes
+		 *
+		 *  Application must reserve this many bytes from the end of a buffer
+		 *  for ODP implementation usage. When the value is zero, ODP implementation does
+		 *  not need trailer space to be reserved for it. Application will not modify this
+		 *  memory area (after buffer populate call).
+		 */
+		uint32_t odp_trailer_size;
+
+		/** Minimum buffer pool memory area alignment in bytes
+		 *
+		 *  The memory area used for a buffer pool, starting from (or before) the lowest
+		 *  addressed buffer and extending to the end (or after) of the highest addressed
+		 *  buffer, must have at least this (power of two) alignment. The value is 1 when
+		 *  there is no alignment requirement.
+		 */
+		uint32_t min_mem_align;
+
+		/** Minimum buffer pointer alignment in bytes
+		 *
+		 *  Buffer pointers populated into a pool must be evenly divisible with
+		 *  this value. The value is 1 when there is no alignment requirement.
+		 */
+		uint32_t min_buf_align;
+
+		/** Buffer alignment flags
+		 *
+		 *  These flags specify additional alignment requirements for buffers.
+		 *  If not stated otherwise, min_buf_align alignment requirement applies also.
+		 */
+		struct {
+			/** Buffers are size aligned
+			 *
+			 *  When set, buffer pointers must be aligned to the buffer size.
+			 *  For example, if the buffer size would be 2304 bytes (0x900),
+			 *  each buffer start address must be a multiple of 0x900
+			 *  (e.g. 0x12000900, 0x12001200, 0x12004800, etc).
+			 */
+			uint16_t buf_size_aligned : 1;
+
+		};
+
+		/** Maximum user area size in bytes */
+		uint32_t max_uarea_size;
+
+		/** Pool user area persistence
+		 *
+		 *  See buf.uarea_persistence of odp_pool_capability_t for details
+		 *  (odp_pool_capability_t::uarea_persistence).
+		 */
+		odp_bool_t uarea_persistence;
+
+	} buf;
+
 	/** Packet pool capabilities  */
 	struct {
 		/** Maximum number of packet buffers */
@@ -874,6 +945,44 @@ typedef struct odp_pool_ext_param_t {
 	 * counters that are actually used. Counters may be read with odp_pool_stats().
 	 */
 	odp_pool_stats_opt_t stats;
+
+	/** Parameters for buffer pools */
+	struct {
+		/** Number of buffers
+		 *
+		 *  The number of buffers application will populate into the pool.
+		 *  The maximum value is defined by pool capability buf.max_num_buf.
+		 */
+		uint32_t num_buf;
+
+		/** Buffer size
+		 *
+		 *  Total buffer size in bytes including all headers, trailer and data.
+		 *  This is calculated from buffer start pointer to the end of buffer
+		 *  data area or ODP trailer (see odp_trailer_size capability).
+		 *  All buffers application populates into the pool are of this size.
+		 */
+		uint32_t buf_size;
+
+		/** Application header size
+		 *
+		 *  Application reserves this many bytes for its own buffer header usage.
+		 *  The application header follows immediately the ODP buffer header
+		 *  (see odp_header_size capability). ODP implementation will not modify this
+		 *  memory area. The default value is 0.
+		 */
+		uint32_t app_header_size;
+
+		/** User area size
+		 *
+		 *  Per buffer user area size in bytes. As with normal pools, user area location
+		 *  is ODP implementation specific. Use zero if no user area is needed.
+		 *  The maximum value is defined by pool capability buf.max_uarea_size.
+		 *  The default value is 0.
+		 */
+		uint32_t uarea_size;
+
+	} buf;
 
 	/** Parameters for packet pools */
 	struct {

--- a/platform/linux-generic/include/odp/api/plat/buffer_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/buffer_inlines.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2019-2023 Nokia
+ * Copyright (c) 2019-2026 Nokia
  */
 
 #ifndef ODP_PLAT_BUFFER_INLINES_H_
@@ -7,6 +7,7 @@
 
 #include <odp/api/buffer_types.h>
 #include <odp/api/event.h>
+#include <odp/api/hints.h>
 #include <odp/api/pool_types.h>
 
 #include <odp/api/plat/buffer_inline_types.h>
@@ -28,6 +29,7 @@ extern "C" {
 	#define odp_buffer_to_event __odp_buffer_to_event
 	#define odp_buffer_to_event_multi __odp_buffer_to_event_multi
 	#define odp_buffer_addr __odp_buffer_addr
+	#define odp_buffer_from_addr __odp_buffer_from_addr
 	#define odp_buffer_size __odp_buffer_size
 	#define odp_buffer_pool __odp_buffer_pool
 	#define odp_buffer_user_area __odp_buffer_user_area
@@ -62,6 +64,17 @@ _ODP_INLINE void odp_buffer_to_event_multi(const odp_buffer_t buf[], odp_event_t
 _ODP_INLINE void *odp_buffer_addr(odp_buffer_t buf)
 {
 	return _odp_event_hdr_field((odp_event_t)buf, void *, base_data);
+}
+
+_ODP_INLINE odp_buffer_t odp_buffer_from_addr(odp_pool_t pool, void *addr)
+{
+	const uint32_t head_offset = _odp_pool_get(pool, uint32_t, ext_head_offset);
+
+	/* Check that pool is external */
+	if (odp_unlikely(!head_offset))
+		return ODP_BUFFER_INVALID;
+
+	return (odp_buffer_t)((uintptr_t)addr - head_offset);
 }
 
 _ODP_INLINE uint32_t odp_buffer_size(odp_buffer_t buf)

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -2070,17 +2070,40 @@ int odp_pool_ext_capability(odp_pool_type_t type, odp_pool_ext_capability_t *cap
 	odp_pool_stats_opt_t supported_stats;
 
 	_ODP_ASSERT(capa != NULL);
+	memset(capa, 0, sizeof(*capa));
 
 	switch (type) {
 	case ODP_POOL_PACKET:
+		capa->pkt.max_num_buf         = _odp_pool_glb->config.pkt_max_num;
+		capa->pkt.max_buf_size        = MAX_SIZE;
+		capa->pkt.odp_header_size     = sizeof(odp_packet_hdr_t);
+		capa->pkt.odp_trailer_size    = _ODP_EV_ENDMARK_SIZE;
+		capa->pkt.min_mem_align       = ODP_CACHE_LINE_SIZE;
+		capa->pkt.min_buf_align       = ODP_CACHE_LINE_SIZE;
+		capa->pkt.min_head_align      = MIN_HEAD_ALIGN;
+		capa->pkt.buf_size_aligned    = 0;
+		capa->pkt.max_headroom        = CONFIG_PACKET_HEADROOM;
+		capa->pkt.max_headroom_size   = CONFIG_PACKET_HEADROOM;
+		capa->pkt.max_segs_per_pkt    = PKT_MAX_SEGS;
+		capa->pkt.max_uarea_size      = MAX_UAREA_SIZE;
+		capa->pkt.uarea_persistence   = true;
 		break;
 	case ODP_POOL_BUFFER:
+		capa->buf.max_num_buf         = CONFIG_POOL_MAX_NUM;
+		capa->buf.max_buf_size        = MAX_SIZE;
+		capa->buf.odp_header_size     = sizeof(odp_buffer_hdr_t);
+		capa->buf.odp_trailer_size    = _ODP_EV_ENDMARK_SIZE;
+		capa->buf.min_mem_align       = ODP_CACHE_LINE_SIZE;
+		capa->buf.min_buf_align       = ODP_CACHE_LINE_SIZE;
+		capa->buf.buf_size_aligned    = 0;
+		capa->buf.max_uarea_size      = MAX_UAREA_SIZE;
+		capa->buf.uarea_persistence   = true;
+		break;
 	case ODP_POOL_TIMEOUT:
 	case ODP_POOL_VECTOR:
 	case ODP_POOL_EVENT_VECTOR:
 	case ODP_POOL_DMA_COMPL:
 	case ODP_POOL_ML_COMPL:
-		memset(capa, 0, sizeof(odp_pool_ext_capability_t));
 		return 0;
 	default:
 		_ODP_ERR("Invalid pool type: %d\n", type);
@@ -2088,59 +2111,85 @@ int odp_pool_ext_capability(odp_pool_type_t type, odp_pool_ext_capability_t *cap
 	}
 
 	supported_stats.all = 0;
-
-	memset(capa, 0, sizeof(odp_pool_ext_capability_t));
-
 	capa->type           = type;
 	capa->max_pools      = CONFIG_POOLS - CONFIG_INTERNAL_POOLS;
 	capa->min_cache_size = 0;
 	capa->max_cache_size = CONFIG_POOL_CACHE_MAX_SIZE;
 	capa->stats.all      = supported_stats.all;
 
-	capa->pkt.max_num_buf         = _odp_pool_glb->config.pkt_max_num;
-	capa->pkt.max_buf_size        = MAX_SIZE;
-	capa->pkt.odp_header_size     = sizeof(odp_packet_hdr_t);
-	capa->pkt.odp_trailer_size    = _ODP_EV_ENDMARK_SIZE;
-	capa->pkt.min_mem_align       = ODP_CACHE_LINE_SIZE;
-	capa->pkt.min_buf_align       = ODP_CACHE_LINE_SIZE;
-	capa->pkt.min_head_align      = MIN_HEAD_ALIGN;
-	capa->pkt.buf_size_aligned    = 0;
-	capa->pkt.max_headroom        = CONFIG_PACKET_HEADROOM;
-	capa->pkt.max_headroom_size   = CONFIG_PACKET_HEADROOM;
-	capa->pkt.max_segs_per_pkt    = PKT_MAX_SEGS;
-	capa->pkt.max_uarea_size      = MAX_UAREA_SIZE;
-	capa->pkt.uarea_persistence   = true;
-
 	return 0;
 }
 
 void odp_pool_ext_param_init(odp_pool_type_t type, odp_pool_ext_param_t *param)
 {
-	uint32_t default_cache_size = _odp_pool_glb->config.local_cache_size;
+	_ODP_ASSERT(param != NULL);
+	memset(param, 0, sizeof(*param));
 
-	memset(param, 0, sizeof(odp_pool_ext_param_t));
-
-	if (type != ODP_POOL_PACKET)
+	if (type != ODP_POOL_PACKET && type != ODP_POOL_BUFFER)
 		return;
 
-	param->type         = ODP_POOL_PACKET;
-	param->cache_size   = default_cache_size;
-	param->pkt.headroom = CONFIG_PACKET_HEADROOM;
+	param->type       = type;
+	param->cache_size = _odp_pool_glb->config.local_cache_size;
+
+	if (type == ODP_POOL_PACKET)
+		param->pkt.headroom = CONFIG_PACKET_HEADROOM;
 }
 
 static int check_pool_ext_param(const odp_pool_ext_param_t *param)
 {
 	odp_pool_ext_capability_t capa;
-	uint32_t head_offset = sizeof(odp_packet_hdr_t) + param->pkt.app_header_size;
-
-	if (param->type != ODP_POOL_PACKET) {
-		_ODP_ERR("Pool type not supported\n");
-		return -1;
-	}
 
 	if (odp_pool_ext_capability(param->type, &capa)) {
 		_ODP_ERR("Capa failed\n");
 		return -1;
+	}
+
+	if (capa.max_pools == 0) {
+		_ODP_ERR("Pool type not supported\n");
+		return -1;
+	}
+
+	if (param->type == ODP_POOL_BUFFER) {
+		if (param->buf.num_buf > capa.buf.max_num_buf) {
+			_ODP_ERR("Too many buffers\n");
+			return -1;
+		}
+
+		if (param->buf.buf_size > capa.buf.max_buf_size) {
+			_ODP_ERR("Too large buffer size %u\n", param->buf.buf_size);
+			return -1;
+		}
+
+		if (param->buf.uarea_size > capa.buf.max_uarea_size) {
+			_ODP_ERR("Too large user area size %u\n", param->buf.uarea_size);
+			return -1;
+		}
+	} else {
+		if (param->pkt.num_buf > capa.pkt.max_num_buf) {
+			_ODP_ERR("Too many packet buffers\n");
+			return -1;
+		}
+
+		if (param->pkt.buf_size > capa.pkt.max_buf_size) {
+			_ODP_ERR("Too large packet buffer size %u\n", param->pkt.buf_size);
+			return -1;
+		}
+
+		if (param->pkt.uarea_size > capa.pkt.max_uarea_size) {
+			_ODP_ERR("Too large user area size %u\n", param->pkt.uarea_size);
+			return -1;
+		}
+
+		if (param->pkt.headroom > capa.pkt.max_headroom) {
+			_ODP_ERR("Too large headroom size\n");
+			return -1;
+		}
+
+		if ((sizeof(odp_packet_hdr_t) + param->pkt.app_header_size) %
+		    capa.pkt.min_head_align) {
+			_ODP_ERR("Head pointer not %u byte aligned\n", capa.pkt.min_head_align);
+			return -1;
+		}
 	}
 
 	if (param->cache_size > capa.max_cache_size) {
@@ -2153,31 +2202,6 @@ static int check_pool_ext_param(const odp_pool_ext_param_t *param)
 		return -1;
 	}
 
-	if (param->pkt.num_buf > capa.pkt.max_num_buf) {
-		_ODP_ERR("Too many packet buffers\n");
-		return -1;
-	}
-
-	if (param->pkt.buf_size > capa.pkt.max_buf_size) {
-		_ODP_ERR("Too large packet buffer size %u\n", param->pkt.buf_size);
-		return -1;
-	}
-
-	if (param->pkt.uarea_size > capa.pkt.max_uarea_size) {
-		_ODP_ERR("Too large user area size %u\n", param->pkt.uarea_size);
-		return -1;
-	}
-
-	if (param->pkt.headroom > capa.pkt.max_headroom) {
-		_ODP_ERR("Too large headroom size\n");
-		return -1;
-	}
-
-	if (head_offset % capa.pkt.min_head_align) {
-		_ODP_ERR("Head pointer not %u byte aligned\n", capa.pkt.min_head_align);
-		return -1;
-	}
-
 	return 0;
 }
 
@@ -2185,15 +2209,26 @@ odp_pool_t odp_pool_ext_create(const char *name, const odp_pool_ext_param_t *par
 {
 	pool_t *pool;
 	uint32_t ring_size;
-	uint32_t num_buf = param->pkt.num_buf;
-	uint32_t buf_size = param->pkt.buf_size;
-	uint32_t head_offset = sizeof(odp_packet_hdr_t) + param->pkt.app_header_size;
-	uint32_t headroom = param->pkt.headroom;
+	uint32_t num_buf, buf_size, head_offset, headroom, uarea_size;
 	uint32_t shm_flags = 0;
 
 	if (check_pool_ext_param(param)) {
 		_ODP_ERR("Bad pool ext param\n");
 		return ODP_POOL_INVALID;
+	}
+
+	if (param->type == ODP_POOL_BUFFER) {
+		num_buf     = param->buf.num_buf;
+		buf_size    = param->buf.buf_size;
+		head_offset = sizeof(odp_buffer_hdr_t) + param->buf.app_header_size;
+		uarea_size  = param->buf.uarea_size;
+		headroom    = 0;
+	} else {
+		num_buf     = param->pkt.num_buf;
+		buf_size    = param->pkt.buf_size;
+		head_offset = sizeof(odp_packet_hdr_t) + param->pkt.app_header_size;
+		uarea_size  = param->pkt.uarea_size;
+		headroom    = param->pkt.headroom;
 	}
 
 	if (odp_global_ro.shm_single_va)
@@ -2210,7 +2245,7 @@ odp_pool_t odp_pool_ext_create(const char *name, const odp_pool_ext_param_t *par
 	set_pool_name(pool, name);
 	set_pool_cache_size(pool, param->cache_size);
 
-	if (reserve_uarea(pool, param->pkt.uarea_size, num_buf, shm_flags)) {
+	if (reserve_uarea(pool, uarea_size, num_buf, shm_flags)) {
 		_ODP_ERR("User area SHM reserve failed\n");
 		goto error;
 	}
@@ -2261,7 +2296,7 @@ int odp_pool_ext_populate(odp_pool_t pool_hdl, void *buf[], uint32_t buf_size, u
 	ring_mpmc_rst_ptr_t *ring;
 	_odp_event_hdr_t **ring_data;
 	uint32_t i, ring_mask, buf_index, head_offset;
-	uint32_t num_populated;
+	uint32_t num_populated, expected_buf_size;
 	uint8_t *data_ptr, *min_addr, *max_addr;
 	void *uarea = NULL;
 
@@ -2272,7 +2307,8 @@ int odp_pool_ext_populate(odp_pool_t pool_hdl, void *buf[], uint32_t buf_size, u
 
 	pool = _odp_pool_entry(pool_hdl);
 
-	if (pool->type != ODP_POOL_PACKET || pool->pool_ext == 0) {
+	if ((pool->type != ODP_POOL_PACKET && pool->type != ODP_POOL_BUFFER) ||
+	    pool->pool_ext == 0) {
 		_ODP_ERR("Bad pool type\n");
 		return -1;
 	}
@@ -2280,7 +2316,12 @@ int odp_pool_ext_populate(odp_pool_t pool_hdl, void *buf[], uint32_t buf_size, u
 	min_addr = pool->base_addr;
 	max_addr = pool->max_addr;
 
-	if (buf_size != pool->ext_param.pkt.buf_size) {
+	if (pool->type == ODP_POOL_BUFFER)
+		expected_buf_size = pool->ext_param.buf.buf_size;
+	else
+		expected_buf_size = pool->ext_param.pkt.buf_size;
+
+	if (buf_size != expected_buf_size) {
 		_ODP_ERR("Bad buffer size\n");
 		return -1;
 	}
@@ -2318,11 +2359,12 @@ int odp_pool_ext_populate(odp_pool_t pool_hdl, void *buf[], uint32_t buf_size, u
 			max_addr = (uint8_t *)event_hdr;
 
 		if ((uintptr_t)event_hdr & (ODP_CACHE_LINE_SIZE - 1)) {
-			_ODP_ERR("Bad packet buffer align: buf[%u]\n", i);
+			_ODP_ERR("Bad buffer align: buf[%u]\n", i);
 			return -1;
 		}
 
-		if (((uintptr_t)event_hdr + head_offset) & (MIN_HEAD_ALIGN - 1)) {
+		if (pool->type == ODP_POOL_PACKET &&
+		    (((uintptr_t)event_hdr + head_offset) & (MIN_HEAD_ALIGN - 1))) {
 			_ODP_ERR("Bad head pointer align: buf[%u]\n", i);
 			return -1;
 		}

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -44,11 +44,21 @@ typedef struct {
 	uint8_t mark[ELEM_NUM];
 } uarea_init_t;
 
+typedef struct {
+	void **buf;
+	uint32_t num_buf;
+	uint32_t buf_size;
+	uint32_t min_align;
+	uint32_t min_mem_align;
+	odp_bool_t size_aligned;
+} pool_ext_populate_t;
+
 static global_shared_mem_t *global_mem;
 
 static odp_pool_capability_t global_pool_capa;
 static odp_pool_param_t default_pool_param;
 static odp_pool_ext_capability_t global_pool_ext_capa;
+static odp_pool_ext_capability_t global_pool_ext_buf_capa;
 
 static void test_param_init(uint8_t fill)
 {
@@ -1951,7 +1961,7 @@ static void pool_ext_init_packet_pool_param(odp_pool_ext_param_t *param)
 	trailer_size = capa.pkt.odp_trailer_size;
 
 	CU_ASSERT_FATAL(head_offset < buf_size);
-	CU_ASSERT_FATAL((head_offset + trailer_size)  < buf_size);
+	CU_ASSERT_FATAL((head_offset + trailer_size) < buf_size);
 
 	while (head_offset % head_align) {
 		app_hdr_size++;
@@ -1964,7 +1974,7 @@ static void pool_ext_init_packet_pool_param(odp_pool_ext_param_t *param)
 	}
 
 	CU_ASSERT_FATAL(head_offset < buf_size);
-	CU_ASSERT_FATAL((head_offset + trailer_size)  < buf_size);
+	CU_ASSERT_FATAL((head_offset + trailer_size) < buf_size);
 	CU_ASSERT_FATAL((head_offset % head_align) == 0);
 
 	param->pkt.num_buf         = num_buf;
@@ -1972,6 +1982,41 @@ static void pool_ext_init_packet_pool_param(odp_pool_ext_param_t *param)
 	param->pkt.app_header_size = app_hdr_size;
 	param->pkt.uarea_size      = uarea_size;
 	param->pkt.headroom        = headroom;
+}
+
+static void pool_ext_init_buffer_pool_param(odp_pool_ext_param_t *param)
+{
+	odp_pool_ext_capability_t capa;
+	uint32_t head_offset, trailer_size;
+	odp_pool_type_t type = ODP_POOL_BUFFER;
+	uint32_t num_buf = EXT_NUM_BUF;
+	uint32_t buf_size = EXT_BUF_SIZE;
+	uint32_t uarea_size = EXT_UAREA_SIZE;
+	uint32_t app_hdr_size = EXT_APP_HDR_SIZE;
+
+	CU_ASSERT_FATAL(odp_pool_ext_capability(type, &capa) == 0);
+
+	odp_pool_ext_param_init(type, param);
+
+	if (num_buf > capa.buf.max_num_buf)
+		num_buf = capa.buf.max_num_buf;
+
+	if (buf_size > capa.buf.max_buf_size)
+		buf_size = capa.buf.max_buf_size;
+
+	if (uarea_size > capa.buf.max_uarea_size)
+		uarea_size = capa.buf.max_uarea_size;
+
+	head_offset = capa.buf.odp_header_size + app_hdr_size;
+	trailer_size = capa.buf.odp_trailer_size;
+
+	CU_ASSERT_FATAL(head_offset < buf_size);
+	CU_ASSERT_FATAL((head_offset + trailer_size) < buf_size);
+
+	param->buf.num_buf         = num_buf;
+	param->buf.buf_size        = buf_size;
+	param->buf.app_header_size = app_hdr_size;
+	param->buf.uarea_size      = uarea_size;
 }
 
 static void test_packet_pool_ext_capa(void)
@@ -1991,28 +2036,40 @@ static void test_packet_pool_ext_capa(void)
 		CU_ASSERT(capa.max_pools == 0);
 	}
 
+	type = ODP_POOL_BUFFER;
+
+	CU_ASSERT_FATAL(odp_pool_ext_capability(type, &capa) == 0);
+
+	CU_ASSERT(capa.type == type);
+
+	if (capa.max_pools > 0) {
+		CU_ASSERT(capa.min_cache_size <= capa.max_cache_size);
+		CU_ASSERT(capa.buf.max_num_buf > 0);
+		CU_ASSERT(capa.buf.max_buf_size > 0);
+		CU_ASSERT(capa.buf.min_mem_align > 0);
+		CU_ASSERT(TEST_CHECK_POW2(capa.buf.min_mem_align));
+		CU_ASSERT(capa.buf.min_buf_align > 0);
+	}
+
 	type = ODP_POOL_PACKET;
 
 	CU_ASSERT_FATAL(odp_pool_ext_capability(type, &capa) == 0);
 
 	CU_ASSERT(capa.type == type);
 
-	/* External memory pools not supported */
-	if (capa.max_pools == 0)
-		return;
-
-	CU_ASSERT(capa.max_pools > 0);
-	CU_ASSERT(capa.min_cache_size <= capa.max_cache_size);
-	CU_ASSERT(capa.pkt.max_num_buf > 0);
-	CU_ASSERT(capa.pkt.max_buf_size > 0);
-	CU_ASSERT(capa.pkt.min_mem_align > 0);
-	CU_ASSERT(TEST_CHECK_POW2(capa.pkt.min_mem_align));
-	CU_ASSERT(capa.pkt.min_buf_align > 0);
-	CU_ASSERT(capa.pkt.min_head_align > 0);
-	CU_ASSERT(capa.pkt.max_headroom > 0);
-	CU_ASSERT(capa.pkt.max_headroom_size > 0);
-	CU_ASSERT(capa.pkt.max_headroom_size >= capa.pkt.max_headroom);
-	CU_ASSERT(capa.pkt.max_segs_per_pkt > 0);
+	if (capa.max_pools > 0) {
+		CU_ASSERT(capa.min_cache_size <= capa.max_cache_size);
+		CU_ASSERT(capa.pkt.max_num_buf > 0);
+		CU_ASSERT(capa.pkt.max_buf_size > 0);
+		CU_ASSERT(capa.pkt.min_mem_align > 0);
+		CU_ASSERT(TEST_CHECK_POW2(capa.pkt.min_mem_align));
+		CU_ASSERT(capa.pkt.min_buf_align > 0);
+		CU_ASSERT(capa.pkt.min_head_align > 0);
+		CU_ASSERT(capa.pkt.max_headroom > 0);
+		CU_ASSERT(capa.pkt.max_headroom_size > 0);
+		CU_ASSERT(capa.pkt.max_headroom_size >= capa.pkt.max_headroom);
+		CU_ASSERT(capa.pkt.max_segs_per_pkt > 0);
+	}
 }
 
 static void test_ext_param_init(uint8_t fill)
@@ -2038,29 +2095,23 @@ static void test_packet_pool_ext_param_init(void)
 	test_ext_param_init(0xff);
 }
 
-static void test_packet_pool_ext_create(void)
+static void pool_ext_create(const odp_pool_ext_param_t *param)
 {
 	odp_pool_t pool;
-	odp_pool_ext_param_t param;
 
-	pool_ext_init_packet_pool_param(&param);
-
-	pool = odp_pool_ext_create("pool_ext_0", &param);
+	pool = odp_pool_ext_create("pool_ext_0", param);
 
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 
 	CU_ASSERT(odp_pool_destroy(pool) == 0);
 }
 
-static void test_packet_pool_ext_lookup(void)
+static void pool_ext_lookup(const odp_pool_ext_param_t *param)
 {
 	odp_pool_t pool, pool_1;
-	odp_pool_ext_param_t param;
 	const char *name = "pool_ext_0";
 
-	pool_ext_init_packet_pool_param(&param);
-
-	pool = odp_pool_ext_create(name, &param);
+	pool = odp_pool_ext_create(name, param);
 
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 
@@ -2072,16 +2123,13 @@ static void test_packet_pool_ext_lookup(void)
 	CU_ASSERT(odp_pool_destroy(pool) == 0);
 }
 
-static void test_packet_pool_ext_info(void)
+static void pool_ext_info(const odp_pool_ext_param_t *param, odp_pool_type_t type)
 {
 	odp_pool_t pool;
-	odp_pool_ext_param_t param;
 	odp_pool_info_t info;
 	const char *name = "pool_ext_0";
 
-	pool_ext_init_packet_pool_param(&param);
-
-	pool = odp_pool_ext_create(name, &param);
+	pool = odp_pool_ext_create(name, param);
 
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 
@@ -2089,25 +2137,23 @@ static void test_packet_pool_ext_info(void)
 	CU_ASSERT_FATAL(odp_pool_info(pool, &info) == 0);
 
 	CU_ASSERT(info.pool_ext);
-	CU_ASSERT(info.type == ODP_POOL_PACKET);
-	CU_ASSERT(info.pool_ext_param.type == ODP_POOL_PACKET);
+	CU_ASSERT(info.type == type);
+	CU_ASSERT(info.pool_ext_param.type == type);
 	CU_ASSERT(strncmp(name, info.name, strlen(name)) == 0);
 
 	CU_ASSERT(odp_pool_destroy(pool) == 0);
 }
 
-static void test_packet_pool_ext_long_name(void)
+static void pool_ext_long_name(const odp_pool_ext_param_t *param)
 {
 	odp_pool_t pool;
-	odp_pool_ext_param_t param;
 	odp_pool_info_t info;
 	char name[ODP_POOL_NAME_LEN];
 
 	memset(name, 'a', sizeof(name));
 	name[sizeof(name) - 1] = 0;
 
-	pool_ext_init_packet_pool_param(&param);
-	pool = odp_pool_ext_create(name, &param);
+	pool = odp_pool_ext_create(name, param);
 
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 	CU_ASSERT_FATAL(pool == odp_pool_lookup(name));
@@ -2121,8 +2167,39 @@ static void test_packet_pool_ext_long_name(void)
 	CU_ASSERT(odp_pool_destroy(pool) == 0);
 }
 
-static odp_shm_t populate_pool(odp_pool_t pool, odp_pool_ext_capability_t *capa,
-			       void *buf[], uint32_t num, uint32_t buf_size)
+static void test_packet_pool_ext_create(void)
+{
+	odp_pool_ext_param_t param;
+
+	pool_ext_init_packet_pool_param(&param);
+	pool_ext_create(&param);
+}
+
+static void test_packet_pool_ext_lookup(void)
+{
+	odp_pool_ext_param_t param;
+
+	pool_ext_init_packet_pool_param(&param);
+	pool_ext_lookup(&param);
+}
+
+static void test_packet_pool_ext_info(void)
+{
+	odp_pool_ext_param_t param;
+
+	pool_ext_init_packet_pool_param(&param);
+	pool_ext_info(&param, ODP_POOL_PACKET);
+}
+
+static void test_packet_pool_ext_long_name(void)
+{
+	odp_pool_ext_param_t param;
+
+	pool_ext_init_packet_pool_param(&param);
+	pool_ext_long_name(&param);
+}
+
+static odp_shm_t populate_pool(odp_pool_t pool, const pool_ext_populate_t *populate)
 {
 	odp_shm_t shm;
 	uint8_t *buf_ptr;
@@ -2130,21 +2207,24 @@ static odp_shm_t populate_pool(odp_pool_t pool, odp_pool_ext_capability_t *capa,
 	uint32_t shm_size, mem_align;
 	uint32_t flags = 0;
 	uint32_t buf_align = EXT_BUF_ALIGN;
-	uint32_t min_align = capa->pkt.min_buf_align;
+	void **buf = populate->buf;
+	uint32_t num = populate->num_buf;
+	uint32_t buf_size = populate->buf_size;
+	uint32_t min_align = populate->min_align;
 
 	CU_ASSERT_FATAL(min_align > 0);
 
 	if (min_align > buf_align)
 		buf_align = min_align;
 
-	if (capa->pkt.buf_size_aligned) {
+	if (populate->size_aligned) {
 		buf_align = buf_size;
 		CU_ASSERT_FATAL((buf_size % min_align) == 0);
 	}
 
 	mem_align = buf_align;
-	if (capa->pkt.min_mem_align > mem_align)
-		mem_align = capa->pkt.min_mem_align;
+	if (populate->min_mem_align > mem_align)
+		mem_align = populate->min_mem_align;
 
 	/* Prepare to align every buffer */
 	shm_size = (num + 1) * (buf_size + buf_align);
@@ -2184,21 +2264,25 @@ static void test_packet_pool_ext_populate(void)
 	odp_pool_t pool;
 	odp_pool_ext_param_t param;
 	odp_pool_ext_capability_t capa;
-	uint32_t buf_size, num_buf;
+	pool_ext_populate_t populate;
 	void *buf[EXT_NUM_BUF];
 
 	CU_ASSERT_FATAL(odp_pool_ext_capability(ODP_POOL_PACKET, &capa) == 0);
 
 	pool_ext_init_packet_pool_param(&param);
-	num_buf  = param.pkt.num_buf;
-	buf_size = param.pkt.buf_size;
+	populate.buf           = buf;
+	populate.num_buf       = param.pkt.num_buf;
+	populate.buf_size      = param.pkt.buf_size;
+	populate.min_align     = capa.pkt.min_buf_align;
+	populate.min_mem_align = capa.pkt.min_mem_align;
+	populate.size_aligned  = capa.pkt.buf_size_aligned;
 
 	CU_ASSERT_FATAL(capa.pkt.min_head_align > 0);
 
 	pool = odp_pool_ext_create("pool_ext_0", &param);
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 
-	shm = populate_pool(pool, &capa, buf, num_buf, buf_size);
+	shm = populate_pool(pool, &populate);
 	CU_ASSERT_FATAL(shm != ODP_SHM_INVALID);
 
 	CU_ASSERT(odp_pool_destroy(pool) == 0);
@@ -2237,6 +2321,7 @@ static void packet_pool_ext_alloc(int len_test)
 	uint32_t hr, tr, uarea_size, max_payload, buf_data_size, app_hdr_size;
 	int num_seg;
 	uint8_t *app_hdr;
+	pool_ext_populate_t populate;
 	void *buf[EXT_NUM_BUF];
 	odp_packet_t pkt[EXT_NUM_BUF];
 	uint32_t seg_len = 0;
@@ -2248,10 +2333,17 @@ static void packet_pool_ext_alloc(int len_test)
 	buf_size   = param.pkt.buf_size;
 	uarea_size = param.pkt.uarea_size;
 
+	populate.buf           = buf;
+	populate.num_buf       = num_buf;
+	populate.buf_size      = buf_size;
+	populate.min_align     = capa.pkt.min_buf_align;
+	populate.min_mem_align = capa.pkt.min_mem_align;
+	populate.size_aligned  = capa.pkt.buf_size_aligned;
+
 	pool = odp_pool_ext_create("pool_ext_0", &param);
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 
-	shm = populate_pool(pool, &capa, buf, num_buf, buf_size);
+	shm = populate_pool(pool, &populate);
 	CU_ASSERT_FATAL(shm != ODP_SHM_INVALID);
 
 	app_hdr_size = param.pkt.app_header_size;
@@ -2348,6 +2440,7 @@ static void test_packet_pool_ext_uarea_init(void)
 	uarea_init_t data;
 	odp_shm_t shm;
 	uint8_t *uarea;
+	pool_ext_populate_t populate;
 
 	CU_ASSERT_FATAL(odp_pool_ext_capability(ODP_POOL_PACKET, &capa) == 0);
 
@@ -2365,7 +2458,14 @@ static void test_packet_pool_ext_uarea_init(void)
 	void *buf[num];
 	odp_packet_t pkts[num];
 
-	shm = populate_pool(pool, &capa, buf, num, param.pkt.buf_size);
+	populate.buf           = buf;
+	populate.num_buf       = num;
+	populate.buf_size      = param.pkt.buf_size;
+	populate.min_align     = capa.pkt.min_buf_align;
+	populate.min_mem_align = capa.pkt.min_mem_align;
+	populate.size_aligned  = capa.pkt.buf_size_aligned;
+
+	shm = populate_pool(pool, &populate);
 
 	CU_ASSERT_FATAL(shm != ODP_SHM_INVALID);
 	CU_ASSERT(data.count == num);
@@ -2414,6 +2514,7 @@ static void test_packet_pool_ext_disassemble(void)
 	uint32_t pkt_len, head_offset, trailer_size, headroom, max_headroom;
 	uint32_t hr, max_payload, buf_data_size;
 	uint32_t num_seg;
+	pool_ext_populate_t populate;
 	void *buf[EXT_NUM_BUF];
 	odp_packet_t pkt_tbl[EXT_NUM_BUF];
 
@@ -2424,10 +2525,17 @@ static void test_packet_pool_ext_disassemble(void)
 	num_buf    = param.pkt.num_buf;
 	buf_size   = param.pkt.buf_size;
 
+	populate.buf           = buf;
+	populate.num_buf       = num_buf;
+	populate.buf_size      = buf_size;
+	populate.min_align     = capa.pkt.min_buf_align;
+	populate.min_mem_align = capa.pkt.min_mem_align;
+	populate.size_aligned  = capa.pkt.buf_size_aligned;
+
 	pool = odp_pool_ext_create("pool_ext_0", &param);
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 
-	shm = populate_pool(pool, &capa, buf, num_buf, buf_size);
+	shm = populate_pool(pool, &populate);
 	CU_ASSERT_FATAL(shm != ODP_SHM_INVALID);
 
 	head_offset  = capa.pkt.odp_header_size + param.pkt.app_header_size;
@@ -2524,6 +2632,296 @@ static void test_packet_pool_ext_disassemble(void)
 	CU_ASSERT(odp_shm_free(shm) == 0);
 }
 
+static void test_ext_buf_param_init(uint8_t fill)
+{
+	odp_pool_ext_param_t param;
+
+	memset(&param, fill, sizeof(param));
+	odp_pool_ext_param_init(ODP_POOL_BUFFER, &param);
+
+	CU_ASSERT(param.type == ODP_POOL_BUFFER);
+	CU_ASSERT(param.uarea_init.init_fn == NULL);
+	CU_ASSERT(param.uarea_init.args == NULL);
+	CU_ASSERT(param.cache_size >= global_pool_ext_buf_capa.min_cache_size &&
+		  param.cache_size <= global_pool_ext_buf_capa.max_cache_size);
+	CU_ASSERT(param.stats.all == 0);
+	CU_ASSERT(param.buf.app_header_size == 0);
+	CU_ASSERT(param.buf.uarea_size == 0);
+}
+
+static void test_buffer_pool_ext_param_init(void)
+{
+	test_ext_buf_param_init(0);
+	test_ext_buf_param_init(0xff);
+}
+
+static void test_buffer_pool_ext_create(void)
+{
+	odp_pool_ext_param_t param;
+
+	pool_ext_init_buffer_pool_param(&param);
+	pool_ext_create(&param);
+}
+
+static void test_buffer_pool_ext_lookup(void)
+{
+	odp_pool_ext_param_t param;
+
+	pool_ext_init_buffer_pool_param(&param);
+	pool_ext_lookup(&param);
+}
+
+static void test_buffer_pool_ext_info(void)
+{
+	odp_pool_ext_param_t param;
+
+	pool_ext_init_buffer_pool_param(&param);
+	pool_ext_info(&param, ODP_POOL_BUFFER);
+}
+
+static void test_buffer_pool_ext_long_name(void)
+{
+	odp_pool_ext_param_t param;
+
+	pool_ext_init_buffer_pool_param(&param);
+	pool_ext_long_name(&param);
+}
+
+static void test_buffer_pool_ext_populate(void)
+{
+	odp_shm_t shm;
+	odp_pool_t pool;
+	odp_pool_ext_param_t param;
+	odp_pool_ext_capability_t capa;
+	pool_ext_populate_t populate;
+	void *buf[EXT_NUM_BUF];
+
+	CU_ASSERT_FATAL(odp_pool_ext_capability(ODP_POOL_BUFFER, &capa) == 0);
+
+	pool_ext_init_buffer_pool_param(&param);
+
+	populate.buf           = buf;
+	populate.num_buf       = param.buf.num_buf;
+	populate.buf_size      = param.buf.buf_size;
+	populate.min_align     = capa.buf.min_buf_align;
+	populate.min_mem_align = capa.buf.min_mem_align;
+	populate.size_aligned  = capa.buf.buf_size_aligned;
+
+	pool = odp_pool_ext_create("pool_ext_0", &param);
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	shm = populate_pool(pool, &populate);
+	CU_ASSERT_FATAL(shm != ODP_SHM_INVALID);
+
+	CU_ASSERT(odp_pool_destroy(pool) == 0);
+	CU_ASSERT(odp_shm_free(shm) == 0);
+}
+
+static uint32_t find_ext_buf(odp_buffer_t buffer, void *buf[], uint32_t num, uint32_t head_offset)
+{
+	uint32_t i;
+	uint8_t *ptr;
+	uint8_t *addr = odp_buffer_addr(buffer);
+
+	for (i = 0; i < num; i++) {
+		ptr  = buf[i];
+		ptr += head_offset;
+
+		if (addr == ptr)
+			break;
+	}
+
+	return i;
+}
+
+static void test_buffer_pool_ext_alloc(void)
+{
+	odp_shm_t shm;
+	odp_pool_t pool;
+	odp_pool_ext_param_t param;
+	odp_pool_ext_capability_t capa;
+	uint32_t i, j, buf_size, num_buf, num_alloc, buf_index;
+	uint32_t head_offset, trailer_size, uarea_size, buf_data_size, app_hdr_size;
+	uint8_t *app_hdr;
+	pool_ext_populate_t populate;
+	void *buf[EXT_NUM_BUF];
+	odp_buffer_t buffer[EXT_NUM_BUF];
+
+	CU_ASSERT_FATAL(odp_pool_ext_capability(ODP_POOL_BUFFER, &capa) == 0);
+
+	pool_ext_init_buffer_pool_param(&param);
+	num_buf    = param.buf.num_buf;
+	buf_size   = param.buf.buf_size;
+	uarea_size = param.buf.uarea_size;
+
+	populate.buf           = buf;
+	populate.num_buf       = num_buf;
+	populate.buf_size      = buf_size;
+	populate.min_align     = capa.buf.min_buf_align;
+	populate.min_mem_align = capa.buf.min_mem_align;
+	populate.size_aligned  = capa.buf.buf_size_aligned;
+
+	pool = odp_pool_ext_create("pool_ext_0", &param);
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	shm = populate_pool(pool, &populate);
+	CU_ASSERT_FATAL(shm != ODP_SHM_INVALID);
+
+	app_hdr_size  = param.buf.app_header_size;
+	head_offset   = capa.buf.odp_header_size + app_hdr_size;
+	trailer_size  = capa.buf.odp_trailer_size;
+	buf_data_size = buf_size - head_offset - trailer_size;
+
+	for (i = 0; i < num_buf; i++) {
+		buffer[i] = odp_buffer_alloc(pool);
+		CU_ASSERT(buffer[i] != ODP_BUFFER_INVALID);
+		if (buffer[i] == ODP_BUFFER_INVALID)
+			break;
+
+		CU_ASSERT(odp_buffer_is_valid(buffer[i]) == 1);
+		CU_ASSERT(odp_event_is_valid(odp_buffer_to_event(buffer[i])) == 1);
+		CU_ASSERT(odp_buffer_pool(buffer[i]) == pool);
+		CU_ASSERT(odp_buffer_addr(buffer[i]) != NULL);
+		CU_ASSERT(odp_buffer_size(buffer[i]) == buf_data_size);
+		buf_index = find_ext_buf(buffer[i], buf, num_buf, head_offset);
+		CU_ASSERT(buf_index < num_buf);
+
+		if (uarea_size)
+			CU_ASSERT(odp_buffer_user_area(buffer[i]) != NULL);
+
+		/* Check that application header content has not changed */
+		app_hdr = (uint8_t *)odp_buffer_addr(buffer[i]) - app_hdr_size;
+		for (j = 0; j < app_hdr_size; j++)
+			CU_ASSERT(app_hdr[j] == MAGIC_U8);
+	}
+
+	num_alloc = i;
+	CU_ASSERT(num_alloc == num_buf);
+
+	/* Pool is now empty */
+	CU_ASSERT(odp_buffer_alloc(pool) == ODP_BUFFER_INVALID);
+
+	for (i = 0; i < num_alloc; i++)
+		odp_buffer_free(buffer[i]);
+
+	CU_ASSERT(odp_pool_destroy(pool) == 0);
+	CU_ASSERT(odp_shm_free(shm) == 0);
+}
+
+static void test_buffer_pool_ext_from_addr(void)
+{
+	odp_shm_t shm;
+	odp_pool_t pool;
+	odp_pool_ext_param_t param;
+	odp_pool_ext_capability_t capa;
+	pool_ext_populate_t populate;
+	int i, num_alloc;
+	uint32_t num_buf;
+	void *buf[EXT_NUM_BUF];
+	void *addr[EXT_NUM_BUF];
+	odp_buffer_t buffer[EXT_NUM_BUF];
+
+	CU_ASSERT_FATAL(odp_pool_ext_capability(ODP_POOL_BUFFER, &capa) == 0);
+
+	pool_ext_init_buffer_pool_param(&param);
+	num_buf = param.buf.num_buf;
+
+	populate.buf           = buf;
+	populate.num_buf       = num_buf;
+	populate.buf_size      = param.buf.buf_size;
+	populate.min_align     = capa.buf.min_buf_align;
+	populate.min_mem_align = capa.buf.min_mem_align;
+	populate.size_aligned  = capa.buf.buf_size_aligned;
+
+	pool = odp_pool_ext_create("pool_ext_0", &param);
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	shm = populate_pool(pool, &populate);
+	CU_ASSERT_FATAL(shm != ODP_SHM_INVALID);
+
+	num_alloc = odp_buffer_alloc_multi(pool, buffer, (int)num_buf);
+	CU_ASSERT_FATAL(num_alloc > 0);
+
+	for (i = 0; i < num_alloc; i++) {
+		addr[i] = odp_buffer_addr(buffer[i]);
+		CU_ASSERT(addr[i] != NULL);
+	}
+
+	/* Buffer addresses alone are enough to get the handles back */
+	for (i = 0; i < num_alloc; i++) {
+		odp_buffer_t buf_hdl = odp_buffer_from_addr(pool, addr[i]);
+
+		CU_ASSERT(odp_buffer_to_u64(buf_hdl) == odp_buffer_to_u64(buffer[i]));
+		CU_ASSERT(odp_buffer_is_valid(buf_hdl) == 1);
+		CU_ASSERT(odp_buffer_addr(buf_hdl) == addr[i]);
+		CU_ASSERT(odp_buffer_pool(buf_hdl) == pool);
+	}
+
+	odp_buffer_free_multi(buffer, num_alloc);
+
+	CU_ASSERT(odp_pool_destroy(pool) == 0);
+	CU_ASSERT(odp_shm_free(shm) == 0);
+}
+
+static void test_buffer_pool_ext_uarea_init(void)
+{
+	odp_pool_ext_capability_t capa;
+	odp_pool_ext_param_t param;
+	uint32_t num = ELEM_NUM, i;
+	odp_pool_t pool;
+	uarea_init_t data;
+	odp_shm_t shm;
+	uint8_t *uarea;
+	pool_ext_populate_t populate;
+
+	CU_ASSERT_FATAL(odp_pool_ext_capability(ODP_POOL_BUFFER, &capa) == 0);
+
+	memset(&data, 0, sizeof(uarea_init_t));
+	pool_ext_init_buffer_pool_param(&param);
+	param.uarea_init.init_fn = init_event_uarea;
+	param.uarea_init.args = &data;
+	num = ODPH_MIN(num, param.buf.num_buf);
+	param.buf.num_buf = num;
+	param.buf.uarea_size = 1;
+	pool = odp_pool_ext_create(NULL, &param);
+
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	void *buf[num];
+	odp_buffer_t buffer[num];
+
+	populate.buf           = buf;
+	populate.num_buf       = num;
+	populate.buf_size      = param.buf.buf_size;
+	populate.min_align     = capa.buf.min_buf_align;
+	populate.min_mem_align = capa.buf.min_mem_align;
+	populate.size_aligned  = capa.buf.buf_size_aligned;
+
+	shm = populate_pool(pool, &populate);
+
+	CU_ASSERT_FATAL(shm != ODP_SHM_INVALID);
+	CU_ASSERT(data.count == num);
+
+	for (i = 0; i < num; i++) {
+		CU_ASSERT(data.mark[i] == 1);
+
+		buffer[i] = odp_buffer_alloc(pool);
+
+		CU_ASSERT(buffer[i] != ODP_BUFFER_INVALID);
+
+		if (buffer[i] == ODP_BUFFER_INVALID)
+			break;
+
+		uarea = odp_buffer_user_area(buffer[i]);
+
+		CU_ASSERT(*uarea == UAREA);
+	}
+
+	odp_buffer_free_multi(buffer, i);
+	odp_pool_destroy(pool);
+	odp_shm_free(shm);
+}
+
 static int pool_suite_init(void)
 {
 	memset(&global_pool_capa, 0, sizeof(odp_pool_capability_t));
@@ -2542,6 +2940,7 @@ static int pool_suite_init(void)
 static int pool_ext_suite_init(void)
 {
 	memset(&global_pool_ext_capa, 0, sizeof(odp_pool_ext_capability_t));
+	memset(&global_pool_ext_buf_capa, 0, sizeof(odp_pool_ext_capability_t));
 
 	if (odp_pool_ext_capability(ODP_POOL_PACKET, &global_pool_ext_capa)) {
 		ODPH_ERR("Pool ext capa failed in suite init\n");
@@ -2550,6 +2949,16 @@ static int pool_ext_suite_init(void)
 
 	if (global_pool_ext_capa.type != ODP_POOL_PACKET) {
 		ODPH_ERR("Bad type from pool ext capa in suite init\n");
+		return -1;
+	}
+
+	if (odp_pool_ext_capability(ODP_POOL_BUFFER, &global_pool_ext_buf_capa)) {
+		ODPH_ERR("Buffer pool ext capa failed in suite init\n");
+		return -1;
+	}
+
+	if (global_pool_ext_buf_capa.type != ODP_POOL_BUFFER) {
+		ODPH_ERR("Bad type from buffer pool ext capa in suite init\n");
 		return -1;
 	}
 
@@ -2568,6 +2977,24 @@ static int check_pool_ext_uarea_init_support(void)
 {
 	if (global_pool_ext_capa.max_pools == 0 || !global_pool_ext_capa.pkt.uarea_persistence ||
 	    global_pool_ext_capa.pkt.max_uarea_size == 0)
+		return ODP_TEST_INACTIVE;
+
+	return ODP_TEST_ACTIVE;
+}
+
+static int check_pool_ext_buf_support(void)
+{
+	if (global_pool_ext_buf_capa.max_pools == 0)
+		return ODP_TEST_INACTIVE;
+
+	return ODP_TEST_ACTIVE;
+}
+
+static int check_pool_ext_buf_uarea_init_support(void)
+{
+	if (global_pool_ext_buf_capa.max_pools == 0 ||
+	    !global_pool_ext_buf_capa.buf.uarea_persistence ||
+	    global_pool_ext_buf_capa.buf.max_uarea_size == 0)
 		return ODP_TEST_INACTIVE;
 
 	return ODP_TEST_ACTIVE;
@@ -2670,6 +3097,16 @@ odp_testinfo_t pool_ext_suite[] = {
 	ODP_TEST_INFO_CONDITIONAL(test_packet_pool_ext_alloc_max, check_pool_ext_support),
 	ODP_TEST_INFO_CONDITIONAL(test_packet_pool_ext_alloc_seg, check_pool_ext_segment_support),
 	ODP_TEST_INFO_CONDITIONAL(test_packet_pool_ext_disassemble, check_pool_ext_segment_support),
+	ODP_TEST_INFO_CONDITIONAL(test_buffer_pool_ext_param_init, check_pool_ext_buf_support),
+	ODP_TEST_INFO_CONDITIONAL(test_buffer_pool_ext_create, check_pool_ext_buf_support),
+	ODP_TEST_INFO_CONDITIONAL(test_buffer_pool_ext_lookup, check_pool_ext_buf_support),
+	ODP_TEST_INFO_CONDITIONAL(test_buffer_pool_ext_info, check_pool_ext_buf_support),
+	ODP_TEST_INFO_CONDITIONAL(test_buffer_pool_ext_long_name, check_pool_ext_buf_support),
+	ODP_TEST_INFO_CONDITIONAL(test_buffer_pool_ext_populate, check_pool_ext_buf_support),
+	ODP_TEST_INFO_CONDITIONAL(test_buffer_pool_ext_alloc, check_pool_ext_buf_support),
+	ODP_TEST_INFO_CONDITIONAL(test_buffer_pool_ext_from_addr, check_pool_ext_buf_support),
+	ODP_TEST_INFO_CONDITIONAL(test_buffer_pool_ext_uarea_init,
+				  check_pool_ext_buf_uarea_init_support),
 	ODP_TEST_INFO_NULL,
 };
 

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
  * Copyright (c) 2020 Marvell
- * Copyright (c) 2020-2025 Nokia
+ * Copyright (c) 2020-2026 Nokia
  */
 
 #include <odp_api.h>
@@ -1978,7 +1978,7 @@ static void test_packet_pool_ext_capa(void)
 {
 	odp_pool_ext_capability_t capa;
 	odp_pool_type_t type;
-	const odp_pool_type_t unsupported_types[] = {ODP_POOL_BUFFER, ODP_POOL_TIMEOUT,
+	const odp_pool_type_t unsupported_types[] = {ODP_POOL_TIMEOUT,
 						     ODP_POOL_EVENT_VECTOR,
 						     ODP_POOL_VECTOR, ODP_POOL_DMA_COMPL,
 						     ODP_POOL_ML_COMPL};


### PR DESCRIPTION
Add buffer pool capability and parameter structures to the external memory pool API, so that `ODP_POOL_BUFFER` pools can be created from application provided memory. Buffers reuse the packet buffer layout, excluding headroom and segmentation which do not apply to buffers.