### PR TITLE
[PATCH v2] api: crypto: deprecate session output pool

### DIFF
--- a/include/odp/api/spec/crypto_types.h
+++ b/include/odp/api/spec/crypto_types.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2014-2018 Linaro Limited
- * Copyright (c) 2021-2025 Nokia
+ * Copyright (c) 2021-2026 Nokia
  */
 
 /**
@@ -942,12 +942,13 @@ typedef struct odp_crypto_session_param_t {
 
 	/** Output pool
 	 *
-	 *  This field is unused and will be deprecated later.
 	 *  The value must be left to the default value.
 	 *
 	 *  Default value is ODP_POOL_INVALID.
+	 *
+	 *  @deprecated Unused by current operation types.
 	 */
-	odp_pool_t output_pool;
+	odp_pool_t ODP_DEPRECATE(output_pool);
 
 } odp_crypto_session_param_t;
 

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2025 Nokia
+ * Copyright (c) 2025-2026 Nokia
  */
 
 #include <odp/api/crypto.h>
@@ -212,7 +212,9 @@ void _odp_crypto_session_print(const char *type, uint32_t index,
 			    param->auth_aad_len);
 	len += _odp_snprint(&str[len], n - len, "  compl_queue               %" PRIu64 "\n",
 			    odp_queue_to_u64(param->compl_queue));
+#if ODP_DEPRECATED_API
 	len += _odp_snprint(&str[len], n - len, "  output_pool               %" PRIu64 "\n",
 			    odp_pool_to_u64(param->output_pool));
+#endif
 	_ODP_PRINT("%s\n", str);
 }

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2017-2018 Linaro Limited
- * Copyright (c) 2018-2023 Nokia
+ * Copyright (c) 2018-2026 Nokia
  */
 
 #include <odp/api/atomic.h>
@@ -632,7 +632,6 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 
 	crypto_param.op_mode   = ODP_CRYPTO_SYNC;
 	crypto_param.compl_queue = ODP_QUEUE_INVALID;
-	crypto_param.output_pool = ODP_POOL_INVALID;
 
 	crypto_param.cipher_alg = param->crypto.cipher_alg;
 	crypto_param.cipher_key = param->crypto.cipher_key;

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -44,7 +44,9 @@ static void test_defaults(uint8_t fill)
 	CU_ASSERT(param.auth_alg == ODP_AUTH_ALG_NULL);
 	CU_ASSERT(param.auth_iv_len == 0);
 	CU_ASSERT(param.auth_aad_len == 0);
+#if ODP_DEPRECATED_API
 	CU_ASSERT(param.output_pool == ODP_POOL_INVALID);
+#endif
 }
 
 static void test_default_values(void)


### PR DESCRIPTION
Deprecate `odp_crypto_session_param_t::output_pool`. The pool is not used by any of the crypto operation types.

v2:
- Added reviewed-by tag