### PR TITLE
[PATCH v3] test: pipeline: distribute example config and work files

### DIFF
--- a/test/performance/pipeline/Makefile.am
+++ b/test/performance/pipeline/Makefile.am
@@ -58,4 +58,10 @@ odp_pipeline_SOURCES = \
 	work_wait.c \
 	worker.h \
 	worker_parser.c
+
+EXTRA_DIST = \
+	pipeline.conf \
+	pipeline_example1.conf \
+	pipeline_example2.conf \
+	work_example.c
 endif


### PR DESCRIPTION
When distributing ODP (`make dist`), add also pipeline example config files and work source to be distributed.

v3:
- Added reviewed-by tag